### PR TITLE
fix(rialto-web): sidebar collapses on mobile for overview page

### DIFF
--- a/apps/rialto-web/src/components/ShowcaseSidebar.module.css
+++ b/apps/rialto-web/src/components/ShowcaseSidebar.module.css
@@ -4,6 +4,7 @@
   display: flex;
   flex-direction: column;
   width: 260px;
+  flex-shrink: 0;
   height: 100%;
   background: var(--rialto-surface-elevated);
   border-inline-end: 1px solid var(--rialto-border);

--- a/apps/rialto-web/src/pages/OverviewPage.module.css
+++ b/apps/rialto-web/src/pages/OverviewPage.module.css
@@ -154,6 +154,20 @@
 }
 
 /* ── Responsive ───────────────────────────────── */
+
+/* Match the sidebar collapse breakpoint so content fills the full width
+   when the sidebar transitions to a mobile drawer at ≤767px. */
+@media (max-width: 767px) {
+  .heroLogo {
+    font-size: 3rem;
+  }
+
+  .page {
+    gap: var(--rialto-space-2xl);
+    padding-block: var(--rialto-space-xl);
+  }
+}
+
 @media (max-width: 640px) {
   .stats {
     flex-direction: column;


### PR DESCRIPTION
## Summary

- Add `flex-shrink: 0` to `ShowcaseSidebar` root — without it, the sidebar could compress below its 260px design width on narrow desktop viewports, squishing both columns
- Add a `max-width: 767px` media query to `OverviewPage.module.css` matching the sidebar-collapse breakpoint: scales the hero logo from 4rem → 3rem and tightens section spacing so the overview fills the full width naturally after the sidebar becomes a mobile drawer

## Test plan

- [ ] Open `/rialto/` at 375px viewport — sidebar should be hidden (hamburger button at bottom-left visible)
- [ ] Tap hamburger → sidebar slides open as a drawer overlay, content not squished
- [ ] Open `/rialto/components/button` at 375px — same behaviour (regression check)
- [ ] At 768px+ — sidebar fixed at 260px, not compressed by wide content

Closes #116

https://claude.ai/code/session_01MnWEtf3mHadztLFaiEL45T