### PR TITLE
feat(marketing): upgrade footer with project links and social links

### DIFF
--- a/apps/marketing/src/App.tsx
+++ b/apps/marketing/src/App.tsx
@@ -38,9 +38,29 @@ export function App({ theme, onThemeToggle }: AppProps) {
           <Route path="*" element={<NotFoundPage />} />
         </Routes>
       </main>
-      <Footer variant="minimal" className={styles.footer}>
-        <span>&copy; {new Date().getFullYear()} Matt Butler Engineering</span>
-      </Footer>
+      <Footer
+        variant="rich"
+        className={styles.footer}
+        logo={<span>MBE</span>}
+        columns={[
+          {
+            title: "Projects",
+            links: [
+              { label: "Rialto Design System", href: "/rialto" },
+              { label: "Hospitality Platform", href: "/hospitality" },
+            ],
+          },
+          {
+            title: "Connect",
+            links: [
+              { label: "GitHub", href: "https://github.com/mattbutlerengineering" },
+              { label: "LinkedIn", href: "https://www.linkedin.com/in/matt-butler-66496a68/" },
+              { label: "Email", href: "mailto:mattbutlerengineering+webapp@gmail.com" },
+            ],
+          },
+        ]}
+        copyright={`\u00A9 ${new Date().getFullYear()} Matt Butler Engineering`}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Upgrades the marketing site footer from `minimal` (copyright only) to `rich` variant
- Adds two footer columns: **Projects** (Rialto, Hospitality) and **Connect** (GitHub, LinkedIn, Email)
- Uses existing Rialto `Footer` component's built-in rich layout — no custom CSS needed
- Improves site navigation and SEO through meaningful footer links

## Test plan

- [ ] Verify footer renders with two columns and copyright on desktop
- [ ] Verify footer layout is responsive on mobile
- [ ] Verify all links (internal and external) work correctly
- [ ] Verify footer looks correct in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)