### PR TITLE
feat(marketing): add Tech Stack section to homepage

### DIFF
--- a/apps/marketing/src/components/TechStackSection.tsx
+++ b/apps/marketing/src/components/TechStackSection.tsx
@@ -1,0 +1,47 @@
+import { Stack, Text, Tag, useScrollReveal, staggerReveal } from "@mbe/rialto";
+import { motion } from "framer-motion";
+import { TECH_STACK } from "../data/tech-stack";
+import styles from "../pages/HomePage.module.css";
+
+export function TechStackSection() {
+  const { ref, controls } = useScrollReveal();
+
+  return (
+    <section id="tech-stack" className={styles.section}>
+      <div className={styles.sectionInner}>
+        <Stack gap="xl">
+          <div>
+            <h2 className={styles.sectionHeading}>Tech Stack</h2>
+            <Text variant="body" color="secondary">
+              The tools and frameworks powering this site and its services.
+            </Text>
+          </div>
+
+          <motion.div
+            ref={ref}
+            variants={staggerReveal.container}
+            initial="hidden"
+            animate={controls}
+          >
+            <Stack gap="lg">
+              {TECH_STACK.map((category) => (
+                <motion.div key={category.title} variants={staggerReveal.item}>
+                  <Stack gap="sm">
+                    <Text variant="body" color="secondary" as="h3">
+                      {category.title}
+                    </Text>
+                    <Stack direction="row" gap="sm" wrap>
+                      {category.items.map((tech) => (
+                        <Tag key={tech}>{tech}</Tag>
+                      ))}
+                    </Stack>
+                  </Stack>
+                </motion.div>
+              ))}
+            </Stack>
+          </motion.div>
+        </Stack>
+      </div>
+    </section>
+  );
+}

--- a/apps/marketing/src/data/tech-stack.ts
+++ b/apps/marketing/src/data/tech-stack.ts
@@ -1,0 +1,23 @@
+export interface TechCategory {
+  title: string;
+  items: string[];
+}
+
+export const TECH_STACK: TechCategory[] = [
+  {
+    title: "Frontend",
+    items: ["React", "TypeScript", "Vite", "Framer Motion"],
+  },
+  {
+    title: "Backend",
+    items: ["Fastify", "Prisma", "PostgreSQL", "Node.js"],
+  },
+  {
+    title: "Infrastructure",
+    items: ["Cloudflare Workers", "DigitalOcean", "Pulumi", "Turborepo"],
+  },
+  {
+    title: "Auth & DevOps",
+    items: ["Auth0", "GitHub Actions", "Docker", "pnpm"],
+  },
+];

--- a/apps/marketing/src/pages/HomePage.tsx
+++ b/apps/marketing/src/pages/HomePage.tsx
@@ -1,5 +1,6 @@
 import { HeroSection } from "../components/HeroSection";
 import { ProjectsSection } from "../components/ProjectsSection";
+import { TechStackSection } from "../components/TechStackSection";
 import { AboutSection } from "../components/AboutSection";
 import { ContactSection } from "../components/ContactSection";
 
@@ -8,6 +9,7 @@ export function HomePage() {
     <>
       <HeroSection />
       <ProjectsSection />
+      <TechStackSection />
       <AboutSection />
       <ContactSection />
     </>


### PR DESCRIPTION
## Summary

- Adds a new "Tech Stack" section between Projects and About on the homepage
- Organized into 4 categories: Frontend, Backend, Infrastructure, Auth & DevOps
- Uses Rialto `Tag` components in a categorized layout with scroll-reveal animations
- Follows the established section pattern (section > sectionInner > heading + content)
- No new CSS needed — reuses existing section styles and Rialto components

## Test plan

- [ ] Verify Tech Stack section renders between Projects and About
- [ ] Verify all 4 categories display with correct tags
- [ ] Verify scroll-reveal animation triggers on scroll
- [ ] Verify layout works on mobile (tags wrap correctly)
- [ ] Verify section divider lines appear above and below

🤖 Generated with [Claude Code](https://claude.com/claude-code)