### PR TITLE
feat(gen): add JSON download button to spec inspector

### DIFF
--- a/apps/gen/src/components/JsonInspector.module.css
+++ b/apps/gen/src/components/JsonInspector.module.css
@@ -19,6 +19,12 @@
   flex-shrink: 0;
 }
 
+.toolbarActions {
+  display: flex;
+  align-items: center;
+  gap: var(--rialto-space-xs);
+}
+
 .label {
   font-size: var(--rialto-text-xs);
   font-weight: 500;

--- a/apps/gen/src/components/JsonInspector.tsx
+++ b/apps/gen/src/components/JsonInspector.tsx
@@ -2,6 +2,16 @@ import { useRef, useEffect, useCallback, type ReactNode } from "react";
 import { Button } from "@mbe/rialto";
 import styles from "./JsonInspector.module.css";
 
+function downloadJson(content: string): void {
+  const blob = new Blob([content], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = `spec-${Date.now()}.json`;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
 export interface JsonInspectorProps {
   rawLines: string[];
   isStreaming: boolean;
@@ -111,18 +121,32 @@ export function JsonInspector({ rawLines, isStreaming }: JsonInspectorProps) {
     void navigator.clipboard.writeText(buildFullJson());
   }
 
+  function handleDownload() {
+    downloadJson(buildFullJson());
+  }
+
   return (
     <aside className={styles.inspector}>
       <div className={styles.toolbar}>
         <span className={styles.label}>JSON</span>
-        <Button
-          variant="ghost"
-          size="sm"
-          disabled={isStreaming || rawLines.length === 0}
-          onClick={handleCopy}
-        >
-          Copy
-        </Button>
+        <div className={styles.toolbarActions}>
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={isStreaming || rawLines.length === 0}
+            onClick={handleDownload}
+          >
+            Download
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={isStreaming || rawLines.length === 0}
+            onClick={handleCopy}
+          >
+            Copy
+          </Button>
+        </div>
       </div>
 
       <div


### PR DESCRIPTION
## Summary
- Add a "Download" button next to the existing "Copy" button in the JsonInspector toolbar
- Downloads the spec JSON as `spec-{timestamp}.json` using Blob URL approach
- Uses Rialto `Button` component with `variant="ghost"` and `size="sm"` to match the existing Copy button

## Test plan
- [ ] Verify the Download button appears next to Copy when not streaming and data exists
- [ ] Verify clicking Download triggers a browser file save with correct JSON content
- [ ] Verify the Copy button still works as before
- [ ] Verify both buttons are disabled during streaming and when no data is present