### PR TITLE
feat(hospitality): redesign dashboard with Rialto Stat cards and quick actions

### DIFF
--- a/apps/hospitality/src/pages/HomePage.module.css
+++ b/apps/hospitality/src/pages/HomePage.module.css
@@ -1,10 +1,40 @@
+.statsRow {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--rialto-space-md);
+  margin-block-end: var(--rialto-space-xl);
+}
+
 .grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: var(--rialto-space-lg);
 }
 
-@media (max-width: 768px) {
+.actionLink {
+  text-decoration: none;
+  display: block;
+}
+
+.actionButton {
+  width: 100%;
+}
+
+@media (max-width: 1024px) {
+  .statsRow {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 640px) {
+  .statsRow {
+    grid-template-columns: 1fr;
+  }
+
   .grid {
     grid-template-columns: 1fr;
   }

--- a/apps/hospitality/src/pages/HomePage.tsx
+++ b/apps/hospitality/src/pages/HomePage.tsx
@@ -1,7 +1,15 @@
+import { Link } from "react-router-dom";
 import { useAuth } from "@mbe/auth/react";
-import { Card, Text, Stack } from "@mbe/rialto";
+import { Card, Text, Stack, Stat, Button, EmptyState } from "@mbe/rialto";
 import { PageHeader } from "../components/PageHeader";
 import styles from "./HomePage.module.css";
+
+const QUICK_ACTIONS = [
+  { label: "New Reservation", to: "/timeline" },
+  { label: "View Floor Plans", to: "/floor-plans" },
+  { label: "Guest Directory", to: "/guests" },
+  { label: "Booking Widget", to: "/booking-widget" },
+];
 
 export function HomePage() {
   const { user } = useAuth();
@@ -13,28 +21,54 @@ export function HomePage() {
         description={`Welcome back${user?.name ? `, ${user.name}` : ""}`}
       />
 
+      {/* Stats row */}
+      <div className={styles.statsRow}>
+        <Card>
+          <Stat label="Today's Reservations" value="—" size="lg" />
+        </Card>
+        <Card>
+          <Stat label="Total Covers" value="—" size="lg" />
+        </Card>
+        <Card>
+          <Stat label="Active Tables" value="—" size="lg" />
+        </Card>
+        <Card>
+          <Stat label="Walk-ins Today" value="—" size="lg" />
+        </Card>
+      </div>
+
+      {/* Quick actions + recent activity */}
       <div className={styles.grid}>
-        <Card title="Quick Stats">
-          <Stack gap="xs">
-            <Text as="p" variant="display" color="primary">
-              0
-            </Text>
-            <Text variant="caption" color="secondary">
-              Active projects
-            </Text>
+        <Card title="Quick Actions">
+          <Stack gap="sm">
+            {QUICK_ACTIONS.map((action) => (
+              <Link key={action.to} to={action.to} className={styles.actionLink}>
+                <Button variant="secondary" size="sm" className={styles.actionButton}>
+                  {action.label}
+                </Button>
+              </Link>
+            ))}
           </Stack>
         </Card>
 
         <Card title="Recent Activity">
-          <Text variant="body" color="secondary">
-            No recent activity
-          </Text>
+          <EmptyState
+            title="No activity yet"
+            description="Reservations, walk-ins, and guest interactions will appear here."
+          />
         </Card>
 
-        <Card title="Notifications">
-          <Text variant="body" color="secondary">
-            No new notifications
-          </Text>
+        <Card title="Getting Started">
+          <Stack gap="sm">
+            <Text variant="body" color="secondary">
+              Set up your venue to start accepting reservations.
+            </Text>
+            <Link to="/onboarding" className={styles.actionLink}>
+              <Button variant="primary" size="sm">
+                Start Venue Setup
+              </Button>
+            </Link>
+          </Stack>
         </Card>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Completely redesigns the hospitality dashboard homepage (was showing hardcoded zeros)
- **Stats row**: 4 Rialto `Stat` cards — Today's Reservations, Total Covers, Active Tables, Walk-ins (placeholder "—" values, ready for API integration)
- **Quick Actions**: Linked buttons to Timeline, Floor Plans, Guests, Booking Widget
- **Recent Activity**: Uses Rialto `EmptyState` component with descriptive text
- **Getting Started**: Venue onboarding CTA for new users
- Responsive: 4-col → 2-col → 1-col breakpoints

## Test plan

- [ ] Verify dashboard renders all 4 stat cards
- [ ] Verify quick action links navigate correctly
- [ ] Verify responsive layout at 1024px and 640px breakpoints
- [ ] Verify dark mode rendering
- [ ] Verify EmptyState renders in Recent Activity card

🤖 Generated with [Claude Code](https://claude.com/claude-code)