### PR TITLE
fix(api): add health endpoints to reservations and users services

### DIFF
--- a/services/reservations/src/routes/health.test.ts
+++ b/services/reservations/src/routes/health.test.ts
@@ -132,4 +132,39 @@ describe("Health Routes", () => {
       expect(body.checks.database.message).toBe("Connection refused");
     });
   });
+
+  describe("GET /api/health", () => {
+    it("returns ok status when database is healthy (ingress-prefixed path)", async () => {
+      vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([{ "?column?": 1 }]);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/health",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.status).toBe("ok");
+      expect(body.version).toBe("1.0.0");
+      expect(body.checks.database.status).toBe("ok");
+      expect(typeof body.checks.database.latency).toBe("number");
+    });
+
+    it("returns degraded status when database is unhealthy (ingress-prefixed path)", async () => {
+      vi.mocked(prisma.$queryRaw).mockRejectedValueOnce(
+        new Error("Connection refused")
+      );
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/health",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.status).toBe("degraded");
+      expect(body.checks.database.status).toBe("error");
+      expect(body.checks.database.message).toBe("Connection refused");
+    });
+  });
 });

--- a/services/reservations/src/routes/health.ts
+++ b/services/reservations/src/routes/health.ts
@@ -1,104 +1,112 @@
-import type { FastifyPluginAsync } from "fastify";
+import type { FastifyPluginAsync, RouteHandlerMethod, RawServerDefault } from "fastify";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import type { HealthResponse } from "@mbe/types";
 import { prisma } from "../services/database.js";
 
-export const healthRoutes: FastifyPluginAsync = async (fastify) => {
-  fastify.get<{ Reply: HealthResponse }>(
-    "/health",
-    {
-      schema: {
-        summary: "Service health check",
-        operationId: "getHealth",
-        description:
-          "Check the health status of the service and its dependencies. Returns status of database connectivity and latency metrics.",
-        tags: ["Health"],
-        response: {
-          200: {
-            description: "Service health status",
+type HealthRouteHandler = RouteHandlerMethod<
+  RawServerDefault,
+  IncomingMessage,
+  ServerResponse,
+  { Reply: HealthResponse }
+>;
+
+const healthSchema = {
+  summary: "Service health check",
+  tags: ["Health"],
+  response: {
+    200: {
+      description: "Service health status",
+      type: "object",
+      properties: {
+        status: {
+          type: "string",
+          enum: ["ok", "degraded", "error"],
+          description:
+            "Overall service status: ok (all checks pass), degraded (some checks failing), error (critical failure)",
+          example: "ok",
+        },
+        version: {
+          type: "string",
+          description: "Service version number",
+          example: "1.0.0",
+        },
+        timestamp: {
+          type: "string",
+          format: "date-time",
+          description: "ISO 8601 timestamp of the health check",
+          example: "2024-01-15T10:30:00.000Z",
+        },
+        checks: {
+          type: "object",
+          description: "Individual health check results",
+          additionalProperties: {
             type: "object",
             properties: {
               status: {
                 type: "string",
-                enum: ["ok", "degraded", "error"],
-                description:
-                  "Overall service status: ok (all checks pass), degraded (some checks failing), error (critical failure)",
-                example: "ok",
+                enum: ["ok", "error"],
+                description: "Status of this specific check",
               },
-              version: {
+              message: {
                 type: "string",
-                description: "Service version number",
-                example: "1.0.0",
+                description: "Error message if check failed",
               },
-              timestamp: {
-                type: "string",
-                format: "date-time",
-                description: "ISO 8601 timestamp of the health check",
-                example: "2024-01-15T10:30:00.000Z",
+              latency: {
+                type: "number",
+                description: "Response time in milliseconds",
               },
-              checks: {
-                type: "object",
-                description: "Individual health check results",
-                additionalProperties: {
-                  type: "object",
-                  properties: {
-                    status: {
-                      type: "string",
-                      enum: ["ok", "error"],
-                      description: "Status of this specific check",
-                    },
-                    message: {
-                      type: "string",
-                      description: "Error message if check failed",
-                    },
-                    latency: {
-                      type: "number",
-                      description: "Response time in milliseconds",
-                    },
-                  },
-                },
-              },
-            },
-          },
-          503: {
-            description: "Service unavailable (critical health check failed)",
-            type: "object",
-            properties: {
-              status: { type: "string", enum: ["error"] },
-              version: { type: "string" },
-              timestamp: { type: "string", format: "date-time" },
-              checks: { type: "object" },
             },
           },
         },
       },
     },
-    async () => {
-      const checks: HealthResponse["checks"] = {};
+    503: {
+      description: "Service unavailable (critical health check failed)",
+      type: "object",
+      properties: {
+        status: { type: "string", enum: ["error"] },
+        version: { type: "string" },
+        timestamp: { type: "string", format: "date-time" },
+        checks: { type: "object" },
+      },
+    },
+  },
+};
 
-      // Check database connection
-      const dbStart = Date.now();
-      try {
-        await prisma.$queryRaw`SELECT 1`;
-        checks.database = {
-          status: "ok",
-          latency: Date.now() - dbStart,
-        };
-      } catch (error) {
-        checks.database = {
-          status: "error",
-          message: error instanceof Error ? error.message : "Database connection failed",
-          latency: Date.now() - dbStart,
-        };
-      }
+const healthHandler: HealthRouteHandler = async () => {
+  const checks: HealthResponse["checks"] = {};
 
-      const hasErrors = Object.values(checks).some((c) => c.status === "error");
+  // Check database connection
+  const dbStart = Date.now();
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    checks.database = {
+      status: "ok",
+      latency: Date.now() - dbStart,
+    };
+  } catch (error) {
+    checks.database = {
+      status: "error",
+      message: error instanceof Error ? error.message : "Database connection failed",
+      latency: Date.now() - dbStart,
+    };
+  }
 
-      return {
-        status: hasErrors ? "degraded" : "ok",
-        version: "1.0.0",
-        timestamp: new Date().toISOString(),
-        checks,
-      };
-    }
-  );
+  const hasErrors = Object.values(checks).some((c) => c.status === "error");
+
+  return {
+    status: hasErrors ? "degraded" : "ok",
+    version: "1.0.0",
+    timestamp: new Date().toISOString(),
+    checks,
+  };
+};
+
+export const healthRoutes: FastifyPluginAsync = async (fastify) => {
+  // /health — used by DO App Platform internal health checks (direct container access)
+  fastify.get("/health", { schema: { ...healthSchema, operationId: "getHealth" } }, healthHandler);
+
+  // /api/health — public path via DO ingress (preservePathPrefix: true, prefix "/api")
+  // Required for post-deploy verification workflow hitting api.mattbutlerengineering.com/api/health
+  fastify.get("/api/health", { schema: { ...healthSchema, operationId: "getHealthApi" } }, healthHandler);
 };

--- a/services/users/src/routes/health.test.ts
+++ b/services/users/src/routes/health.test.ts
@@ -57,4 +57,38 @@ describe("Health Routes", () => {
       expect(body.checks.database.message).toBe("Connection failed");
     });
   });
+
+  describe("GET /api/v1/users/health", () => {
+    it("returns ok status when database is healthy (ingress-prefixed path)", async () => {
+      vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([{ "?column?": 1 }]);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/v1/users/health",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.status).toBe("ok");
+      expect(body.version).toBe("1.0.0");
+      expect(body.timestamp).toBeDefined();
+      expect(body.checks.database.status).toBe("ok");
+      expect(body.checks.database.latency).toBeGreaterThanOrEqual(0);
+    });
+
+    it("returns degraded status when database is unhealthy (ingress-prefixed path)", async () => {
+      vi.mocked(prisma.$queryRaw).mockRejectedValueOnce(new Error("Connection failed"));
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/v1/users/health",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.status).toBe("degraded");
+      expect(body.checks.database.status).toBe("error");
+      expect(body.checks.database.message).toBe("Connection failed");
+    });
+  });
 });

--- a/services/users/src/routes/health.ts
+++ b/services/users/src/routes/health.ts
@@ -1,104 +1,113 @@
-import type { FastifyPluginAsync } from "fastify";
+import type { FastifyPluginAsync, RouteHandlerMethod, RawServerDefault } from "fastify";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import type { HealthResponse } from "@mbe/types";
 import { prisma } from "../services/database.js";
 
-export const healthRoutes: FastifyPluginAsync = async (fastify) => {
-  fastify.get<{ Reply: HealthResponse }>(
-    "/health",
-    {
-      schema: {
-        summary: "Service health check",
-        operationId: "getHealth",
-        description:
-          "Check the health status of the service and its dependencies. Returns status of database connectivity and latency metrics.",
-        tags: ["Health"],
-        response: {
-          200: {
-            description: "Service health status",
+type HealthRouteHandler = RouteHandlerMethod<
+  RawServerDefault,
+  IncomingMessage,
+  ServerResponse,
+  { Reply: HealthResponse }
+>;
+
+const healthSchema = {
+  summary: "Service health check",
+  tags: ["Health"],
+  response: {
+    200: {
+      description: "Service health status",
+      type: "object",
+      properties: {
+        status: {
+          type: "string",
+          enum: ["ok", "degraded", "error"],
+          description:
+            "Overall service status: ok (all checks pass), degraded (some checks failing), error (critical failure)",
+          example: "ok",
+        },
+        version: {
+          type: "string",
+          description: "Service version number",
+          example: "1.0.0",
+        },
+        timestamp: {
+          type: "string",
+          format: "date-time",
+          description: "ISO 8601 timestamp of the health check",
+          example: "2024-01-15T10:30:00.000Z",
+        },
+        checks: {
+          type: "object",
+          description: "Individual health check results",
+          additionalProperties: {
             type: "object",
             properties: {
               status: {
                 type: "string",
-                enum: ["ok", "degraded", "error"],
-                description:
-                  "Overall service status: ok (all checks pass), degraded (some checks failing), error (critical failure)",
-                example: "ok",
+                enum: ["ok", "error"],
+                description: "Status of this specific check",
               },
-              version: {
+              message: {
                 type: "string",
-                description: "Service version number",
-                example: "1.0.0",
+                description: "Error message if check failed",
               },
-              timestamp: {
-                type: "string",
-                format: "date-time",
-                description: "ISO 8601 timestamp of the health check",
-                example: "2024-01-15T10:30:00.000Z",
+              latency: {
+                type: "number",
+                description: "Response time in milliseconds",
               },
-              checks: {
-                type: "object",
-                description: "Individual health check results",
-                additionalProperties: {
-                  type: "object",
-                  properties: {
-                    status: {
-                      type: "string",
-                      enum: ["ok", "error"],
-                      description: "Status of this specific check",
-                    },
-                    message: {
-                      type: "string",
-                      description: "Error message if check failed",
-                    },
-                    latency: {
-                      type: "number",
-                      description: "Response time in milliseconds",
-                    },
-                  },
-                },
-              },
-            },
-          },
-          503: {
-            description: "Service unavailable (critical health check failed)",
-            type: "object",
-            properties: {
-              status: { type: "string", enum: ["error"] },
-              version: { type: "string" },
-              timestamp: { type: "string", format: "date-time" },
-              checks: { type: "object" },
             },
           },
         },
       },
     },
-    async () => {
-      const checks: HealthResponse["checks"] = {};
+    503: {
+      description: "Service unavailable (critical health check failed)",
+      type: "object",
+      properties: {
+        status: { type: "string", enum: ["error"] },
+        version: { type: "string" },
+        timestamp: { type: "string", format: "date-time" },
+        checks: { type: "object" },
+      },
+    },
+  },
+};
 
-      // Check database connection
-      const dbStart = Date.now();
-      try {
-        await prisma.$queryRaw`SELECT 1`;
-        checks.database = {
-          status: "ok",
-          latency: Date.now() - dbStart,
-        };
-      } catch (error) {
-        checks.database = {
-          status: "error",
-          message: error instanceof Error ? error.message : "Database connection failed",
-          latency: Date.now() - dbStart,
-        };
-      }
+const healthHandler: HealthRouteHandler = async () => {
+  const checks: HealthResponse["checks"] = {};
 
-      const hasErrors = Object.values(checks).some((c) => c.status === "error");
+  // Check database connection
+  const dbStart = Date.now();
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    checks.database = {
+      status: "ok",
+      latency: Date.now() - dbStart,
+    };
+  } catch (error) {
+    checks.database = {
+      status: "error",
+      message: error instanceof Error ? error.message : "Database connection failed",
+      latency: Date.now() - dbStart,
+    };
+  }
 
-      return {
-        status: hasErrors ? "degraded" : "ok",
-        version: "1.0.0",
-        timestamp: new Date().toISOString(),
-        checks,
-      };
-    }
-  );
+  const hasErrors = Object.values(checks).some((c) => c.status === "error");
+
+  return {
+    status: hasErrors ? "degraded" : "ok",
+    version: "1.0.0",
+    timestamp: new Date().toISOString(),
+    checks,
+  };
+};
+
+export const healthRoutes: FastifyPluginAsync = async (fastify) => {
+  // /health — used by DO App Platform internal health checks (direct container access)
+  // Also reachable via api.mattbutlerengineering.com/health (catch-all "/" ingress rule)
+  fastify.get("/health", { schema: { ...healthSchema, operationId: "getHealth" } }, healthHandler);
+
+  // /api/v1/users/health — public path via DO ingress (preservePathPrefix: true, prefix "/api/v1/users")
+  // Required for post-deploy verification and public health monitoring
+  fastify.get("/api/v1/users/health", { schema: { ...healthSchema, operationId: "getHealthApiUsers" } }, healthHandler);
 };


### PR DESCRIPTION
## Summary

- **Root cause**: DO App Platform uses `preservePathPrefix: true` on ingress rules, so services receive the full ingress-prefixed path (e.g., `/api/health` not `/health`). Both services only registered `/health`, so post-deploy verification at `api.mattbutlerengineering.com/api/health` returned 404.
- Added `/api/health` route to `reservations-api` (matches the `/api` ingress prefix)
- Added `/api/v1/users/health` route to `users-api` (matches the `/api/v1/users` ingress prefix)
- Kept the original `/health` routes for DO App Platform internal container health checks (`httpPath: "/health"` in Pulumi config hits the container directly, bypassing ingress)
- Refactored both health modules to share a single handler function and schema object (avoids duplication)

## Test plan

- [ ] `cd services/reservations && pnpm test` — 4 health tests pass (covers `/health` and `/api/health`)
- [ ] `cd services/users && pnpm test` — 4 health tests pass (covers `/health` and `/api/v1/users/health`)
- [ ] `pnpm lint` passes for both services
- [ ] `pnpm typecheck` passes for both services
- [ ] After merge, deploy-services CI workflow `Post-Deploy Verification` step should pass

Closes #96