### PR TITLE
feat(marketing): add Hospitality Platform project card to homepage

### DIFF
--- a/apps/marketing/src/data/projects.ts
+++ b/apps/marketing/src/data/projects.ts
@@ -14,4 +14,12 @@ export const PROJECTS: Project[] = [
     tags: ["React", "TypeScript", "Vite", "Framer Motion"],
     href: "/rialto",
   },
+  {
+    title: "Hospitality Platform",
+    description:
+      "A full-stack restaurant management app with Auth0 authentication, dark mode, " +
+      "offline-capable PWA support, and route-level code splitting. Built on the Rialto design system.",
+    tags: ["React", "Auth0", "PWA", "Fastify", "Prisma"],
+    href: "/hospitality",
+  },
 ];


### PR DESCRIPTION
## Summary

- Adds the Hospitality Platform as a second project card on the marketing homepage
- The Projects section previously only showcased Rialto — now it highlights both shipped products
- Uses existing `ProjectCard` component and `projectGrid` CSS (already supports multiple cards with `auto-fill`)
- Tags: React, Auth0, PWA, Fastify, Prisma

## Test plan

- [ ] Verify homepage shows two project cards side-by-side on desktop
- [ ] Verify cards stack vertically on mobile (< 640px)
- [ ] Verify "View live" links to `/hospitality`
- [ ] Verify scroll reveal animation works for both cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)