### PR TITLE
fix(hospitality): add aria-hidden to decorative SVGs and type=button

### DIFF
--- a/apps/hospitality/src/components/booking-widget/BookingWidget.tsx
+++ b/apps/hospitality/src/components/booking-widget/BookingWidget.tsx
@@ -234,7 +234,7 @@ export function BookingWidget({
                 ].join(" ")}
               >
                 {currentStepIndex > i ? (
-                  <svg className={styles.stepIcon} fill="currentColor" viewBox="0 0 20 20">
+                  <svg className={styles.stepIcon} fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
                     <path
                       fillRule="evenodd"
                       d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"

--- a/apps/hospitality/src/components/booking-widget/ConfirmationView.tsx
+++ b/apps/hospitality/src/components/booking-widget/ConfirmationView.tsx
@@ -31,6 +31,7 @@ export function ConfirmationView({ reservation, onNewBooking }: ConfirmationView
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
+          aria-hidden="true"
         >
           <path
             strokeLinecap="round"
@@ -95,7 +96,7 @@ export function ConfirmationView({ reservation, onNewBooking }: ConfirmationView
 
       {/* Actions */}
       <div className={styles.actions}>
-        <button onClick={onNewBooking} className={styles.secondaryButton}>
+        <button type="button" onClick={onNewBooking} className={styles.secondaryButton}>
           Make Another Reservation
         </button>
       </div>


### PR DESCRIPTION
## Summary

- Adds `aria-hidden="true"` to decorative SVG icons in ConfirmationView and BookingWidget
- Adds `type="button"` to the "Make Another Reservation" button to prevent form submission
- Screen readers will now skip decorative checkmark icons

## Test plan

- [ ] Verify screen readers skip decorative SVGs
- [ ] Verify "Make Another Reservation" button still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)