### PR TITLE
feat(site-audit): skip smoke audit when only docs/configs/tests changed

### DIFF
--- a/packages/agent-core/src/__tests__/audit-inventory.test.ts
+++ b/packages/agent-core/src/__tests__/audit-inventory.test.ts
@@ -16,6 +16,8 @@ import {
   loadInventory,
   saveInventory,
   mapFilesToSurfaces,
+  isNonAuditableFile,
+  allFilesNonAuditable,
   findStalestZone,
   updateSurfaceScore,
   detectRegression,
@@ -172,6 +174,103 @@ describe("saveInventory", () => {
       "/repo/.audit-state/inventory.json",
       expect.stringContaining("marketing:home")
     );
+  });
+});
+
+// ── isNonAuditableFile ──────────────────────────────────────────────
+
+describe("isNonAuditableFile", () => {
+  it("returns true for markdown files", () => {
+    expect(isNonAuditableFile("README.md")).toBe(true);
+    expect(isNonAuditableFile("docs/architecture.md")).toBe(true);
+  });
+
+  it("returns true for all files under docs/ directory", () => {
+    expect(isNonAuditableFile("docs/evaluations/2026-03-29-test.md")).toBe(true);
+    expect(isNonAuditableFile("docs/guides/setup.txt")).toBe(true);
+  });
+
+  it("returns true for all files under .github/ directory", () => {
+    expect(isNonAuditableFile(".github/workflows/ci.yml")).toBe(true);
+    expect(isNonAuditableFile(".github/CODEOWNERS")).toBe(true);
+  });
+
+  it("returns true for YAML files", () => {
+    expect(isNonAuditableFile(".github/workflows/deploy.yml")).toBe(true);
+    expect(isNonAuditableFile("some-config.yaml")).toBe(true);
+  });
+
+  it("returns true for test files", () => {
+    expect(isNonAuditableFile("src/utils.test.ts")).toBe(true);
+    expect(isNonAuditableFile("src/components/Button.test.tsx")).toBe(true);
+    expect(isNonAuditableFile("src/utils.spec.js")).toBe(true);
+  });
+
+  it("returns true for .claude/ directory", () => {
+    expect(isNonAuditableFile(".claude/skills/site-audit/SKILL.md")).toBe(true);
+    expect(isNonAuditableFile(".claude/agents/planner.md")).toBe(true);
+  });
+
+  it("returns true for .gitignore", () => {
+    expect(isNonAuditableFile(".gitignore")).toBe(true);
+  });
+
+  it("returns true for turbo.json", () => {
+    expect(isNonAuditableFile("turbo.json")).toBe(true);
+  });
+
+  it("returns false for source files", () => {
+    expect(isNonAuditableFile("apps/marketing/src/App.tsx")).toBe(false);
+    expect(isNonAuditableFile("packages/rialto/src/Button.tsx")).toBe(false);
+    expect(isNonAuditableFile("services/users/src/routes/users.ts")).toBe(false);
+    expect(isNonAuditableFile("infrastructure/worker/edge-router.js")).toBe(false);
+  });
+
+  it("returns false for package.json", () => {
+    expect(isNonAuditableFile("package.json")).toBe(false);
+    expect(isNonAuditableFile("apps/marketing/package.json")).toBe(false);
+  });
+});
+
+// ── allFilesNonAuditable ────────────────────────────────────────────
+
+describe("allFilesNonAuditable", () => {
+  it("returns true when all files are non-auditable", () => {
+    expect(allFilesNonAuditable([
+      "docs/guide.md",
+      ".github/workflows/ci.yml",
+      "src/utils.test.ts",
+      ".gitignore",
+      "turbo.json",
+    ])).toBe(true);
+  });
+
+  it("returns false when any file is auditable", () => {
+    expect(allFilesNonAuditable([
+      "docs/guide.md",
+      "apps/marketing/src/App.tsx",
+    ])).toBe(false);
+  });
+
+  it("returns false for empty list", () => {
+    expect(allFilesNonAuditable([])).toBe(false);
+  });
+
+  it("returns false for a single auditable file", () => {
+    expect(allFilesNonAuditable(["packages/rialto/src/Button.tsx"])).toBe(false);
+  });
+
+  it("returns true for a single non-auditable file", () => {
+    expect(allFilesNonAuditable(["README.md"])).toBe(true);
+  });
+
+  it("returns true for a mix of docs and CI changes", () => {
+    expect(allFilesNonAuditable([
+      "docs/evaluations/2026-03-29-database.md",
+      ".claude/skills/site-audit/SKILL.md",
+      ".github/workflows/deploy-static.yml",
+      "services/users/src/routes/users.test.ts",
+    ])).toBe(true);
   });
 });
 

--- a/packages/agent-core/src/audit-inventory.ts
+++ b/packages/agent-core/src/audit-inventory.ts
@@ -240,6 +240,46 @@ export async function saveInventory(
   await writeFile(filePath, JSON.stringify(inventory, null, 2));
 }
 
+// ── Non-Auditable File Detection ────────────────────────────────────
+
+/**
+ * Glob-style patterns for files that never affect auditable surfaces.
+ * When ALL changed files match these patterns, the smoke audit can be skipped entirely.
+ */
+const NON_AUDITABLE_PATTERNS: readonly RegExp[] = [
+  // Documentation
+  /^docs\//,
+  /\.md$/,
+  // CI / GitHub config
+  /^\.github\//,
+  /\.ya?ml$/,
+  // Test files
+  /\.(test|spec)\.(ts|tsx|js|jsx)$/,
+  // Claude / editor / repo config
+  /^\.claude\//,
+  /^\.gitignore$/,
+  /^turbo\.json$/,
+];
+
+/**
+ * Returns true when the file is known to have no effect on any auditable surface.
+ * The smoke audit can be skipped when every changed file satisfies this check.
+ */
+export function isNonAuditableFile(filePath: string): boolean {
+  return NON_AUDITABLE_PATTERNS.some((pattern) => pattern.test(filePath));
+}
+
+/**
+ * Returns true when every file in the list is non-auditable, meaning no
+ * Lighthouse or API health checks are needed for this set of changes.
+ *
+ * An empty list returns false (nothing to skip).
+ */
+export function allFilesNonAuditable(changedFiles: readonly string[]): boolean {
+  if (changedFiles.length === 0) return false;
+  return changedFiles.every(isNonAuditableFile);
+}
+
 // ── File-to-Surface Mapping ─────────────────────────────────────────
 
 const FRONTEND_ZONES: readonly Zone[] = ["marketing", "hospitality", "rialto", "gen"];

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -5,6 +5,8 @@ export {
   saveInventory,
   mergeInventory,
   mapFilesToSurfaces,
+  isNonAuditableFile,
+  allFilesNonAuditable,
   findStalestZone,
   updateSurfaceScore,
   detectRegression,


### PR DESCRIPTION
## Summary

- Adds `isNonAuditableFile(filePath)` to `audit-inventory.ts` — returns `true` when a file matches non-auditable patterns (docs, markdown, CI configs, test files, `.claude/`, `.gitignore`, `turbo.json`)
- Adds `allFilesNonAuditable(changedFiles)` — returns `true` when every changed file is non-auditable, enabling the smoke audit to be skipped entirely
- Exports both helpers from `@mbe/agent-core` index
- Adds 16 new unit tests (44 total in audit-inventory suite, all passing)

Closes #80

## Non-auditable patterns covered

| Pattern | Example |
|---------|---------|
| `docs/**` | `docs/evaluations/2026-03-29-db.md` |
| `*.md` | `README.md`, `CLAUDE.md` |
| `.github/**` | `.github/workflows/ci.yml` |
| `*.yml` / `*.yaml` | `deploy-static.yml` |
| `**/*.test.ts` / `**/*.test.tsx` | `src/utils.test.ts` |
| `.claude/**` | `.claude/skills/site-audit/SKILL.md` |
| `.gitignore` | `.gitignore` |
| `turbo.json` | `turbo.json` |

## How smoke mode uses this

The site-audit SKILL.md documents that after `git diff HEAD~1 --name-only`, the smoke audit should call `allFilesNonAuditable(changedFiles)` and print `"Skipping smoke audit: only docs/configs/tests changed."` when all files are non-auditable.

## Test plan

- [x] `isNonAuditableFile` returns `true` for all covered patterns
- [x] `isNonAuditableFile` returns `false` for source files (`apps/`, `packages/`, `services/`, `infrastructure/`)
- [x] `allFilesNonAuditable` returns `true` when all files are non-auditable
- [x] `allFilesNonAuditable` returns `false` when any file is auditable
- [x] `allFilesNonAuditable` returns `false` for empty list (no skip on empty)
- [x] Typecheck passes (`pnpm typecheck`)
- [x] All 44 audit-inventory tests pass