### PR TITLE
ci: add post-deploy verification to deploy workflows

### DIFF
--- a/.github/workflows/deploy-services.yml
+++ b/.github/workflows/deploy-services.yml
@@ -37,3 +37,26 @@ jobs:
           fi
           echo "Triggering deployment for app $APP_ID"
           doctl apps create-deployment "$APP_ID" --wait
+
+  verify:
+    name: Post-Deploy Verification
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - name: Verify users API health
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 https://api.mattbutlerengineering.com/health)
+          if [ "$STATUS" != "200" ]; then
+            echo "::error::Users API health check returned HTTP $STATUS (expected 200)"
+            exit 1
+          fi
+          echo "Users API health OK (HTTP $STATUS)"
+
+      - name: Verify reservations API health
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 https://api.mattbutlerengineering.com/api/health)
+          if [ "$STATUS" != "200" ]; then
+            echo "::error::Reservations API health check returned HTTP $STATUS (expected 200)"
+            exit 1
+          fi
+          echo "Reservations API health OK (HTTP $STATUS)"

--- a/.github/workflows/deploy-static.yml
+++ b/.github/workflows/deploy-static.yml
@@ -136,3 +136,43 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.MBE_CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
+  verify:
+    name: Post-Deploy Verification
+    runs-on: ubuntu-latest
+    needs: [detect-changes, deploy-marketing, deploy-hospitality, deploy-rialto-web]
+    if: |
+      always() &&
+      (needs.deploy-marketing.result == 'success' ||
+       needs.deploy-hospitality.result == 'success' ||
+       needs.deploy-rialto-web.result == 'success')
+    steps:
+      - name: Verify marketing site
+        if: needs.detect-changes.outputs.marketing == 'true'
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 https://mattbutlerengineering.com/)
+          if [ "$STATUS" != "200" ]; then
+            echo "::error::Marketing site returned HTTP $STATUS (expected 200)"
+            exit 1
+          fi
+          echo "Marketing site OK (HTTP $STATUS)"
+
+      - name: Verify hospitality app
+        if: needs.detect-changes.outputs.hospitality == 'true'
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 https://mattbutlerengineering.com/hospitality)
+          if [ "$STATUS" != "200" ]; then
+            echo "::error::Hospitality app returned HTTP $STATUS (expected 200)"
+            exit 1
+          fi
+          echo "Hospitality app OK (HTTP $STATUS)"
+
+      - name: Verify rialto web
+        if: needs.detect-changes.outputs.rialto-web == 'true'
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 https://mattbutlerengineering.com/rialto)
+          if [ "$STATUS" != "200" ]; then
+            echo "::error::Rialto web returned HTTP $STATUS (expected 200)"
+            exit 1
+          fi
+          echo "Rialto web OK (HTTP $STATUS)"
+


### PR DESCRIPTION
## Summary
- Adds `verify` job to `deploy-services.yml` that checks API health endpoints after deploy
- Adds `verify` job to `deploy-static.yml` that checks each static site returns 200 (only for changed apps)
- Uses `always()` + conditional logic so verification runs even if some deploy jobs were skipped

Closes #60

## Test plan
- [ ] Verify `verify` job appears in deploy-static workflow runs
- [ ] Verify `verify` job appears in deploy-services workflow runs
- [ ] Confirm verification only checks endpoints for apps that were actually deployed