### PR TITLE
fix(audit): performance + accessibility fixes from light audit

### DIFF
--- a/apps/marketing/index.html
+++ b/apps/marketing/index.html
@@ -9,9 +9,17 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      rel="stylesheet"
+      rel="preload"
+      as="style"
       href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;1,9..40,300;1,9..40,400&family=DM+Mono:wght@300;400&family=Bricolage+Grotesque:opsz,wght@12..96,300;12..96,400;12..96,500&display=swap"
+      onload="this.onload=null;this.rel='stylesheet'"
     />
+    <noscript>
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;1,9..40,300;1,9..40,400&family=DM+Mono:wght@300;400&family=Bricolage+Grotesque:opsz,wght@12..96,300;12..96,400;12..96,500&display=swap"
+      />
+    </noscript>
     <title>Matt Butler Engineering</title>
     <meta name="description" content="Matt Butler Engineering — software engineering solutions for hospitality and beyond" />
     <meta property="og:title" content="Matt Butler Engineering" />

--- a/apps/marketing/src/components/ProjectCard.module.css
+++ b/apps/marketing/src/components/ProjectCard.module.css
@@ -21,7 +21,24 @@
   padding-block-start: var(--rialto-space-xs);
 }
 
-.link {
+.buttonLink {
+  display: inline-flex;
+  align-items: center;
   text-decoration: none;
-  display: inline-block;
+  padding: var(--rialto-space-xs) var(--rialto-space-sm);
+  border-radius: var(--rialto-radius-sm);
+  border: 1px solid var(--rialto-border-default);
+  background: transparent;
+  color: var(--rialto-text-primary);
+  font-size: var(--rialto-text-sm);
+  font-family: inherit;
+  font-weight: var(--rialto-weight-medium);
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.buttonLink:hover {
+  background: var(--rialto-surface-subtle);
+  border-color: var(--rialto-border-strong);
 }

--- a/apps/marketing/src/components/ProjectCard.tsx
+++ b/apps/marketing/src/components/ProjectCard.tsx
@@ -1,4 +1,4 @@
-import { Card, Stack, Text, Tag, Button } from "@mbe/rialto";
+import { Card, Stack, Text, Tag } from "@mbe/rialto";
 import type { Project } from "../data/projects";
 import styles from "./ProjectCard.module.css";
 
@@ -26,10 +26,13 @@ export function ProjectCard({ project }: ProjectCardProps) {
 
         {project.href && (
           <div className={styles.actions}>
-            <a href={project.href} className={styles.link}>
-              <Button variant="secondary" size="sm">
-                View live
-              </Button>
+            <a
+              href={project.href}
+              className={styles.buttonLink}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              View live
             </a>
           </div>
         )}

--- a/apps/rialto-web/index.html
+++ b/apps/rialto-web/index.html
@@ -6,9 +6,17 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      rel="stylesheet"
+      rel="preload"
+      as="style"
       href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;1,9..40,300;1,9..40,400&family=DM+Mono:wght@300;400&family=Bricolage+Grotesque:opsz,wght@12..96,300;12..96,400;12..96,500&display=swap"
+      onload="this.onload=null;this.rel='stylesheet'"
     />
+    <noscript>
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;1,9..40,300;1,9..40,400&family=DM+Mono:wght@300;400&family=Bricolage+Grotesque:opsz,wght@12..96,300;12..96,400;12..96,500&display=swap"
+      />
+    </noscript>
     <meta name="theme-color" content="#f8f6f3" />
     <meta
       name="description"

--- a/apps/rialto-web/src/pages/OverviewPage.tsx
+++ b/apps/rialto-web/src/pages/OverviewPage.tsx
@@ -26,7 +26,7 @@ export function OverviewPage() {
           Ri<span className={styles.heroLogoAccent}>a</span>lto
         </div>
         <Stack gap="sm" align="center">
-          <Text variant="display" color="primary" align="center">
+          <Text variant="display" color="primary" align="center" as="h1">
             Precision-crafted React components
           </Text>
           <Text variant="body" color="secondary" align="center">


### PR DESCRIPTION
## Summary

- **#164 Performance**: Convert Google Fonts from render-blocking `<link rel="stylesheet">` to non-blocking `preload` + `onload` swap in both `apps/marketing/index.html` and `apps/rialto-web/index.html`. Includes `<noscript>` fallback.
- **#165 Accessibility**: Promote Rialto `OverviewPage` hero tagline to `<h1>` via `as="h1"` on the `Text` component. Fixes missing page-level heading (WCAG 1.3.1).
- **#166 Accessibility**: Remove invalid `<a><Button>` nesting in `ProjectCard`. Replaced with a styled `<a>` element using Rialto CSS tokens, eliminating the nested interactive element violation.

## Test plan

- [ ] Marketing site renders fonts correctly (may flash system font briefly on first load — expected with async font loading)
- [ ] `/rialto` overview page has a visible `<h1>` in devtools accessibility tree
- [ ] ProjectCard "View live" links work and open in new tab; no nested `<button>` inside `<a>` in DOM

Closes #164
Closes #165
Closes #166

https://claude.ai/code/session_01Msw7RUjnvG6ZC2yQrvwzoj