### PR TITLE
ci: parallelize lint and typecheck as concurrent jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint-typecheck:
-    name: Lint & Typecheck
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
 
     steps:
@@ -37,13 +37,36 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter @mbe/users-service db:generate
+
       - name: Typecheck
         run: pnpm typecheck
 
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: lint-typecheck
+    needs: [lint, typecheck]
 
     steps:
       - name: Checkout
@@ -82,7 +105,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    needs: lint-typecheck
+    needs: [lint, typecheck]
 
     steps:
       - name: Checkout
@@ -116,7 +139,7 @@ jobs:
   migrations:
     name: Validate Migrations
     runs-on: ubuntu-latest
-    needs: lint-typecheck
+    needs: [lint, typecheck]
 
     services:
       postgres:


### PR DESCRIPTION
## Summary
- Splits the `lint-typecheck` job into separate `lint` and `typecheck` jobs that run concurrently
- Updates `build`, `test`, and `migrations` jobs to depend on both `[lint, typecheck]`
- Reduces CI wall-clock time by running lint and typecheck in parallel

Closes #74

## Test plan
- [ ] Verify both `lint` and `typecheck` jobs appear in CI run
- [ ] Verify `build`, `test`, and `migrations` jobs wait for both to pass
- [ ] Confirm overall CI time is reduced