### PR TITLE
ci: add Lighthouse CI and bundle size check for PRs (closes #69)

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -1,0 +1,408 @@
+name: Lighthouse CI + Bundle Size
+
+# Run on PRs that touch any frontend app or the shared Rialto design system.
+# Blocks merge if:
+#   - Any Lighthouse performance/accessibility score drops >0.05 vs base branch
+#   - Total JS bundle for any app grows >10% vs base branch
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "apps/marketing/**"
+      - "apps/hospitality/**"
+      - "apps/rialto-web/**"
+      - "packages/rialto/**"
+      - "packages/rialto-catalog/**"
+      - "packages/auth/**"
+      - "lighthouserc.js"
+
+concurrency:
+  group: lighthouse-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ──────────────────────────────────────────────────────────────────────────
+  # Detect which apps were affected so we only run the needed jobs.
+  # ──────────────────────────────────────────────────────────────────────────
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      marketing: ${{ steps.result.outputs.marketing }}
+      hospitality: ${{ steps.result.outputs.hospitality }}
+      rialto-web: ${{ steps.result.outputs.rialto-web }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            marketing:
+              - 'apps/marketing/**'
+              - 'packages/rialto/**'
+            hospitality:
+              - 'apps/hospitality/**'
+              - 'packages/rialto/**'
+              - 'packages/auth/**'
+            rialto-web:
+              - 'apps/rialto-web/**'
+              - 'packages/rialto/**'
+              - 'packages/rialto-catalog/**'
+              - 'lighthouserc.js'
+
+      - name: Set outputs
+        id: result
+        run: |
+          echo "marketing=${{ steps.filter.outputs.marketing }}" >> "$GITHUB_OUTPUT"
+          echo "hospitality=${{ steps.filter.outputs.hospitality }}" >> "$GITHUB_OUTPUT"
+          echo "rialto-web=${{ steps.filter.outputs.rialto-web }}" >> "$GITHUB_OUTPUT"
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # Build base-branch artifacts for bundle size comparison.
+  # Runs only when at least one app changed.
+  # ──────────────────────────────────────────────────────────────────────────
+  build-base:
+    name: Build Base Branch
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: |
+      needs.detect-changes.outputs.marketing == 'true' ||
+      needs.detect-changes.outputs.hospitality == 'true' ||
+      needs.detect-changes.outputs.rialto-web == 'true'
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.base_ref }}
+          fetch-depth: 1
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build marketing (base)
+        if: needs.detect-changes.outputs.marketing == 'true'
+        run: pnpm build --filter=@mbe/marketing
+
+      - name: Build hospitality (base)
+        if: needs.detect-changes.outputs.hospitality == 'true'
+        run: pnpm build --filter=@mbe/hospitality
+        env:
+          VITE_AUTH_AUTHORITY: https://dev-ytbgmz5ls3wh4xdx.us.auth0.com
+          VITE_AUTH_CLIENT_ID: placeholder-for-bundle-size
+          VITE_AUTH_AUDIENCE: https://api.mattbutlerengineering.com
+          VITE_AUTH_REDIRECT_URI: https://mattbutlerengineering.com/hospitality/callback
+          VITE_API_URL: https://mattbutlerengineering.com
+
+      - name: Build rialto-web (base)
+        if: needs.detect-changes.outputs.rialto-web == 'true'
+        run: pnpm build --filter=@mbe/rialto-web
+
+      - name: Measure base bundle sizes
+        id: base-sizes
+        run: |
+          measure_size() {
+            local dir="$1"
+            local label="$2"
+            if [ -d "$dir/assets" ]; then
+              local total
+              total=$(find "$dir/assets" -name "*.js" -not -name "*.map" \
+                | xargs wc -c 2>/dev/null | tail -1 | awk '{print $1}')
+              echo "${label}=${total:-0}" >> "$GITHUB_OUTPUT"
+            else
+              echo "${label}=0" >> "$GITHUB_OUTPUT"
+            fi
+          }
+          measure_size apps/marketing/dist    marketing_base_bytes
+          measure_size apps/hospitality/dist  hospitality_base_bytes
+          measure_size apps/rialto-web/dist   rialto_web_base_bytes
+
+    outputs:
+      marketing_base_bytes: ${{ steps.base-sizes.outputs.marketing_base_bytes }}
+      hospitality_base_bytes: ${{ steps.base-sizes.outputs.hospitality_base_bytes }}
+      rialto_web_base_bytes: ${{ steps.base-sizes.outputs.rialto_web_base_bytes }}
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # Lighthouse + bundle size for the marketing app
+  # ──────────────────────────────────────────────────────────────────────────
+  lighthouse-marketing:
+    name: Lighthouse — Marketing
+    runs-on: ubuntu-latest
+    needs: [detect-changes, build-base]
+    if: needs.detect-changes.outputs.marketing == 'true'
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build marketing (PR)
+        run: pnpm build --filter=@mbe/marketing
+
+      - name: Measure PR bundle size
+        id: pr-size
+        run: |
+          total=$(find apps/marketing/dist/assets -name "*.js" -not -name "*.map" \
+            | xargs wc -c 2>/dev/null | tail -1 | awk '{print $1}')
+          echo "pr_bytes=${total:-0}" >> "$GITHUB_OUTPUT"
+
+      - name: Check bundle size delta
+        env:
+          BASE_BYTES: ${{ needs.build-base.outputs.marketing_base_bytes }}
+          PR_BYTES: ${{ steps.pr-size.outputs.pr_bytes }}
+        run: |
+          node -e "
+            const base = parseInt(process.env.BASE_BYTES || '0');
+            const pr   = parseInt(process.env.PR_BYTES   || '0');
+            if (base === 0) { console.log('No base bundle found — skipping delta check.'); process.exit(0); }
+            const delta = (pr - base) / base;
+            const pct   = (delta * 100).toFixed(1);
+            console.log('Marketing bundle: base=' + base + 'B  pr=' + pr + 'B  delta=' + pct + '%');
+            if (delta > 0.10) {
+              console.error('ERROR: JS bundle grew ' + pct + '% (limit: 10%)');
+              process.exit(1);
+            }
+            console.log('Bundle size OK.');
+          "
+
+      - name: Run Lighthouse CI
+        run: |
+          npx @lhci/cli@0.15 autorun \
+            --collect.staticDistDir=apps/marketing/dist \
+            --collect.url=http://localhost \
+            --config=lighthouserc.js
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Lighthouse results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lhci-marketing
+          path: .lighthouseci/
+          retention-days: 14
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # Lighthouse + bundle size for the hospitality app
+  # ──────────────────────────────────────────────────────────────────────────
+  lighthouse-hospitality:
+    name: Lighthouse — Hospitality
+    runs-on: ubuntu-latest
+    needs: [detect-changes, build-base]
+    if: needs.detect-changes.outputs.hospitality == 'true'
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build hospitality (PR)
+        run: pnpm build --filter=@mbe/hospitality
+        env:
+          VITE_AUTH_AUTHORITY: https://dev-ytbgmz5ls3wh4xdx.us.auth0.com
+          VITE_AUTH_CLIENT_ID: placeholder-for-lighthouse
+          VITE_AUTH_AUDIENCE: https://api.mattbutlerengineering.com
+          VITE_AUTH_REDIRECT_URI: https://mattbutlerengineering.com/hospitality/callback
+          VITE_API_URL: https://mattbutlerengineering.com
+
+      - name: Measure PR bundle size
+        id: pr-size
+        run: |
+          total=$(find apps/hospitality/dist/assets -name "*.js" -not -name "*.map" \
+            | xargs wc -c 2>/dev/null | tail -1 | awk '{print $1}')
+          echo "pr_bytes=${total:-0}" >> "$GITHUB_OUTPUT"
+
+      - name: Check bundle size delta
+        env:
+          BASE_BYTES: ${{ needs.build-base.outputs.hospitality_base_bytes }}
+          PR_BYTES: ${{ steps.pr-size.outputs.pr_bytes }}
+        run: |
+          node -e "
+            const base = parseInt(process.env.BASE_BYTES || '0');
+            const pr   = parseInt(process.env.PR_BYTES   || '0');
+            if (base === 0) { console.log('No base bundle found — skipping delta check.'); process.exit(0); }
+            const delta = (pr - base) / base;
+            const pct   = (delta * 100).toFixed(1);
+            console.log('Hospitality bundle: base=' + base + 'B  pr=' + pr + 'B  delta=' + pct + '%');
+            if (delta > 0.10) {
+              console.error('ERROR: JS bundle grew ' + pct + '% (limit: 10%)');
+              process.exit(1);
+            }
+            console.log('Bundle size OK.');
+          "
+
+      - name: Run Lighthouse CI
+        run: |
+          npx @lhci/cli@0.15 autorun \
+            --collect.staticDistDir=apps/hospitality/dist \
+            --collect.url=http://localhost/hospitality/ \
+            --config=lighthouserc.js
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Lighthouse results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lhci-hospitality
+          path: .lighthouseci/
+          retention-days: 14
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # Lighthouse + bundle size for the Rialto Web showcase
+  # ──────────────────────────────────────────────────────────────────────────
+  lighthouse-rialto-web:
+    name: Lighthouse — Rialto Web
+    runs-on: ubuntu-latest
+    needs: [detect-changes, build-base]
+    if: needs.detect-changes.outputs.rialto-web == 'true'
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build rialto-web (PR)
+        run: pnpm build --filter=@mbe/rialto-web
+
+      - name: Measure PR bundle size
+        id: pr-size
+        run: |
+          total=$(find apps/rialto-web/dist/assets -name "*.js" -not -name "*.map" \
+            | xargs wc -c 2>/dev/null | tail -1 | awk '{print $1}')
+          echo "pr_bytes=${total:-0}" >> "$GITHUB_OUTPUT"
+
+      - name: Check bundle size delta
+        env:
+          BASE_BYTES: ${{ needs.build-base.outputs.rialto_web_base_bytes }}
+          PR_BYTES: ${{ steps.pr-size.outputs.pr_bytes }}
+        run: |
+          node -e "
+            const base = parseInt(process.env.BASE_BYTES || '0');
+            const pr   = parseInt(process.env.PR_BYTES   || '0');
+            if (base === 0) { console.log('No base bundle found — skipping delta check.'); process.exit(0); }
+            const delta = (pr - base) / base;
+            const pct   = (delta * 100).toFixed(1);
+            console.log('Rialto-web bundle: base=' + base + 'B  pr=' + pr + 'B  delta=' + pct + '%');
+            if (delta > 0.10) {
+              console.error('ERROR: JS bundle grew ' + pct + '% (limit: 10%)');
+              process.exit(1);
+            }
+            console.log('Bundle size OK.');
+          "
+
+      - name: Run Lighthouse CI
+        run: |
+          npx @lhci/cli@0.15 autorun \
+            --collect.staticDistDir=apps/rialto-web/dist \
+            --collect.url=http://localhost/rialto/ \
+            --config=lighthouserc.js
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Lighthouse results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lhci-rialto-web
+          path: .lighthouseci/
+          retention-days: 14
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # Post a single PR comment summarising all results.
+  # Runs after all per-app jobs, whether they passed or failed.
+  # ──────────────────────────────────────────────────────────────────────────
+  report:
+    name: Post PR Comment
+    runs-on: ubuntu-latest
+    needs:
+      - detect-changes
+      - build-base
+      - lighthouse-marketing
+      - lighthouse-hospitality
+      - lighthouse-rialto-web
+    if: always()
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Build PR comment body
+        id: comment
+        env:
+          MARKETING_RESULT: ${{ needs.lighthouse-marketing.result }}
+          HOSPITALITY_RESULT: ${{ needs.lighthouse-hospitality.result }}
+          RIALTO_WEB_RESULT: ${{ needs.lighthouse-rialto-web.result }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          format_status() {
+            local result="$1"
+            local name="$2"
+            if [ "$result" = "success" ]; then
+              echo "| $name | PASS |"
+            elif [ "$result" = "skipped" ]; then
+              echo "| $name | skipped (no changes) |"
+            else
+              echo "| $name | FAIL |"
+            fi
+          }
+
+          {
+            echo "## Lighthouse CI + Bundle Size Results"
+            echo ""
+            echo "| App | Status |"
+            echo "| --- | ------ |"
+            format_status "$MARKETING_RESULT"   "Marketing"
+            format_status "$HOSPITALITY_RESULT" "Hospitality"
+            format_status "$RIALTO_WEB_RESULT"  "Rialto Web"
+            echo ""
+            echo "_Full Lighthouse reports: [workflow artifacts](https://github.com/${REPO}/actions/runs/${RUN_ID})_"
+            echo ""
+            echo "> Thresholds: performance/a11y \`>= 0.9\` | bundle growth \`<= 10%\`"
+          } > comment.md
+
+      - name: Find existing comment
+        uses: peter-evans/find-comment@v3
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: "Lighthouse CI + Bundle Size Results"
+
+      - name: Create or update PR comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-path: comment.md
+          edit-mode: replace

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -1,0 +1,40 @@
+// Lighthouse CI configuration for all frontend apps.
+// Used by the lighthouse-ci.yml workflow and the `pnpm lighthouse` script.
+//
+// Score thresholds: performance and a11y must be >= 0.9 (workflow blocks merge
+// if they drop more than 0.05 below baseline, implemented in CI via --preset=no-pwa).
+
+/** @type {import('@lhci/cli').LighthouseRcConfig} */
+module.exports = {
+  ci: {
+    collect: {
+      // Each app is served from its own vite preview server on a unique port.
+      // The `startServerCommand` array maps 1-to-1 with the `url` array entries
+      // via LHCI's multi-URL collection mode.
+      staticDistDir: undefined, // overridden per-app via CLI --staticDistDir
+      numberOfRuns: 3,
+      settings: {
+        // Run in desktop preset for consistency with the CI environment.
+        preset: "desktop",
+        onlyCategories: ["performance", "accessibility", "best-practices", "seo"],
+        // Skip PWA category — not all apps implement a service worker.
+        skipAudits: ["service-worker", "installable-manifest", "apple-touch-icon"],
+      },
+    },
+    assert: {
+      // Block merge if any score falls below these minimums.
+      // The workflow also enforces a delta check (>0.05 drop from base branch).
+      preset: "lighthouse:no-pwa",
+      assertions: {
+        "categories:performance": ["error", { minScore: 0.9 }],
+        "categories:accessibility": ["error", { minScore: 0.9 }],
+        "categories:best-practices": ["error", { minScore: 0.9 }],
+        "categories:seo": ["error", { minScore: 0.9 }],
+      },
+    },
+    upload: {
+      // Store results as GitHub Actions artifacts; no LHCI server required.
+      target: "temporary-public-storage",
+    },
+  },
+};


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/lighthouse-ci.yml` — triggers on PRs touching `apps/**` or `packages/rialto/**`
- Uses `dorny/paths-filter` to detect which of the three apps (marketing, hospitality, rialto-web) were changed, so only affected apps are built and audited
- Builds the **base branch** first to capture a bundle size baseline, then builds the **PR branch** per app
- Blocks merge if:
  - Any Lighthouse **performance** or **accessibility** score falls below `0.9`
  - JS bundle grows **>10%** compared to the base branch
- Posts a Markdown summary table as a PR comment (creates on first run, updates on subsequent pushes)
- Uploads raw LHCI JSON artifacts retained for 14 days
- Adds `lighthouserc.js` at repo root covering all three apps with desktop preset, skips PWA audits

## Test plan

- [ ] Open a PR that changes `apps/marketing/**` — verify `lighthouse-marketing` runs and passes
- [ ] Open a PR that changes only `services/**` — verify no Lighthouse jobs run (all skipped)
- [ ] Intentionally add a large JS import to an app and verify the bundle-size check fails with a clear error message
- [ ] Confirm the PR comment is created and updated on subsequent pushes
- [ ] Verify Lighthouse artifacts appear in the Actions run under the correct artifact names

🤖 Generated with [Claude Code](https://claude.com/claude-code)