### PR TITLE
fix(services): add input validation bounds for pagination and party size

### DIFF
--- a/services/agent/src/routes/sessions.ts
+++ b/services/agent/src/routes/sessions.ts
@@ -92,8 +92,8 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
       },
     },
     async (request) => {
-      const page = Math.max(1, parseInt(request.query.page ?? "1", 10));
-      const limit = Math.min(100, Math.max(1, parseInt(request.query.limit ?? "10", 10)));
+      const page = Math.max(1, parseInt(request.query.page ?? "1", 10) || 1);
+      const limit = Math.max(1, Math.min(100, parseInt(request.query.limit ?? "10", 10) || 10));
       const status = request.query.status as AgentSessionStatus | undefined;
 
       const prismaStatus = status?.toUpperCase() as

--- a/services/reservations/src/routes/floor-plans.ts
+++ b/services/reservations/src/routes/floor-plans.ts
@@ -122,8 +122,8 @@ export const floorPlanRoutes: FastifyPluginAsync = async (fastify) => {
       },
     },
     async (request) => {
-      const page = parseInt(request.query.page ?? "1", 10);
-      const limit = Math.min(parseInt(request.query.limit ?? "10", 10), 100);
+      const page = Math.max(1, parseInt(request.query.page ?? "1", 10) || 1);
+      const limit = Math.max(1, Math.min(100, parseInt(request.query.limit ?? "10", 10) || 10));
       return floorPlanService.list(page, limit, request.query.venueId);
     }
   );

--- a/services/reservations/src/routes/guests.ts
+++ b/services/reservations/src/routes/guests.ts
@@ -130,8 +130,8 @@ export const guestRoutes: FastifyPluginAsync = async (fastify) => {
           statusCode: 400,
         });
       }
-      const page = parseInt(request.query.page ?? "1", 10);
-      const limit = Math.min(parseInt(request.query.limit ?? "20", 10), 100);
+      const page = Math.max(1, parseInt(request.query.page ?? "1", 10) || 1);
+      const limit = Math.max(1, Math.min(100, parseInt(request.query.limit ?? "20", 10) || 20));
       return guestService.list(venueId, page, limit);
     }
   );

--- a/services/reservations/src/routes/holds.ts
+++ b/services/reservations/src/routes/holds.ts
@@ -117,7 +117,7 @@ export const holdRoutes: FastifyPluginAsync = async (fastify) => {
               format: "date-time",
               description: "Start time in ISO 8601 format",
             },
-            partySize: { type: "integer", minimum: 1, description: "Number of guests" },
+            partySize: { type: "integer", minimum: 1, maximum: 20, description: "Number of guests" },
             tableId: {
               type: "string",
               description: "Optional specific table to hold. If not provided, best available table is assigned.",

--- a/services/reservations/src/routes/reservations.ts
+++ b/services/reservations/src/routes/reservations.ts
@@ -182,8 +182,8 @@ export const reservationRoutes: FastifyPluginAsync = async (fastify) => {
       },
     },
     async (request) => {
-      const page = parseInt(request.query.page ?? "1", 10);
-      const limit = parseInt(request.query.limit ?? "10", 10);
+      const page = Math.max(1, parseInt(request.query.page ?? "1", 10) || 1);
+      const limit = Math.max(1, Math.min(100, parseInt(request.query.limit ?? "10", 10) || 10));
       return reservationService.list({
         page,
         limit,
@@ -258,8 +258,8 @@ export const reservationRoutes: FastifyPluginAsync = async (fastify) => {
         });
       }
 
-      const page = parseInt(request.query.page ?? "1", 10);
-      const limit = parseInt(request.query.limit ?? "10", 10);
+      const page = Math.max(1, parseInt(request.query.page ?? "1", 10) || 1);
+      const limit = Math.max(1, Math.min(100, parseInt(request.query.limit ?? "10", 10) || 10));
       return reservationService.listByUserId(authUser.id, page, limit);
     }
   );

--- a/services/reservations/src/routes/tables.ts
+++ b/services/reservations/src/routes/tables.ts
@@ -123,8 +123,8 @@ export const tableRoutes: FastifyPluginAsync = async (fastify) => {
       },
     },
     async (request) => {
-      const page = parseInt(request.query.page ?? "1", 10);
-      const limit = parseInt(request.query.limit ?? "10", 10);
+      const page = Math.max(1, parseInt(request.query.page ?? "1", 10) || 1);
+      const limit = Math.max(1, Math.min(100, parseInt(request.query.limit ?? "10", 10) || 10));
       const activeOnly = request.query.activeOnly === "true";
       return tableService.list(page, limit, activeOnly);
     }

--- a/services/reservations/src/routes/venues.ts
+++ b/services/reservations/src/routes/venues.ts
@@ -119,8 +119,8 @@ export const venueRoutes: FastifyPluginAsync = async (fastify) => {
       },
     },
     async (request) => {
-      const page = parseInt(request.query.page ?? "1", 10);
-      const limit = Math.min(parseInt(request.query.limit ?? "10", 10), 100);
+      const page = Math.max(1, parseInt(request.query.page ?? "1", 10) || 1);
+      const limit = Math.max(1, Math.min(100, parseInt(request.query.limit ?? "10", 10) || 10));
       return venueGroupService.list(page, limit);
     }
   );
@@ -425,8 +425,8 @@ export const venueRoutes: FastifyPluginAsync = async (fastify) => {
       },
     },
     async (request) => {
-      const page = parseInt(request.query.page ?? "1", 10);
-      const limit = Math.min(parseInt(request.query.limit ?? "10", 10), 100);
+      const page = Math.max(1, parseInt(request.query.page ?? "1", 10) || 1);
+      const limit = Math.max(1, Math.min(100, parseInt(request.query.limit ?? "10", 10) || 10));
       return venueService.list(page, limit, request.query.venueGroupId);
     }
   );

--- a/services/users/src/routes/users.ts
+++ b/services/users/src/routes/users.ts
@@ -118,8 +118,8 @@ export const userRoutes: FastifyPluginAsync = async (fastify) => {
       },
     },
     async (request) => {
-      const page = parseInt(request.query.page ?? "1", 10);
-      const limit = parseInt(request.query.limit ?? "10", 10);
+      const page = Math.max(1, parseInt(request.query.page ?? "1", 10) || 1);
+      const limit = Math.max(1, Math.min(100, parseInt(request.query.limit ?? "10", 10) || 10));
       return userService.list(page, limit);
     }
   );


### PR DESCRIPTION
Clamp page to >= 1, limit to 1-100 with NaN fallback. Add maximum party size of 20 to hold creation. Applied across users, reservations, and agent services.

Closes #21