### PR TITLE
perf(agent-core): direct-merge trivial dependency bumps without PR (closes #79)

### DIFF
--- a/packages/agent-core/src/__tests__/dep-bump-merger.test.ts
+++ b/packages/agent-core/src/__tests__/dep-bump-merger.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect } from "vitest";
+import { isTrivialDepBump } from "../dep-bump-merger.js";
+
+// ── Diff fixtures ────────────────────────────────────────────────────
+
+/**
+ * Minimal unified diff touching only package.json (a typical single-package
+ * version bump — well under the 20-line limit).
+ */
+const PACKAGE_JSON_ONLY_DIFF = `diff --git a/package.json b/package.json
+index 1234567..abcdefg 100644
+--- a/package.json
++++ b/package.json
+@@ -5,7 +5,7 @@ {
+   "dependencies": {
+-    "lodash": "4.17.20",
++    "lodash": "4.17.21",
+   }
+ }
+`;
+
+/**
+ * Diff that also touches pnpm-lock.yaml (normal for pnpm installs).
+ * The non-lockfile portion is still tiny.
+ */
+const PACKAGE_JSON_AND_LOCKFILE_DIFF = `diff --git a/package.json b/package.json
+index 1234567..abcdefg 100644
+--- a/package.json
++++ b/package.json
+@@ -5,7 +5,7 @@ {
+   "dependencies": {
+-    "axios": "1.6.0",
++    "axios": "1.7.0",
+   }
+ }
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index aaaaaaa..bbbbbbb 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -1,10 +1,10 @@
+-  axios: 1.6.0
++  axios: 1.7.0
+`;
+
+/**
+ * Workspace monorepo layout: package.json lives under apps/marketing/.
+ */
+const WORKSPACE_PACKAGE_JSON_DIFF = `diff --git a/apps/marketing/package.json b/apps/marketing/package.json
+index 1111111..2222222 100644
+--- a/apps/marketing/package.json
++++ b/apps/marketing/package.json
+@@ -3,3 +3,3 @@
+-    "react": "18.2.0",
++    "react": "18.3.0",
+`;
+
+/**
+ * Diff that also touches a source file — NOT trivial.
+ */
+const SOURCE_FILE_CHANGED_DIFF = `diff --git a/package.json b/package.json
+index 1234567..abcdefg 100644
+--- a/package.json
++++ b/package.json
+@@ -5,7 +5,7 @@ {
+-    "zod": "3.22.0",
++    "zod": "3.23.0",
+ }
+diff --git a/src/validation.ts b/src/validation.ts
+index aaaaaaa..bbbbbbb 100644
+--- a/src/validation.ts
++++ b/src/validation.ts
+@@ -1,3 +1,5 @@
++import { z } from "zod";
++export const schema = z.string();
+`;
+
+/**
+ * Diff whose non-lockfile portion exceeds the 20-line threshold.
+ */
+function buildLargePackageJsonDiff(): string {
+  const removedLines = Array.from(
+    { length: 12 },
+    (_, i) => `-    "dep-${i}": "1.0.${i}",`
+  ).join("\n");
+  const addedLines = Array.from(
+    { length: 12 },
+    (_, i) => `+    "dep-${i}": "1.0.${i + 1}",`
+  ).join("\n");
+
+  return [
+    "diff --git a/package.json b/package.json",
+    "index 1234567..abcdefg 100644",
+    "--- a/package.json",
+    "+++ b/package.json",
+    "@@ -5,20 +5,20 @@ {",
+    removedLines,
+    addedLines,
+    "",
+  ].join("\n");
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("isTrivialDepBump", () => {
+  describe("returns isTrivial: true", () => {
+    it("when only package.json is changed with a small diff", () => {
+      const result = isTrivialDepBump(PACKAGE_JSON_ONLY_DIFF);
+      expect(result.isTrivial).toBe(true);
+      expect(result.reason).toBeUndefined();
+    });
+
+    it("when package.json and pnpm-lock.yaml are both changed", () => {
+      const result = isTrivialDepBump(PACKAGE_JSON_AND_LOCKFILE_DIFF);
+      expect(result.isTrivial).toBe(true);
+    });
+
+    it("when package.json is in a workspace subdirectory", () => {
+      const result = isTrivialDepBump(WORKSPACE_PACKAGE_JSON_DIFF);
+      expect(result.isTrivial).toBe(true);
+    });
+
+    it("when only pnpm-lock.yaml is changed (lockfile-only sync)", () => {
+      const lockOnlyDiff = `diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index aaaaaaa..bbbbbbb 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -1,3 +1,3 @@
+-  some-dep: 1.0.0
++  some-dep: 1.0.1
+`;
+      const result = isTrivialDepBump(lockOnlyDiff);
+      expect(result.isTrivial).toBe(true);
+    });
+  });
+
+  describe("returns isTrivial: false", () => {
+    it("when the diff is empty", () => {
+      const result = isTrivialDepBump("");
+      expect(result.isTrivial).toBe(false);
+      expect(result.reason).toContain("Empty diff");
+    });
+
+    it("when a source file is also changed", () => {
+      const result = isTrivialDepBump(SOURCE_FILE_CHANGED_DIFF);
+      expect(result.isTrivial).toBe(false);
+      expect(result.reason).toContain("src/validation.ts");
+    });
+
+    it("when the non-lockfile diff exceeds the 20-line limit", () => {
+      const largeDiff = buildLargePackageJsonDiff();
+      const result = isTrivialDepBump(largeDiff);
+      expect(result.isTrivial).toBe(false);
+      expect(result.reason).toMatch(/\d+ changed lines/);
+    });
+
+    it("when a migration file is changed alongside package.json", () => {
+      const migrationDiff = `diff --git a/package.json b/package.json
+index 1234567..abcdefg 100644
+--- a/package.json
++++ b/package.json
+@@ -5,3 +5,3 @@
+-    "prisma": "5.10.0",
++    "prisma": "5.11.0",
+diff --git a/prisma/migrations/001_init.sql b/prisma/migrations/001_init.sql
+index aaaaaaa..bbbbbbb 100644
+--- a/prisma/migrations/001_init.sql
++++ b/prisma/migrations/001_init.sql
+@@ -1 +1 @@
+-CREATE TABLE users ();
++CREATE TABLE users (id TEXT);
+`;
+      const result = isTrivialDepBump(migrationDiff);
+      expect(result.isTrivial).toBe(false);
+      expect(result.reason).toContain("prisma/migrations/001_init.sql");
+    });
+
+    it("when diff has no parseable file headers", () => {
+      const result = isTrivialDepBump("not a real diff\njust some text");
+      expect(result.isTrivial).toBe(false);
+      expect(result.reason).toContain("Could not detect changed files");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles whitespace-only diff", () => {
+      const result = isTrivialDepBump("   \n\t\n  ");
+      expect(result.isTrivial).toBe(false);
+    });
+
+    it("allows exactly 19 non-lockfile changed lines", () => {
+      // Build a diff with exactly 19 changed lines (below the limit of 20)
+      const lines = Array.from({ length: 10 }, (_, i) => `-    "d${i}": "1.${i}",`);
+      const plusLines = Array.from({ length: 9 }, (_, i) => `+    "d${i}": "2.${i}",`);
+      const diff = [
+        "diff --git a/package.json b/package.json",
+        "index 1234567..abcdefg 100644",
+        "--- a/package.json",
+        "+++ b/package.json",
+        "@@ -1,10 +1,10 @@",
+        ...lines,
+        ...plusLines,
+      ].join("\n");
+
+      const result = isTrivialDepBump(diff);
+      expect(result.isTrivial).toBe(true);
+    });
+
+    it("rejects exactly 20 non-lockfile changed lines", () => {
+      const lines = Array.from({ length: 10 }, (_, i) => `-    "d${i}": "1.${i}",`);
+      const plusLines = Array.from({ length: 10 }, (_, i) => `+    "d${i}": "2.${i}",`);
+      const diff = [
+        "diff --git a/package.json b/package.json",
+        "index 1234567..abcdefg 100644",
+        "--- a/package.json",
+        "+++ b/package.json",
+        "@@ -1,10 +1,10 @@",
+        ...lines,
+        ...plusLines,
+      ].join("\n");
+
+      const result = isTrivialDepBump(diff);
+      expect(result.isTrivial).toBe(false);
+    });
+
+    it("lockfile lines do NOT count toward the 20-line limit", () => {
+      // Large lockfile diff but tiny package.json diff — should still be trivial
+      const lockfileLines = Array.from(
+        { length: 100 },
+        (_, i) => `+  resolution-${i}: 1.0.0`
+      ).join("\n");
+
+      const diff = [
+        "diff --git a/package.json b/package.json",
+        "index 1234567..abcdefg 100644",
+        "--- a/package.json",
+        "+++ b/package.json",
+        "@@ -3,3 +3,3 @@",
+        `-    "react": "18.2.0",`,
+        `+    "react": "18.3.0",`,
+        "diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml",
+        "index aaaaaaa..bbbbbbb 100644",
+        "--- a/pnpm-lock.yaml",
+        "+++ b/pnpm-lock.yaml",
+        "@@ -1,100 +1,100 @@",
+        lockfileLines,
+      ].join("\n");
+
+      const result = isTrivialDepBump(diff);
+      expect(result.isTrivial).toBe(true);
+    });
+  });
+});

--- a/packages/agent-core/src/dep-bump-merger.ts
+++ b/packages/agent-core/src/dep-bump-merger.ts
@@ -1,0 +1,175 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+// ── Constants ────────────────────────────────────────────────────────
+
+/** Files that are allowed to change in a trivial dependency bump. */
+const ALLOWED_DEP_FILES = new Set(["package.json", "pnpm-lock.yaml"]);
+
+/**
+ * Maximum number of changed lines (additions + deletions) in the non-lockfile
+ * portion of the diff before we consider the bump non-trivial.
+ */
+const MAX_NON_LOCK_DIFF_LINES = 20;
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface TrivialDepBumpResult {
+  readonly isTrivial: boolean;
+  /** Reason the bump was deemed non-trivial (undefined when isTrivial=true). */
+  readonly reason?: string;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Extract the set of file paths changed in a unified diff.
+ *
+ * Handles both top-level and workspace paths, e.g.:
+ *   "diff --git a/package.json b/package.json"
+ *   "diff --git a/apps/foo/package.json b/apps/foo/package.json"
+ */
+function extractChangedFiles(diff: string): readonly string[] {
+  const files: string[] = [];
+  for (const line of diff.split("\n")) {
+    if (!line.startsWith("diff --git ")) continue;
+    // e.g. "diff --git a/some/path/package.json b/some/path/package.json"
+    const match = line.match(/diff --git a\/.+ b\/(.+)$/);
+    if (match) {
+      files.push(match[1]);
+    }
+  }
+  return files;
+}
+
+/**
+ * Count added + removed lines in a diff.
+ * Excludes unified-diff file headers (lines starting with `---` or `+++`).
+ */
+function countDiffLines(diff: string): number {
+  return diff
+    .split("\n")
+    .filter(
+      (line) =>
+        (line.startsWith("+") || line.startsWith("-")) &&
+        !line.startsWith("---") &&
+        !line.startsWith("+++")
+    ).length;
+}
+
+/**
+ * Extract only the hunks that belong to non-lockfile files from the diff.
+ * We strip pnpm-lock.yaml sections to apply the line-count guard only to
+ * the meaningful version bump lines in package.json.
+ */
+function extractNonLockfileDiff(diff: string): string {
+  const sections = diff.split(/(?=^diff --git )/m);
+  return sections
+    .filter((section) => !section.includes("pnpm-lock.yaml"))
+    .join("");
+}
+
+// ── Public API ───────────────────────────────────────────────────────
+
+/**
+ * Determines whether a git diff represents a trivial dependency bump that can
+ * be merged directly without a PR review cycle.
+ *
+ * A diff is considered trivial when ALL of the following are true:
+ * 1. Every changed file is either `package.json` or `pnpm-lock.yaml`
+ *    (matched by basename — workspace nesting is allowed).
+ * 2. The non-lockfile diff is less than MAX_NON_LOCK_DIFF_LINES lines.
+ */
+export function isTrivialDepBump(diff: string): TrivialDepBumpResult {
+  if (!diff.trim()) {
+    return { isTrivial: false, reason: "Empty diff — nothing to evaluate" };
+  }
+
+  const changedFiles = extractChangedFiles(diff);
+
+  if (changedFiles.length === 0) {
+    return { isTrivial: false, reason: "Could not detect changed files in diff" };
+  }
+
+  // Check 1: every changed file must be an allowed dependency file (by basename)
+  const disallowedFiles = changedFiles.filter(
+    (filePath) => !ALLOWED_DEP_FILES.has(filePath.split("/").at(-1) ?? "")
+  );
+
+  if (disallowedFiles.length > 0) {
+    return {
+      isTrivial: false,
+      reason: `Non-dependency files changed: ${disallowedFiles.join(", ")}`,
+    };
+  }
+
+  // Check 2: non-lockfile diff must be small
+  const nonLockDiff = extractNonLockfileDiff(diff);
+  const nonLockLines = countDiffLines(nonLockDiff);
+
+  if (nonLockLines >= MAX_NON_LOCK_DIFF_LINES) {
+    return {
+      isTrivial: false,
+      reason: `Non-lockfile diff has ${nonLockLines} changed lines (limit: ${MAX_NON_LOCK_DIFF_LINES})`,
+    };
+  }
+
+  return { isTrivial: true };
+}
+
+// ── Direct merge ─────────────────────────────────────────────────────
+
+/**
+ * Merges a branch directly into the base branch without creating a PR for
+ * human review. This is only safe for trivial dependency bumps that have
+ * already been guarded by `isTrivialDepBump` and confirmed passing tests.
+ *
+ * Strategy:
+ *   1. Create the PR (needed for the merge audit trail on GitHub).
+ *   2. Immediately squash-merge and delete the branch.
+ *
+ * Returns the PR URL that was created and merged.
+ */
+export async function mergeDirectly(options: {
+  readonly branchName: string;
+  readonly baseBranch: string;
+  readonly repoPath: string;
+  readonly commitTitle: string;
+}): Promise<string> {
+  const { branchName, baseBranch, repoPath, commitTitle } = options;
+
+  // Step 1: Create the PR (gets us a URL / audit trail)
+  const createArgs = [
+    "pr",
+    "create",
+    "--title",
+    commitTitle,
+    "--body",
+    "Trivial dependency bump — auto-merged by agent-core (no PR review required).",
+    "--base",
+    baseBranch,
+    "--head",
+    branchName,
+    "--json",
+    "url",
+  ];
+
+  const { stdout: createOut } = await execFileAsync("gh", createArgs, { cwd: repoPath });
+  const { url } = JSON.parse(createOut.trim()) as { url: string };
+
+  // Step 2: Squash-merge and delete the branch immediately
+  const mergeArgs = [
+    "pr",
+    "merge",
+    "--squash",
+    "--delete-branch",
+    "--auto",
+    url,
+  ];
+
+  await execFileAsync("gh", mergeArgs, { cwd: repoPath });
+
+  return url;
+}

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -45,6 +45,10 @@ export {
   buildFailurePrBody,
 } from "./pr-creator.js";
 
+// Dependency bump direct-merge
+export { isTrivialDepBump, mergeDirectly } from "./dep-bump-merger.js";
+export type { TrivialDepBumpResult } from "./dep-bump-merger.js";
+
 // Prompt building
 export {
   buildSystemPrompt,

--- a/packages/agent-core/src/session-runner.ts
+++ b/packages/agent-core/src/session-runner.ts
@@ -25,6 +25,7 @@ import {
   buildPrBody,
   buildFailurePrBody,
 } from "./pr-creator.js";
+import { isTrivialDepBump, mergeDirectly } from "./dep-bump-merger.js";
 import { evaluateSuccess, getGitDiff, shouldEvaluate } from "./success-evaluator.js";
 import type { EvaluationResult } from "./success-evaluator.js";
 import { mapSdkMessage } from "./event-mapper.js";
@@ -177,37 +178,68 @@ export async function runSession(
       }
 
       if (config.createPr) {
-        const title = evaluationPassed
-          ? buildPrTitle(config.taskDescription)
-          : `wip: ${config.taskDescription.slice(0, 57)}`;
+        // Fast-path: trivial dependency bumps that passed tests are merged
+        // directly without waiting for PR review.
+        if (evaluationPassed) {
+          const depBumpCheck = isTrivialDepBump(await getGitDiff(worktree.path));
+          if (depBumpCheck.isTrivial) {
+            const commitTitle = buildPrTitle(config.taskDescription);
+            prUrl = await mergeDirectly({
+              branchName: worktree.branchName,
+              baseBranch: config.baseBranch,
+              repoPath: worktree.path,
+              commitTitle,
+            });
+            emitEvent(onEvent, "session:result", {
+              message: `Trivial dep bump — direct-merged: ${prUrl}`,
+            });
+          } else {
+            const title = buildPrTitle(config.taskDescription);
+            const body = resultMessage
+              ? buildPrBody(
+                  config.taskDescription,
+                  resultMessage.session_id,
+                  resultMessage.total_cost_usd,
+                  resultMessage.num_turns
+                )
+              : buildFailurePrBody(config.taskDescription, errors, stuckReason?.type);
 
-        const body = evaluationPassed && resultMessage
-          ? buildPrBody(
-              config.taskDescription,
-              resultMessage.session_id,
-              resultMessage.total_cost_usd,
-              resultMessage.num_turns
-            )
-          : buildFailurePrBody(
-              config.taskDescription,
-              errors,
-              stuckReason?.type
-            );
+            const pr = await createPullRequest({
+              title,
+              body,
+              baseBranch: config.baseBranch,
+              branchName: worktree.branchName,
+              repoPath: worktree.path,
+              draft: false,
+            });
 
-        const pr = await createPullRequest({
-          title,
-          body,
-          baseBranch: config.baseBranch,
-          branchName: worktree.branchName,
-          repoPath: worktree.path,
-          draft: !evaluationPassed,
-        });
+            prUrl = pr.url;
+            emitEvent(onEvent, "session:result", {
+              message: `PR created: ${pr.url}`,
+            });
+          }
+        } else {
+          const title = `wip: ${config.taskDescription.slice(0, 57)}`;
+          const body = buildFailurePrBody(
+            config.taskDescription,
+            errors,
+            stuckReason?.type
+          );
 
-        prUrl = pr.url;
-        const prType = evaluationPassed ? "PR" : "Draft PR";
-        emitEvent(onEvent, "session:result", {
-          message: `${prType} created: ${pr.url}`,
-        });
+          const pr = await createPullRequest({
+            title,
+            body,
+            baseBranch: config.baseBranch,
+            branchName: worktree.branchName,
+            repoPath: worktree.path,
+            draft: true,
+          });
+
+          prUrl = pr.url;
+          emitEvent(onEvent, "session:result", {
+            message: `Draft PR created: ${pr.url}`,
+          });
+        }
       }
     } else {
       emitEvent(onEvent, "session:result", {


### PR DESCRIPTION
## Summary

- Add `isTrivialDepBump(diff)` to `dep-bump-merger.ts` that returns `{ isTrivial: true }` when all changed files are `package.json`/`pnpm-lock.yaml` and the non-lockfile diff is <20 lines
- Add `mergeDirectly()` that creates a PR then immediately squash-merges and deletes the branch via `gh pr merge --squash --delete-branch --auto`
- Update `session-runner.ts` to take the fast-path when `isTrivialDepBump` is true and evaluation passed — skipping the human review wait cycle
- Export `isTrivialDepBump`, `mergeDirectly`, and `TrivialDepBumpResult` from the package index
- 13 new tests covering trivial cases, non-trivial rejections, workspace paths, line-limit boundary conditions, and lockfile line exclusion

## Test plan

- [x] `pnpm test` passes (232 tests, 13 new for `dep-bump-merger`)
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [ ] Verify direct-merge path fires on a real Dependabot-style bump
- [ ] Confirm PR is created + squash-merged on GitHub without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)