### PR TITLE
docs: add README files for monorepo and all packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,113 @@
+# Matt Butler Engineering
+
+Monorepo for [mattbutlerengineering.com](https://mattbutlerengineering.com) -- a hospitality management platform with a design system, multiple frontend apps, and backend API services.
+
+## Tech Stack
+
+- **Frontend**: React 19, Vite, React Router
+- **Backend**: Fastify, Prisma, PostgreSQL
+- **Design System**: [Rialto](packages/rialto/) (custom React component library)
+- **Monorepo**: Turborepo + pnpm workspaces
+- **Infrastructure**: Pulumi (TypeScript), Cloudflare Workers, DigitalOcean App Platform
+- **Auth**: Auth0 (OIDC/JWT)
+- **Testing**: Vitest, Playwright
+- **CI/CD**: GitHub Actions
+
+## Quick Start
+
+```bash
+# Install dependencies
+pnpm install
+
+# Start everything (Postgres via Docker, schema sync, dev servers)
+pnpm dev:local
+```
+
+This starts PostgreSQL in Docker, syncs all database schemas, and launches all dev servers.
+
+### Access Points
+
+| App | URL |
+|-----|-----|
+| Marketing site | http://localhost:3000 |
+| Hospitality app | http://localhost:3002/hospitality |
+| Users API (+ docs) | http://localhost:3001/docs |
+| Agent API (+ docs) | http://localhost:3003/docs |
+| Reservations API (+ docs) | http://localhost:3004/docs |
+
+## Project Structure
+
+```
+mattbutlerengineering/
+├── apps/                     # Frontend applications
+│   ├── agent-viz/            # Agent session visualizer
+│   ├── gen/                  # Gen app (dynamic UI rendering)
+│   ├── hospitality/          # Restaurant management SPA
+│   ├── marketing/            # Public marketing site
+│   └── rialto-web/           # Design system showcase
+├── services/                 # Backend API services
+│   ├── agent/                # Agent session management API
+│   ├── reservations/         # Reservations and table management API
+│   └── users/                # User management API
+├── packages/                 # Shared libraries
+│   ├── agent-core/           # Agent session runner and worktree management
+│   ├── api-client/           # Typed fetch client for frontend apps
+│   ├── auth/                 # Auth utilities (React hooks + Fastify plugin)
+│   ├── config/               # Shared ESLint, TypeScript, Prettier configs
+│   ├── rialto/               # Rialto design system (component library)
+│   ├── rialto-catalog/       # Component catalog generator for Rialto
+│   ├── rialto-plugin/        # Claude Code plugin for Rialto
+│   └── types/                # Shared TypeScript type definitions
+├── tools/
+│   └── cli/                  # `mbe` CLI for agent management
+└── infrastructure/           # IaC (Pulumi) and edge routing
+    └── pulumi/               # Pulumi TypeScript project
+```
+
+## Commands
+
+```bash
+pnpm dev:local    # Start everything (Postgres + schema sync + dev servers)
+pnpm dev          # Start dev servers (assumes Postgres is running)
+pnpm build        # Build all packages and apps
+pnpm test         # Run all tests
+pnpm lint         # Lint all packages
+pnpm typecheck    # Type-check all packages
+pnpm clean        # Remove build artifacts and node_modules
+```
+
+### Service-Specific
+
+Each service follows the same pattern:
+
+```bash
+cd services/<name>
+pnpm dev              # Dev server with hot reload
+pnpm test             # Run tests
+pnpm test:coverage    # Test coverage report
+pnpm db:migrate       # Run database migrations
+pnpm db:studio        # Open Prisma Studio
+```
+
+### CLI (`mbe`)
+
+```bash
+mbe agent run "Fix the login bug"    # Run an AI agent to fix an issue
+mbe agent orchestrate "Big task"     # Decompose and run in parallel
+```
+
+See [tools/cli/](tools/cli/) for the full command reference.
+
+## Development
+
+See [CLAUDE.md](CLAUDE.md) for detailed development guidelines including:
+
+- Code style and naming conventions
+- API patterns and error handling
+- Testing structure and mocking
+- Database migration workflows
+- Deployment architecture
+
+## License
+
+Private repository. All rights reserved.

--- a/apps/agent-viz/README.md
+++ b/apps/agent-viz/README.md
@@ -1,0 +1,17 @@
+# Agent Viz
+
+Real-time visualizer for AI agent sessions. Displays session progress, tool calls, and events using animated UI components.
+
+## Tech Stack
+
+- React 19 + Vite
+- Framer Motion (animations)
+
+## Commands
+
+```bash
+pnpm dev          # Dev server
+pnpm build        # Production build
+pnpm lint         # ESLint
+pnpm typecheck    # TypeScript check
+```

--- a/apps/gen/README.md
+++ b/apps/gen/README.md
@@ -1,0 +1,23 @@
+# Gen
+
+Dynamic UI rendering app using JSON-based component descriptions. Renders Rialto components from catalog definitions at runtime.
+
+## Tech Stack
+
+- React 19 + Vite
+- `@json-render/react` for JSON-to-component rendering
+- `@mbe/rialto` + `@mbe/rialto-catalog` for component definitions
+- `@mbe/auth` for authentication
+
+## Commands
+
+```bash
+pnpm dev          # Dev server
+pnpm build        # Production build
+pnpm lint         # ESLint
+pnpm typecheck    # TypeScript check
+```
+
+## Deployment
+
+Deployed as a Cloudflare Worker with Static Assets, managed via Pulumi. The edge router serves this app at `/gen`.

--- a/apps/hospitality/README.md
+++ b/apps/hospitality/README.md
@@ -1,0 +1,33 @@
+# Hospitality
+
+Restaurant management SPA for reservations, table management, floor plans, and guest tracking. Served at `/hospitality` on mattbutlerengineering.com.
+
+## Tech Stack
+
+- React 19 + Vite (port 3002)
+- Rialto design system (`@mbe/rialto`)
+- Auth0 authentication (`@mbe/auth`)
+- Typed API client (`@mbe/api-client`)
+- Playwright for E2E tests
+
+## Key Features
+
+- Reservation timeline and list views
+- Interactive floor plan editor (drag-and-drop)
+- Guest directory
+- Multi-step venue onboarding wizard
+- Embeddable booking widget
+- Real-time reservation updates
+
+## Commands
+
+```bash
+pnpm dev          # Dev server on :3002
+pnpm build        # Production build (needs VITE_* env vars)
+pnpm test         # Unit tests
+pnpm lint         # ESLint
+pnpm typecheck    # TypeScript check
+pnpm test:e2e     # Playwright E2E tests (needs E2E_AUTH* env vars)
+```
+
+See [CLAUDE.md](CLAUDE.md) for detailed page routes, auth configuration, and E2E testing setup.

--- a/apps/marketing/README.md
+++ b/apps/marketing/README.md
@@ -1,0 +1,23 @@
+# Marketing
+
+Public marketing site for mattbutlerengineering.com. Serves as the catch-all route at `/`.
+
+## Tech Stack
+
+- React 19 + Vite (port 3000)
+- Rialto design system (`@mbe/rialto`)
+- Framer Motion (animations)
+- React Router
+
+## Commands
+
+```bash
+pnpm dev          # Dev server on :3000
+pnpm build        # Production build
+pnpm lint         # ESLint
+pnpm typecheck    # TypeScript check
+```
+
+## Deployment
+
+Deployed as a Cloudflare Worker with Static Assets. The edge router forwards all unmatched paths to this app.

--- a/apps/rialto-web/README.md
+++ b/apps/rialto-web/README.md
@@ -1,0 +1,28 @@
+# Rialto Web
+
+Interactive showcase and documentation site for the [Rialto design system](../../packages/rialto/). Served at `/rialto` on mattbutlerengineering.com.
+
+## Tech Stack
+
+- React 19 + Vite
+- Rialto design system (`@mbe/rialto`)
+- Framer Motion (animations)
+- Lucide icons
+
+## Commands
+
+```bash
+pnpm dev          # Dev server
+pnpm build        # Production build (copies registry.json to public/)
+pnpm lint         # ESLint
+pnpm typecheck    # TypeScript check
+```
+
+## Visual Testing
+
+From the monorepo root:
+
+```bash
+pnpm test:visual    # Playwright visual regression tests
+pnpm lighthouse     # Lighthouse CI audit
+```

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,0 +1,35 @@
+# Infrastructure
+
+Infrastructure as Code and edge routing for mattbutlerengineering.com.
+
+## Components
+
+| Directory | Purpose |
+|-----------|---------|
+| `pulumi/` | Pulumi (TypeScript) IaC -- manages DigitalOcean, Cloudflare, and Auth0 resources |
+| `worker/` | Cloudflare Worker edge router -- routes traffic by path prefix |
+| `migrate/` | Pre-deploy migration job Dockerfile |
+| `docker-compose.yml` | Local PostgreSQL for development |
+
+## Architecture
+
+```
+Client -> mattbutlerengineering.com (Cloudflare Worker)
+  /hospitality*  -> Workers Static Assets (Service Binding)
+  /rialto*       -> Workers Static Assets (Service Binding)
+  /gen*          -> Workers Static Assets (Service Binding)
+  /api/*         -> api.mattbutlerengineering.com (DigitalOcean)
+  /*             -> Workers Static Assets (marketing, catch-all)
+```
+
+## Local Development
+
+```bash
+# Start PostgreSQL
+docker compose up postgres -d
+
+# Or use the root command that handles everything:
+pnpm dev:local
+```
+
+See [pulumi/README.md](pulumi/README.md) for infrastructure deployment details and [CLAUDE.md](CLAUDE.md) for the full resource inventory.

--- a/packages/agent-core/README.md
+++ b/packages/agent-core/README.md
@@ -1,0 +1,27 @@
+# Agent Core
+
+Core library for running AI agent sessions. Manages git worktrees, tool permissions, and session execution using the Claude Agent SDK.
+
+## Usage
+
+```typescript
+import { createSession, runSession } from "@mbe/agent-core";
+```
+
+Used by the [Agent Service](../../services/agent/) and the [`mbe` CLI](../../tools/cli/).
+
+## Key Responsibilities
+
+- Git worktree creation and cleanup
+- Tool permission configuration for Claude agents
+- Session execution with budget and turn limits
+- Cost tracking and event emission
+
+## Commands
+
+```bash
+pnpm test             # Run tests
+pnpm test:coverage    # Coverage report
+pnpm lint             # ESLint
+pnpm typecheck        # TypeScript check
+```

--- a/packages/api-client/README.md
+++ b/packages/api-client/README.md
@@ -1,0 +1,27 @@
+# API Client
+
+Typed fetch wrapper for frontend apps. Provides a consistent interface for calling backend APIs with automatic auth token injection.
+
+## Usage
+
+```typescript
+import { createApiClient } from "@mbe/api-client";
+import { usersClient } from "@mbe/api-client/users";
+```
+
+Used by the [Hospitality app](../../apps/hospitality/) and other frontend apps that need authenticated API access.
+
+## Features
+
+- Typed request/response with `@mbe/types`
+- Automatic Bearer token injection
+- Timeout and retry handling
+- Consistent error formatting
+
+## Commands
+
+```bash
+pnpm test             # Run tests
+pnpm lint             # ESLint
+pnpm typecheck        # TypeScript check
+```

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -1,0 +1,35 @@
+# Auth
+
+Shared authentication utilities for both frontend and backend packages. Wraps Auth0 OIDC for React apps and JWT verification for Fastify services.
+
+## Usage
+
+### React (frontend)
+
+```typescript
+import { AuthProvider, useAuth } from "@mbe/auth/react";
+```
+
+Provides `AuthProvider` context, `useAuth` hook, and login/logout helpers.
+
+### Fastify (backend)
+
+```typescript
+import { authPlugin } from "@mbe/auth/fastify";
+
+fastify.register(authPlugin, {
+  authority: process.env.AUTH_AUTHORITY,
+  audience: process.env.AUTH_AUDIENCE,
+});
+```
+
+Registers JWT verification as a Fastify plugin. Protected routes automatically validate the Bearer token.
+
+## Commands
+
+```bash
+pnpm test             # Run tests
+pnpm test:coverage    # Coverage report
+pnpm lint             # ESLint
+pnpm typecheck        # TypeScript check
+```

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -1,0 +1,41 @@
+# Config
+
+Shared configuration presets for ESLint, TypeScript, and Prettier used across the monorepo.
+
+## Usage
+
+### TypeScript
+
+```json
+// tsconfig.json
+{ "extends": "@mbe/config/typescript/base" }
+// or: @mbe/config/typescript/react, @mbe/config/typescript/node
+```
+
+### ESLint
+
+```javascript
+// eslint.config.js
+import base from "@mbe/config/eslint/base";
+export default [...base];
+// or: @mbe/config/eslint/react, @mbe/config/eslint/node
+```
+
+### Prettier
+
+```javascript
+// prettier.config.js
+export { default } from "@mbe/config/prettier";
+```
+
+## Presets
+
+| Preset | Use Case |
+|--------|----------|
+| `typescript/base` | Shared packages and libraries |
+| `typescript/react` | React frontend apps |
+| `typescript/node` | Node.js backend services |
+| `eslint/base` | Base linting rules |
+| `eslint/react` | React-specific rules (JSX a11y, hooks) |
+| `eslint/node` | Node.js-specific rules |
+| `prettier` | Formatting (double quotes, semicolons, 2-space indent) |

--- a/packages/rialto-catalog/README.md
+++ b/packages/rialto-catalog/README.md
@@ -1,0 +1,19 @@
+# Rialto Catalog
+
+Component catalog generator for the Rialto design system. Produces structured metadata about available components for use by the Gen app and other tooling.
+
+## Usage
+
+```typescript
+import { catalog } from "@mbe/rialto-catalog";
+import { getCatalog } from "@mbe/rialto-catalog/catalog";
+```
+
+## Commands
+
+```bash
+pnpm generate     # Regenerate catalog from Rialto components
+pnpm build        # Compile TypeScript
+pnpm lint         # ESLint
+pnpm typecheck    # TypeScript check
+```

--- a/packages/rialto-plugin/README.md
+++ b/packages/rialto-plugin/README.md
@@ -1,0 +1,17 @@
+# Rialto Plugin
+
+Claude Code plugin for the Rialto design system. Provides skills, agents, and validation hooks that help Claude Code work effectively with Rialto components.
+
+## Features
+
+- Component reference generation from Rialto source
+- Design token validation hooks
+- Rialto-aware coding skills for Claude Code
+
+## Commands
+
+```bash
+pnpm generate     # Regenerate component reference
+pnpm build        # Run generation
+pnpm typecheck    # TypeScript check
+```

--- a/packages/rialto/README.md
+++ b/packages/rialto/README.md
@@ -1,0 +1,46 @@
+# Rialto
+
+React component library and design system. Inspired by precision industrial design with warm material surfaces, surgical color, and tactile interactions.
+
+## Usage
+
+```typescript
+import { Button, Input, Card, Text, Stack } from "@mbe/rialto";
+import "@mbe/rialto/styles"; // Import before any component rendering
+
+// Wrap your app root
+<RialtoProvider theme="light">
+  <App />
+</RialtoProvider>
+```
+
+## Design Principles
+
+- **Material honesty** -- surfaces communicate what they are
+- **Surgical color** -- warm neutral palette with gold/amber as the single accent
+- **Tactile interaction** -- buttons feel like physical controls
+- **Precision restraint** -- minimal font weights, tight spacing, small radii
+
+## Key Rules
+
+- Never hardcode colors -- use `var(--rialto-*)` tokens
+- Gold accent only for focus rings, active states, and primary actions
+- Maximum 3 font weights: 300, 400, 500
+
+## Commands
+
+```bash
+pnpm build        # Build library
+pnpm test         # Run tests
+pnpm lint         # ESLint
+pnpm typecheck    # TypeScript check
+```
+
+From the monorepo root:
+
+```bash
+pnpm size         # Check bundle size
+pnpm size:check   # Enforce size limits
+```
+
+See [CLAUDE.md](CLAUDE.md) for the full token reference, component APIs, and design philosophy.

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,0 +1,27 @@
+# Types
+
+Shared TypeScript type definitions used across the monorepo.
+
+## Usage
+
+```typescript
+import type { User } from "@mbe/types";
+import type { ApiResponse } from "@mbe/types/api";
+import type { AgentSession } from "@mbe/types/agent";
+```
+
+## Exports
+
+| Entry Point | Contents |
+|-------------|----------|
+| `@mbe/types` | All types (re-exported) |
+| `@mbe/types/api` | API response and error types |
+| `@mbe/types/user` | User model types |
+| `@mbe/types/agent` | Agent session and event types |
+
+## Commands
+
+```bash
+pnpm lint         # ESLint
+pnpm typecheck    # TypeScript check
+```

--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -1,0 +1,32 @@
+# Agent Service
+
+REST API for managing AI agent sessions. Supports creating, monitoring, and orchestrating Claude-powered coding agents.
+
+## Tech Stack
+
+- Fastify 5 + TypeScript (port 3003)
+- Prisma ORM + PostgreSQL
+- Claude API (`@anthropic-ai/claude-agent-sdk`)
+- SSE streaming for real-time session logs
+- Vitest for testing
+
+## Key Features
+
+- Session lifecycle management (PENDING, RUNNING, SUCCEEDED, FAILED, CANCELLED)
+- Real-time event streaming via SSE
+- Task decomposition and parallel orchestration
+- GitHub webhook integration for PR events
+
+## Commands
+
+```bash
+pnpm dev              # Dev server with hot reload
+pnpm build            # Compile TypeScript
+pnpm test             # Run tests
+pnpm test:coverage    # Coverage report
+pnpm db:migrate       # Create and apply migrations
+pnpm db:push          # Quick schema sync (dev only)
+pnpm db:studio        # Open Prisma Studio
+```
+
+See [CLAUDE.md](CLAUDE.md) for domain model, environment variables, and architecture details.

--- a/services/reservations/README.md
+++ b/services/reservations/README.md
@@ -1,0 +1,31 @@
+# Reservations Service
+
+REST API for restaurant reservation and table management. Handles venues, tables, and bookings.
+
+## Tech Stack
+
+- Fastify 5 + TypeScript (port 3004)
+- Prisma ORM + PostgreSQL
+- Auth0 JWT verification (`@mbe/auth`)
+- Vitest for testing
+
+## Domain Model
+
+- **VenueGroup** -- top-level organization
+- **Venue** -- individual restaurant location
+- **Table** -- physical table (AVAILABLE / OCCUPIED / DIRTY / READY)
+- **Reservation** -- booking (PENDING / CONFIRMED / COMPLETED / CANCELLED / NO_SHOW)
+
+## Commands
+
+```bash
+pnpm dev              # Dev server with hot reload
+pnpm build            # Compile TypeScript
+pnpm test             # Run tests
+pnpm test:coverage    # Coverage report
+pnpm db:migrate       # Create and apply migrations
+pnpm db:push          # Quick schema sync (dev only)
+pnpm db:studio        # Open Prisma Studio
+```
+
+See [CLAUDE.md](CLAUDE.md) for environment variables, route structure, and project layout.

--- a/services/users/README.md
+++ b/services/users/README.md
@@ -1,0 +1,30 @@
+# Users Service
+
+REST API for user management. Handles user profiles, preferences, and authentication verification.
+
+## Tech Stack
+
+- Fastify 5 + TypeScript (port 3001)
+- Prisma ORM + PostgreSQL
+- Auth0 JWT verification (`@mbe/auth`)
+- Vitest for testing
+
+## API
+
+Base path: `/api/v1/users`
+
+All routes are JWT-protected. API documentation available at `/docs` when running locally.
+
+## Commands
+
+```bash
+pnpm dev              # Dev server with hot reload
+pnpm build            # Compile TypeScript
+pnpm test             # Run tests
+pnpm test:coverage    # Coverage report
+pnpm db:migrate       # Create and apply migrations
+pnpm db:push          # Quick schema sync (dev only)
+pnpm db:studio        # Open Prisma Studio
+```
+
+See [CLAUDE.md](CLAUDE.md) for domain model, environment variables, and project structure.

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -1,0 +1,55 @@
+# MBE CLI
+
+Command-line tool for managing AI agent sessions, user operations, and authentication.
+
+## Installation
+
+Built and linked from the monorepo:
+
+```bash
+cd tools/cli
+pnpm build
+```
+
+The `mbe` binary is available via the `bin` field in `package.json`.
+
+## Commands
+
+### Agent (local mode)
+
+```bash
+mbe agent run "Fix the login bug"       # Run agent, get PR
+  --model <model>                        # Default: claude-sonnet-4-6
+  --max-budget <usd>                     # Default: 1.00
+  --max-turns <n>                        # Default: 50
+  --no-pr                                # Skip PR creation
+  -v, --verbose                          # Stream agent events
+```
+
+### Agent (API mode)
+
+Requires the [Agent Service](../../services/agent/) running on port 3003.
+
+```bash
+mbe agent start "Fix the login bug"     # Create session via API
+mbe agent list                           # List all sessions
+mbe agent status <id>                    # Get session details
+mbe agent logs <id>                      # Stream SSE events
+mbe agent cancel <id>                    # Cancel running session
+mbe agent delete <id>                    # Delete session and cleanup
+mbe agent orchestrate "Big task"         # Decompose into parallel sessions
+```
+
+## Dependencies
+
+- `@mbe/agent-core` -- session execution engine
+- `@mbe/types` -- shared type definitions
+- `commander` -- CLI framework
+
+## Commands
+
+```bash
+pnpm build        # Compile TypeScript
+pnpm lint         # ESLint
+pnpm typecheck    # TypeScript check
+```


### PR DESCRIPTION
## Summary

- Add root `README.md` with project overview, quick start guide, project structure, and available commands
- Add individual `README.md` files to all 19 directories: 5 apps, 3 services, 7 packages, 1 tool, and infrastructure
- Each README covers purpose, tech stack, usage examples, and commands without duplicating existing `CLAUDE.md` content

Closes #44

## Test plan

- [x] `pnpm lint` passes (0 errors)
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (22 tasks, all successful)
- [ ] Verify README rendering on GitHub