### PR TITLE
feat(rialto): add GlobalNav component for cross-app navigation

### DIFF
--- a/apps/hospitality/src/App.tsx
+++ b/apps/hospitality/src/App.tsx
@@ -1,6 +1,6 @@
 import { Outlet, Navigate } from "react-router-dom";
 import { useAuth } from "@mbe/auth/react";
-import { Stack, Text, Button } from "@mbe/rialto";
+import { Stack, Text, Button, GlobalNav } from "@mbe/rialto";
 import { LoadingPage } from "./pages/LoadingPage";
 import styles from "./App.module.css";
 
@@ -13,7 +13,12 @@ export function App() {
   const { isLoading, isAuthenticated, error } = useAuth();
 
   if (isLoading) {
-    return <LoadingPage />;
+    return (
+      <>
+        <GlobalNav currentApp="hospitality" />
+        <LoadingPage />
+      </>
+    );
   }
 
   // If on the callback path, show loading while OIDC finishes processing
@@ -21,31 +26,49 @@ export function App() {
 
   if (error) {
     return (
-      <div className={styles.loginContainer}>
-        <Stack gap="md" align="center">
-          <Text as="h1" variant="display" color="primary">
-            Authentication Error
-          </Text>
-          <Text variant="body" color="secondary">
-            {error.message}
-          </Text>
-          <Button variant="primary" onClick={() => window.location.assign("/hospitality")}>
-            Try Again
-          </Button>
-        </Stack>
-      </div>
+      <>
+        <GlobalNav currentApp="hospitality" />
+        <div className={styles.loginContainer}>
+          <Stack gap="md" align="center">
+            <Text as="h1" variant="display" color="primary">
+              Authentication Error
+            </Text>
+            <Text variant="body" color="secondary">
+              {error.message}
+            </Text>
+            <Button variant="primary" onClick={() => window.location.assign("/hospitality")}>
+              Try Again
+            </Button>
+          </Stack>
+        </div>
+      </>
     );
   }
 
   if (isCallback && !isAuthenticated) {
-    return <LoadingPage />;
+    return (
+      <>
+        <GlobalNav currentApp="hospitality" />
+        <LoadingPage />
+      </>
+    );
   }
 
   if (!isAuthenticated) {
-    return <LoginPrompt />;
+    return (
+      <>
+        <GlobalNav currentApp="hospitality" />
+        <LoginPrompt />
+      </>
+    );
   }
 
-  return <Outlet />;
+  return (
+    <>
+      <GlobalNav currentApp="hospitality" />
+      <Outlet />
+    </>
+  );
 }
 
 function LoginPrompt() {

--- a/apps/marketing/src/App.tsx
+++ b/apps/marketing/src/App.tsx
@@ -1,5 +1,5 @@
 import { Routes, Route } from "react-router-dom";
-import { Footer } from "@mbe/rialto";
+import { Footer, GlobalNav } from "@mbe/rialto";
 import { Navbar } from "./components/Navbar";
 import { HomePage } from "./pages/HomePage";
 import styles from "./App.module.css";
@@ -12,6 +12,7 @@ interface AppProps {
 export function App({ theme, onThemeToggle }: AppProps) {
   return (
     <div className={styles.layout}>
+      <GlobalNav currentApp="marketing" />
       <Navbar theme={theme} onThemeToggle={onThemeToggle} />
       <main className={styles.main}>
         <Routes>

--- a/apps/rialto-web/src/layouts/DemoLayout.tsx
+++ b/apps/rialto-web/src/layouts/DemoLayout.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { Outlet } from "react-router-dom";
-import { RialtoProvider, type VibeName } from "@mbe/rialto";
+import { GlobalNav, RialtoProvider, type VibeName } from "@mbe/rialto";
 import { useCookieConsent } from "../components/CookieConsent/useCookieConsent";
 import { CookieBanner, CookiePreferencesDialog } from "../components/CookieConsent/CookieConsent";
 import styles from "./DemoLayout.module.css";
@@ -162,6 +162,7 @@ export function DemoLayout() {
   return (
     <RialtoProvider vibe={activeVibe} theme={darkMode ? "dark" : "light"}>
       <div dir={rtl ? "rtl" : undefined}>
+        <GlobalNav currentApp="rialto" />
         <div className={styles.floatingControls}>
           <FloatingControls
             darkMode={darkMode}

--- a/apps/rialto-web/src/layouts/ShowcaseLayout.tsx
+++ b/apps/rialto-web/src/layouts/ShowcaseLayout.tsx
@@ -1,5 +1,5 @@
 import { Outlet, Link, useNavigate, useLocation } from "react-router-dom";
-import { Footer, ThemeToggle } from "@mbe/rialto";
+import { Footer, GlobalNav, ThemeToggle } from "@mbe/rialto";
 import { ShowcaseSidebar } from "../components/ShowcaseSidebar";
 import { NAV_SECTIONS, DEMO_PAGES } from "../data/nav-sections";
 import { useThemeContext } from "../ThemeContext";
@@ -44,6 +44,7 @@ export function ShowcaseLayout(props: ShowcaseLayoutProps) {
 
   return (
     <div className={styles.root}>
+      <GlobalNav currentApp="rialto" />
       {/* ── Top header bar ─────────────────────── */}
       <header className={styles.header}>
         <div className={styles.headerStart}>

--- a/packages/rialto/src/components/GlobalNav/GlobalNav.module.css
+++ b/packages/rialto/src/components/GlobalNav/GlobalNav.module.css
@@ -1,0 +1,200 @@
+/* ── GlobalNav — cross-app top bar ─────────────── */
+
+.globalNav {
+  position: sticky;
+  top: 0;
+  z-index: var(--rialto-z-sticky);
+  background: var(--rialto-surface);
+  border-block-end: 1px solid var(--rialto-border);
+}
+
+.inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-inline-size: 1200px;
+  margin-inline: auto;
+  padding-block: var(--rialto-space-sm);
+  padding-inline: var(--rialto-space-lg);
+  block-size: var(--rialto-space-3xl);
+}
+
+/* ── Brand ──────────────────────────────────────── */
+
+.brand {
+  font-family: var(--rialto-font-sans);
+  font-size: var(--rialto-text-md);
+  font-weight: var(--rialto-weight-medium);
+  letter-spacing: var(--rialto-tracking-wide);
+  color: var(--rialto-text-primary);
+  text-decoration: none;
+  flex-shrink: 0;
+}
+
+.brand:hover {
+  color: var(--rialto-accent);
+}
+
+/* ── Desktop links ──────────────────────────────── */
+
+.desktopLinks {
+  display: flex;
+  align-items: center;
+  gap: var(--rialto-space-lg);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.link {
+  position: relative;
+  font-family: var(--rialto-font-sans);
+  font-size: var(--rialto-text-sm);
+  font-weight: var(--rialto-weight-regular);
+  color: var(--rialto-text-secondary);
+  text-decoration: none;
+  padding-block: var(--rialto-space-xs);
+  transition: color 0.15s var(--rialto-ease-precision);
+}
+
+.link:hover {
+  color: var(--rialto-text-primary);
+}
+
+.link.active {
+  color: var(--rialto-text-primary);
+  font-weight: var(--rialto-weight-medium);
+}
+
+/* Gold underline for the active link */
+.link.active::after {
+  content: "";
+  position: absolute;
+  inset-inline: 0;
+  inset-block-end: -2px;
+  block-size: 2px;
+  background: var(--rialto-accent);
+  border-radius: var(--rialto-radius-round);
+}
+
+/* ── Hamburger button ───────────────────────────── */
+
+.hamburger {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  inline-size: var(--rialto-space-2xl);
+  block-size: var(--rialto-space-2xl);
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.hamburgerBar,
+.hamburgerBar::before,
+.hamburgerBar::after {
+  display: block;
+  inline-size: 18px;
+  block-size: 2px;
+  background: var(--rialto-text-primary);
+  border-radius: var(--rialto-radius-round);
+  transition:
+    transform 0.2s var(--rialto-ease-precision),
+    opacity 0.2s var(--rialto-ease-precision);
+}
+
+.hamburgerBar {
+  position: relative;
+}
+
+.hamburgerBar::before,
+.hamburgerBar::after {
+  content: "";
+  position: absolute;
+  inset-inline-start: 0;
+}
+
+.hamburgerBar::before {
+  transform: translateY(-6px);
+}
+
+.hamburgerBar::after {
+  transform: translateY(6px);
+}
+
+/* Open state — X shape */
+.hamburgerBar.open {
+  background: transparent;
+}
+
+.hamburgerBar.open::before {
+  transform: rotate(45deg);
+}
+
+.hamburgerBar.open::after {
+  transform: rotate(-45deg);
+}
+
+/* ── Mobile menu ────────────────────────────────── */
+
+.mobileMenu {
+  display: none;
+  flex-direction: column;
+  list-style: none;
+  margin: 0;
+  padding: var(--rialto-space-sm) var(--rialto-space-lg) var(--rialto-space-lg);
+  border-block-end: 1px solid var(--rialto-border);
+  background: var(--rialto-surface);
+}
+
+.mobileLink {
+  display: block;
+  font-family: var(--rialto-font-sans);
+  font-size: var(--rialto-text-sm);
+  font-weight: var(--rialto-weight-regular);
+  color: var(--rialto-text-secondary);
+  text-decoration: none;
+  padding-block: var(--rialto-space-sm);
+  padding-inline: var(--rialto-space-sm);
+  border-radius: var(--rialto-radius-default);
+  transition: background 0.15s var(--rialto-ease-precision);
+}
+
+.mobileLink:hover {
+  background: var(--rialto-surface-elevated);
+  color: var(--rialto-text-primary);
+}
+
+.mobileLink.active {
+  color: var(--rialto-text-primary);
+  font-weight: var(--rialto-weight-medium);
+  border-inline-start: 2px solid var(--rialto-accent);
+}
+
+/* ── Responsive ─────────────────────────────────── */
+
+@media (max-width: 767px) {
+  .desktopLinks {
+    display: none;
+  }
+
+  .hamburger {
+    display: flex;
+  }
+
+  .mobileMenu {
+    display: flex;
+  }
+}
+
+/* ── Reduced motion ─────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .hamburgerBar,
+  .hamburgerBar::before,
+  .hamburgerBar::after {
+    transition: none;
+  }
+}

--- a/packages/rialto/src/components/GlobalNav/GlobalNav.test.tsx
+++ b/packages/rialto/src/components/GlobalNav/GlobalNav.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GlobalNav } from "./GlobalNav";
+
+describe("GlobalNav", () => {
+  it("renders all navigation links", () => {
+    render(<GlobalNav currentApp="marketing" />);
+
+    expect(screen.getByRole("link", { name: "Home" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Hospitality" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Design System" })).toBeTruthy();
+  });
+
+  it("renders the brand link pointing to root", () => {
+    render(<GlobalNav currentApp="marketing" />);
+
+    const brand = screen.getByRole("link", { name: "MBE" });
+    expect(brand).toBeTruthy();
+    expect(brand.getAttribute("href")).toBe("/");
+  });
+
+  it("applies active class to the current app link", () => {
+    render(<GlobalNav currentApp="hospitality" />);
+
+    const hospitalityLink = screen.getByRole("link", { name: "Hospitality" });
+    expect(hospitalityLink.className).toContain("active");
+    expect(hospitalityLink.getAttribute("aria-current")).toBe("page");
+
+    const homeLink = screen.getByRole("link", { name: "Home" });
+    expect(homeLink.className).not.toContain("active");
+    expect(homeLink.getAttribute("aria-current")).toBeNull();
+  });
+
+  it("applies active class for marketing app", () => {
+    render(<GlobalNav currentApp="marketing" />);
+
+    const homeLink = screen.getByRole("link", { name: "Home" });
+    expect(homeLink.className).toContain("active");
+    expect(homeLink.getAttribute("aria-current")).toBe("page");
+  });
+
+  it("applies active class for rialto app", () => {
+    render(<GlobalNav currentApp="rialto" />);
+
+    const designLink = screen.getByRole("link", { name: "Design System" });
+    expect(designLink.className).toContain("active");
+    expect(designLink.getAttribute("aria-current")).toBe("page");
+  });
+
+  it("links use correct href values", () => {
+    render(<GlobalNav currentApp="marketing" />);
+
+    expect(screen.getByRole("link", { name: "Home" }).getAttribute("href")).toBe("/");
+    expect(screen.getByRole("link", { name: "Hospitality" }).getAttribute("href")).toBe(
+      "/hospitality"
+    );
+    expect(screen.getByRole("link", { name: "Design System" }).getAttribute("href")).toBe(
+      "/rialto"
+    );
+  });
+
+  it("mobile menu is hidden by default", () => {
+    render(<GlobalNav currentApp="marketing" />);
+
+    expect(document.getElementById("global-nav-mobile-menu")).toBeNull();
+  });
+
+  it("toggles mobile menu on hamburger click", async () => {
+    const user = userEvent.setup();
+    render(<GlobalNav currentApp="marketing" />);
+
+    const hamburger = screen.getByRole("button", { name: "Open menu" });
+    expect(hamburger.getAttribute("aria-expanded")).toBe("false");
+
+    // Open
+    await user.click(hamburger);
+    expect(document.getElementById("global-nav-mobile-menu")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Close menu" }).getAttribute("aria-expanded")).toBe(
+      "true"
+    );
+
+    // Close
+    await user.click(screen.getByRole("button", { name: "Close menu" }));
+    expect(document.getElementById("global-nav-mobile-menu")).toBeNull();
+  });
+
+  it("closes mobile menu on Escape key", async () => {
+    const user = userEvent.setup();
+    render(<GlobalNav currentApp="marketing" />);
+
+    // Open menu
+    await user.click(screen.getByRole("button", { name: "Open menu" }));
+    expect(document.getElementById("global-nav-mobile-menu")).toBeTruthy();
+
+    // Press Escape
+    await user.keyboard("{Escape}");
+    expect(document.getElementById("global-nav-mobile-menu")).toBeNull();
+  });
+
+  it("has accessible navigation landmark", () => {
+    render(<GlobalNav currentApp="marketing" />);
+
+    const nav = screen.getByRole("navigation", { name: "Global navigation" });
+    expect(nav).toBeTruthy();
+  });
+
+  it("forwards ref to the nav element", () => {
+    const ref = { current: null } as React.RefObject<HTMLElement | null>;
+    render(<GlobalNav ref={ref} currentApp="marketing" />);
+
+    expect(ref.current).toBeInstanceOf(HTMLElement);
+    expect(ref.current?.tagName).toBe("NAV");
+  });
+
+  it("applies custom className", () => {
+    render(<GlobalNav currentApp="marketing" className="custom-class" />);
+
+    const nav = screen.getByRole("navigation", { name: "Global navigation" });
+    expect(nav.className).toContain("custom-class");
+  });
+});

--- a/packages/rialto/src/components/GlobalNav/GlobalNav.tsx
+++ b/packages/rialto/src/components/GlobalNav/GlobalNav.tsx
@@ -1,0 +1,122 @@
+import { forwardRef, useState, useCallback, type HTMLAttributes } from "react";
+import styles from "./GlobalNav.module.css";
+
+/** Navigation item definition. */
+interface NavItem {
+  readonly label: string;
+  readonly href: string;
+  readonly app: "marketing" | "hospitality" | "rialto";
+}
+
+const NAV_ITEMS: readonly NavItem[] = [
+  { label: "Home", href: "/", app: "marketing" },
+  { label: "Hospitality", href: "/hospitality", app: "hospitality" },
+  { label: "Design System", href: "/rialto", app: "rialto" },
+];
+
+/**
+ * Cross-app navigation bar for mattbutlerengineering.com.
+ *
+ * Uses full `<a href>` tags (not React Router `<Link>`) because
+ * navigation between apps requires full page loads — each app is
+ * served by a separate Cloudflare Worker.
+ *
+ * @example
+ * <GlobalNav currentApp="marketing" />
+ */
+export interface GlobalNavProps
+  extends Pick<HTMLAttributes<HTMLElement>, "id" | "aria-label" | "className" | "style"> {
+  /** Which app is currently active — drives the active link indicator. */
+  currentApp: "marketing" | "hospitality" | "rialto";
+}
+
+export const GlobalNav = forwardRef<HTMLElement, GlobalNavProps>(
+  ({ currentApp, className, ...props }, ref) => {
+    const [menuOpen, setMenuOpen] = useState(false);
+
+    const handleToggle = useCallback(() => {
+      setMenuOpen((prev) => !prev);
+    }, []);
+
+    const handleKeyDown = useCallback(
+      (e: React.KeyboardEvent) => {
+        if (e.key === "Escape" && menuOpen) {
+          setMenuOpen(false);
+        }
+      },
+      [menuOpen]
+    );
+
+    const classes = [styles.globalNav, className].filter(Boolean).join(" ");
+
+    return (
+      <nav
+        ref={ref}
+        className={classes}
+        aria-label="Global navigation"
+        {...props}
+      >
+        <div className={styles.inner}>
+          {/* ── Brand ──────────────────────────────── */}
+          <a href="/" className={styles.brand}>
+            MBE
+          </a>
+
+          {/* ── Desktop links ─────────────────────── */}
+          <ul className={styles.desktopLinks}>
+            {NAV_ITEMS.map((item) => (
+              <li key={item.app}>
+                <a
+                  href={item.href}
+                  className={[styles.link, currentApp === item.app ? styles.active : ""]
+                    .filter(Boolean)
+                    .join(" ")}
+                  aria-current={currentApp === item.app ? "page" : undefined}
+                >
+                  {item.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+
+          {/* ── Mobile hamburger ──────────────────── */}
+          <button
+            type="button"
+            className={styles.hamburger}
+            onClick={handleToggle}
+            onKeyDown={handleKeyDown}
+            aria-expanded={menuOpen}
+            aria-controls="global-nav-mobile-menu"
+            aria-label={menuOpen ? "Close menu" : "Open menu"}
+          >
+            <span className={[styles.hamburgerBar, menuOpen ? styles.open : ""].filter(Boolean).join(" ")} />
+          </button>
+        </div>
+
+        {/* ── Mobile menu ─────────────────────────── */}
+        {menuOpen && (
+          <ul
+            id="global-nav-mobile-menu"
+            className={styles.mobileMenu}
+          >
+            {NAV_ITEMS.map((item) => (
+              <li key={item.app}>
+                <a
+                  href={item.href}
+                  className={[styles.mobileLink, currentApp === item.app ? styles.active : ""]
+                    .filter(Boolean)
+                    .join(" ")}
+                  aria-current={currentApp === item.app ? "page" : undefined}
+                >
+                  {item.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        )}
+      </nav>
+    );
+  }
+);
+
+GlobalNav.displayName = "GlobalNav";

--- a/packages/rialto/src/components/GlobalNav/index.ts
+++ b/packages/rialto/src/components/GlobalNav/index.ts
@@ -1,0 +1,1 @@
+export * from "./GlobalNav";

--- a/packages/rialto/src/components/index.ts
+++ b/packages/rialto/src/components/index.ts
@@ -38,6 +38,7 @@ export * from "./Tree";
 
 // ── Layout components ─────────────────────────────
 export * from "./Footer";
+export * from "./GlobalNav";
 export * from "./Hero";
 export * from "./PageHeader";
 


### PR DESCRIPTION
## Summary
- Add `GlobalNav` component to `@mbe/rialto` design system for cross-app navigation across mattbutlerengineering.com
- Uses full `<a href>` tags (not React Router `<Link>`) since cross-app nav requires full page loads between separate Cloudflare Workers
- Responsive: collapses to hamburger menu on mobile (< 768px), Escape key to close
- Integrated into marketing, hospitality, and rialto-web apps

## Details
- `GlobalNav` accepts `currentApp` prop (`"marketing" | "hospitality" | "rialto"`) to drive active link styling (gold accent underline)
- Uses Rialto CSS tokens exclusively, CSS Modules, CSS logical properties, and `prefers-reduced-motion` support
- 12 unit tests covering: rendering, active states, href values, mobile menu toggle, Escape key, ref forwarding, accessibility landmark

## Test plan
- [x] `pnpm --filter @mbe/rialto lint` passes
- [x] `pnpm --filter @mbe/rialto typecheck` passes
- [x] `pnpm --filter @mbe/rialto build` succeeds
- [x] GlobalNav tests pass (12/12)
- [x] Marketing, hospitality, and rialto-web apps build successfully

Closes #2