### PR TITLE
fix(rialto-web): fix broken GitHub link in footer (404)

### DIFF
--- a/apps/rialto-web/src/layouts/ShowcaseLayout.tsx
+++ b/apps/rialto-web/src/layouts/ShowcaseLayout.tsx
@@ -110,7 +110,7 @@ export function ShowcaseLayout(props: ShowcaseLayoutProps) {
                 {
                   title: "Design System",
                   links: [
-                    { label: "GitHub", href: "https://github.com/mattbutlerengineering/mattbutlerengineering" },
+                    { label: "GitHub", href: "https://github.com/mattbutlerengineering" },
                     { label: "Overview", href: "/rialto/" },
                   ],
                 },


### PR DESCRIPTION
## Summary

- Fixes the Rialto footer GitHub link which pointed to the repo URL (private, returns 404)
- Updated to point to the GitHub org page (`https://github.com/mattbutlerengineering`) which is public and matches the marketing site

## Test plan

- [ ] Click "GitHub" link in Rialto footer — should open the org page, not 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)