### PR TITLE
feat(hospitality): upgrade FloorPlansPage with Rialto components

### DIFF
--- a/apps/hospitality/src/pages/FloorPlansPage.module.css
+++ b/apps/hospitality/src/pages/FloorPlansPage.module.css
@@ -2,36 +2,7 @@
   padding: var(--rialto-space-lg);
 }
 
-.header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-block-end: var(--rialto-space-lg);
-}
-
-.title {
-  font-size: var(--rialto-text-2xl);
-  font-weight: var(--rialto-weight-bold);
-  color: var(--rialto-text-primary);
-}
-
-.newButton {
-  padding-inline: var(--rialto-space-md);
-  padding-block: var(--rialto-space-xs);
-  background: #2563eb;
-  color: #ffffff;
-  border: none;
-  border-radius: var(--rialto-radius-default);
-  font-size: var(--rialto-text-sm);
-  font-weight: var(--rialto-weight-medium);
-  cursor: pointer;
-}
-
-.newButton:hover {
-  background: #1d4ed8;
-}
-
-/* Loading / error / empty states */
+/* Loading state */
 .loadingWrapper {
   display: flex;
   align-items: center;
@@ -44,7 +15,7 @@
   height: 2rem;
   border-radius: var(--rialto-radius-round);
   border: 2px solid transparent;
-  border-block-end-color: #2563eb;
+  border-block-end-color: var(--rialto-accent);
   animation: spin 0.75s linear infinite;
 }
 
@@ -52,30 +23,6 @@
   to {
     transform: rotate(360deg);
   }
-}
-
-.errorBox {
-  background: #fef2f2;
-  color: #dc2626;
-  padding: var(--rialto-space-md);
-  border-radius: var(--rialto-radius-default);
-  margin-block-end: var(--rialto-space-md);
-  font-size: var(--rialto-text-sm);
-}
-
-.emptyState {
-  text-align: center;
-  padding-block: var(--rialto-space-2xl);
-  color: var(--rialto-text-secondary);
-}
-
-.emptyStateText {
-  font-size: var(--rialto-text-base);
-  margin-block-end: var(--rialto-space-md);
-}
-
-.emptyStateHint {
-  font-size: var(--rialto-text-sm);
 }
 
 /* Cards grid */
@@ -86,16 +33,8 @@
 }
 
 .card {
-  background: var(--rialto-surface);
-  border-radius: var(--rialto-radius-soft);
-  border: 1px solid var(--rialto-border);
-  overflow: hidden;
   cursor: pointer;
-  transition: box-shadow 0.15s ease;
-}
-
-.card:hover {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+  overflow: hidden;
 }
 
 .cardPreview {
@@ -116,35 +55,6 @@
   padding: var(--rialto-space-md);
 }
 
-.cardMeta {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-block-end: var(--rialto-space-xs);
-}
-
 .cardName {
   font-size: var(--rialto-text-lg);
-  font-weight: var(--rialto-weight-medium);
-  color: var(--rialto-text-primary);
-}
-
-.activeBadge {
-  display: inline-block;
-  padding-inline: var(--rialto-space-xs);
-  padding-block: 0.125rem;
-  font-size: var(--rialto-text-xs);
-  font-weight: var(--rialto-weight-medium);
-  background: #dcfce7;
-  color: #166534;
-  border-radius: var(--rialto-radius-round);
-}
-
-.cardDetails {
-  font-size: var(--rialto-text-sm);
-  color: var(--rialto-text-secondary);
-}
-
-.cardDetails p {
-  margin: 0;
 }

--- a/apps/hospitality/src/pages/FloorPlansPage.tsx
+++ b/apps/hospitality/src/pages/FloorPlansPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { useAuth } from "@mbe/auth/react";
 import { createApiClient } from "@mbe/api-client";
 import type { FloorPlan } from "@mbe/types";
+import { Button, Card, Text, Stack, Badge, EmptyState, Alert } from "@mbe/rialto";
 import { NewFloorPlanDialog } from "../components/floor-plan";
 import styles from "./FloorPlansPage.module.css";
 
@@ -67,17 +68,15 @@ export function FloorPlansPage() {
   };
 
   return (
-    <div className={styles.container}>
-      <div className={styles.header}>
-        <h1 className={styles.title}>Floor Plans</h1>
-        <button
-          className={styles.newButton}
-          onClick={() => setShowNewDialog(true)}
-          disabled={!venueId}
-        >
+    <Stack gap="lg" className={styles.container}>
+      <Stack direction="row" align="center" justify="between">
+        <Text variant="display" as="h1">
+          Floor Plans
+        </Text>
+        <Button variant="primary" onClick={() => setShowNewDialog(true)} disabled={!venueId}>
           New Floor Plan
-        </button>
-      </div>
+        </Button>
+      </Stack>
 
       {showNewDialog && venueId && (
         <NewFloorPlanDialog
@@ -94,28 +93,42 @@ export function FloorPlansPage() {
         </div>
       )}
 
-      {error && <div className={styles.errorBox} role="alert">{error}</div>}
+      {error && (
+        <Alert variant="error" title="Error">
+          {error}
+        </Alert>
+      )}
 
       {!isLoading && !error && floorPlans.length === 0 && (
-        <div className={styles.emptyState}>
-          <p className={styles.emptyStateText}>No floor plans yet</p>
-          <p className={styles.emptyStateHint}>
-            Create a floor plan to start arranging tables for your venue.
-          </p>
-        </div>
+        <EmptyState
+          heading="No floor plans yet"
+          description="Create a floor plan to start arranging tables for your venue."
+          action={
+            <Button variant="primary" onClick={() => setShowNewDialog(true)} disabled={!venueId}>
+              New Floor Plan
+            </Button>
+          }
+        />
       )}
 
       {!isLoading && !error && floorPlans.length > 0 && (
         <div className={styles.grid}>
           {floorPlans.map((floorPlan) => (
-            <button
+            <Card
               key={floorPlan.id}
-              onClick={() => navigate(`/floor-plans/${floorPlan.id}`)}
+              variant="elevated"
               className={styles.card}
-              type="button"
+              onClick={() => navigate(`/floor-plans/${floorPlan.id}`)}
+              role="button"
+              tabIndex={0}
               aria-label={`Open floor plan: ${floorPlan.name}`}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  navigate(`/floor-plans/${floorPlan.id}`);
+                }
+              }}
             >
-              {/* Placeholder for floor plan preview */}
               <div className={styles.cardPreview}>
                 <svg
                   className={styles.cardPreviewIcon}
@@ -131,22 +144,30 @@ export function FloorPlansPage() {
                   />
                 </svg>
               </div>
-              <div className={styles.cardBody}>
-                <div className={styles.cardMeta}>
-                  <h3 className={styles.cardName}>{floorPlan.name}</h3>
+              <Stack gap="xs" className={styles.cardBody}>
+                <Stack direction="row" align="center" justify="between">
+                  <Text variant="label" as="h3" className={styles.cardName}>
+                    {floorPlan.name}
+                  </Text>
                   {floorPlan.isActive && (
-                    <span className={styles.activeBadge}>Active</span>
+                    <Badge variant="success" size="sm">
+                      Active
+                    </Badge>
                   )}
-                </div>
-                <div className={styles.cardDetails}>
-                  <p>{floorPlan.tables?.length ?? 0} tables</p>
-                  <p>Updated {formatDate(floorPlan.updatedAt)}</p>
-                </div>
-              </div>
-            </button>
+                </Stack>
+                <Stack direction="row" gap="sm">
+                  <Text variant="caption" color="secondary">
+                    {floorPlan.tables?.length ?? 0} tables
+                  </Text>
+                  <Text variant="caption" color="secondary">
+                    Updated {formatDate(floorPlan.updatedAt)}
+                  </Text>
+                </Stack>
+              </Stack>
+            </Card>
           ))}
         </div>
       )}
-    </div>
+    </Stack>
   );
 }


### PR DESCRIPTION
Replace raw HTML elements with Rialto Card, Button, EmptyState, Text, Stack, Badge, and Alert. Remove hardcoded hex colors in favor of Rialto design tokens.