### PR TITLE
feat(ship-loop): auto-merge low-risk PRs immediately after CI passes

### DIFF
--- a/.claude/skills/ship-loop/SKILL.md
+++ b/.claude/skills/ship-loop/SKILL.md
@@ -87,19 +87,40 @@ gh pr list --author "@me" --json number,title,headRefName,statusCheckRollup,revi
   --jq '.[] | select(.headRefName | startswith("agent/"))'
 ```
 
-For each agent PR:
-- **CI passed + approved/no review required**: Merge it, close the linked issue
-- **CI failed**: Create `ci-fix` issue, label original as `agent-failed`
-- **Changes requested**: Queue for PR feedback loop (if wired in)
-- **CI pending**: Skip — check again next iteration
+For each agent PR, first classify the PR's risk level:
 
 ```bash
-# Auto-merge PRs where CI passed
+# Get the list of changed files for the PR
+gh pr diff <number> --name-only
+```
+
+**Low-risk patterns** — a PR is low-risk when ALL changed files fall into one of:
+- Test files: `*.test.ts`, `*.test.tsx`, `*.spec.ts`, `*.spec.tsx`, `*.test.js`, `*.spec.js`, `*.test.jsx`, `*.spec.jsx`
+- Documentation: `*.md`, `docs/**`
+- Dependency manifests: `package.json`, `pnpm-lock.yaml`, `package-lock.json`, `yarn.lock`
+- Config files: `.github/**`, `.claude/**`, `turbo.json`, `*.config.ts`, `*.config.js`, `*.config.mjs`
+
+Use `isLowRiskPR(files)` from `@mbe/agent-core` if scripting this check.
+
+**Decision matrix:**
+
+| CI status | Risk level | Action |
+|-----------|-----------|--------|
+| passed | low-risk | **Merge immediately** — do not wait for next iteration |
+| passed | other | Merge it, close the linked issue |
+| failed | any | Create `ci-fix` issue, label original as `agent-failed` |
+| changes requested | any | Queue for PR feedback loop (if wired in) |
+| pending | any | Skip — check again next iteration |
+
+```bash
+# Auto-merge PRs where CI passed (low-risk: merge right now)
 gh pr merge <number> --squash --delete-branch
 
 # Close linked issue
 gh issue close <linked-number> --comment "Merged via ship-loop. Deployed."
 ```
+
+**Why immediate merge for low-risk PRs?** Test/docs/deps/config changes cannot break the running application. Merging them right away frees up issue slots and keeps the backlog moving without wasting an entire loop iteration on a trivial wait.
 
 ### A4. Gather & Claim Batch
 

--- a/.claude/skills/site-audit/SKILL.md
+++ b/.claude/skills/site-audit/SKILL.md
@@ -81,18 +81,37 @@ If no files in `apps/`, `services/`, `packages/`, or `infrastructure/` changed, 
 
 2. **List all surfaces** in the chosen zone.
 
-3. **Dispatch parallel subagents** — up to 5 simultaneously (wave-based for larger zones). Each agent runs:
+3. **Filter surfaces with code changes** — before dispatching, check each surface to see if any of its source files changed since `lastChecked`. Skip Lighthouse entirely for surfaces with no changes.
+
+For each surface, run:
+
+```bash
+# LAST_CHECKED = surface.lastChecked (ISO timestamp, e.g. "2026-03-01T12:00:00.000Z")
+# SOURCE_FILES = space-separated list from surface.sourceFiles
+git log --since='$LAST_CHECKED' --name-only -- $SOURCE_FILES | head -1
+```
+
+- If the output is **empty** → no changes since last audit → **skip this surface** (keep its existing inventory entry unchanged)
+- If the output is **non-empty** → source changed → include in this sweep
+- If `lastChecked` is **null** (never audited) → always include
+
+Log skipped surfaces in the final report:
+```
+Skipped 4 unchanged surfaces: marketing/home, rialto/tokens, ...
+```
+
+4. **Dispatch parallel subagents** — up to 5 simultaneously (wave-based for larger zones), **only for surfaces that passed the change filter**. Each agent runs:
    - **Full Lighthouse** (all 4 categories: performance, accessibility, best-practices, SEO)
    - **Mobile responsive check** (375x812 viewport via Playwright `browser_resize`)
    - **Console error check** via Playwright `browser_console_messages`
    - **Network request check** via Playwright `browser_network_requests` (flag 4xx/5xx, >3s responses)
    - **Dead link check** — click navigation links, verify they load
 
-4. **Update inventory** with new scores.
+5. **Update inventory** with new scores.
 
-5. **Create issues** for anything below 0.9 threshold on any Lighthouse category, or any console errors.
+6. **Create issues** for anything below 0.9 threshold on any Lighthouse category, or any console errors.
 
-6. **Report coverage stats:**
+7. **Report coverage stats:**
 
 ```
 Sweep complete: zone "hospitality" (11 surfaces checked)

--- a/packages/agent-core/src/__tests__/pr-risk-classifier.test.ts
+++ b/packages/agent-core/src/__tests__/pr-risk-classifier.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from "vitest";
+import { isLowRiskPR } from "../pr-risk-classifier.js";
+
+// ── Test files ──────────────────────────────────────────────────────────────
+
+describe("isLowRiskPR — test files", () => {
+  it("returns true for a single .test.ts file", () => {
+    expect(isLowRiskPR(["src/routes.test.ts"])).toBe(true);
+  });
+
+  it("returns true for a .test.tsx file", () => {
+    expect(isLowRiskPR(["src/Button.test.tsx"])).toBe(true);
+  });
+
+  it("returns true for a .spec.ts file", () => {
+    expect(isLowRiskPR(["src/auth.spec.ts"])).toBe(true);
+  });
+
+  it("returns true for a .spec.tsx file", () => {
+    expect(isLowRiskPR(["src/Modal.spec.tsx"])).toBe(true);
+  });
+
+  it("returns true for a .test.js file", () => {
+    expect(isLowRiskPR(["utils/helpers.test.js"])).toBe(true);
+  });
+
+  it("returns true for a .spec.jsx file", () => {
+    expect(isLowRiskPR(["components/Card.spec.jsx"])).toBe(true);
+  });
+
+  it("returns true for multiple test files", () => {
+    expect(
+      isLowRiskPR(["src/routes.test.ts", "src/utils.spec.ts", "src/Button.test.tsx"])
+    ).toBe(true);
+  });
+});
+
+// ── Documentation ───────────────────────────────────────────────────────────
+
+describe("isLowRiskPR — documentation", () => {
+  it("returns true for a root .md file", () => {
+    expect(isLowRiskPR(["README.md"])).toBe(true);
+  });
+
+  it("returns true for a CHANGELOG.md", () => {
+    expect(isLowRiskPR(["CHANGELOG.md"])).toBe(true);
+  });
+
+  it("returns true for a nested .md file", () => {
+    expect(isLowRiskPR(["packages/rialto/CLAUDE.md"])).toBe(true);
+  });
+
+  it("returns true for a file under docs/", () => {
+    expect(isLowRiskPR(["docs/evaluations/2026-02-26-caching.md"])).toBe(true);
+  });
+
+  it("returns true for a docs/ file without .md extension", () => {
+    expect(isLowRiskPR(["docs/adr/001-use-postgres"])).toBe(true);
+  });
+});
+
+// ── Dependency manifests ─────────────────────────────────────────────────────
+
+describe("isLowRiskPR — dependency manifests", () => {
+  it("returns true for root package.json", () => {
+    expect(isLowRiskPR(["package.json"])).toBe(true);
+  });
+
+  it("returns true for a nested package.json", () => {
+    expect(isLowRiskPR(["apps/marketing/package.json"])).toBe(true);
+  });
+
+  it("returns true for pnpm-lock.yaml", () => {
+    expect(isLowRiskPR(["pnpm-lock.yaml"])).toBe(true);
+  });
+
+  it("returns true for package-lock.json", () => {
+    expect(isLowRiskPR(["package-lock.json"])).toBe(true);
+  });
+
+  it("returns true for yarn.lock", () => {
+    expect(isLowRiskPR(["yarn.lock"])).toBe(true);
+  });
+
+  it("returns true for a combined package.json + lockfile bump", () => {
+    expect(isLowRiskPR(["package.json", "pnpm-lock.yaml"])).toBe(true);
+  });
+});
+
+// ── Config files ─────────────────────────────────────────────────────────────
+
+describe("isLowRiskPR — config files", () => {
+  it("returns true for a .github/ workflow file", () => {
+    expect(isLowRiskPR([".github/workflows/deploy-static.yml"])).toBe(true);
+  });
+
+  it("returns true for a .claude/ skill file", () => {
+    expect(isLowRiskPR([".claude/skills/ship-loop/SKILL.md"])).toBe(true);
+  });
+
+  it("returns true for turbo.json", () => {
+    expect(isLowRiskPR(["turbo.json"])).toBe(true);
+  });
+
+  it("returns true for vite.config.ts", () => {
+    expect(isLowRiskPR(["apps/marketing/vite.config.ts"])).toBe(true);
+  });
+
+  it("returns true for vitest.config.ts", () => {
+    expect(isLowRiskPR(["packages/agent-core/vitest.config.ts"])).toBe(true);
+  });
+
+  it("returns true for eslint.config.js", () => {
+    expect(isLowRiskPR(["eslint.config.js"])).toBe(true);
+  });
+
+  it("returns true for prettier.config.mjs", () => {
+    expect(isLowRiskPR(["prettier.config.mjs"])).toBe(true);
+  });
+});
+
+// ── Mixed / multi-category batches ───────────────────────────────────────────
+
+describe("isLowRiskPR — mixed low-risk files", () => {
+  it("returns true when combining docs, tests, and config changes", () => {
+    expect(
+      isLowRiskPR([
+        "README.md",
+        "src/utils.test.ts",
+        ".github/workflows/ci.yml",
+        "package.json",
+        "pnpm-lock.yaml",
+      ])
+    ).toBe(true);
+  });
+});
+
+// ── High-risk files ──────────────────────────────────────────────────────────
+
+describe("isLowRiskPR — high-risk files", () => {
+  it("returns false for a regular source file", () => {
+    expect(isLowRiskPR(["src/routes.ts"])).toBe(false);
+  });
+
+  it("returns false for a React component", () => {
+    expect(isLowRiskPR(["src/components/Button.tsx"])).toBe(false);
+  });
+
+  it("returns false for a migration file", () => {
+    expect(isLowRiskPR(["prisma/migrations/20260101_add_users/migration.sql"])).toBe(false);
+  });
+
+  it("returns false when mix contains one high-risk file", () => {
+    expect(isLowRiskPR(["src/routes.test.ts", "src/routes.ts"])).toBe(false);
+  });
+
+  it("returns false when mix of docs and source", () => {
+    expect(isLowRiskPR(["README.md", "src/index.ts"])).toBe(false);
+  });
+
+  it("returns false for a shell script", () => {
+    expect(isLowRiskPR(["scripts/deploy.sh"])).toBe(false);
+  });
+
+  it("returns false for a Dockerfile", () => {
+    expect(isLowRiskPR(["Dockerfile"])).toBe(false);
+  });
+});
+
+// ── Edge cases ───────────────────────────────────────────────────────────────
+
+describe("isLowRiskPR — edge cases", () => {
+  it("returns false for an empty file list", () => {
+    expect(isLowRiskPR([])).toBe(false);
+  });
+
+  it("is not confused by a file named 'package.json.bak'", () => {
+    // Does not match the exact name or /package.json suffix rule correctly
+    // package.json.bak ends with .bak, not /package.json — should be false
+    expect(isLowRiskPR(["package.json.bak"])).toBe(false);
+  });
+
+  it("returns true for deeply nested test file", () => {
+    expect(isLowRiskPR(["services/users/src/__tests__/users.test.ts"])).toBe(true);
+  });
+});

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -165,3 +165,6 @@ export type {
 } from "./task-decomposer.js";
 
 export { DEFAULT_ORCHESTRATOR_CONFIG } from "./task-decomposer.js";
+
+// PR risk classification
+export { isLowRiskPR } from "./pr-risk-classifier.js";

--- a/packages/agent-core/src/pr-risk-classifier.ts
+++ b/packages/agent-core/src/pr-risk-classifier.ts
@@ -1,0 +1,50 @@
+/**
+ * PR risk classifier — identifies PRs that are safe to auto-merge as soon as
+ * CI passes, without waiting for the next ship-loop iteration.
+ *
+ * A PR is "low-risk" when every changed file falls into one of these categories:
+ *   - Test files  (*.test.ts, *.test.tsx, *.spec.ts, *.spec.tsx, *.test.js, *.spec.js, *.test.jsx, *.spec.jsx)
+ *   - Documentation  (*.md, docs/**)
+ *   - Dependency manifests  (package.json, pnpm-lock.yaml, package-lock.json, yarn.lock)
+ *   - Config files  (.github/**, .claude/**, turbo.json, *.config.ts, *.config.js, *.config.mjs)
+ */
+
+/** Pattern groups that are considered low-risk. */
+const LOW_RISK_PATTERNS: ReadonlyArray<(file: string) => boolean> = [
+  // Test files
+  (f) => /\.(test|spec)\.(ts|tsx|js|jsx|mjs|cjs)$/.test(f),
+
+  // Documentation
+  (f) => f.endsWith(".md") || f.startsWith("docs/"),
+
+  // Dependency manifests
+  (f) =>
+    f === "package.json" ||
+    f.endsWith("/package.json") ||
+    f === "pnpm-lock.yaml" ||
+    f === "package-lock.json" ||
+    f === "yarn.lock",
+
+  // Config files
+  (f) =>
+    f.startsWith(".github/") ||
+    f.startsWith(".claude/") ||
+    f === "turbo.json" ||
+    /\.(config)\.(ts|js|mjs|cjs)$/.test(f) ||
+    /\.(config)\.(ts|js|mjs|cjs)$/.test(f.split("/").pop() ?? ""),
+];
+
+/**
+ * Returns `true` when every file in `files` is considered low-risk and the PR
+ * can be auto-merged immediately once CI passes.
+ *
+ * Returns `false` for an empty file list — a PR with no changed files is
+ * unusual and should not be auto-merged without human review.
+ */
+export function isLowRiskPR(files: readonly string[]): boolean {
+  if (files.length === 0) {
+    return false;
+  }
+
+  return files.every((file) => LOW_RISK_PATTERNS.some((matches) => matches(file)));
+}


### PR DESCRIPTION
## Summary

- Adds `isLowRiskPR(files: readonly string[]): boolean` utility to `@mbe/agent-core` that classifies a PR as low-risk when every changed file is a test, doc, dependency manifest, or config file
- Updates ship-loop Phase A3 with a decision matrix that merges low-risk PRs immediately once CI passes, instead of waiting for the next loop iteration
- Exports the new function from the package index

## Why

Low-risk PRs (tests/docs/deps/config) cannot break the running application. Merging them immediately after CI passes instead of queuing them for the next iteration removes a full loop cycle of unnecessary latency from the backlog.

## Low-risk file patterns

| Category | Patterns |
|----------|---------|
| Test files | `*.test.ts`, `*.test.tsx`, `*.spec.ts`, `*.spec.tsx`, `*.test.js`, `*.spec.js`, `*.test.jsx`, `*.spec.jsx` |
| Documentation | `*.md`, `docs/**` |
| Dependency manifests | `package.json`, `pnpm-lock.yaml`, `package-lock.json`, `yarn.lock` |
| Config files | `.github/**`, `.claude/**`, `turbo.json`, `*.config.ts`, `*.config.js`, `*.config.mjs` |

## Test plan

- [x] 36 unit tests covering all four pattern categories, mixed low-risk batches, high-risk files, and edge cases (empty list, unusual filenames)
- [x] All 255 existing tests pass (`pnpm test` in `packages/agent-core`)
- [x] `pnpm lint` and `pnpm typecheck` pass clean
- [ ] Verify ship-loop behavior in practice on next loop run with a low-risk PR queued

Closes #68