### PR TITLE
fix(rialto-web): add mobile hamburger menu for sidebar navigation

### DIFF
--- a/apps/rialto-web/src/components/ShowcaseSidebar.module.css
+++ b/apps/rialto-web/src/components/ShowcaseSidebar.module.css
@@ -234,10 +234,39 @@
   color: var(--rialto-text-tertiary);
 }
 
-/* ── Responsive: hide on mobile ──────────────── */
+/* ── Mobile backdrop overlay ─────────────────── */
+
+.backdrop {
+  display: none;
+}
+
+/* ── Responsive: mobile drawer ──────────────── */
 
 @media (max-width: 767px) {
   .root {
     display: none;
+    position: fixed;
+    inset-block-start: 0;
+    inset-inline-start: 0;
+    z-index: 200;
+    width: 280px;
+    max-width: 80vw;
+    height: 100dvh;
+    box-shadow: var(--rialto-shadow-lg, 0 8px 24px rgba(0, 0, 0, 0.2));
+    transform: translateX(-100%);
+    transition: transform 0.25s ease;
+  }
+
+  .mobileOpen {
+    display: flex;
+    transform: translateX(0);
+  }
+
+  .backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 199;
+    background: rgba(0, 0, 0, 0.4);
   }
 }

--- a/apps/rialto-web/src/components/ShowcaseSidebar.tsx
+++ b/apps/rialto-web/src/components/ShowcaseSidebar.tsx
@@ -66,6 +66,10 @@ export interface ShowcaseSidebarProps {
   demoPages: readonly NavItem[];
   activePath: string;
   onNavigate: (path: string) => void;
+  /** Whether the mobile drawer is open (only affects screens < 768px) */
+  isMobileOpen?: boolean;
+  /** Called when the mobile drawer should close */
+  onMobileClose?: () => void;
 }
 
 /* ── Component ───────────────────────────────── */
@@ -75,15 +79,42 @@ export function ShowcaseSidebar({
   demoPages,
   activePath,
   onNavigate,
+  isMobileOpen = false,
+  onMobileClose,
 }: ShowcaseSidebarProps) {
   const [filter, setFilter] = useState("");
   const [collapsed, setCollapsed] = useState<Set<string>>(loadCollapsed);
   const inputRef = useRef<HTMLInputElement>(null);
+  const sidebarRef = useRef<HTMLElement>(null);
 
   // Persist collapsed state
   useEffect(() => {
     saveCollapsed(collapsed);
   }, [collapsed]);
+
+  // Close mobile drawer on Escape key
+  useEffect(() => {
+    if (!isMobileOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onMobileClose?.();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isMobileOpen, onMobileClose]);
+
+  // Prevent body scroll when mobile drawer is open
+  useEffect(() => {
+    if (isMobileOpen) {
+      document.body.style.overflow = "hidden";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isMobileOpen]);
 
   const normalizedFilter = filter.toLowerCase().trim();
   const isFiltering = normalizedFilter.length > 0;
@@ -126,8 +157,9 @@ export function ShowcaseSidebar({
   const handleItemClick = useCallback(
     (path: string) => {
       onNavigate(path);
+      onMobileClose?.();
     },
-    [onNavigate]
+    [onNavigate, onMobileClose]
   );
 
   const clearFilter = useCallback(() => {
@@ -135,8 +167,24 @@ export function ShowcaseSidebar({
     inputRef.current?.focus();
   }, []);
 
+  const rootClassName = `${styles.root} ${isMobileOpen ? styles.mobileOpen : ""}`;
+
   return (
-    <nav className={styles.root} aria-label="Component navigation">
+    <>
+      {/* ── Mobile backdrop ────────────────── */}
+      {isMobileOpen && (
+        <div
+          className={styles.backdrop}
+          onClick={onMobileClose}
+          aria-hidden="true"
+        />
+      )}
+
+      <nav
+        ref={sidebarRef}
+        className={rootClassName}
+        aria-label="Component navigation"
+      >
       {/* ── Search ──────────────────────────── */}
       <div className={styles.searchWrapper}>
         <div className={styles.searchInputWrapper}>
@@ -218,6 +266,7 @@ export function ShowcaseSidebar({
         })}
       </div>
     </nav>
+    </>
   );
 }
 

--- a/apps/rialto-web/src/layouts/ShowcaseLayout.module.css
+++ b/apps/rialto-web/src/layouts/ShowcaseLayout.module.css
@@ -29,6 +29,32 @@
   gap: var(--rialto-space-md);
 }
 
+/* ── Hamburger button (mobile only) ──────────── */
+.hamburger {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border: none;
+  border-radius: var(--rialto-radius-default);
+  background: transparent;
+  color: var(--rialto-text-secondary);
+  cursor: pointer;
+  transition: color 0.15s ease, background-color 0.15s ease;
+}
+
+.hamburger:hover {
+  color: var(--rialto-text-primary);
+  background: var(--rialto-surface);
+}
+
+.hamburger:focus-visible {
+  outline: none;
+  box-shadow: var(--rialto-shadow-focus);
+}
+
 .headerEnd {
   display: flex;
   align-items: center;
@@ -103,8 +129,12 @@
   margin-block-start: var(--rialto-space-2xl);
 }
 
-/* ── Responsive: mobile sidebar collapse ─────── */
+/* ── Responsive: mobile layout ───────────────── */
 @media (max-width: 767px) {
+  .hamburger {
+    display: flex;
+  }
+
   .content {
     padding: var(--rialto-space-md);
   }

--- a/apps/rialto-web/src/layouts/ShowcaseLayout.tsx
+++ b/apps/rialto-web/src/layouts/ShowcaseLayout.tsx
@@ -1,9 +1,31 @@
+import { useState, useCallback } from "react";
 import { Outlet, Link, useNavigate, useLocation } from "react-router-dom";
 import { Footer, GlobalNav, ThemeToggle } from "@mbe/rialto";
 import { ShowcaseSidebar } from "../components/ShowcaseSidebar";
 import { NAV_SECTIONS, DEMO_PAGES } from "../data/nav-sections";
 import { useThemeContext } from "../ThemeContext";
 import styles from "./ShowcaseLayout.module.css";
+
+/* ── Hamburger icon (mobile only) ────────────── */
+function HamburgerIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <line x1="3" y1="6" x2="21" y2="6" />
+      <line x1="3" y1="12" x2="21" y2="12" />
+      <line x1="3" y1="18" x2="21" y2="18" />
+    </svg>
+  );
+}
 
 /* ── GitHub icon ─────────────────────────────── */
 function GitHubIcon() {
@@ -41,6 +63,15 @@ export function ShowcaseLayout(props: ShowcaseLayoutProps) {
   const onThemeToggle = props.onThemeToggle ?? themeCtx.onThemeToggle;
   const navigate = useNavigate();
   const location = useLocation();
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+
+  const handleMobileClose = useCallback(() => {
+    setIsMobileMenuOpen(false);
+  }, []);
+
+  const handleMobileToggle = useCallback(() => {
+    setIsMobileMenuOpen((prev) => !prev);
+  }, []);
 
   return (
     <div className={styles.root}>
@@ -48,6 +79,15 @@ export function ShowcaseLayout(props: ShowcaseLayoutProps) {
       {/* ── Top header bar ─────────────────────── */}
       <header className={styles.header}>
         <div className={styles.headerStart}>
+          <button
+            className={styles.hamburger}
+            onClick={handleMobileToggle}
+            aria-label={isMobileMenuOpen ? "Close navigation" : "Open navigation"}
+            aria-expanded={isMobileMenuOpen}
+            type="button"
+          >
+            <HamburgerIcon />
+          </button>
           <Link to="/" className={styles.logo} aria-label="Rialto home">
             Ri<span className={styles.logoAccent}>a</span>lto
           </Link>
@@ -74,6 +114,8 @@ export function ShowcaseLayout(props: ShowcaseLayoutProps) {
           demoPages={DEMO_PAGES}
           activePath={location.pathname}
           onNavigate={navigate}
+          isMobileOpen={isMobileMenuOpen}
+          onMobileClose={handleMobileClose}
         />
 
         <main className={styles.content}>


### PR DESCRIPTION
Sidebar was hidden on mobile with no alternative. Added a hamburger toggle that opens the sidebar as an overlay drawer on screens below 768px. Closes on navigation, backdrop click, or Escape key.

Closes #17