### PR TITLE
feat(rialto-web): dynamic page titles for all 68+ component pages

### DIFF
--- a/apps/rialto-web/src/pages/components/ComponentPageLayout.tsx
+++ b/apps/rialto-web/src/pages/components/ComponentPageLayout.tsx
@@ -1,6 +1,8 @@
-import type { ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
 import { Text, Divider, Stack } from "@mbe/rialto";
 import styles from "./ComponentPageLayout.module.css";
+
+const BASE_TITLE = "Rialto — Design System";
 
 export interface ComponentPageLayoutProps {
   /** Component name, e.g. "Button" */
@@ -21,6 +23,13 @@ export interface ComponentPageLayoutProps {
  * - Children (page-specific sections)
  */
 export function ComponentPageLayout({ name, description, children }: ComponentPageLayoutProps) {
+  useEffect(() => {
+    document.title = `${name} — Rialto`;
+    return () => {
+      document.title = BASE_TITLE;
+    };
+  }, [name]);
+
   return (
     <div className={styles.page}>
       <div className={styles.header}>


### PR DESCRIPTION
## Summary

- Adds dynamic `document.title` to all Rialto component pages (e.g. "Button — Rialto", "Card — Rialto")
- Previously every page showed the generic "Rialto — Design System"
- Single-point change in `ComponentPageLayout` — automatically applies to all 68+ component pages
- Restores base title on unmount

## Test plan

- [ ] Navigate to `/rialto/components/button` — tab should show "Button — Rialto"
- [ ] Navigate to `/rialto/components/card` — tab should show "Card — Rialto"
- [ ] Navigate back to `/rialto/` — tab should show "Rialto — Design System"

🤖 Generated with [Claude Code](https://claude.com/claude-code)