### PR TITLE
fix(marketing): improve accessibility with aria-labels and dynamic 404 title

### DIFF
--- a/apps/marketing/src/components/ContactSection.tsx
+++ b/apps/marketing/src/components/ContactSection.tsx
@@ -28,6 +28,7 @@ export function ContactSection() {
                   href={link.href}
                   target={link.external ? "_blank" : undefined}
                   rel={link.external ? "noopener noreferrer" : undefined}
+                  aria-label={link.external ? `${link.label} (opens in new tab)` : undefined}
                   className={styles.contactLink}
                   variants={staggerReveal.item}
                   whileHover={shouldReduceMotion ? undefined : { scale: boop.scale }}

--- a/apps/marketing/src/pages/NotFoundPage.tsx
+++ b/apps/marketing/src/pages/NotFoundPage.tsx
@@ -1,7 +1,15 @@
+import { useEffect } from "react";
 import { Link } from "react-router-dom";
 import styles from "./NotFoundPage.module.css";
 
 export function NotFoundPage() {
+  useEffect(() => {
+    document.title = "Page not found — Matt Butler Engineering";
+    return () => {
+      document.title = "Matt Butler Engineering";
+    };
+  }, []);
+
   return (
     <div className={styles.container}>
       <h1 className={styles.heading}>404</h1>


### PR DESCRIPTION
## Summary

- Adds `aria-label="GitHub (opens in new tab)"` and `aria-label="LinkedIn (opens in new tab)"` to external links in ContactSection (WCAG 3.2.5)
- Sets dynamic `document.title` on the 404 page ("Page not found — Matt Butler Engineering") for SEO and browser tab clarity
- Restores default title on unmount to prevent stale titles

## Test plan

- [ ] Screen reader announces "GitHub (opens in new tab)" for external links
- [ ] Email link has no aria-label override (it doesn't open a new tab)
- [ ] 404 page shows "Page not found — Matt Butler Engineering" in browser tab
- [ ] Navigating away from 404 restores "Matt Butler Engineering" title

🤖 Generated with [Claude Code](https://claude.com/claude-code)