### PR TITLE
fix(ci): add pull-requests:read permission to lighthouse detect-changes job

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -28,6 +28,9 @@ jobs:
   detect-changes:
     name: Detect Changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       marketing: ${{ steps.result.outputs.marketing }}
       hospitality: ${{ steps.result.outputs.hospitality }}


### PR DESCRIPTION
## Summary

- `dorny/paths-filter@v4` requires `pull-requests: read` to list PR-changed files via the GitHub API
- Without an explicit `permissions:` block, the job inherits the repo's default restricted token, causing the API call to fail
- This has been silently breaking `Detect Changes` on every PR (confirmed on #151, #156), skipping all Lighthouse and bundle-size checks

## Test plan

- [ ] Verify `Detect Changes` job passes on this PR
- [ ] Verify Lighthouse jobs run (or correctly skip if no frontend files changed)

Closes #157

https://claude.ai/code/session_01WbQ63FNoGdrvFkF7KFfjBF