### PR TITLE
feat(marketing): enhance 404 page with suggested navigation links

### DIFF
--- a/apps/marketing/src/pages/NotFoundPage.module.css
+++ b/apps/marketing/src/pages/NotFoundPage.module.css
@@ -17,12 +17,14 @@
 }
 
 .message {
-  font-size: var(--rialto-text-lg);
-  color: var(--rialto-text-secondary);
   margin: 0 0 var(--rialto-space-xl) 0;
 }
 
-.homeLink {
+.primaryLink {
+  text-decoration: none;
+}
+
+.suggestedLink {
   color: var(--rialto-text-secondary);
   text-decoration: none;
   font-size: var(--rialto-text-base);
@@ -34,7 +36,7 @@
   transition: color 150ms ease, border-color 150ms ease;
 }
 
-.homeLink:hover {
+.suggestedLink:hover {
   color: var(--rialto-text-primary);
   border-color: var(--rialto-border-strong);
 }

--- a/apps/marketing/src/pages/NotFoundPage.tsx
+++ b/apps/marketing/src/pages/NotFoundPage.tsx
@@ -1,6 +1,13 @@
 import { useEffect } from "react";
 import { Link } from "react-router-dom";
+import { Stack, Text, Button } from "@mbe/rialto";
 import styles from "./NotFoundPage.module.css";
+
+const SUGGESTED_LINKS = [
+  { to: "/", label: "Home" },
+  { to: "/rialto", label: "Design System" },
+  { to: "/hospitality", label: "Hospitality" },
+];
 
 export function NotFoundPage() {
   useEffect(() => {
@@ -13,10 +20,29 @@ export function NotFoundPage() {
   return (
     <div className={styles.container}>
       <h1 className={styles.heading}>404</h1>
-      <p className={styles.message}>Page not found</p>
-      <Link to="/" className={styles.homeLink}>
-        Back to home
-      </Link>
+      <Text variant="body" color="secondary" className={styles.message}>
+        This page doesn&apos;t exist. It may have been moved or removed.
+      </Text>
+
+      <Stack gap="lg" align="center">
+        <Link to="/" className={styles.primaryLink}>
+          <Button variant="primary" size="md">
+            Back to home
+          </Button>
+        </Link>
+
+        <Text variant="body" color="secondary">
+          Or try one of these:
+        </Text>
+
+        <Stack direction="row" gap="md" wrap>
+          {SUGGESTED_LINKS.filter((link) => link.to !== "/").map((link) => (
+            <Link key={link.to} to={link.to} className={styles.suggestedLink}>
+              {link.label}
+            </Link>
+          ))}
+        </Stack>
+      </Stack>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Replaces the bare-bones 404 page with a richer experience using Rialto components
- Adds a primary "Back to home" button (Rialto Button, gold primary variant)
- Adds "Or try one of these" suggested links to Design System and Hospitality
- Better copy: "This page doesn't exist. It may have been moved or removed."
- Uses Stack component for responsive layout

## Test plan

- [ ] Navigate to a non-existent URL and verify enhanced 404 page
- [ ] Verify "Back to home" button navigates to `/`
- [ ] Verify suggested links navigate correctly
- [ ] Verify layout looks good on mobile
- [ ] Verify dark mode rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)