### PR TITLE
fix(reservations): reject invalid JWT tokens in optional auth

### DIFF
--- a/services/reservations/src/routes/reservations.test.ts
+++ b/services/reservations/src/routes/reservations.test.ts
@@ -380,6 +380,32 @@ describe("Reservation Routes", () => {
       );
     });
 
+    it("returns 401 when Bearer token is invalid", async () => {
+      vi.mocked(jwtVerify).mockRejectedValueOnce(new Error("invalid signature"));
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/v1/reservations",
+        headers: {
+          authorization: "Bearer invalid-token",
+        },
+        payload: {
+          date: "2026-02-15",
+          startTime: "2026-02-15T18:00:00.000Z",
+          endTime: "2026-02-15T20:00:00.000Z",
+          partySize: 4,
+          tableId: "table-123",
+          guestName: "John Doe",
+        },
+      });
+
+      expect(response.statusCode).toBe(401);
+      const body = JSON.parse(response.body);
+      expect(body.error).toBe("Unauthorized");
+      expect(body.message).toBe("Invalid token");
+      expect(reservationService.createWithConflictCheck).not.toHaveBeenCalled();
+    });
+
     it("returns 409 when conflict exists", async () => {
       vi.mocked(reservationService.createWithConflictCheck).mockResolvedValueOnce({
         success: false,

--- a/services/reservations/src/routes/reservations.ts
+++ b/services/reservations/src/routes/reservations.ts
@@ -71,13 +71,14 @@ export const reservationRoutes: FastifyPluginAsync = async (fastify) => {
     }
   };
 
-  const optionalAuth = async (request: FastifyRequest) => {
+  const optionalAuth = async (request: FastifyRequest, reply: FastifyReply) => {
     if (!JWKS || !authority || !audience) {
       return;
     }
 
     const authHeader = request.headers.authorization;
     if (!authHeader?.startsWith("Bearer ")) {
+      // No token provided — continue as anonymous
       return;
     }
 
@@ -97,8 +98,14 @@ export const reservationRoutes: FastifyPluginAsync = async (fastify) => {
         emailVerified: jwtPayload.email_verified,
         raw: jwtPayload,
       };
-    } catch {
-      // Invalid token for optional auth - just ignore
+    } catch (error) {
+      // Token was provided but is invalid — reject with 401
+      fastify.log.warn({ error }, "Invalid JWT token");
+      return reply.code(401).send({
+        error: "Unauthorized",
+        message: "Invalid token",
+        statusCode: 401,
+      });
     }
   };
 


### PR DESCRIPTION
Previously, invalid tokens were silently ignored and treated as anonymous requests. Now returns 401 when a Bearer token is present but fails verification. Missing auth header still allows anonymous access.

Closes #15