### PR TITLE
fix(api-client): add timeout, retry, and AbortController support

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -9,13 +9,16 @@
   },
   "scripts": {
     "lint": "eslint src/",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@mbe/types": "workspace:*"
   },
   "devDependencies": {
     "@mbe/config": "workspace:*",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.2"
   }
 }

--- a/packages/api-client/src/client.test.ts
+++ b/packages/api-client/src/client.test.ts
@@ -1,0 +1,362 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ApiClient, ApiClientError } from "./client.js";
+
+// Mock global fetch
+const mockFetch = vi.fn<typeof fetch>();
+vi.stubGlobal("fetch", mockFetch);
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("ApiClient", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("basic request functionality", () => {
+    it("should make a GET request with correct URL and headers", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: "ok" }));
+
+      const client = new ApiClient({ baseUrl: "https://api.test.com" });
+      await client.get("/users");
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/users");
+      expect((options?.headers as Record<string, string>)["Content-Type"]).toBe(
+        "application/json"
+      );
+    });
+
+    it("should include authorization header when token is available", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: "ok" }));
+
+      const client = new ApiClient({
+        baseUrl: "https://api.test.com",
+        getAccessToken: () => "my-token",
+      });
+      await client.get("/users");
+
+      const [, options] = mockFetch.mock.calls[0]!;
+      expect((options?.headers as Record<string, string>).Authorization).toBe("Bearer my-token");
+    });
+
+    it("should handle 204 No Content responses", async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(null, { status: 204, statusText: "No Content" })
+      );
+
+      const client = new ApiClient({ baseUrl: "https://api.test.com" });
+      const result = await client.delete("/users/1");
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should POST with JSON body", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: { id: "1" } }));
+
+      const client = new ApiClient({ baseUrl: "https://api.test.com" });
+      await client.post("/users", { name: "Alice" });
+
+      const [, options] = mockFetch.mock.calls[0]!;
+      expect(options?.method).toBe("POST");
+      expect(options?.body).toBe(JSON.stringify({ name: "Alice" }));
+    });
+
+    it("should PATCH with JSON body", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: { id: "1" } }));
+
+      const client = new ApiClient({ baseUrl: "https://api.test.com" });
+      await client.patch("/users/1", { name: "Bob" });
+
+      const [, options] = mockFetch.mock.calls[0]!;
+      expect(options?.method).toBe("PATCH");
+      expect(options?.body).toBe(JSON.stringify({ name: "Bob" }));
+    });
+  });
+
+  describe("error handling", () => {
+    it("should throw ApiClientError with method and path on non-ok response", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ error: "Not Found", message: "User not found", statusCode: 404 }, 404)
+      );
+
+      const client = new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 0 });
+
+      await expect(client.get("/api/v1/users/999")).rejects.toThrow(ApiClientError);
+
+      try {
+        await client.get("/api/v1/users/999");
+      } catch (error) {
+        // Second call also fails, but we check the first throw above
+      }
+    });
+
+    it("should include method and path in error message", async () => {
+      mockFetch.mockResolvedValue(
+        jsonResponse({ error: "Server Error", message: "Internal Server Error", statusCode: 500 }, 500)
+      );
+
+      const client = new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 0 });
+
+      try {
+        await client.get("/api/v1/users");
+        expect.unreachable("Should have thrown");
+      } catch (error) {
+        expect(error).toBeInstanceOf(ApiClientError);
+        const apiError = error as ApiClientError;
+        expect(apiError.message).toBe("GET /api/v1/users failed: 500 Internal Server Error");
+        expect(apiError.method).toBe("GET");
+        expect(apiError.path).toBe("/api/v1/users");
+        expect(apiError.statusCode).toBe(500);
+      }
+    });
+
+    it("should handle non-JSON error responses gracefully", async () => {
+      mockFetch.mockResolvedValue(
+        new Response("Bad Gateway", {
+          status: 502,
+          statusText: "Bad Gateway",
+        })
+      );
+
+      const client = new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 0 });
+
+      try {
+        await client.get("/api/v1/users");
+        expect.unreachable("Should have thrown");
+      } catch (error) {
+        expect(error).toBeInstanceOf(ApiClientError);
+        const apiError = error as ApiClientError;
+        expect(apiError.statusCode).toBe(502);
+      }
+    });
+  });
+
+  describe("retry with exponential backoff", () => {
+    it("should retry on 503 and succeed on subsequent attempt", async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          jsonResponse({ error: "Unavailable", message: "Service Unavailable", statusCode: 503 }, 503)
+        )
+        .mockResolvedValueOnce(jsonResponse({ data: "ok" }));
+
+      const client = new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 3 });
+      const result = await client.get<{ data: string }>("/users");
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(result).toEqual({ data: "ok" });
+    });
+
+    it("should retry on 502 and 504 status codes", async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          jsonResponse({ error: "Bad Gateway", message: "Bad Gateway", statusCode: 502 }, 502)
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({ error: "Timeout", message: "Gateway Timeout", statusCode: 504 }, 504)
+        )
+        .mockResolvedValueOnce(jsonResponse({ data: "ok" }));
+
+      const client = new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 3 });
+      const result = await client.get<{ data: string }>("/users");
+
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(result).toEqual({ data: "ok" });
+    });
+
+    it("should NOT retry on 400 client errors", async () => {
+      mockFetch.mockResolvedValue(
+        jsonResponse({ error: "Bad Request", message: "Invalid input", statusCode: 400 }, 400)
+      );
+
+      const client = new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 3 });
+
+      await expect(client.get("/users")).rejects.toThrow(ApiClientError);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("should NOT retry on 500 server errors", async () => {
+      mockFetch.mockResolvedValue(
+        jsonResponse(
+          { error: "Server Error", message: "Internal Server Error", statusCode: 500 },
+          500
+        )
+      );
+
+      const client = new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 3 });
+
+      await expect(client.get("/users")).rejects.toThrow(ApiClientError);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("should NOT retry on 401 unauthorized", async () => {
+      mockFetch.mockResolvedValue(
+        jsonResponse({ error: "Unauthorized", message: "Unauthorized", statusCode: 401 }, 401)
+      );
+
+      const client = new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 3 });
+
+      await expect(client.get("/users")).rejects.toThrow(ApiClientError);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("should retry on network errors (TypeError)", async () => {
+      mockFetch
+        .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+        .mockResolvedValueOnce(jsonResponse({ data: "ok" }));
+
+      const client = new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 3 });
+      const result = await client.get<{ data: string }>("/users");
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(result).toEqual({ data: "ok" });
+    });
+
+    it("should throw after exhausting all retries", async () => {
+      mockFetch.mockResolvedValue(
+        jsonResponse(
+          { error: "Unavailable", message: "Service Unavailable", statusCode: 503 },
+          503
+        )
+      );
+
+      const client = new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 2 });
+
+      await expect(client.get("/users")).rejects.toThrow(ApiClientError);
+      // 1 initial + 2 retries = 3 total
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it("should disable retries when maxRetries is 0", async () => {
+      mockFetch.mockResolvedValue(
+        jsonResponse(
+          { error: "Unavailable", message: "Service Unavailable", statusCode: 503 },
+          503
+        )
+      );
+
+      const client = new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 0 });
+
+      await expect(client.get("/users")).rejects.toThrow(ApiClientError);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("timeout via AbortController", () => {
+    it("should pass an AbortSignal to fetch", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: "ok" }));
+
+      const client = new ApiClient({ baseUrl: "https://api.test.com", timeout: 5000 });
+      await client.get("/users");
+
+      const [, options] = mockFetch.mock.calls[0]!;
+      expect(options?.signal).toBeDefined();
+      expect(options?.signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it("should use default 30s timeout when not configured", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: "ok" }));
+
+      const client = new ApiClient({ baseUrl: "https://api.test.com" });
+      await client.get("/users");
+
+      const [, options] = mockFetch.mock.calls[0]!;
+      expect(options?.signal).toBeDefined();
+    });
+  });
+
+  describe("caller-provided AbortSignal", () => {
+    it("should respect caller abort signal", async () => {
+      const controller = new AbortController();
+
+      mockFetch.mockImplementation(async (_url, options) => {
+        // Simulate checking the signal
+        if (options?.signal?.aborted) {
+          throw new DOMException("The operation was aborted.", "AbortError");
+        }
+        return jsonResponse({ data: "ok" });
+      });
+
+      controller.abort();
+
+      const client = new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 0 });
+
+      await expect(
+        client.request("/users", { method: "GET", signal: controller.signal })
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("configuration defaults", () => {
+    it("should use default timeout of 30000ms", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: "ok" }));
+
+      const client = new ApiClient({ baseUrl: "https://api.test.com" });
+      await client.get("/users");
+
+      // Signal should be present (timeout is active)
+      const [, options] = mockFetch.mock.calls[0]!;
+      expect(options?.signal).toBeDefined();
+    });
+
+    it(
+      "should use default maxRetries of 3",
+      async () => {
+        mockFetch.mockResolvedValue(
+          jsonResponse(
+            { error: "Unavailable", message: "Service Unavailable", statusCode: 503 },
+            503
+          )
+        );
+
+        const client = new ApiClient({ baseUrl: "https://api.test.com" });
+
+        await expect(client.get("/users")).rejects.toThrow(ApiClientError);
+        // 1 initial + 3 retries = 4 total
+        expect(mockFetch).toHaveBeenCalledTimes(4);
+      },
+      15_000
+    );
+
+    it("should allow custom timeout", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: "ok" }));
+
+      const client = new ApiClient({
+        baseUrl: "https://api.test.com",
+        timeout: 5000,
+      });
+      await client.get("/users");
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+    });
+
+    it("should allow custom maxRetries", async () => {
+      mockFetch.mockResolvedValue(
+        jsonResponse(
+          { error: "Unavailable", message: "Service Unavailable", statusCode: 503 },
+          503
+        )
+      );
+
+      const client = new ApiClient({
+        baseUrl: "https://api.test.com",
+        maxRetries: 1,
+      });
+
+      await expect(client.get("/users")).rejects.toThrow(ApiClientError);
+      // 1 initial + 1 retry = 2 total
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -1,18 +1,35 @@
 import type { ApiError } from "@mbe/types";
 
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_RETRIES = 3;
+const BASE_BACKOFF_MS = 1_000;
+const JITTER_FACTOR = 0.2;
+
+const RETRYABLE_STATUS_CODES = new Set([502, 503, 504]);
+
 export interface ClientConfig {
   baseUrl: string;
   getAccessToken?: () => string | null | Promise<string | null>;
+  timeout?: number;
+  maxRetries?: number;
+}
+
+export interface RequestOptions extends RequestInit {
+  signal?: AbortSignal;
 }
 
 export class ApiClient {
-  constructor(private config: ClientConfig) {}
+  private readonly timeout: number;
+  private readonly maxRetries: number;
 
-  async request<T>(
-    path: string,
-    options: RequestInit = {}
-  ): Promise<T> {
+  constructor(private config: ClientConfig) {
+    this.timeout = config.timeout ?? DEFAULT_TIMEOUT_MS;
+    this.maxRetries = config.maxRetries ?? DEFAULT_MAX_RETRIES;
+  }
+
+  async request<T>(path: string, options: RequestOptions = {}): Promise<T> {
     const { baseUrl, getAccessToken } = this.config;
+    const method = options.method ?? "GET";
 
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
@@ -26,10 +43,16 @@ export class ApiClient {
       }
     }
 
-    const response = await fetch(`${baseUrl}${path}`, {
+    const combinedSignal = createCombinedSignal(this.timeout, options.signal);
+
+    const fetchOptions: RequestInit = {
       ...options,
       headers,
-    });
+      signal: combinedSignal,
+    };
+
+    const url = `${baseUrl}${path}`;
+    const response = await fetchWithRetry(url, fetchOptions, this.maxRetries);
 
     if (!response.ok) {
       const error = (await response.json().catch(() => ({
@@ -37,7 +60,7 @@ export class ApiClient {
         message: response.statusText,
         statusCode: response.status,
       }))) as ApiError;
-      throw new ApiClientError(error);
+      throw new ApiClientError(error, method, path);
     }
 
     if (response.status === 204) {
@@ -71,12 +94,95 @@ export class ApiClient {
 }
 
 export class ApiClientError extends Error {
-  constructor(public response: ApiError) {
-    super(response.message);
+  constructor(
+    public response: ApiError,
+    public method?: string,
+    public path?: string
+  ) {
+    const prefix = method && path ? `${method} ${path} failed: ` : "";
+    super(`${prefix}${response.statusCode} ${response.message}`);
     this.name = "ApiClientError";
   }
 
   get statusCode(): number {
     return this.response.statusCode;
   }
+}
+
+/**
+ * Creates an AbortSignal that fires when either the timeout expires
+ * or the caller-provided signal aborts (whichever comes first).
+ */
+function createCombinedSignal(
+  timeoutMs: number,
+  callerSignal?: AbortSignal | null
+): AbortSignal {
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+
+  if (!callerSignal) {
+    return timeoutSignal;
+  }
+
+  return AbortSignal.any([timeoutSignal, callerSignal]);
+}
+
+/**
+ * Returns whether an error is retryable (network errors from fetch).
+ */
+function isRetryableError(error: unknown): boolean {
+  return error instanceof TypeError;
+}
+
+/**
+ * Returns whether an HTTP status code is retryable.
+ */
+function isRetryableStatus(status: number): boolean {
+  return RETRYABLE_STATUS_CODES.has(status);
+}
+
+/**
+ * Calculates exponential backoff with jitter.
+ * Base delay doubles each attempt: 1s, 2s, 4s, ...
+ * Jitter adds +-20% to prevent thundering herd.
+ */
+function getBackoffMs(attempt: number): number {
+  const base = BASE_BACKOFF_MS * Math.pow(2, attempt);
+  const jitter = base * JITTER_FACTOR * (2 * Math.random() - 1);
+  return base + jitter;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Wraps fetch with retry logic for transient failures.
+ * Retries on network errors (TypeError) and 502/503/504 status codes.
+ */
+async function fetchWithRetry(
+  url: string,
+  options: RequestInit,
+  maxRetries: number
+): Promise<Response> {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const response = await fetch(url, options);
+
+      if (isRetryableStatus(response.status) && attempt < maxRetries) {
+        await sleep(getBackoffMs(attempt));
+        continue;
+      }
+
+      return response;
+    } catch (error) {
+      if (attempt < maxRetries && isRetryableError(error)) {
+        await sleep(getBackoffMs(attempt));
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  // Unreachable, but TypeScript needs it
+  throw new Error("fetchWithRetry: exhausted all retries");
 }

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -24,10 +24,14 @@ import { AvailabilityClient, HoldsClient } from "./availability.js";
 export function createApiClient(config: {
   baseUrl?: string;
   getAccessToken?: () => string | null | Promise<string | null>;
+  timeout?: number;
+  maxRetries?: number;
 }) {
   const client = new ApiClient({
     baseUrl: config.baseUrl ?? "",
     getAccessToken: config.getAccessToken,
+    timeout: config.timeout,
+    maxRetries: config.maxRetries,
   });
 
   return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,6 +346,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.3.1)(jsdom@28.1.0)(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/auth:
     dependencies:
@@ -2829,6 +2832,9 @@ packages:
   '@vitest/expect@4.0.18':
     resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
 
+  '@vitest/expect@4.1.2':
+    resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
+
   '@vitest/mocker@3.2.4':
     resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
     peerDependencies:
@@ -2851,11 +2857,25 @@ packages:
       vite:
         optional: true
 
+  '@vitest/mocker@4.1.2':
+    resolution: {integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
   '@vitest/pretty-format@4.0.18':
     resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
+
+  '@vitest/pretty-format@4.1.2':
+    resolution: {integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==}
 
   '@vitest/runner@3.2.4':
     resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
@@ -2863,11 +2883,17 @@ packages:
   '@vitest/runner@4.0.18':
     resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
 
+  '@vitest/runner@4.1.2':
+    resolution: {integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==}
+
   '@vitest/snapshot@3.2.4':
     resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
 
   '@vitest/snapshot@4.0.18':
     resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
+
+  '@vitest/snapshot@4.1.2':
+    resolution: {integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==}
 
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
@@ -2875,11 +2901,17 @@ packages:
   '@vitest/spy@4.0.18':
     resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
 
+  '@vitest/spy@4.1.2':
+    resolution: {integrity: sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==}
+
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
+
+  '@vitest/utils@4.1.2':
+    resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
 
   '@volar/language-core@2.4.28':
     resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
@@ -3746,6 +3778,9 @@ packages:
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -6028,6 +6063,9 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
@@ -6225,6 +6263,10 @@ packages:
 
   tinyrainbow@3.0.3:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+    engines: {node: '>=14.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@4.0.4:
@@ -6620,6 +6662,41 @@ packages:
       '@vitest/ui': 4.0.18
       happy-dom: '*'
       jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vitest@4.1.2:
+    resolution: {integrity: sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.2
+      '@vitest/browser-preview': 4.1.2
+      '@vitest/browser-webdriverio': 4.1.2
+      '@vitest/ui': 4.1.2
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -9372,6 +9449,15 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
+  '@vitest/expect@4.1.2':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
   '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -9396,6 +9482,14 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@25.3.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  '@vitest/mocker@4.1.2(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.2
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@25.3.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
@@ -9403,6 +9497,10 @@ snapshots:
   '@vitest/pretty-format@4.0.18':
     dependencies:
       tinyrainbow: 3.0.3
+
+  '@vitest/pretty-format@4.1.2':
+    dependencies:
+      tinyrainbow: 3.1.0
 
   '@vitest/runner@3.2.4':
     dependencies:
@@ -9413,6 +9511,11 @@ snapshots:
   '@vitest/runner@4.0.18':
     dependencies:
       '@vitest/utils': 4.0.18
+      pathe: 2.0.3
+
+  '@vitest/runner@4.1.2':
+    dependencies:
+      '@vitest/utils': 4.1.2
       pathe: 2.0.3
 
   '@vitest/snapshot@3.2.4':
@@ -9427,11 +9530,20 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  '@vitest/snapshot@4.1.2':
+    dependencies:
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/utils': 4.1.2
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
   '@vitest/spy@3.2.4':
     dependencies:
       tinyspy: 4.0.4
 
   '@vitest/spy@4.0.18': {}
+
+  '@vitest/spy@4.1.2': {}
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -9443,6 +9555,12 @@ snapshots:
     dependencies:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
+
+  '@vitest/utils@4.1.2':
+    dependencies:
+      '@vitest/pretty-format': 4.1.2
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@volar/language-core@2.4.28':
     dependencies:
@@ -10385,6 +10503,8 @@ snapshots:
       safe-array-concat: 1.1.3
 
   es-module-lexer@1.7.0: {}
+
+  es-module-lexer@2.0.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -12938,6 +13058,8 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  std-env@4.0.0: {}
+
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -13206,6 +13328,8 @@ snapshots:
   tinyrainbow@2.0.0: {}
 
   tinyrainbow@3.0.3: {}
+
+  tinyrainbow@3.1.0: {}
 
   tinyspy@4.0.4: {}
 
@@ -13685,6 +13809,35 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.3.1)(jsdom@28.1.0)(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.2
+      '@vitest/mocker': 4.1.2(vite@7.3.1(@types/node@25.3.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/runner': 4.1.2
+      '@vitest/snapshot': 4.1.2
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 7.3.1(@types/node@25.3.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 25.3.1
+      jsdom: 28.1.0
+    transitivePeerDependencies:
+      - msw
 
   vscode-uri@3.1.0: {}
 


### PR DESCRIPTION
## Summary

- Add configurable request timeout via `AbortSignal.timeout()` (default 30s) with support for composing caller-provided `AbortSignal` via `AbortSignal.any()`
- Add retry with exponential backoff and jitter for transient errors (502, 503, 504, network `TypeError`); no retry on 4xx or 500
- Enhance `ApiClientError` to include request method and path in the error message (e.g., `"GET /api/v1/users failed: 500 Internal Server Error"`)
- All new options (`timeout`, `maxRetries`) have backward-compatible defaults preserving existing behavior

## Test plan

- [x] 23 unit tests covering: basic requests, error handling, retry on 502/503/504, no retry on 400/401/500, network error retry, retry exhaustion, timeout signal presence, caller abort signal, configuration defaults
- [x] TypeScript typecheck passes (`pnpm --filter @mbe/api-client typecheck`)
- [x] Full monorepo build passes (`pnpm build` — all 13 tasks successful)
- [ ] Verify in browser that hospitality app still loads and makes API calls correctly

Closes #18