### PR TITLE
fix(routing): unregister stale hospitality SW on marketing and rialto pages

### DIFF
--- a/apps/marketing/src/main.tsx
+++ b/apps/marketing/src/main.tsx
@@ -7,6 +7,19 @@ import { BrowserRouter } from "react-router-dom";
 import { RialtoProvider } from "@mbe/rialto";
 import { App } from "./App";
 
+// Unregister stale service workers. A previous build registered the hospitality
+// SW at scope "/" instead of "/hospitality/", causing marketing pages to redirect
+// to /hospitality for returning visitors. Clears any SW not scoped to /hospitality/.
+if ("serviceWorker" in navigator) {
+  navigator.serviceWorker.getRegistrations().then((registrations) => {
+    for (const registration of registrations) {
+      if (!registration.scope.includes("/hospitality/")) {
+        void registration.unregister();
+      }
+    }
+  });
+}
+
 /* ── Theme persistence ────────────────────────── */
 const THEME_KEY = "mbe-theme-preference";
 

--- a/apps/rialto-web/src/main.tsx
+++ b/apps/rialto-web/src/main.tsx
@@ -8,6 +8,19 @@ import { RialtoProvider, ToastProvider } from "@mbe/rialto";
 import { ThemeContext } from "./ThemeContext";
 import { routeTree } from "./routes";
 
+// Unregister stale service workers. A previous build registered the hospitality
+// SW at scope "/" instead of "/hospitality/", causing rialto pages to redirect
+// to /hospitality for returning visitors. Clears any SW not scoped to /hospitality/.
+if ("serviceWorker" in navigator) {
+  navigator.serviceWorker.getRegistrations().then((registrations) => {
+    for (const registration of registrations) {
+      if (!registration.scope.includes("/hospitality/")) {
+        void registration.unregister();
+      }
+    }
+  });
+}
+
 /* ── Theme persistence ────────────────────────── */
 const THEME_KEY = "mbe-theme-preference";
 


### PR DESCRIPTION
## Summary

- Adds a `getRegistrations()` + `unregister()` call in `apps/marketing/src/main.tsx` and `apps/rialto-web/src/main.tsx` to purge any stale service worker not scoped to `/hospitality/`
- The hospitality `vite.config.ts` already has `scope: "/hospitality/"` (fix from #39), so new registrations are correct — this clears old cached SWs in returning visitors' browsers
- No SW is registered by marketing or rialto-web, so the unregister logic is purely defensive cleanup

The stale SW was also the root cause of the rialto sidebar active-state bug (#115): the SW hijacked navigation and changed the URL after page load, causing the sidebar to show zero active items or highlight the wrong component.

## Test plan

- [ ] Visit `/hospitality` to register the SW, then navigate to `/` — confirm no redirect to `/hospitality`
- [ ] Visit `/hospitality` to register the SW, then navigate to `/rialto/` — confirm no redirect
- [ ] DevTools → Application → Service Workers: confirm no SW with scope `/` exists after visiting marketing or rialto
- [ ] Navigate to `/rialto/components/button` — confirm only "Button" is highlighted in sidebar (no Slider/Meter)

Closes #98
Closes #115

https://claude.ai/code/session_01Y4Xx7b4bGMUnvYawNfeSZr