### PR TITLE
perf(agent-core): add lightweight branch mode for small changes

### DIFF
--- a/packages/agent-core/src/__tests__/worktree-manager.test.ts
+++ b/packages/agent-core/src/__tests__/worktree-manager.test.ts
@@ -15,6 +15,7 @@ vi.mock("node:fs/promises", () => ({
 
 import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
+import { rm } from "node:fs/promises";
 import {
   createWorktree,
   removeWorktree,
@@ -40,19 +41,43 @@ function setupExecFileMock(stdoutResponses: string[] = [""]) {
   );
 }
 
-describe("createWorktree", () => {
+// ── Full worktree mode (default) ──────────────────────────────────────────────
+
+describe("createWorktree (full mode)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("creates a worktree with a generated branch name", async () => {
+  it("creates a full worktree with a generated branch name", async () => {
     setupExecFileMock([""]);
 
     const result = await createWorktree("/repo", "main", "Fix login bug");
 
     expect(result.branchName).toMatch(/^agent\/fix-login-bug-[a-f0-9]{6}$/);
     expect(result.path).toContain(".agent-worktrees");
+    expect(result.mode).toBe("full");
     expect(execFile).toHaveBeenCalled();
+  });
+
+  it("defaults to full mode when no options are provided", async () => {
+    setupExecFileMock([""]);
+
+    const result = await createWorktree("/repo", "main", "task");
+
+    expect(result.mode).toBe("full");
+  });
+
+  it("explicitly uses full mode when mode: 'full' is passed", async () => {
+    setupExecFileMock([""]);
+
+    const result = await createWorktree("/repo", "main", "task", { mode: "full" });
+
+    expect(result.mode).toBe("full");
+    // 'git worktree add' should be the command used
+    const calls = vi.mocked(execFile).mock.calls;
+    const gitArgs = calls[0][1] as string[];
+    expect(gitArgs).toContain("worktree");
+    expect(gitArgs).toContain("add");
   });
 
   it("generates branch names from task descriptions", async () => {
@@ -75,17 +100,97 @@ describe("createWorktree", () => {
   });
 });
 
+// ── Lightweight worktree mode ────────────────────────────────────────────────
+
+describe("createWorktree (lightweight mode)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a lightweight clone and returns mode: 'lightweight'", async () => {
+    // Two execFile calls: git clone, then git checkout -b
+    setupExecFileMock(["", ""]);
+
+    const result = await createWorktree("/repo", "main", "Fix typo", { mode: "lightweight" });
+
+    expect(result.branchName).toMatch(/^agent\/fix-typo-[a-f0-9]{6}$/);
+    expect(result.path).toContain(".agent-worktrees");
+    expect(result.mode).toBe("lightweight");
+  });
+
+  it("uses git clone --depth 1 for the shallow clone step", async () => {
+    setupExecFileMock(["", ""]);
+
+    await createWorktree("/repo", "main", "Fix typo", { mode: "lightweight" });
+
+    const calls = vi.mocked(execFile).mock.calls;
+    // First call should be the clone
+    const firstArgs = calls[0][1] as string[];
+    expect(firstArgs).toContain("clone");
+    expect(firstArgs).toContain("--depth");
+    expect(firstArgs).toContain("1");
+  });
+
+  it("creates a new branch in the cloned directory", async () => {
+    setupExecFileMock(["", ""]);
+
+    const result = await createWorktree("/repo", "main", "Fix typo", { mode: "lightweight" });
+
+    const calls = vi.mocked(execFile).mock.calls;
+    // Second call should be the branch creation
+    const secondArgs = calls[1][1] as string[];
+    expect(secondArgs).toContain("checkout");
+    expect(secondArgs).toContain("-b");
+    expect(secondArgs).toContain(result.branchName);
+  });
+
+  it("places the clone under .agent-worktrees with the branch name as directory", async () => {
+    setupExecFileMock(["", ""]);
+
+    const result = await createWorktree("/repo", "main", "Fix typo", { mode: "lightweight" });
+
+    expect(result.path).toMatch(/\.agent-worktrees\/agent-fix-typo-[a-f0-9]{6}$/);
+  });
+});
+
+// ── removeWorktree ────────────────────────────────────────────────────────────
+
 describe("removeWorktree", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("removes an existing worktree", async () => {
+  it("removes an existing full worktree via git worktree remove", async () => {
+    vi.mocked(existsSync).mockReturnValueOnce(true);
+    setupExecFileMock([""]);
+
+    await removeWorktree("/repo", "/repo/.agent-worktrees/test", "full");
+    expect(execFile).toHaveBeenCalled();
+    const gitArgs = vi.mocked(execFile).mock.calls[0][1] as string[];
+    expect(gitArgs).toContain("worktree");
+    expect(gitArgs).toContain("remove");
+  });
+
+  it("removes an existing lightweight worktree via rm (no git command)", async () => {
+    vi.mocked(existsSync).mockReturnValueOnce(true);
+    vi.mocked(rm).mockResolvedValueOnce(undefined);
+
+    await removeWorktree("/repo", "/repo/.agent-worktrees/test", "lightweight");
+
+    expect(execFile).not.toHaveBeenCalled();
+    expect(rm).toHaveBeenCalledWith("/repo/.agent-worktrees/test", {
+      recursive: true,
+      force: true,
+    });
+  });
+
+  it("defaults to full mode when no mode is passed", async () => {
     vi.mocked(existsSync).mockReturnValueOnce(true);
     setupExecFileMock([""]);
 
     await removeWorktree("/repo", "/repo/.agent-worktrees/test");
-    expect(execFile).toHaveBeenCalled();
+    const gitArgs = vi.mocked(execFile).mock.calls[0][1] as string[];
+    expect(gitArgs).toContain("worktree");
   });
 
   it("skips removal if worktree does not exist", async () => {
@@ -93,8 +198,11 @@ describe("removeWorktree", () => {
 
     await removeWorktree("/repo", "/repo/.agent-worktrees/nonexistent");
     expect(execFile).not.toHaveBeenCalled();
+    expect(rm).not.toHaveBeenCalled();
   });
 });
+
+// ── commitChanges ─────────────────────────────────────────────────────────────
 
 describe("commitChanges", () => {
   beforeEach(() => {
@@ -115,6 +223,8 @@ describe("commitChanges", () => {
     expect(sha).toBe("");
   });
 });
+
+// ── hasChanges ────────────────────────────────────────────────────────────────
 
 describe("hasChanges", () => {
   beforeEach(() => {

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -33,6 +33,7 @@ export {
   pushBranch,
   hasChanges,
 } from "./worktree-manager.js";
+export type { CreateWorktreeOptions } from "./worktree-manager.js";
 
 // PR creation
 export {
@@ -71,11 +72,13 @@ export type {
 export {
   evaluateSuccess,
   getGitDiff,
+  shouldEvaluate,
   DEFAULT_EVALUATION_CONFIG,
 } from "./success-evaluator.js";
 export type {
   EvaluationResult,
   EvaluationConfig,
+  ShouldEvaluateConfig,
 } from "./success-evaluator.js";
 
 // Failure memory
@@ -139,6 +142,7 @@ export type {
   SessionEventCallback,
   TokenUsage,
   WorktreeInfo,
+  WorktreeMode,
   PrResult,
   PrOptions,
 } from "./types.js";

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -87,9 +87,16 @@ export type SessionEventCallback = (event: SessionEvent) => void;
 
 // ── Worktree ─────────────────────────────────────────────────────────
 
+/**
+ * 'full'        – git worktree add (full working tree, current behavior)
+ * 'lightweight' – shallow clone + checkout -b (faster for small changes)
+ */
+export type WorktreeMode = "full" | "lightweight";
+
 export interface WorktreeInfo {
   readonly path: string;
   readonly branchName: string;
+  readonly mode: WorktreeMode;
 }
 
 // ── PR creation ──────────────────────────────────────────────────────

--- a/packages/agent-core/src/worktree-manager.ts
+++ b/packages/agent-core/src/worktree-manager.ts
@@ -4,7 +4,7 @@ import { existsSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { join } from "node:path";
 import { randomBytes } from "node:crypto";
-import type { WorktreeInfo } from "./types.js";
+import type { WorktreeInfo, WorktreeMode } from "./types.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -20,35 +20,84 @@ function generateBranchName(taskDescription: string): string {
   return `agent/${slug}-${suffix}`;
 }
 
-async function git(
-  args: readonly string[],
-  cwd: string
-): Promise<string> {
+async function git(args: readonly string[], cwd: string): Promise<string> {
   const { stdout } = await execFileAsync("git", [...args], { cwd });
   return stdout.trim();
+}
+
+/**
+ * Create a full git worktree for the given task. This is the default mode and
+ * suits tasks that touch many files. The worktree is placed under
+ * `.agent-worktrees/` inside the repo.
+ */
+async function createFullWorktree(
+  repoPath: string,
+  baseBranch: string,
+  branchName: string
+): Promise<string> {
+  const worktreePath = join(repoPath, WORKTREE_DIR, branchName.replace(/\//g, "-"));
+  await git(["worktree", "add", "-b", branchName, worktreePath, baseBranch], repoPath);
+  return worktreePath;
+}
+
+/**
+ * Create a lightweight clone for the given task. A shallow clone is faster for
+ * small, isolated changes (1-2 files). The clone is placed under
+ * `.agent-worktrees/` inside the repo and a fresh branch is checked out.
+ */
+async function createLightweightWorktree(
+  repoPath: string,
+  baseBranch: string,
+  branchName: string
+): Promise<string> {
+  const clonePath = join(repoPath, WORKTREE_DIR, branchName.replace(/\//g, "-"));
+  // Shallow clone from the local repo; --depth 1 keeps it fast and minimal.
+  await execFileAsync("git", ["clone", "--depth", "1", "--branch", baseBranch, repoPath, clonePath]);
+  // Create and switch to the task branch inside the clone.
+  await git(["checkout", "-b", branchName], clonePath);
+  return clonePath;
+}
+
+export interface CreateWorktreeOptions {
+  /**
+   * 'full'        – git worktree add (default; suited for multi-file changes)
+   * 'lightweight' – shallow clone (faster; suited for 1-2 file changes)
+   */
+  readonly mode?: WorktreeMode;
 }
 
 export async function createWorktree(
   repoPath: string,
   baseBranch: string,
-  taskDescription: string
+  taskDescription: string,
+  options: CreateWorktreeOptions = {}
 ): Promise<WorktreeInfo> {
+  const mode = options.mode ?? "full";
   const branchName = generateBranchName(taskDescription);
-  const worktreePath = join(repoPath, WORKTREE_DIR, branchName.replace(/\//g, "-"));
 
-  await git(["worktree", "add", "-b", branchName, worktreePath, baseBranch], repoPath);
+  const worktreePath =
+    mode === "lightweight"
+      ? await createLightweightWorktree(repoPath, baseBranch, branchName)
+      : await createFullWorktree(repoPath, baseBranch, branchName);
 
-  return { path: worktreePath, branchName };
+  return { path: worktreePath, branchName, mode };
 }
 
 export async function removeWorktree(
   repoPath: string,
-  worktreePath: string
+  worktreePath: string,
+  mode: WorktreeMode = "full"
 ): Promise<void> {
   if (!existsSync(worktreePath)) {
     return;
   }
-  await git(["worktree", "remove", worktreePath, "--force"], repoPath);
+
+  if (mode === "lightweight") {
+    // Lightweight clones are standalone directories — just remove them.
+    await rm(worktreePath, { recursive: true, force: true });
+  } else {
+    await git(["worktree", "remove", worktreePath, "--force"], repoPath);
+  }
 }
 
 export async function cleanupWorktrees(repoPath: string): Promise<void> {


### PR DESCRIPTION
## Summary

- Add `mode: 'full' | 'lightweight'` option to `createWorktree` and `removeWorktree` in `worktree-manager.ts`
- Lightweight mode uses `git clone --depth 1` + `checkout -b` instead of `git worktree add`, making it faster for 1-2 file changes
- Cleanup for lightweight worktrees uses `rm -rf` instead of `git worktree remove` (standalone clone, not a registered worktree)
- Export new `WorktreeMode` type and `CreateWorktreeOptions` interface from the package root
- Both modes default to `"full"` for backward compatibility

## Test plan

- [ ] All 17 worktree-manager tests pass (`pnpm test` in `packages/agent-core`)
- [ ] Verify `createWorktree("/repo", "main", "Fix typo", { mode: "lightweight" })` calls `git clone --depth 1` then `git checkout -b`
- [ ] Verify `createWorktree("/repo", "main", "Big feature")` still calls `git worktree add` (full mode default)
- [ ] Verify `removeWorktree(repo, path, "lightweight")` calls `rm` not `git worktree remove`
- [ ] Verify `removeWorktree(repo, path)` still defaults to full mode behavior
- [ ] Typecheck passes: `pnpm typecheck`
- [ ] Lint passes: `pnpm lint`

Closes #78