### PR TITLE
fix(hospitality,rialto-web): add missing og:image and twitter:image meta tags

### DIFF
--- a/apps/hospitality/index.html
+++ b/apps/hospitality/index.html
@@ -12,9 +12,11 @@
     <meta property="og:description" content="Hospitality management platform" />
     <meta property="og:url" content="https://mattbutlerengineering.com/hospitality" />
     <meta property="og:type" content="website" />
+    <meta property="og:image" content="https://mattbutlerengineering.com/og-image.svg" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Matt Butler Engineering — Hospitality" />
     <meta name="twitter:description" content="Hospitality management platform" />
+    <meta name="twitter:image" content="https://mattbutlerengineering.com/og-image.svg" />
     <title>Dashboard - Matt Butler Engineering</title>
   </head>
   <body>

--- a/apps/rialto-web/index.html
+++ b/apps/rialto-web/index.html
@@ -20,9 +20,11 @@
     <meta property="og:description" content="Component library and design system showcase" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://mattbutlerengineering.com/rialto/" />
+    <meta property="og:image" content="https://mattbutlerengineering.com/og-image.svg" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Rialto Design System" />
     <meta name="twitter:description" content="Component library and design system showcase" />
+    <meta name="twitter:image" content="https://mattbutlerengineering.com/og-image.svg" />
     <title>Rialto — Design System</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary

- Adds `og:image` and `twitter:image` meta tags to both hospitality and rialto-web apps
- These were the only two apps missing social preview images
- Points to the shared marketing site og-image (`/og-image.svg`)
- Social media links to `/hospitality` and `/rialto` will now show a preview image

## Test plan

- [ ] Share a `/hospitality` link and verify social preview shows image
- [ ] Share a `/rialto` link and verify social preview shows image
- [ ] Validate HTML meta tags with an OG validator tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)