### PR TITLE
chore(services): extract duplicated JWT auth into shared @mbe/auth plugin

### DIFF
--- a/packages/auth/src/fastify/index.ts
+++ b/packages/auth/src/fastify/index.ts
@@ -1,2 +1,7 @@
-export { authPlugin, requireAuth, getAuthPluginOptionsFromEnv } from "./plugin.js";
+export {
+  authPlugin,
+  requireAuth,
+  optionalAuth,
+  getAuthPluginOptionsFromEnv,
+} from "./plugin.js";
 export type { AuthPluginOptions } from "./plugin.js";

--- a/packages/auth/src/fastify/plugin.test.ts
+++ b/packages/auth/src/fastify/plugin.test.ts
@@ -89,18 +89,19 @@ describe("Auth Plugin", () => {
       });
     });
 
-    it("returns 401 for missing Authorization header", async () => {
+    it("passes through when no Authorization header is present (permissive)", async () => {
       const response = await app.inject({
         method: "GET",
         url: "/protected",
       });
 
-      expect(response.statusCode).toBe(401);
+      expect(response.statusCode).toBe(200);
       const body = JSON.parse(response.body);
-      expect(body.error).toBe("Missing or invalid authorization header");
+      expect(body.user).toBeUndefined();
+      expect(mockJwtVerify).not.toHaveBeenCalled();
     });
 
-    it("returns 401 for invalid header format (no Bearer)", async () => {
+    it("passes through when Authorization header is not Bearer (permissive)", async () => {
       const response = await app.inject({
         method: "GET",
         url: "/protected",
@@ -109,9 +110,10 @@ describe("Auth Plugin", () => {
         },
       });
 
-      expect(response.statusCode).toBe(401);
+      expect(response.statusCode).toBe(200);
       const body = JSON.parse(response.body);
-      expect(body.error).toBe("Missing or invalid authorization header");
+      expect(body.user).toBeUndefined();
+      expect(mockJwtVerify).not.toHaveBeenCalled();
     });
 
     it("returns 401 for invalid/malformed token", async () => {
@@ -127,7 +129,8 @@ describe("Auth Plugin", () => {
 
       expect(response.statusCode).toBe(401);
       const body = JSON.parse(response.body);
-      expect(body.error).toBe("Invalid token");
+      expect(body.error).toBe("Unauthorized");
+      expect(body.message).toBe("Invalid token");
     });
 
     it("returns 401 for expired token", async () => {
@@ -143,7 +146,8 @@ describe("Auth Plugin", () => {
 
       expect(response.statusCode).toBe(401);
       const body = JSON.parse(response.body);
-      expect(body.error).toBe("Invalid token");
+      expect(body.error).toBe("Unauthorized");
+      expect(body.message).toBe("Invalid token");
     });
 
     it("bypasses auth for excluded paths", async () => {
@@ -228,7 +232,7 @@ describe("Auth Plugin", () => {
     });
 
     it("returns 401 when user is not set (no token)", async () => {
-      // Without a token, the auth plugin hook returns 401 before requireAuth runs
+      // Without a token, the permissive hook passes through, then requireAuth rejects
       const response = await app.inject({
         method: "GET",
         url: "/with-require-auth",
@@ -236,20 +240,19 @@ describe("Auth Plugin", () => {
 
       expect(response.statusCode).toBe(401);
       const body = JSON.parse(response.body);
-      expect(body.error).toBe("Missing or invalid authorization header");
+      expect(body.error).toBe("Unauthorized");
+      expect(body.message).toBe("Missing or invalid authorization header");
     });
 
     it("returns 401 and does not execute route handler when user is missing", async () => {
       const handlerSpy = vi.fn();
 
-      // Create a separate app where requireAuth guards a route on an excluded path
-      // so the onRequest hook is skipped but requireAuth still runs as preHandler
+      // Create a separate app where requireAuth guards a route
       const spyApp = Fastify({ logger: false });
       const spyRoutesPlugin: FastifyPluginAsync = async (fastify) => {
         await fastify.register(authPlugin, {
           authority: "https://test.auth0.com",
           audience: "https://api.example.com",
-          excludePaths: ["/guarded"],
         });
 
         fastify.get("/guarded", { preHandler: requireAuth }, async (_request, _reply) => {
@@ -268,7 +271,8 @@ describe("Auth Plugin", () => {
 
       expect(response.statusCode).toBe(401);
       const body = JSON.parse(response.body);
-      expect(body.error).toBe("Authentication required");
+      expect(body.error).toBe("Unauthorized");
+      expect(body.message).toBe("Missing or invalid authorization header");
       expect(handlerSpy).not.toHaveBeenCalled();
 
       await spyApp.close();
@@ -295,7 +299,7 @@ describe("Auth Plugin", () => {
       expect(options).toEqual({
         authority: "https://test.auth0.com",
         audience: "https://api.example.com",
-        excludePaths: ["/health", "/api/v1/docs"],
+        excludePaths: ["/health", "/docs"],
       });
     });
 

--- a/packages/auth/src/fastify/plugin.ts
+++ b/packages/auth/src/fastify/plugin.ts
@@ -14,14 +14,22 @@ export interface AuthPluginOptions {
   authority: string;
   /** Expected audience */
   audience: string;
-  /** Routes to exclude from auth (e.g., ["/health"]) */
+  /** Routes to exclude from token verification (e.g., ["/health"]) */
   excludePaths?: string[];
 }
 
 /**
- * Fastify plugin for JWT validation using OIDC provider's JWKS
- * Uses jose library for standard JWT/JWKS handling (not Auth0-specific)
- * Wrapped with fastify-plugin to break encapsulation - hooks apply to parent context
+ * Fastify plugin for JWT validation using OIDC provider's JWKS.
+ *
+ * The onRequest hook is **permissive**: it populates `request.user` when a
+ * valid Bearer token is present, rejects requests with *invalid* tokens, and
+ * silently passes through requests with no token. Use the `requireAuth`
+ * preHandler on routes that must be authenticated, or `optionalAuth` on
+ * routes that accept either authenticated or anonymous access (invalid tokens
+ * are still rejected by the global hook).
+ *
+ * Uses jose library for standard JWT/JWKS handling (not Auth0-specific).
+ * Wrapped with fastify-plugin to break encapsulation — hooks apply to parent context.
  */
 async function authPluginImpl(
   fastify: FastifyInstance,
@@ -33,16 +41,17 @@ async function authPluginImpl(
   const jwksUri = `${authority.replace(/\/$/, "")}/.well-known/jwks.json`;
   const JWKS = createRemoteJWKSet(new URL(jwksUri));
 
-  // Add authentication hook
+  // Permissive authentication hook — populates request.user when a valid
+  // token is present, rejects invalid tokens, passes through missing tokens.
   fastify.addHook("onRequest", async (request: FastifyRequest, reply: FastifyReply) => {
-    // Skip excluded paths
+    // Skip excluded paths entirely
     if (excludePaths.some((path) => request.url.startsWith(path))) {
       return;
     }
 
     const authHeader = request.headers.authorization;
     if (!authHeader?.startsWith("Bearer ")) {
-      reply.code(401).send({ error: "Missing or invalid authorization header" });
+      // No token provided — continue as anonymous
       return;
     }
 
@@ -66,7 +75,11 @@ async function authPluginImpl(
       };
     } catch (error) {
       fastify.log.warn({ error }, "JWT validation failed");
-      reply.code(401).send({ error: "Invalid token" });
+      reply.code(401).send({
+        error: "Unauthorized",
+        message: "Invalid token",
+        statusCode: 401,
+      });
       return;
     }
   });
@@ -78,14 +91,30 @@ export const authPlugin = fp(authPluginImpl, {
 });
 
 /**
- * Require authentication for a specific route
- * Use as a preHandler on routes that need auth
+ * Require authentication for a specific route.
+ * Use as a preHandler — returns 401 if no valid token was provided.
  */
 export async function requireAuth(request: FastifyRequest, reply: FastifyReply) {
   if (!request.user) {
-    reply.code(401).send({ error: "Authentication required" });
+    reply.code(401).send({
+      error: "Unauthorized",
+      message: "Missing or invalid authorization header",
+      statusCode: 401,
+    });
     return;
   }
+}
+
+/**
+ * Allow optional authentication for a specific route.
+ * The global onRequest hook already rejects invalid tokens and populates
+ * request.user for valid ones, so this is a no-op preHandler that
+ * documents the route's intent. Routes can inspect `request.user` to
+ * determine if the caller is authenticated.
+ */
+export async function optionalAuth(_request: FastifyRequest, _reply: FastifyReply) {
+  // No-op: the global hook already handled token verification.
+  // request.user is set if a valid token was provided, undefined otherwise.
 }
 
 /**
@@ -102,6 +131,6 @@ export function getAuthPluginOptionsFromEnv(): AuthPluginOptions {
   return {
     authority,
     audience,
-    excludePaths: ["/health", "/api/v1/docs"],
+    excludePaths: ["/health", "/docs"],
   };
 }

--- a/services/reservations/src/app.ts
+++ b/services/reservations/src/app.ts
@@ -2,6 +2,7 @@ import Fastify, { type FastifyInstance } from "fastify";
 import cors from "@fastify/cors";
 import swagger from "@fastify/swagger";
 import ScalarApiReference from "@scalar/fastify-api-reference";
+import { authPlugin, getAuthPluginOptionsFromEnv } from "@mbe/auth/fastify";
 import { registerSchemas } from "./schemas/index.js";
 import { healthRoutes } from "./routes/health.js";
 import { tableRoutes } from "./routes/tables.js";
@@ -120,6 +121,11 @@ export async function buildApp(options: AppOptions = {}): Promise<FastifyInstanc
 
   // Register shared schemas
   registerSchemas(fastify);
+
+  // Register auth plugin (permissive — populates request.user when token present)
+  if (process.env.AUTH_AUTHORITY && process.env.AUTH_AUDIENCE) {
+    await fastify.register(authPlugin, getAuthPluginOptionsFromEnv());
+  }
 
   // Register routes
   await fastify.register(healthRoutes);

--- a/services/reservations/src/routes/floor-plans.ts
+++ b/services/reservations/src/routes/floor-plans.ts
@@ -1,4 +1,4 @@
-import type { FastifyPluginAsync, FastifyRequest, FastifyReply } from "fastify";
+import type { FastifyPluginAsync } from "fastify";
 import type {
   FloorPlan,
   Table,
@@ -10,66 +10,10 @@ import type {
   ApiError,
   PaginatedResponse,
 } from "@mbe/types";
-import type { AuthUser, JWTPayload } from "@mbe/auth/types";
-import { createRemoteJWKSet, jwtVerify } from "jose";
+import { requireAuth } from "@mbe/auth/fastify";
 import { floorPlanService } from "../services/floor-plan.js";
 
-declare module "fastify" {
-  interface FastifyRequest {
-    user?: AuthUser;
-  }
-}
-
 export const floorPlanRoutes: FastifyPluginAsync = async (fastify) => {
-  const authority = process.env.AUTH_AUTHORITY;
-  const audience = process.env.AUTH_AUDIENCE;
-
-  let JWKS: ReturnType<typeof createRemoteJWKSet> | null = null;
-  if (authority && audience) {
-    const jwksUri = `${authority.replace(/\/$/, "")}/.well-known/jwks.json`;
-    JWKS = createRemoteJWKSet(new URL(jwksUri));
-  }
-
-  const verifyAuth = async (request: FastifyRequest, reply: FastifyReply) => {
-    if (!JWKS || !authority || !audience) {
-      return reply.code(500).send({ error: "Auth not configured" });
-    }
-
-    const authHeader = request.headers.authorization;
-    if (!authHeader?.startsWith("Bearer ")) {
-      return reply.code(401).send({
-        error: "Unauthorized",
-        message: "Missing or invalid authorization header",
-        statusCode: 401,
-      });
-    }
-
-    const token = authHeader.slice(7);
-    try {
-      const { payload } = await jwtVerify(token, JWKS, {
-        issuer: authority.replace(/\/$/, "") + "/",
-        audience,
-      });
-
-      const jwtPayload = payload as unknown as JWTPayload;
-      request.user = {
-        id: jwtPayload.sub,
-        email: jwtPayload.email,
-        name: jwtPayload.name,
-        picture: jwtPayload.picture,
-        emailVerified: jwtPayload.email_verified,
-        raw: jwtPayload,
-      };
-    } catch (error) {
-      fastify.log.warn({ error }, "JWT validation failed");
-      return reply.code(401).send({
-        error: "Unauthorized",
-        message: "Invalid token",
-        statusCode: 401,
-      });
-    }
-  };
-
   // List floor plans
   fastify.get<{
     Querystring: { page?: string; limit?: string; venueId?: string };
@@ -235,7 +179,7 @@ export const floorPlanRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/",
     {
-      preHandler: verifyAuth,
+      preHandler: requireAuth,
       schema: {
         summary: "Create a new floor plan",
         operationId: "createFloorPlan",
@@ -306,7 +250,7 @@ export const floorPlanRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/:id",
     {
-      preHandler: verifyAuth,
+      preHandler: requireAuth,
       schema: {
         summary: "Update a floor plan",
         operationId: "updateFloorPlan",
@@ -382,7 +326,7 @@ export const floorPlanRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/:id/activate",
     {
-      preHandler: verifyAuth,
+      preHandler: requireAuth,
       schema: {
         summary: "Set floor plan as active",
         operationId: "activateFloorPlan",
@@ -451,7 +395,7 @@ export const floorPlanRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/:id",
     {
-      preHandler: verifyAuth,
+      preHandler: requireAuth,
       schema: {
         summary: "Delete a floor plan",
         operationId: "deleteFloorPlan",
@@ -505,7 +449,7 @@ export const floorPlanRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/tables/positions",
     {
-      preHandler: verifyAuth,
+      preHandler: requireAuth,
       schema: {
         summary: "Bulk update table positions",
         operationId: "bulkUpdateTablePositions",
@@ -574,7 +518,7 @@ export const floorPlanRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/tables/:tableId/assign",
     {
-      preHandler: verifyAuth,
+      preHandler: requireAuth,
       schema: {
         summary: "Assign table to floor plan",
         operationId: "assignTableToFloorPlan",
@@ -646,7 +590,7 @@ export const floorPlanRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/tables/:tableId/remove",
     {
-      preHandler: verifyAuth,
+      preHandler: requireAuth,
       schema: {
         summary: "Remove table from floor plan",
         operationId: "removeTableFromFloorPlan",

--- a/services/reservations/src/routes/guests.ts
+++ b/services/reservations/src/routes/guests.ts
@@ -1,4 +1,4 @@
-import type { FastifyPluginAsync, FastifyRequest, FastifyReply } from "fastify";
+import type { FastifyPluginAsync } from "fastify";
 import type {
   Guest,
   CreateGuestRequest,
@@ -8,66 +8,10 @@ import type {
   ApiError,
   PaginatedResponse,
 } from "@mbe/types";
-import type { AuthUser, JWTPayload } from "@mbe/auth/types";
-import { createRemoteJWKSet, jwtVerify } from "jose";
+import { requireAuth } from "@mbe/auth/fastify";
 import { guestService } from "../services/guest.js";
 
-declare module "fastify" {
-  interface FastifyRequest {
-    user?: AuthUser;
-  }
-}
-
 export const guestRoutes: FastifyPluginAsync = async (fastify) => {
-  const authority = process.env.AUTH_AUTHORITY;
-  const audience = process.env.AUTH_AUDIENCE;
-
-  let JWKS: ReturnType<typeof createRemoteJWKSet> | null = null;
-  if (authority && audience) {
-    const jwksUri = `${authority.replace(/\/$/, "")}/.well-known/jwks.json`;
-    JWKS = createRemoteJWKSet(new URL(jwksUri));
-  }
-
-  const verifyAuth = async (request: FastifyRequest, reply: FastifyReply) => {
-    if (!JWKS || !authority || !audience) {
-      return reply.code(500).send({ error: "Auth not configured" });
-    }
-
-    const authHeader = request.headers.authorization;
-    if (!authHeader?.startsWith("Bearer ")) {
-      return reply.code(401).send({
-        error: "Unauthorized",
-        message: "Missing or invalid authorization header",
-        statusCode: 401,
-      });
-    }
-
-    const token = authHeader.slice(7);
-    try {
-      const { payload } = await jwtVerify(token, JWKS, {
-        issuer: authority.replace(/\/$/, "") + "/",
-        audience,
-      });
-
-      const jwtPayload = payload as unknown as JWTPayload;
-      request.user = {
-        id: jwtPayload.sub,
-        email: jwtPayload.email,
-        name: jwtPayload.name,
-        picture: jwtPayload.picture,
-        emailVerified: jwtPayload.email_verified,
-        raw: jwtPayload,
-      };
-    } catch (error) {
-      fastify.log.warn({ error }, "JWT validation failed");
-      return reply.code(401).send({
-        error: "Unauthorized",
-        message: "Invalid token",
-        statusCode: 401,
-      });
-    }
-  };
-
   // List guests for a venue
   fastify.get<{
     Querystring: { venueId: string; page?: string; limit?: string };
@@ -75,7 +19,7 @@ export const guestRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/",
     {
-      preHandler: verifyAuth,
+      preHandler: requireAuth,
       schema: {
         summary: "List guests for a venue",
         operationId: "listGuests",
@@ -148,7 +92,7 @@ export const guestRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/search",
     {
-      preHandler: verifyAuth,
+      preHandler: requireAuth,
       schema: {
         summary: "Search guests",
         operationId: "searchGuests",
@@ -221,7 +165,7 @@ export const guestRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/segments",
     {
-      preHandler: verifyAuth,
+      preHandler: requireAuth,
       schema: {
         summary: "Get guest segments",
         operationId: "getGuestSegments",
@@ -277,7 +221,7 @@ export const guestRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/:id",
     {
-      preHandler: verifyAuth,
+      preHandler: requireAuth,
       schema: {
         summary: "Get guest by ID",
         operationId: "getGuestById",
@@ -329,7 +273,7 @@ export const guestRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/",
     {
-      preHandler: verifyAuth,
+      preHandler: requireAuth,
       schema: {
         summary: "Create a new guest",
         operationId: "createGuest",
@@ -414,7 +358,7 @@ export const guestRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/find-or-create",
     {
-      preHandler: verifyAuth,
+      preHandler: requireAuth,
       schema: {
         summary: "Find or create guest",
         operationId: "findOrCreateGuest",
@@ -485,7 +429,7 @@ export const guestRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/:id",
     {
-      preHandler: verifyAuth,
+      preHandler: requireAuth,
       schema: {
         summary: "Update a guest",
         operationId: "updateGuest",
@@ -550,7 +494,7 @@ export const guestRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/:id",
     {
-      preHandler: verifyAuth,
+      preHandler: requireAuth,
       schema: {
         summary: "Delete a guest",
         operationId: "deleteGuest",

--- a/services/reservations/src/routes/reservations.ts
+++ b/services/reservations/src/routes/reservations.ts
@@ -1,4 +1,4 @@
-import type { FastifyPluginAsync, FastifyRequest, FastifyReply } from "fastify";
+import type { FastifyPluginAsync } from "fastify";
 import type {
   Reservation,
   ReservationStatus,
@@ -9,106 +9,12 @@ import type {
   ApiError,
   PaginatedResponse,
 } from "@mbe/types";
-import type { AuthUser, JWTPayload } from "@mbe/auth/types";
-import { createRemoteJWKSet, jwtVerify } from "jose";
+import { requireAuth, optionalAuth } from "@mbe/auth/fastify";
 import { reservationService } from "../services/reservation.js";
 import { emitReservationCancelled, emitReservationCreated, emitTableUpdated } from "../services/events.js";
 import { tableService } from "../services/table.js";
 
-declare module "fastify" {
-  interface FastifyRequest {
-    user?: AuthUser;
-  }
-}
-
 export const reservationRoutes: FastifyPluginAsync = async (fastify) => {
-  const authority = process.env.AUTH_AUTHORITY;
-  const audience = process.env.AUTH_AUDIENCE;
-
-  let JWKS: ReturnType<typeof createRemoteJWKSet> | null = null;
-  if (authority && audience) {
-    const jwksUri = `${authority.replace(/\/$/, "")}/.well-known/jwks.json`;
-    JWKS = createRemoteJWKSet(new URL(jwksUri));
-  }
-
-  const verifyAuth = async (request: FastifyRequest, reply: FastifyReply) => {
-    if (!JWKS || !authority || !audience) {
-      return reply.code(500).send({ error: "Auth not configured" });
-    }
-
-    const authHeader = request.headers.authorization;
-    if (!authHeader?.startsWith("Bearer ")) {
-      return reply.code(401).send({
-        error: "Unauthorized",
-        message: "Missing or invalid authorization header",
-        statusCode: 401,
-      });
-    }
-
-    const token = authHeader.slice(7);
-    try {
-      const { payload } = await jwtVerify(token, JWKS, {
-        issuer: authority.replace(/\/$/, "") + "/",
-        audience,
-      });
-
-      const jwtPayload = payload as unknown as JWTPayload;
-      request.user = {
-        id: jwtPayload.sub,
-        email: jwtPayload.email,
-        name: jwtPayload.name,
-        picture: jwtPayload.picture,
-        emailVerified: jwtPayload.email_verified,
-        raw: jwtPayload,
-      };
-    } catch (error) {
-      fastify.log.warn({ error }, "JWT validation failed");
-      return reply.code(401).send({
-        error: "Unauthorized",
-        message: "Invalid token",
-        statusCode: 401,
-      });
-    }
-  };
-
-  const optionalAuth = async (request: FastifyRequest, reply: FastifyReply) => {
-    if (!JWKS || !authority || !audience) {
-      return;
-    }
-
-    const authHeader = request.headers.authorization;
-    if (!authHeader?.startsWith("Bearer ")) {
-      // No token provided — continue as anonymous
-      return;
-    }
-
-    const token = authHeader.slice(7);
-    try {
-      const { payload } = await jwtVerify(token, JWKS, {
-        issuer: authority.replace(/\/$/, "") + "/",
-        audience,
-      });
-
-      const jwtPayload = payload as unknown as JWTPayload;
-      request.user = {
-        id: jwtPayload.sub,
-        email: jwtPayload.email,
-        name: jwtPayload.name,
-        picture: jwtPayload.picture,
-        emailVerified: jwtPayload.email_verified,
-        raw: jwtPayload,
-      };
-    } catch (error) {
-      // Token was provided but is invalid — reject with 401
-      fastify.log.warn({ error }, "Invalid JWT token");
-      return reply.code(401).send({
-        error: "Unauthorized",
-        message: "Invalid token",
-        statusCode: 401,
-      });
-    }
-  };
-
   // List reservations
   fastify.get<{
     Querystring: {
@@ -202,7 +108,7 @@ export const reservationRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/me",
     {
-      preHandler: verifyAuth,
+      preHandler: requireAuth,
       schema: {
         summary: "Get current user's reservations",
         operationId: "getMyReservations",
@@ -271,7 +177,7 @@ export const reservationRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/walk-in",
     {
-      preHandler: verifyAuth,
+      preHandler: requireAuth,
       schema: {
         summary: "Create a walk-in reservation",
         operationId: "createWalkIn",

--- a/services/reservations/src/routes/tables.ts
+++ b/services/reservations/src/routes/tables.ts
@@ -1,4 +1,4 @@
-import type { FastifyPluginAsync, FastifyRequest, FastifyReply } from "fastify";
+import type { FastifyPluginAsync } from "fastify";
 import type {
   Table,
   CreateTableRequest,
@@ -8,67 +8,11 @@ import type {
   ApiError,
   PaginatedResponse,
 } from "@mbe/types";
-import type { AuthUser, JWTPayload } from "@mbe/auth/types";
-import { createRemoteJWKSet, jwtVerify } from "jose";
+import { requireAuth } from "@mbe/auth/fastify";
 import { tableService } from "../services/table.js";
 import { emitTableUpdated } from "../services/events.js";
 
-declare module "fastify" {
-  interface FastifyRequest {
-    user?: AuthUser;
-  }
-}
-
 export const tableRoutes: FastifyPluginAsync = async (fastify) => {
-  const authority = process.env.AUTH_AUTHORITY;
-  const audience = process.env.AUTH_AUDIENCE;
-
-  let JWKS: ReturnType<typeof createRemoteJWKSet> | null = null;
-  if (authority && audience) {
-    const jwksUri = `${authority.replace(/\/$/, "")}/.well-known/jwks.json`;
-    JWKS = createRemoteJWKSet(new URL(jwksUri));
-  }
-
-  const verifyAuth = async (request: FastifyRequest, reply: FastifyReply) => {
-    if (!JWKS || !authority || !audience) {
-      return reply.code(500).send({ error: "Auth not configured" });
-    }
-
-    const authHeader = request.headers.authorization;
-    if (!authHeader?.startsWith("Bearer ")) {
-      return reply.code(401).send({
-        error: "Unauthorized",
-        message: "Missing or invalid authorization header",
-        statusCode: 401,
-      });
-    }
-
-    const token = authHeader.slice(7);
-    try {
-      const { payload } = await jwtVerify(token, JWKS, {
-        issuer: authority.replace(/\/$/, "") + "/",
-        audience,
-      });
-
-      const jwtPayload = payload as unknown as JWTPayload;
-      request.user = {
-        id: jwtPayload.sub,
-        email: jwtPayload.email,
-        name: jwtPayload.name,
-        picture: jwtPayload.picture,
-        emailVerified: jwtPayload.email_verified,
-        raw: jwtPayload,
-      };
-    } catch (error) {
-      fastify.log.warn({ error }, "JWT validation failed");
-      return reply.code(401).send({
-        error: "Unauthorized",
-        message: "Invalid token",
-        statusCode: 401,
-      });
-    }
-  };
-
   // List tables
   fastify.get<{
     Querystring: { page?: string; limit?: string; activeOnly?: string };
@@ -191,7 +135,7 @@ export const tableRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/",
     {
-      preHandler: verifyAuth,
+      preHandler: requireAuth,
       schema: {
         summary: "Create a new table",
         operationId: "createTable",
@@ -273,7 +217,7 @@ export const tableRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/:id",
     {
-      preHandler: verifyAuth,
+      preHandler: requireAuth,
       schema: {
         summary: "Update a table",
         operationId: "updateTable",
@@ -358,7 +302,7 @@ export const tableRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/:id/status",
     {
-      preHandler: verifyAuth,
+      preHandler: requireAuth,
       schema: {
         summary: "Update table status",
         operationId: "updateTableStatus",
@@ -435,7 +379,7 @@ export const tableRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/:id",
     {
-      preHandler: verifyAuth,
+      preHandler: requireAuth,
       schema: {
         summary: "Delete a table",
         operationId: "deleteTable",

--- a/services/reservations/src/routes/venues.ts
+++ b/services/reservations/src/routes/venues.ts
@@ -1,4 +1,4 @@
-import type { FastifyPluginAsync, FastifyRequest, FastifyReply } from "fastify";
+import type { FastifyPluginAsync } from "fastify";
 import type {
   Venue,
   VenueGroup,
@@ -10,66 +10,10 @@ import type {
   ApiError,
   PaginatedResponse,
 } from "@mbe/types";
-import type { AuthUser, JWTPayload } from "@mbe/auth/types";
-import { createRemoteJWKSet, jwtVerify } from "jose";
+import { requireAuth } from "@mbe/auth/fastify";
 import { venueService, venueGroupService } from "../services/venue.js";
 
-declare module "fastify" {
-  interface FastifyRequest {
-    user?: AuthUser;
-  }
-}
-
 export const venueRoutes: FastifyPluginAsync = async (fastify) => {
-  const authority = process.env.AUTH_AUTHORITY;
-  const audience = process.env.AUTH_AUDIENCE;
-
-  let JWKS: ReturnType<typeof createRemoteJWKSet> | null = null;
-  if (authority && audience) {
-    const jwksUri = `${authority.replace(/\/$/, "")}/.well-known/jwks.json`;
-    JWKS = createRemoteJWKSet(new URL(jwksUri));
-  }
-
-  const verifyAuth = async (request: FastifyRequest, reply: FastifyReply) => {
-    if (!JWKS || !authority || !audience) {
-      return reply.code(500).send({ error: "Auth not configured" });
-    }
-
-    const authHeader = request.headers.authorization;
-    if (!authHeader?.startsWith("Bearer ")) {
-      return reply.code(401).send({
-        error: "Unauthorized",
-        message: "Missing or invalid authorization header",
-        statusCode: 401,
-      });
-    }
-
-    const token = authHeader.slice(7);
-    try {
-      const { payload } = await jwtVerify(token, JWKS, {
-        issuer: authority.replace(/\/$/, "") + "/",
-        audience,
-      });
-
-      const jwtPayload = payload as unknown as JWTPayload;
-      request.user = {
-        id: jwtPayload.sub,
-        email: jwtPayload.email,
-        name: jwtPayload.name,
-        picture: jwtPayload.picture,
-        emailVerified: jwtPayload.email_verified,
-        raw: jwtPayload,
-      };
-    } catch (error) {
-      fastify.log.warn({ error }, "JWT validation failed");
-      return reply.code(401).send({
-        error: "Unauthorized",
-        message: "Invalid token",
-        statusCode: 401,
-      });
-    }
-  };
-
   // ============ VENUE GROUP ROUTES ============
 
   // List venue groups
@@ -182,7 +126,7 @@ export const venueRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/groups",
     {
-      preHandler: verifyAuth,
+      preHandler: requireAuth,
       schema: {
         summary: "Create a new venue group",
         operationId: "createVenueGroup",
@@ -255,7 +199,7 @@ export const venueRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/groups/:id",
     {
-      preHandler: verifyAuth,
+      preHandler: requireAuth,
       schema: {
         summary: "Update a venue group",
         operationId: "updateVenueGroup",
@@ -320,7 +264,7 @@ export const venueRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/groups/:id",
     {
-      preHandler: verifyAuth,
+      preHandler: requireAuth,
       schema: {
         summary: "Delete a venue group",
         operationId: "deleteVenueGroup",
@@ -538,7 +482,7 @@ export const venueRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/",
     {
-      preHandler: verifyAuth,
+      preHandler: requireAuth,
       schema: {
         summary: "Create a new venue",
         operationId: "createVenue",
@@ -628,7 +572,7 @@ export const venueRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/:id",
     {
-      preHandler: verifyAuth,
+      preHandler: requireAuth,
       schema: {
         summary: "Update a venue",
         operationId: "updateVenue",
@@ -697,7 +641,7 @@ export const venueRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/:id",
     {
-      preHandler: verifyAuth,
+      preHandler: requireAuth,
       schema: {
         summary: "Delete a venue",
         operationId: "deleteVenue",

--- a/services/users/src/app.ts
+++ b/services/users/src/app.ts
@@ -2,6 +2,7 @@ import Fastify, { type FastifyInstance } from "fastify";
 import cors from "@fastify/cors";
 import swagger from "@fastify/swagger";
 import ScalarApiReference from "@scalar/fastify-api-reference";
+import { authPlugin, getAuthPluginOptionsFromEnv } from "@mbe/auth/fastify";
 import { registerSchemas } from "./schemas/index.js";
 import { healthRoutes } from "./routes/health.js";
 import { userRoutes } from "./routes/users.js";
@@ -81,6 +82,11 @@ export async function buildApp(options: AppOptions = {}): Promise<FastifyInstanc
 
   // Register shared schemas
   registerSchemas(fastify);
+
+  // Register auth plugin (permissive — populates request.user when token present)
+  if (process.env.AUTH_AUTHORITY && process.env.AUTH_AUDIENCE) {
+    await fastify.register(authPlugin, getAuthPluginOptionsFromEnv());
+  }
 
   // Register routes
   await fastify.register(healthRoutes);

--- a/services/users/src/routes/users.ts
+++ b/services/users/src/routes/users.ts
@@ -1,4 +1,4 @@
-import type { FastifyPluginAsync, FastifyRequest, FastifyReply } from "fastify";
+import type { FastifyPluginAsync } from "fastify";
 import type {
   User,
   CreateUserRequest,
@@ -8,68 +8,10 @@ import type {
   ApiError,
   PaginatedResponse,
 } from "@mbe/types";
-import type { AuthUser, JWTPayload } from "@mbe/auth/types";
-import { createRemoteJWKSet, jwtVerify } from "jose";
+import { requireAuth } from "@mbe/auth/fastify";
 import { userService } from "../services/user.js";
 
-// Augment FastifyRequest to include user from auth
-declare module "fastify" {
-  interface FastifyRequest {
-    user?: AuthUser;
-  }
-}
-
 export const userRoutes: FastifyPluginAsync = async (fastify) => {
-  // JWT verification for protected routes
-  const authority = process.env.AUTH_AUTHORITY;
-  const audience = process.env.AUTH_AUDIENCE;
-
-  let JWKS: ReturnType<typeof createRemoteJWKSet> | null = null;
-  if (authority && audience) {
-    const jwksUri = `${authority.replace(/\/$/, "")}/.well-known/jwks.json`;
-    JWKS = createRemoteJWKSet(new URL(jwksUri));
-  }
-
-  const verifyAuth = async (request: FastifyRequest, reply: FastifyReply) => {
-    if (!JWKS || !authority || !audience) {
-      return reply.code(500).send({ error: "Auth not configured" });
-    }
-
-    const authHeader = request.headers.authorization;
-    if (!authHeader?.startsWith("Bearer ")) {
-      return reply.code(401).send({
-        error: "Unauthorized",
-        message: "Missing or invalid authorization header",
-        statusCode: 401,
-      });
-    }
-
-    const token = authHeader.slice(7);
-    try {
-      const { payload } = await jwtVerify(token, JWKS, {
-        issuer: authority.replace(/\/$/, "") + "/",
-        audience,
-      });
-
-      const jwtPayload = payload as unknown as JWTPayload;
-      request.user = {
-        id: jwtPayload.sub,
-        email: jwtPayload.email,
-        name: jwtPayload.name,
-        picture: jwtPayload.picture,
-        emailVerified: jwtPayload.email_verified,
-        raw: jwtPayload,
-      };
-    } catch (error) {
-      fastify.log.warn({ error }, "JWT validation failed");
-      return reply.code(401).send({
-        error: "Unauthorized",
-        message: "Invalid token",
-        statusCode: 401,
-      });
-    }
-  };
-
   // List users
   fastify.get<{
     Querystring: { page?: string; limit?: string };
@@ -358,7 +300,7 @@ export const userRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/me",
     {
-      preHandler: verifyAuth,
+      preHandler: requireAuth,
       schema: {
         summary: "Get current authenticated user",
         operationId: "getCurrentUser",
@@ -415,7 +357,7 @@ export const userRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/me/preferences",
     {
-      preHandler: verifyAuth,
+      preHandler: requireAuth,
       schema: {
         summary: "Update current user's preferences",
         operationId: "updateCurrentUserPreferences",


### PR DESCRIPTION
## Summary
- Replaced inline JWKS/JWT verification duplicated across 6 route files (venues, guests, floor-plans, tables, reservations, users) with the shared `authPlugin` from `@mbe/auth`
- Made the auth plugin's `onRequest` hook **permissive**: populates `request.user` when a valid token is present, rejects invalid tokens, and passes through requests with no token
- Added `optionalAuth` export to `@mbe/auth/fastify` for routes that accept both authenticated and anonymous access (e.g., `POST /reservations`)
- Registered the auth plugin at the `app.ts` level in both `services/users` and `services/reservations` (guarded by env var check)
- Net reduction: **119 lines added, 445 removed** (-326 lines)

## Test plan
- [x] `pnpm test` in `services/users` — 15 tests pass
- [x] `pnpm test` in `services/reservations` — 117 tests pass
- [x] `pnpm test` in `packages/auth` — 14 tests pass (updated to match new permissive behavior)
- [x] `pnpm typecheck` — all 19 packages pass
- [x] `pnpm lint` — all packages pass (0 errors)

Closes #20