### PR TITLE
fix(edge-router): widen CSP to allow Google Fonts, Cloudflare Analytics, and inline scripts

### DIFF
--- a/infrastructure/worker/edge-router.js
+++ b/infrastructure/worker/edge-router.js
@@ -18,11 +18,11 @@ const SECURITY_HEADERS = {
   "Referrer-Policy": "strict-origin-when-cross-origin",
   "Content-Security-Policy": [
     "default-src 'self'",
-    "script-src 'self'",
-    "style-src 'self' 'unsafe-inline'",
+    "script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com",
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "img-src 'self' data: https:",
-    "font-src 'self'",
-    "connect-src 'self' https://dev-ytbgmz5ls3wh4xdx.us.auth0.com https://api.mattbutlerengineering.com",
+    "font-src 'self' https://fonts.gstatic.com",
+    "connect-src 'self' https://dev-ytbgmz5ls3wh4xdx.us.auth0.com https://api.mattbutlerengineering.com https://cloudflareinsights.com",
     "frame-ancestors 'none'",
   ].join("; "),
 };


### PR DESCRIPTION
## Summary

- Adds `https://fonts.googleapis.com` to `style-src` and `https://fonts.gstatic.com` to `font-src` so Google Fonts load correctly
- Adds `'unsafe-inline'` to `script-src` for Vite module preloading and service worker cleanup inline scripts
- Adds `https://static.cloudflareinsights.com` to `script-src` and `https://cloudflareinsights.com` to `connect-src` for Cloudflare Web Analytics
- Resolves 3 console errors on every page (marketing, rialto, hospitality)

## Test plan

- [ ] Deploy edge router and verify no CSP console errors on `/`, `/rialto`, `/hospitality`
- [ ] Verify Google Fonts (DM Sans, DM Mono, Bricolage Grotesque) load correctly
- [ ] Verify Cloudflare Web Analytics beacon loads and sends data
- [ ] Verify no new CSP violations appear in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)