### PR TITLE
fix(hospitality): wire dark mode preference to RialtoProvider (closes…

### DIFF
--- a/apps/hospitality/src/hooks/use-theme.ts
+++ b/apps/hospitality/src/hooks/use-theme.ts
@@ -1,0 +1,59 @@
+import { createContext, useContext, useState, useCallback } from "react";
+
+type ThemePreference = "light" | "dark" | "system";
+
+const STORAGE_KEY = "mbe-theme-preference";
+
+function getStoredTheme(): ThemePreference {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === "light" || stored === "dark" || stored === "system") {
+      return stored;
+    }
+  } catch {
+    // localStorage unavailable (private browsing, etc.)
+  }
+  return "system";
+}
+
+function storeTheme(theme: ThemePreference): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, theme);
+  } catch {
+    // Theme still works in memory for the session
+  }
+}
+
+/* ── Context ────────────────────────────────────── */
+
+export interface ThemeContextValue {
+  readonly theme: ThemePreference;
+  readonly setTheme: (theme: ThemePreference) => void;
+}
+
+export const ThemeContext = createContext<ThemeContextValue>({
+  theme: "system",
+  setTheme: () => {},
+});
+
+/* ── Hooks ──────────────────────────────────────── */
+
+/** Consume the current theme preference from context. */
+export function useTheme(): ThemeContextValue {
+  return useContext(ThemeContext);
+}
+
+/**
+ * State hook for the provider in main.tsx.
+ * Reads the initial value from localStorage and persists changes back.
+ */
+export function useThemeState(): ThemeContextValue {
+  const [theme, setThemeState] = useState<ThemePreference>(getStoredTheme);
+
+  const setTheme = useCallback((next: ThemePreference) => {
+    storeTheme(next);
+    setThemeState(next);
+  }, []);
+
+  return { theme, setTheme };
+}

--- a/apps/hospitality/src/main.tsx
+++ b/apps/hospitality/src/main.tsx
@@ -5,6 +5,7 @@ import { createRoot } from "react-dom/client";
 import { createBrowserRouter, RouterProvider, Navigate } from "react-router-dom";
 import { RialtoProvider } from "@mbe/rialto";
 import { AuthProvider } from "@mbe/auth/react";
+import { ThemeContext, useThemeState } from "./hooks/use-theme";
 import { App, CallbackRedirect } from "./App";
 import { DashboardLayout } from "./components/DashboardLayout";
 import { HomePage } from "./pages/HomePage";
@@ -69,12 +70,27 @@ const router = createBrowserRouter(
   { basename: "/hospitality" }
 );
 
+/**
+ * Wrapper that reads the persisted theme preference from localStorage
+ * and passes it to RialtoProvider. Wrapped in its own component so the
+ * `useThemeState` hook can live inside the React tree.
+ */
+function Root() {
+  const themeState = useThemeState();
+
+  return (
+    <ThemeContext.Provider value={themeState}>
+      <RialtoProvider theme={themeState.theme}>
+        <AuthProvider config={authConfig}>
+          <RouterProvider router={router} />
+        </AuthProvider>
+      </RialtoProvider>
+    </ThemeContext.Provider>
+  );
+}
+
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <RialtoProvider theme="light">
-      <AuthProvider config={authConfig}>
-        <RouterProvider router={router} />
-      </AuthProvider>
-    </RialtoProvider>
+    <Root />
   </StrictMode>
 );

--- a/apps/hospitality/src/pages/SettingsPage.tsx
+++ b/apps/hospitality/src/pages/SettingsPage.tsx
@@ -3,11 +3,13 @@ import { useAuth } from "@mbe/auth/react";
 import { Card, Button, Text, Stack } from "@mbe/rialto";
 import { ApiClient, UsersClient } from "@mbe/api-client";
 import type { User, UserPreferences } from "@mbe/types";
+import { useTheme } from "../hooks/use-theme";
 import { PageHeader } from "../components/PageHeader";
 import styles from "./SettingsPage.module.css";
 
 export function SettingsPage() {
   const { accessToken, signOut } = useAuth();
+  const { setTheme: setLocalTheme } = useTheme();
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
@@ -27,6 +29,10 @@ export function SettingsPage() {
         const usersClient = new UsersClient(apiClient);
         const userData = await usersClient.me();
         setUser(userData);
+        // Sync API preference to localStorage so theme persists without auth
+        if (userData.preferences.theme) {
+          setLocalTheme(userData.preferences.theme);
+        }
       } catch (err) {
         setError(err instanceof Error ? err.message : "Failed to load settings");
       } finally {
@@ -35,7 +41,7 @@ export function SettingsPage() {
     }
 
     fetchUser();
-  }, [accessToken]);
+  }, [accessToken, setLocalTheme]);
 
   async function updatePreference<K extends keyof UserPreferences>(
     key: K,
@@ -105,9 +111,11 @@ export function SettingsPage() {
             <select
               id="settings-theme"
               value={preferences.theme ?? "system"}
-              onChange={(e) =>
-                updatePreference("theme", e.target.value as "light" | "dark" | "system")
-              }
+              onChange={(e) => {
+                const next = e.target.value as "light" | "dark" | "system";
+                setLocalTheme(next);
+                updatePreference("theme", next);
+              }}
               disabled={isSaving}
               className={styles.select}
             >


### PR DESCRIPTION
… #40)

The Settings page saved a theme preference to the API but main.tsx hardcoded theme="light" on RialtoProvider. Added a ThemeContext backed by localStorage so the preference is applied immediately and persists across page refreshes. The Settings page now writes to both localStorage (for instant local effect) and the API (for cross-device sync).