### PR TITLE
feat(agent-core): add AI code review step before auto-merging (closes #70)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,16 +35,16 @@
   },
   "lint-staged": {
     "apps/**/*.{ts,tsx}": [
-      "eslint --fix"
+      "eslint --fix --flag v10_config_lookup_from_file"
     ],
     "packages/**/*.{ts,tsx}": [
-      "eslint --fix"
+      "eslint --fix --flag v10_config_lookup_from_file"
     ],
     "services/**/*.{ts,tsx}": [
-      "eslint --fix"
+      "eslint --fix --flag v10_config_lookup_from_file"
     ],
     "tools/**/*.{ts,tsx}": [
-      "eslint --fix"
+      "eslint --fix --flag v10_config_lookup_from_file"
     ]
   },
   "pnpm": {

--- a/packages/agent-core/src/__tests__/diff-reviewer.test.ts
+++ b/packages/agent-core/src/__tests__/diff-reviewer.test.ts
@@ -1,0 +1,341 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: vi.fn(),
+}));
+
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import { reviewDiff, DEFAULT_REVIEW_CONFIG } from "../diff-reviewer.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+async function* mockQueryGenerator(messages: unknown[]) {
+  for (const msg of messages) {
+    yield msg;
+  }
+}
+
+function createMockReviewResult(review: { approved: boolean; issues: string[] }) {
+  return {
+    type: "result" as const,
+    subtype: "success" as const,
+    structured_output: review,
+    session_id: "review-session",
+    uuid: "review-uuid",
+    duration_ms: 1000,
+    duration_api_ms: 900,
+    is_error: false,
+    num_turns: 1,
+    result: "",
+    total_cost_usd: 0.01,
+    usage: {
+      input_tokens: 500,
+      output_tokens: 100,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+    },
+    modelUsage: {},
+    permission_denials: [],
+  };
+}
+
+const SAMPLE_DIFF = `diff --git a/src/routes.ts b/src/routes.ts
++export async function createUser(req, res) {
++  const user = await db.query("SELECT * FROM users WHERE id = " + req.params.id);
++  res.json(user);
++}`;
+
+// ── reviewDiff ────────────────────────────────────────────────────────
+
+describe("reviewDiff", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns approved=true when LLM finds no issues", async () => {
+    const mockResult = createMockReviewResult({ approved: true, issues: [] });
+
+    vi.mocked(query).mockReturnValue(
+      mockQueryGenerator([mockResult]) as ReturnType<typeof query>
+    );
+
+    const result = await reviewDiff(SAMPLE_DIFF);
+
+    expect(result.approved).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it("returns approved=false with issues when LLM finds security problems", async () => {
+    const mockResult = createMockReviewResult({
+      approved: false,
+      issues: [
+        "Security: SQL injection via string concatenation in db.query call",
+        "Security: Hardcoded API key 'sk-prod-123' in environment config",
+      ],
+    });
+
+    vi.mocked(query).mockReturnValue(
+      mockQueryGenerator([mockResult]) as ReturnType<typeof query>
+    );
+
+    const result = await reviewDiff(SAMPLE_DIFF);
+
+    expect(result.approved).toBe(false);
+    expect(result.issues).toHaveLength(2);
+    expect(result.issues[0]).toContain("SQL injection");
+  });
+
+  it("returns approved=false with issues when LLM finds a11y problems", async () => {
+    const mockResult = createMockReviewResult({
+      approved: false,
+      issues: ["a11y: <img> element missing alt attribute", "a11y: button missing aria-label"],
+    });
+
+    vi.mocked(query).mockReturnValue(
+      mockQueryGenerator([mockResult]) as ReturnType<typeof query>
+    );
+
+    const diff = `diff --git a/src/Button.tsx b/src/Button.tsx\n+<img src="logo.png" />\n+<button onClick={submit} />`;
+    const result = await reviewDiff(diff);
+
+    expect(result.approved).toBe(false);
+    expect(result.issues).toContain("a11y: <img> element missing alt attribute");
+  });
+
+  it("returns approved=false with issues when LLM finds performance concerns", async () => {
+    const mockResult = createMockReviewResult({
+      approved: false,
+      issues: ["Performance: Missing pagination on db.findAll() — could return unbounded results"],
+    });
+
+    vi.mocked(query).mockReturnValue(
+      mockQueryGenerator([mockResult]) as ReturnType<typeof query>
+    );
+
+    const result = await reviewDiff(SAMPLE_DIFF);
+
+    expect(result.approved).toBe(false);
+    expect(result.issues[0]).toContain("Performance");
+  });
+
+  it("returns approved=false with issues when LLM finds hardcoded values", async () => {
+    const mockResult = createMockReviewResult({
+      approved: false,
+      issues: [
+        "Hardcoded value: port 5432 should come from DATABASE_PORT env var",
+        "Hardcoded value: URL 'http://localhost:3001' should be in config",
+      ],
+    });
+
+    vi.mocked(query).mockReturnValue(
+      mockQueryGenerator([mockResult]) as ReturnType<typeof query>
+    );
+
+    const result = await reviewDiff("diff --git a/src/db.ts b/src/db.ts\n+const port = 5432;");
+
+    expect(result.approved).toBe(false);
+    expect(result.issues).toHaveLength(2);
+  });
+
+  it("returns approved=false for empty diff", async () => {
+    const result = await reviewDiff("");
+
+    expect(result.approved).toBe(false);
+    expect(result.issues).toContain("Empty diff — nothing to review");
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it("returns approved=false for whitespace-only diff", async () => {
+    const result = await reviewDiff("   \n\t  ");
+
+    expect(result.approved).toBe(false);
+    expect(result.issues).toContain("Empty diff — nothing to review");
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it("returns approved=true (fail-open) when SDK query throws", async () => {
+    vi.mocked(query).mockImplementation(() => {
+      throw new Error("SDK unavailable");
+    });
+
+    const result = await reviewDiff(SAMPLE_DIFF);
+
+    expect(result.approved).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it("returns approved=true (fail-open) when result subtype is not success", async () => {
+    const errorResult = {
+      type: "result" as const,
+      subtype: "error_max_turns" as const,
+      structured_output: undefined,
+      session_id: "review-session",
+      uuid: "review-uuid",
+      duration_ms: 500,
+      duration_api_ms: 400,
+      is_error: true,
+      num_turns: 1,
+      result: "",
+      total_cost_usd: 0.005,
+      usage: { input_tokens: 100, output_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+      modelUsage: {},
+      permission_denials: [],
+    };
+
+    vi.mocked(query).mockReturnValue(
+      mockQueryGenerator([errorResult]) as ReturnType<typeof query>
+    );
+
+    const result = await reviewDiff(SAMPLE_DIFF);
+
+    expect(result.approved).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it("returns approved=true (fail-open) when structured_output is missing", async () => {
+    const badResult = {
+      type: "result" as const,
+      subtype: "success" as const,
+      structured_output: undefined,
+      session_id: "review-session",
+      uuid: "review-uuid",
+      duration_ms: 1000,
+      duration_api_ms: 900,
+      is_error: false,
+      num_turns: 1,
+      result: "",
+      total_cost_usd: 0.01,
+      usage: { input_tokens: 500, output_tokens: 100, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+      modelUsage: {},
+      permission_denials: [],
+    };
+
+    vi.mocked(query).mockReturnValue(
+      mockQueryGenerator([badResult]) as ReturnType<typeof query>
+    );
+
+    const result = await reviewDiff(SAMPLE_DIFF);
+
+    expect(result.approved).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it("returns approved=true (fail-open) when structured_output.approved is not boolean", async () => {
+    const malformedResult = createMockReviewResult({
+      approved: "yes" as unknown as boolean,
+      issues: [],
+    });
+
+    vi.mocked(query).mockReturnValue(
+      mockQueryGenerator([malformedResult]) as ReturnType<typeof query>
+    );
+
+    const result = await reviewDiff(SAMPLE_DIFF);
+
+    expect(result.approved).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it("normalizes issues to empty array when structured_output.issues is not an array", async () => {
+    const malformedResult = {
+      ...createMockReviewResult({ approved: false, issues: [] }),
+      structured_output: { approved: false, issues: null },
+    };
+
+    vi.mocked(query).mockReturnValue(
+      mockQueryGenerator([malformedResult]) as ReturnType<typeof query>
+    );
+
+    const result = await reviewDiff(SAMPLE_DIFF);
+
+    expect(result.issues).toEqual([]);
+  });
+
+  it("uses haiku model by default", async () => {
+    const mockResult = createMockReviewResult({ approved: true, issues: [] });
+
+    vi.mocked(query).mockReturnValue(
+      mockQueryGenerator([mockResult]) as ReturnType<typeof query>
+    );
+
+    await reviewDiff(SAMPLE_DIFF);
+
+    expect(query).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          model: DEFAULT_REVIEW_CONFIG.model,
+        }),
+      })
+    );
+    expect(DEFAULT_REVIEW_CONFIG.model).toContain("haiku");
+  });
+
+  it("accepts custom model override", async () => {
+    const mockResult = createMockReviewResult({ approved: true, issues: [] });
+
+    vi.mocked(query).mockReturnValue(
+      mockQueryGenerator([mockResult]) as ReturnType<typeof query>
+    );
+
+    await reviewDiff(SAMPLE_DIFF, { model: "claude-sonnet-4-6" });
+
+    expect(query).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          model: "claude-sonnet-4-6",
+        }),
+      })
+    );
+  });
+
+  it("accepts custom budget override", async () => {
+    const mockResult = createMockReviewResult({ approved: true, issues: [] });
+
+    vi.mocked(query).mockReturnValue(
+      mockQueryGenerator([mockResult]) as ReturnType<typeof query>
+    );
+
+    await reviewDiff(SAMPLE_DIFF, { maxBudgetUsd: 0.10 });
+
+    expect(query).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          maxBudgetUsd: 0.10,
+        }),
+      })
+    );
+  });
+
+  it("truncates very large diffs before sending to LLM", async () => {
+    const mockResult = createMockReviewResult({ approved: true, issues: [] });
+
+    vi.mocked(query).mockReturnValue(
+      mockQueryGenerator([mockResult]) as ReturnType<typeof query>
+    );
+
+    // Generate a diff larger than MAX_DIFF_LENGTH (50_000 chars)
+    const hugeDiff = "diff --git a/big.ts b/big.ts\n" + "+line\n".repeat(15_000);
+    expect(hugeDiff.length).toBeGreaterThan(50_000);
+
+    await reviewDiff(hugeDiff);
+
+    const calledPrompt = vi.mocked(query).mock.calls[0][0].prompt as string;
+    expect(calledPrompt).toContain("diff truncated");
+  });
+
+  it("returns immutable issues array", async () => {
+    const mockResult = createMockReviewResult({
+      approved: false,
+      issues: ["Security: hardcoded token"],
+    });
+
+    vi.mocked(query).mockReturnValue(
+      mockQueryGenerator([mockResult]) as ReturnType<typeof query>
+    );
+
+    const result = await reviewDiff(SAMPLE_DIFF);
+
+    // Verify we can read issues but result should be treated as readonly
+    expect(result.issues[0]).toBe("Security: hardcoded token");
+  });
+});

--- a/packages/agent-core/src/diff-reviewer.ts
+++ b/packages/agent-core/src/diff-reviewer.ts
@@ -1,0 +1,170 @@
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import type { SDKResultMessage } from "@anthropic-ai/claude-agent-sdk";
+
+// ── Types ───────────────────────────────────────────────────────────
+
+export interface ReviewResult {
+  readonly approved: boolean;
+  readonly issues: readonly string[];
+}
+
+export interface ReviewConfig {
+  readonly model: string;
+  readonly maxBudgetUsd: number;
+}
+
+export const DEFAULT_REVIEW_CONFIG: ReviewConfig = {
+  model: "claude-haiku-4-5-20250929",
+  maxBudgetUsd: 0.05,
+};
+
+const APPROVED_RESULT: ReviewResult = {
+  approved: true,
+  issues: [],
+};
+
+const MAX_DIFF_LENGTH = 50_000;
+
+// ── JSON Schema ──────────────────────────────────────────────────────
+
+const REVIEW_SCHEMA = {
+  type: "object" as const,
+  properties: {
+    approved: {
+      type: "boolean" as const,
+      description: "Whether the diff is safe to auto-merge (true = no blocking issues found)",
+    },
+    issues: {
+      type: "array" as const,
+      items: { type: "string" as const },
+      description: "List of blocking issues found, if any. Empty when approved is true.",
+    },
+  },
+  required: ["approved", "issues"] as const,
+  additionalProperties: false as const,
+};
+
+// ── Prompt ───────────────────────────────────────────────────────────
+
+function buildReviewPrompt(diff: string): string {
+  const truncatedDiff =
+    diff.length > MAX_DIFF_LENGTH ? diff.slice(0, MAX_DIFF_LENGTH) + "\n\n... (diff truncated)" : diff;
+
+  return [
+    "You are a senior code reviewer performing a quick safety check before an auto-merge.",
+    "Analyze the git diff for blocking issues across four categories.",
+    "Be pragmatic — only flag real problems, not style preferences.",
+    "",
+    "## Git Diff",
+    "```diff",
+    truncatedDiff,
+    "```",
+    "",
+    "## Review Categories",
+    "",
+    "### 1. Security",
+    "- Hardcoded secrets, API keys, tokens, or passwords",
+    "- SQL injection vulnerabilities (string concatenation in queries)",
+    "- XSS vulnerabilities (unsanitized user input rendered as HTML)",
+    "- Disabled authentication or authorization checks",
+    "- Sensitive data logged or exposed in error messages",
+    "",
+    "### 2. Accessibility (a11y)",
+    "- Interactive elements missing accessible labels (aria-label, aria-labelledby)",
+    "- Images missing alt text",
+    "- Form inputs missing associated labels",
+    "- Focus management broken (e.g., modal traps removed)",
+    "- Color contrast issues introduced via hardcoded style values",
+    "",
+    "### 3. Performance",
+    "- Unbounded loops or O(n²) algorithms on large datasets",
+    "- Missing pagination on database queries that could return large result sets",
+    "- Large assets (images, videos) added without optimization",
+    "- Synchronous blocking I/O in hot paths",
+    "",
+    "### 4. Hardcoded Values",
+    "- Magic numbers or strings that should be named constants or config",
+    "- Hardcoded URLs, ports, or environment-specific values",
+    "- Hardcoded user IDs, tenant IDs, or other data that varies by environment",
+    "",
+    "## Instructions",
+    "- Set `approved: true` only when no blocking issues are found",
+    "- Set `approved: false` and list each issue concisely in `issues` when problems exist",
+    "- Each issue string should identify the category and specific problem",
+    "- Return your review as JSON.",
+  ].join("\n");
+}
+
+// ── Core function ────────────────────────────────────────────────────
+
+/**
+ * Performs a lightweight AI code review on a git diff before auto-merging.
+ *
+ * Checks for: security issues, a11y problems, performance concerns, hardcoded values.
+ * Uses Haiku by default for speed (~5s per review).
+ *
+ * Returns `{ approved: true, issues: [] }` when the diff is safe to merge,
+ * or `{ approved: false, issues: [...] }` when blocking issues are found.
+ * On LLM failure, returns approved=true (fail-open) to avoid blocking merges.
+ */
+export async function reviewDiff(
+  diff: string,
+  configOverrides?: Partial<ReviewConfig>
+): Promise<ReviewResult> {
+  if (!diff.trim()) {
+    return {
+      approved: false,
+      issues: ["Empty diff — nothing to review"],
+    };
+  }
+
+  const config = { ...DEFAULT_REVIEW_CONFIG, ...configOverrides };
+
+  try {
+    const prompt = buildReviewPrompt(diff);
+
+    const conversation = query({
+      prompt,
+      options: {
+        model: config.model,
+        maxTurns: 1,
+        maxBudgetUsd: config.maxBudgetUsd,
+        permissionMode: "plan",
+        systemPrompt: "You are a code reviewer. Respond only with the requested JSON.",
+        outputFormat: {
+          type: "json_schema",
+          schema: REVIEW_SCHEMA,
+        },
+      },
+    });
+
+    let result: SDKResultMessage | null = null;
+    for await (const message of conversation) {
+      if (message.type === "result") {
+        result = message as SDKResultMessage;
+      }
+    }
+
+    if (!result || result.subtype !== "success") {
+      return APPROVED_RESULT;
+    }
+
+    const parsed = result.structured_output as
+      | {
+          approved: boolean;
+          issues: string[];
+        }
+      | undefined;
+
+    if (!parsed || typeof parsed.approved !== "boolean") {
+      return APPROVED_RESULT;
+    }
+
+    return {
+      approved: parsed.approved,
+      issues: Array.isArray(parsed.issues) ? parsed.issues : [],
+    };
+  } catch {
+    return APPROVED_RESULT;
+  }
+}

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -83,6 +83,10 @@ export type {
   ShouldEvaluateConfig,
 } from "./success-evaluator.js";
 
+// Diff review (AI code review before auto-merge)
+export { reviewDiff, DEFAULT_REVIEW_CONFIG } from "./diff-reviewer.js";
+export type { ReviewResult, ReviewConfig } from "./diff-reviewer.js";
+
 // Failure memory
 export {
   recordFailure,


### PR DESCRIPTION
## Summary

- Adds `reviewDiff(diff, options)` to `packages/agent-core` — a lightweight AI safety check that runs on the PR diff before auto-merge
- Checks four categories: **security** (SQLi, hardcoded secrets, XSS, auth bypass), **a11y** (missing alt/aria-label, broken focus), **performance** (unbounded queries, blocking I/O), and **hardcoded values** (magic strings, env-specific URLs)
- Uses Haiku by default for speed (~5s per review); returns `{ approved: boolean, issues: string[] }`
- Fails-open on LLM errors (approved=true) so a transient API failure never blocks a merge
- Exports `reviewDiff`, `ReviewResult`, and `ReviewConfig` from the package index for the ship-loop to call before merging

Also fixes a pre-existing bug where `lint-staged` could not find the per-package `eslint.config.js` files when running from the repo root under ESLint 9 flat config. Adds `--flag v10_config_lookup_from_file` to all lint-staged ESLint commands.

## Test plan

- [ ] `cd packages/agent-core && pnpm test` — 17 new tests in `diff-reviewer.test.ts`, all 236 tests pass
- [ ] `pnpm lint` — no lint errors
- [ ] `pnpm typecheck` — no type errors
- [ ] Pre-commit hook runs cleanly with the new `--flag v10_config_lookup_from_file` fix
- [ ] Verify `reviewDiff` is importable from `@mbe/agent-core` in a downstream consumer

🤖 Generated with [Claude Code](https://claude.com/claude-code)