### PR TITLE
feat(gen): add social meta tags and prompt suggestion buttons

### DIFF
--- a/apps/gen/index.html
+++ b/apps/gen/index.html
@@ -5,6 +5,17 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Generative UI playground — type a prompt, watch Rialto components render" />
+    <meta property="og:title" content="Gen | Matt Butler Engineering" />
+    <meta property="og:description" content="Generative UI playground — type a prompt, watch Rialto components render" />
+    <meta property="og:image" content="https://mattbutlerengineering.com/og-image.svg" />
+    <meta property="og:url" content="https://mattbutlerengineering.com/gen" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Gen | Matt Butler Engineering" />
+    <meta name="twitter:description" content="Generative UI playground — type a prompt, watch Rialto components render" />
+    <meta name="twitter:image" content="https://mattbutlerengineering.com/og-image.svg" />
+    <meta name="theme-color" content="#1a1a1a" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.svg" />
     <title>Gen | MBE</title>
   </head>
   <body>

--- a/apps/gen/src/components/PromptBar.module.css
+++ b/apps/gen/src/components/PromptBar.module.css
@@ -1,11 +1,21 @@
+.wrapper {
+  flex-shrink: 0;
+  border-block-start: 1px solid var(--rialto-border);
+  background-color: var(--rialto-surface-default);
+}
+
+.suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--rialto-space-xs);
+  padding: var(--rialto-space-xs) var(--rialto-space-lg);
+}
+
 .bar {
   display: flex;
   align-items: flex-end;
   gap: var(--rialto-space-sm);
   padding: var(--rialto-space-sm) var(--rialto-space-lg);
-  border-block-start: 1px solid var(--rialto-border);
-  background-color: var(--rialto-surface-default);
-  flex-shrink: 0;
 }
 
 .input {

--- a/apps/gen/src/components/PromptBar.tsx
+++ b/apps/gen/src/components/PromptBar.tsx
@@ -1,4 +1,4 @@
-import { useState, type KeyboardEvent } from "react";
+import { useState, useRef, type KeyboardEvent } from "react";
 import { Button } from "@mbe/rialto";
 import styles from "./PromptBar.module.css";
 
@@ -18,6 +18,13 @@ export interface PromptBarProps {
  * Submits on Enter (unless empty). Clears input after submit.
  * In "refine" mode, shows a different placeholder and a "New" exit button.
  */
+const SUGGESTIONS = [
+  "Create a login form",
+  "Build a dashboard card",
+  "Design a pricing table",
+  "Make a settings page",
+] as const;
+
 export function PromptBar({
   onSubmit,
   onStop,
@@ -27,12 +34,20 @@ export function PromptBar({
   onExitRefinement,
 }: PromptBarProps) {
   const [value, setValue] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const isRefineMode = mode === "refine";
   const placeholder = isRefineMode
     ? "Refine this UI..."
     : "Describe the UI you want to build...";
   const submitLabel = isRefineMode ? "Refine" : "Generate";
+
+  const showSuggestions = value.trim().length === 0 && !isStreaming && mode === "generate";
+
+  function handleSuggestionClick(suggestion: string) {
+    setValue(suggestion);
+    textareaRef.current?.focus();
+  }
 
   function handleSubmit() {
     const trimmed = value.trim();
@@ -51,7 +66,23 @@ export function PromptBar({
   }
 
   return (
-    <div className={styles.bar}>
+    <div className={styles.wrapper}>
+      {showSuggestions && (
+        <div className={styles.suggestions}>
+          {SUGGESTIONS.map((suggestion) => (
+            <Button
+              key={suggestion}
+              variant="ghost"
+              size="sm"
+              onClick={() => handleSuggestionClick(suggestion)}
+              disabled={disabled}
+            >
+              {suggestion}
+            </Button>
+          ))}
+        </div>
+      )}
+      <div className={styles.bar}>
       {isRefineMode && onExitRefinement && (
         <Button
           variant="ghost"
@@ -63,6 +94,7 @@ export function PromptBar({
         </Button>
       )}
       <textarea
+        ref={textareaRef}
         className={styles.input}
         value={value}
         onChange={(e) => setValue(e.target.value)}
@@ -87,6 +119,7 @@ export function PromptBar({
           {submitLabel}
         </Button>
       )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add Open Graph, Twitter Card, theme-color, and apple-touch-icon meta tags to `apps/gen/index.html` for proper social sharing
- Add quick-start prompt suggestion buttons (ghost/sm Rialto Buttons) above the textarea in PromptBar when idle and empty — clicking fills the prompt and focuses the textarea

## Test plan
- [ ] Verify meta tags render in HTML source at `/gen`
- [ ] Verify social preview with og/twitter validators
- [ ] Verify suggestion buttons appear when textarea is empty and not streaming
- [ ] Verify clicking a suggestion fills the textarea and focuses it
- [ ] Verify suggestions hide when textarea has content or during streaming
- [ ] Verify suggestions do not appear in refine mode