### PR TITLE
feat(ship-loop): add evaluator phase, issue enrichment, and structured failure handoffs

### DIFF
--- a/.claude/skills/ship-loop/SKILL.md
+++ b/.claude/skills/ship-loop/SKILL.md
@@ -69,10 +69,33 @@ gh issue edit <number> --add-label "in-progress" --remove-label "ready"
 
 ## Phase B: Implement in Worktree Agent
 
-Launch a worktree agent for the claimed issue:
+### B0. Issue Enrichment (Planner Step)
+
+Before launching the worktree agent, expand the raw issue title into a structured spec. This significantly improves first-iteration quality by giving the agent concrete acceptance criteria and scope boundaries.
+
+Run a planner sub-agent (prefer `claude-haiku-4-5` to minimize cost) with the following prompt:
+
+```
+Given this GitHub issue:
+Title: <issue title>
+Body: <issue body>
+
+Produce a structured implementation spec:
+1. **Goal** — One sentence summary of what success looks like.
+2. **Acceptance Criteria** — Bullet list of testable conditions that must be true.
+3. **Files Likely Affected** — List of files/directories most likely to need changes.
+4. **Edge Cases** — Potential failure modes or tricky scenarios to handle.
+5. **Out of Scope** — What NOT to change.
+```
+
+Save the enriched spec for use in B1 (agent prompt) and B2 (evaluator criteria).
+
+### B1. Launch Worktree Agent
+
+Pass the enriched spec (from B0) rather than just the raw issue title:
 
 ```bash
-mbe agent run "<issue title> (closes #<number>)" \
+mbe agent run "<enriched spec from B0> (closes #<number>)" \
   --model claude-sonnet-4-6 \
   --max-budget 1.00 \
   --max-turns 50
@@ -94,16 +117,53 @@ Every worktree agent prompt MUST include the following security guidance:
 > - For any changes touching auth, crypto, or input handling, use the **security-reviewer** agent.
 > - If you discover an existing security vulnerability, stop feature work and fix it first.
 
-### Agent Outcome Handling
+### B2. Evaluate the PR (Evaluator Phase)
 
-- **Success** (PR created): Label issue `has-pr`, remove `in-progress`.
-- **Failure**: Label issue `agent-failed`, remove `in-progress`. Log failure reason.
+After the worktree agent creates a PR, run a **separate evaluator agent** against the diff before accepting. Models have strong self-evaluation bias — a fresh skeptical agent catches issues the generator misses.
+
+Run an evaluator sub-agent with:
+
+```
+Review this PR diff against the acceptance criteria below. Be skeptical — your job is to
+find problems, not validate success.
+
+Acceptance Criteria:
+<criteria from B0 enrichment>
+
+PR diff:
+<output of: gh pr diff <pr-number>>
+
+Answer: PASS or FAIL.
+If FAIL, list specific issues as bullet points — reference file names and line numbers.
+Do not give partial credit. If any criterion is unmet, it is a FAIL.
+```
+
+**Evaluator outcomes:**
+
+- **PASS**: Proceed to Phase C.
+- **FAIL (first attempt)**: Feed the evaluator's feedback back to the worktree agent as a follow-up prompt requesting fixes. Allow one retry, then re-run the evaluator.
+- **FAIL (second attempt)**: Treat as agent failure — proceed to B3 failure path.
+
+### B3. Agent Outcome Handling
+
+- **Success** (PR created and evaluator passes): Label issue `has-pr`, remove `in-progress`.
+- **Failure**: Write a structured handoff comment, then label `agent-failed`, remove `in-progress`.
 
 ```bash
 # On success
 gh issue edit <number> --add-label "has-pr" --remove-label "in-progress"
 
-# On failure
+# On failure — post structured handoff first, then update labels
+gh issue comment <number> --body "## Agent Failure Handoff
+
+**What was attempted:** <summary of the approach taken>
+**What succeeded:** <list of steps that completed successfully>
+**What failed:** <specific error message or blocker>
+**Files changed:** <list any partial changes; include branch name if one was created>
+**Suggested next step:** <concrete recommendation for the next agent or human reviewer>
+
+*Logged by ship-loop automation*"
+
 gh issue edit <number> --add-label "agent-failed" --remove-label "in-progress"
 ```
 
@@ -177,7 +237,7 @@ gh issue close <number> --comment "Deployed and verified on production."
 ## GitHub Labels (State Machine)
 
 | Label | Meaning |
-|-------|---------|
+|-------|--------|
 | `ready` | Available for agent pickup |
 | `in-progress` | Agent is working on it |
 | `has-pr` | PR created, awaiting merge/review |

--- a/docs/ship-loop-learnings.md
+++ b/docs/ship-loop-learnings.md
@@ -1,0 +1,33 @@
+# Ship Loop Learnings
+
+Ongoing notes on improving the autonomous ship-loop process.
+
+## 2026-03-29 — Harness Design Best Practices
+
+*Source: [Anthropic Engineering — Harness Design for Long-Running Apps](https://www.anthropic.com/engineering/harness-design-long-running-apps)*
+
+### Key insight: Self-evaluation bias
+
+Models strongly tend to approve their own output. A generator agent that also evaluates its own PR will nearly always pass it. The fix is a separate evaluator agent with a skeptical prompt, running after the generator completes.
+
+### Key insight: Garbage in, garbage out
+
+Passing only an issue title to a worktree agent leaves too much ambiguity. The agent has to guess at acceptance criteria, scope, and affected files. An upfront planner step that expands the issue into a structured spec dramatically improves first-iteration quality — and failures become more actionable when they reference concrete criteria.
+
+### Key insight: Stateless retries waste budget
+
+When an agent fails and the next agent starts from scratch, effort is duplicated. A structured failure handoff (what was attempted, what succeeded, what failed, suggested next step) lets the next agent or human pick up efficiently.
+
+### Changes applied (closes #46)
+
+| Phase | Change | Priority |
+|-------|--------|----------|
+| B0 (new) | Issue enrichment — planner expands issue to spec before agent launch | P1 |
+| B2 (new) | Evaluator phase — separate skeptical agent reviews PR diff vs criteria | P0 |
+| B3 (updated) | Structured failure handoffs — agent-failed comments include full context | P2 |
+
+### Future improvements to consider
+
+- Upgrade smoke tests to Playwright `@smoke` tag for faster, more reliable verification
+- Per-issue cost tracking (log `--max-budget` vs actual spend from agent run output)
+- Model selection per phase: Haiku for planner/evaluator (cheap), Sonnet for generator (capable)


### PR DESCRIPTION
## Summary

Applies three harness design best practices from the [Anthropic engineering blog](https://www.anthropic.com/engineering/harness-design-long-running-apps) to the ship-loop skill:

- **B0 (new) — Issue Enrichment**: Before launching the worktree agent, a planner sub-agent expands the raw issue title into a structured spec (goal, acceptance criteria, affected files, edge cases, out of scope). Passes the enriched spec to the agent instead of just the title.
- **B2 (new) — Evaluator Phase**: After the worktree agent creates a PR, a separate skeptical evaluator agent reviews the diff against the acceptance criteria. One retry on fail; second fail → `agent-failed`. Addresses self-evaluation bias.
- **B3 (updated) — Structured Failure Handoffs**: `agent-failed` comments now include what was attempted, what succeeded, what failed, files changed, and a suggested next step — so the next agent or human can pick up without starting from scratch.

Also adds `docs/ship-loop-learnings.md` to capture the reasoning and note future improvements (Playwright smoke tests, per-issue cost tracking, model selection per phase).

## Test plan

- [ ] Review updated `SKILL.md` — phases B0, B1, B2, B3 flow logically
- [ ] Verify evaluator prompt is concrete and skeptical (references file/line numbers)
- [ ] Verify failure handoff template covers all useful context fields
- [ ] Run a ship-loop iteration manually and confirm enrichment + evaluator steps execute

Closes #46

https://claude.ai/code/session_01RnkerdTsJNNNVENK2ntuL6