### PR TITLE
perf(agent-core): skip LLM success evaluation for trivial diffs

### DIFF
--- a/packages/agent-core/src/__tests__/session-runner.test.ts
+++ b/packages/agent-core/src/__tests__/session-runner.test.ts
@@ -24,6 +24,7 @@ vi.mock("../pr-creator.js", () => ({
 vi.mock("../success-evaluator.js", () => ({
   evaluateSuccess: vi.fn(),
   getGitDiff: vi.fn(),
+  shouldEvaluate: vi.fn().mockReturnValue(true),
 }));
 
 vi.mock("../failure-memory.js", () => ({

--- a/packages/agent-core/src/__tests__/success-evaluator.test.ts
+++ b/packages/agent-core/src/__tests__/success-evaluator.test.ts
@@ -14,7 +14,7 @@ vi.mock("node:util", () => ({
 
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import { execFile } from "node:child_process";
-import { evaluateSuccess, getGitDiff } from "../success-evaluator.js";
+import { evaluateSuccess, getGitDiff, shouldEvaluate } from "../success-evaluator.js";
 
 async function* mockQueryGenerator(messages: unknown[]) {
   for (const msg of messages) {
@@ -241,5 +241,104 @@ describe("getGitDiff", () => {
     const diff = await getGitDiff("/not-a-repo");
 
     expect(diff).toBe("");
+  });
+});
+
+// ── shouldEvaluate ────────────────────────────────────────────────────
+
+function buildDiff(files: string[], linesPerFile = 5): string {
+  return files
+    .map((f) => {
+      const lines = Array.from({ length: linesPerFile }, (_, i) => `+line ${i + 1}`).join("\n");
+      return `diff --git a/${f} b/${f}\n${lines}`;
+    })
+    .join("\n");
+}
+
+describe("shouldEvaluate", () => {
+  it("returns true for a normal non-trivial diff", () => {
+    const diff = buildDiff(["src/routes.ts"], 60);
+    expect(shouldEvaluate(diff, {})).toBe(true);
+  });
+
+  it("returns true for an empty diff (let evaluateSuccess handle it)", () => {
+    expect(shouldEvaluate("", {})).toBe(true);
+  });
+
+  // ── Condition 1: small diff + tests passed ────────────────────────
+
+  it("returns false when diff < 50 lines and tests passed", () => {
+    const diff = buildDiff(["src/routes.ts"], 20);
+    expect(shouldEvaluate(diff, { testsPassed: true })).toBe(false);
+  });
+
+  it("returns true when diff < 50 lines but tests did NOT pass", () => {
+    const diff = buildDiff(["src/routes.ts"], 20);
+    expect(shouldEvaluate(diff, { testsPassed: false })).toBe(true);
+  });
+
+  it("returns true when diff < 50 lines and testsPassed is undefined", () => {
+    const diff = buildDiff(["src/routes.ts"], 20);
+    expect(shouldEvaluate(diff, {})).toBe(true);
+  });
+
+  it("returns true when diff >= 50 lines even if tests passed", () => {
+    const diff = buildDiff(["src/routes.ts"], 55);
+    expect(shouldEvaluate(diff, { testsPassed: true })).toBe(true);
+  });
+
+  // ── Condition 2: dependency bump commit title ─────────────────────
+
+  it("returns false for chore(deps): commit title", () => {
+    const diff = buildDiff(["package.json"], 100);
+    expect(shouldEvaluate(diff, { commitTitle: "chore(deps): bump lodash to 4.18" })).toBe(false);
+  });
+
+  it("returns false for fix(security): commit title", () => {
+    const diff = buildDiff(["package-lock.json"], 200);
+    expect(shouldEvaluate(diff, { commitTitle: "fix(security): patch CVE-2025-1234" })).toBe(false);
+  });
+
+  it("is case-insensitive for dependency bump titles", () => {
+    const diff = buildDiff(["package.json"], 100);
+    expect(shouldEvaluate(diff, { commitTitle: "CHORE(DEPS): upgrade all" })).toBe(false);
+  });
+
+  it("returns true for a regular feat: commit title", () => {
+    const diff = buildDiff(["src/feature.ts"], 100);
+    expect(shouldEvaluate(diff, { commitTitle: "feat: add new endpoint" })).toBe(true);
+  });
+
+  // ── Condition 3: only test files changed ─────────────────────────
+
+  it("returns false when only .test.ts files changed", () => {
+    const diff = buildDiff(["src/routes.test.ts", "src/utils.test.ts"], 60);
+    expect(shouldEvaluate(diff, {})).toBe(false);
+  });
+
+  it("returns false when only .spec.ts files changed", () => {
+    const diff = buildDiff(["src/auth.spec.ts"], 60);
+    expect(shouldEvaluate(diff, {})).toBe(false);
+  });
+
+  it("returns false when only .test.js files changed", () => {
+    const diff = buildDiff(["src/helpers.test.js"], 60);
+    expect(shouldEvaluate(diff, {})).toBe(false);
+  });
+
+  it("returns false when only .spec.jsx files changed", () => {
+    const diff = buildDiff(["src/Button.spec.jsx"], 60);
+    expect(shouldEvaluate(diff, {})).toBe(false);
+  });
+
+  it("returns true when mix of test and non-test files changed", () => {
+    const diff = buildDiff(["src/routes.ts", "src/routes.test.ts"], 60);
+    expect(shouldEvaluate(diff, {})).toBe(true);
+  });
+
+  it("returns true when no file headers are present in diff", () => {
+    // A diff with changes but no 'diff --git' header — can't classify as test-only
+    const diff = "+some change\n-old line";
+    expect(shouldEvaluate(diff, {})).toBe(true);
   });
 });

--- a/packages/agent-core/src/session-runner.ts
+++ b/packages/agent-core/src/session-runner.ts
@@ -25,7 +25,7 @@ import {
   buildPrBody,
   buildFailurePrBody,
 } from "./pr-creator.js";
-import { evaluateSuccess, getGitDiff } from "./success-evaluator.js";
+import { evaluateSuccess, getGitDiff, shouldEvaluate } from "./success-evaluator.js";
 import type { EvaluationResult } from "./success-evaluator.js";
 import { mapSdkMessage } from "./event-mapper.js";
 import {
@@ -158,15 +158,21 @@ export async function runSession(
       let evaluationPassed = isSuccess;
       if (isSuccess && config.evaluateSuccess !== false) {
         const diff = await getGitDiff(worktree.path);
-        evaluation = await evaluateSuccess(config.taskDescription, diff);
-        evaluationPassed = evaluation.passed;
+        if (!shouldEvaluate(diff, { commitTitle: commitMsg })) {
+          emitEvent(onEvent, "session:evaluation", {
+            message: "Evaluation skipped — trivial diff",
+          });
+        } else {
+          evaluation = await evaluateSuccess(config.taskDescription, diff);
+          evaluationPassed = evaluation.passed;
 
-        emitEvent(onEvent, "session:evaluation", {
-          message: `Evaluation: ${evaluation.passed ? "PASS" : "FAIL"} (confidence: ${evaluation.confidence.toFixed(2)})`,
-        });
+          emitEvent(onEvent, "session:evaluation", {
+            message: `Evaluation: ${evaluation.passed ? "PASS" : "FAIL"} (confidence: ${evaluation.confidence.toFixed(2)})`,
+          });
 
-        if (!evaluation.passed) {
-          errors.push(`Evaluation failed: ${evaluation.reasoning}`);
+          if (!evaluation.passed) {
+            errors.push(`Evaluation failed: ${evaluation.reasoning}`);
+          }
         }
       }
 

--- a/packages/agent-core/src/success-evaluator.ts
+++ b/packages/agent-core/src/success-evaluator.ts
@@ -33,6 +33,66 @@ const INCONCLUSIVE_RESULT: EvaluationResult = {
 
 const MAX_DIFF_LENGTH = 50_000;
 
+// ── Skip-evaluation heuristics ──────────────────────────────────────
+
+export interface ShouldEvaluateConfig {
+  /** Whether tests passed during the agent run */
+  readonly testsPassed?: boolean;
+  /** Commit title, used for dependency bump detection */
+  readonly commitTitle?: string;
+}
+
+const TRIVIAL_TITLE_PATTERNS = [/^fix\(security\):/i, /^chore\(deps\):/i];
+
+/** Count the number of changed lines (additions + deletions) in a diff. */
+function countDiffLines(diff: string): number {
+  return diff.split("\n").filter((line) => line.startsWith("+") || line.startsWith("-")).length;
+}
+
+/**
+ * Returns false when the LLM evaluation step can safely be skipped.
+ *
+ * Conditions that skip evaluation:
+ * 1. Diff is < 50 lines AND tests passed
+ * 2. Commit title matches a dependency-bump pattern
+ * 3. Every changed file is a test file (*.test.ts / *.spec.ts / *.test.js / *.spec.js)
+ */
+export function shouldEvaluate(diff: string, config: ShouldEvaluateConfig = {}): boolean {
+  if (!diff.trim()) {
+    // Empty diff — evaluateSuccess handles this case directly; don't skip
+    return true;
+  }
+
+  // Condition 2: dependency bump by commit title
+  const { commitTitle } = config;
+  if (commitTitle && TRIVIAL_TITLE_PATTERNS.some((re) => re.test(commitTitle))) {
+    return false;
+  }
+
+  // Condition 3: only test files changed
+  const changedFiles = diff
+    .split("\n")
+    .filter((line) => line.startsWith("diff --git "))
+    .map((line) => {
+      // e.g. "diff --git a/src/foo.test.ts b/src/foo.test.ts"
+      const match = line.match(/diff --git a\/.+ b\/(.+)$/);
+      return match ? match[1] : "";
+    })
+    .filter(Boolean);
+
+  const TEST_FILE_RE = /\.(test|spec)\.[jt]sx?$/;
+  if (changedFiles.length > 0 && changedFiles.every((f) => TEST_FILE_RE.test(f))) {
+    return false;
+  }
+
+  // Condition 1: small diff AND tests passed
+  if (config.testsPassed === true && countDiffLines(diff) < 50) {
+    return false;
+  }
+
+  return true;
+}
+
 // ── Evaluation ──────────────────────────────────────────────────────
 
 const EVALUATION_SCHEMA = {


### PR DESCRIPTION
## Summary

- Adds `shouldEvaluate(diff, config)` to `success-evaluator.ts` that returns `false` (skip LLM) for three classes of trivial diffs: small diffs (<50 changed lines) when tests passed, dependency bump commits (`chore(deps):` / `fix(security):`), and changes touching only test files
- Adds a guard in `session-runner.ts` before the `evaluateSuccess()` call using `shouldEvaluate`, emitting a `session:evaluation` event with "skipped" message instead of making the LLM call
- Exports `shouldEvaluate` and `ShouldEvaluateConfig` from the package public API

## Test plan

- [x] 16 new unit tests for `shouldEvaluate` covering all three skip conditions and their boundaries
- [x] Session-runner mock updated to include `shouldEvaluate` so existing tests continue passing
- [x] `pnpm test` — 203 tests, all passing
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)