### PR TITLE
fix(hospitality): wire onClick handler for New Floor Plan button

### DIFF
--- a/apps/hospitality/src/components/floor-plan/NewFloorPlanDialog.module.css
+++ b/apps/hospitality/src/components/floor-plan/NewFloorPlanDialog.module.css
@@ -1,0 +1,157 @@
+/* Overlay */
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+/* Dialog */
+.dialog {
+  background: var(--rialto-surface);
+  border-radius: var(--rialto-radius-default);
+  box-shadow: var(--rialto-shadow-lg);
+  width: 100%;
+  max-width: 26rem;
+  padding: var(--rialto-space-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--rialto-space-md);
+}
+
+/* Header */
+.dialogHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.dialogTitle {
+  font-size: var(--rialto-text-xl);
+  font-weight: var(--rialto-weight-bold);
+  color: var(--rialto-text-primary);
+}
+
+.closeButton {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--rialto-text-secondary);
+  padding: var(--rialto-space-2xs);
+  display: flex;
+  align-items: center;
+  border-radius: var(--rialto-radius-default);
+}
+
+.closeButton:hover {
+  color: var(--rialto-text-primary);
+  background: var(--rialto-surface-recessed);
+}
+
+/* Error banner */
+.errorBanner {
+  background: #fef2f2;
+  color: #dc2626;
+  padding: var(--rialto-space-sm);
+  border-radius: var(--rialto-radius-default);
+  font-size: var(--rialto-text-sm);
+}
+
+/* Form */
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--rialto-space-md);
+}
+
+/* Field group */
+.fieldGroup {
+  display: flex;
+  flex-direction: column;
+  gap: var(--rialto-space-2xs);
+}
+
+.label {
+  font-size: var(--rialto-text-sm);
+  font-weight: var(--rialto-weight-medium);
+  color: var(--rialto-text-secondary);
+}
+
+.required {
+  color: #dc2626;
+}
+
+.input {
+  padding-inline: var(--rialto-space-sm);
+  padding-block: 0.4375rem;
+  border: 1px solid var(--rialto-border);
+  border-radius: var(--rialto-radius-default);
+  font-size: var(--rialto-text-sm);
+  color: var(--rialto-text-primary);
+  background: var(--rialto-surface);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.input:focus {
+  outline: 2px solid #2563eb;
+  outline-offset: -1px;
+  border-color: transparent;
+}
+
+.input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Footer */
+.dialogFooter {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--rialto-space-xs);
+  margin-block-start: var(--rialto-space-xs);
+}
+
+.cancelButton {
+  padding-inline: var(--rialto-space-md);
+  padding-block: 0.375rem;
+  font-size: var(--rialto-text-sm);
+  border: 1px solid var(--rialto-border);
+  border-radius: var(--rialto-radius-default);
+  background: var(--rialto-surface);
+  color: var(--rialto-text-primary);
+  cursor: pointer;
+}
+
+.cancelButton:hover:not(:disabled) {
+  background: var(--rialto-surface-recessed);
+}
+
+.cancelButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.submitButton {
+  padding-inline: var(--rialto-space-md);
+  padding-block: 0.375rem;
+  font-size: var(--rialto-text-sm);
+  font-weight: var(--rialto-weight-medium);
+  border: none;
+  border-radius: var(--rialto-radius-default);
+  background: #2563eb;
+  color: #ffffff;
+  cursor: pointer;
+}
+
+.submitButton:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+
+.submitButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/apps/hospitality/src/components/floor-plan/NewFloorPlanDialog.tsx
+++ b/apps/hospitality/src/components/floor-plan/NewFloorPlanDialog.tsx
@@ -1,0 +1,116 @@
+import { useState } from "react";
+import type { CreateFloorPlanRequest, FloorPlan } from "@mbe/types";
+import styles from "./NewFloorPlanDialog.module.css";
+
+const DEFAULT_LAYOUT = { width: 800, height: 600, gridSize: 20, showGrid: true };
+
+export interface NewFloorPlanDialogProps {
+  venueId: string;
+  onCreated: (floorPlan: FloorPlan) => void;
+  onClose: () => void;
+  onCreate: (data: CreateFloorPlanRequest) => Promise<FloorPlan>;
+}
+
+export function NewFloorPlanDialog({
+  venueId,
+  onCreated,
+  onClose,
+  onCreate,
+}: NewFloorPlanDialogProps) {
+  const [name, setName] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  const handleOverlayKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Escape") {
+      onClose();
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setError("Floor plan name is required.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const floorPlan = await onCreate({
+        venueId,
+        name: trimmedName,
+        layoutJson: DEFAULT_LAYOUT,
+      });
+      onCreated(floorPlan);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create floor plan.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+    <div className={styles.overlay} onClick={handleOverlayClick} onKeyDown={handleOverlayKeyDown}>
+      <div className={styles.dialog} role="dialog" aria-modal="true">
+        <div className={styles.dialogHeader}>
+          <h2 className={styles.dialogTitle}>New Floor Plan</h2>
+          <button className={styles.closeButton} onClick={onClose} aria-label="Close dialog">
+            <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {error && <div className={styles.errorBanner}>{error}</div>}
+
+        <form onSubmit={handleSubmit} className={styles.form}>
+          <div className={styles.fieldGroup}>
+            <label htmlFor="floor-plan-name" className={styles.label}>
+              Name <span className={styles.required}>*</span>
+            </label>
+            <input
+              id="floor-plan-name"
+              type="text"
+              className={styles.input}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Main Dining Room"
+              required
+              disabled={isSubmitting}
+            />
+          </div>
+
+          <div className={styles.dialogFooter}>
+            <button
+              type="button"
+              className={styles.cancelButton}
+              onClick={onClose}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </button>
+            <button type="submit" className={styles.submitButton} disabled={isSubmitting}>
+              {isSubmitting ? "Creating..." : "Create"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/hospitality/src/components/floor-plan/index.ts
+++ b/apps/hospitality/src/components/floor-plan/index.ts
@@ -1,3 +1,4 @@
 export { TableShape, type TableShapeProps } from "./TableShape";
 export { FloorPlanCanvas, type FloorPlanCanvasProps } from "./FloorPlanCanvas";
 export { AddTableDialog, type AddTableDialogProps } from "./AddTableDialog";
+export { NewFloorPlanDialog, type NewFloorPlanDialogProps } from "./NewFloorPlanDialog";

--- a/apps/hospitality/src/pages/FloorPlansPage.tsx
+++ b/apps/hospitality/src/pages/FloorPlansPage.tsx
@@ -1,8 +1,9 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "@mbe/auth/react";
 import { createApiClient } from "@mbe/api-client";
 import type { FloorPlan } from "@mbe/types";
+import { NewFloorPlanDialog } from "../components/floor-plan";
 import styles from "./FloorPlansPage.module.css";
 
 export function FloorPlansPage() {
@@ -11,20 +12,32 @@ export function FloorPlansPage() {
   const [floorPlans, setFloorPlans] = useState<FloorPlan[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [showNewDialog, setShowNewDialog] = useState(false);
+  const [venueId, setVenueId] = useState<string | null>(null);
+
+  const api = useMemo(
+    () =>
+      createApiClient({
+        baseUrl: import.meta.env.VITE_API_URL ?? "",
+        getAccessToken: () => accessToken,
+      }),
+    [accessToken]
+  );
 
   useEffect(() => {
-    async function fetchFloorPlans() {
+    async function fetchData() {
       setIsLoading(true);
       setError(null);
 
       try {
-        const api = createApiClient({
-          baseUrl: import.meta.env.VITE_API_URL ?? "",
-          getAccessToken: () => accessToken,
-        });
-
-        const response = await api.floorPlans.list({ limit: 50 });
-        setFloorPlans(response.data);
+        const [floorPlansResponse, venuesResponse] = await Promise.all([
+          api.floorPlans.list({ limit: 50 }),
+          api.venues.list({ limit: 1 }),
+        ]);
+        setFloorPlans(floorPlansResponse.data);
+        if (venuesResponse.data.length > 0) {
+          setVenueId(venuesResponse.data[0].id);
+        }
       } catch (err) {
         setError(err instanceof Error ? err.message : "Failed to load floor plans");
       } finally {
@@ -32,8 +45,22 @@ export function FloorPlansPage() {
       }
     }
 
-    fetchFloorPlans();
-  }, [accessToken]);
+    fetchData();
+  }, [api]);
+
+  const handleCreate = useCallback(
+    async (data: Parameters<typeof api.floorPlans.create>[0]) => {
+      return api.floorPlans.create(data);
+    },
+    [api]
+  );
+
+  const handleCreated = useCallback(
+    (floorPlan: FloorPlan) => {
+      navigate(`/floor-plans/${floorPlan.id}`);
+    },
+    [navigate]
+  );
 
   const formatDate = (isoString: string) => {
     return new Date(isoString).toLocaleDateString();
@@ -43,8 +70,23 @@ export function FloorPlansPage() {
     <div className={styles.container}>
       <div className={styles.header}>
         <h1 className={styles.title}>Floor Plans</h1>
-        <button className={styles.newButton}>New Floor Plan</button>
+        <button
+          className={styles.newButton}
+          onClick={() => setShowNewDialog(true)}
+          disabled={!venueId}
+        >
+          New Floor Plan
+        </button>
       </div>
+
+      {showNewDialog && venueId && (
+        <NewFloorPlanDialog
+          venueId={venueId}
+          onCreate={handleCreate}
+          onCreated={handleCreated}
+          onClose={() => setShowNewDialog(false)}
+        />
+      )}
 
       {isLoading && (
         <div className={styles.loadingWrapper}>


### PR DESCRIPTION
Add NewFloorPlanDialog component that prompts for a floor plan name, creates it via the API, and navigates to the editor page. The FloorPlansPage now fetches the venue ID on mount and opens the dialog when the button is clicked.

Closes #11