### PR TITLE
feat(hospitality): progressive sidebar with setup/operational modes

### DIFF
--- a/apps/hospitality/src/components/DashboardLayout.tsx
+++ b/apps/hospitality/src/components/DashboardLayout.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, useEffect } from "react";
 import { useNavigate, useLocation, Outlet } from "react-router-dom";
 import { useAuth } from "@mbe/auth/react";
 import { Breadcrumb, CommandPalette, ErrorBoundary, GenCopilot, Kbd, useToast } from "@mbe/rialto";
@@ -9,14 +9,16 @@ import { HOSPITALITY_DOMAIN_CONTEXT } from "../constants/copilotContext.js";
 import { useCommandPalette } from "../hooks/use-command-palette.js";
 import { useReservationEvents } from "../hooks/useReservationEvents.js";
 import { useTheme, resolveTheme } from "../hooks/use-theme.js";
-import { NAV_SECTIONS } from "../nav-sections.js";
+import { useVenueReadiness } from "../hooks/useVenueReadiness.js";
+import { buildNavSections } from "../nav-sections.js";
 import type { NavItem } from "../nav-sections.js";
 import { VenueProvider } from "../contexts/VenueContext.js";
 import { DashboardSidebar } from "./DashboardSidebar.js";
+import { VenueSwitcher } from "./VenueSwitcher.js";
 import styles from "./DashboardLayout.module.css";
 
 const ROUTE_LABELS: Record<string, string> = {
-  "": "Dashboard",
+  "": "Timeline",
   "timeline": "Timeline",
   "reservations": "Reservations",
   "guests": "Guests",
@@ -26,17 +28,58 @@ const ROUTE_LABELS: Record<string, string> = {
   "profile": "Profile",
   "settings": "Settings",
   "admin": "Admin",
+  "dashboard": "Dashboard",
+  "setup": "Setup",
+  "hours": "Operating Hours",
 };
 
-export function DashboardLayout() {
+/** Operational pages that should redirect to /setup when not yet ready */
+const OPERATIONAL_ONLY_PATHS = ["/timeline", "/reservations", "/guests"];
+
+/**
+ * Inner layout that has access to VenueProvider context.
+ * Uses useVenueReadiness to build dynamic nav sections and enforce redirects.
+ */
+function DashboardLayoutInner() {
   const navigate = useNavigate();
   const location = useLocation();
   const { signOut, accessToken } = useAuth();
   const { theme, setTheme } = useTheme();
+  const readiness = useVenueReadiness();
 
   const { toast } = useToast();
   const [copilotOpen, setCopilotOpen] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+
+  // Readiness-based redirect guard
+  useEffect(() => {
+    const path = location.pathname.replace(/^\/hospitality/, "");
+
+    if (readiness.status === "no-venue") {
+      if (!path.startsWith("/onboarding") && !path.startsWith("/callback")) {
+        navigate("/onboarding", { replace: true });
+      }
+      return;
+    }
+
+    if (readiness.status === "setup") {
+      const isOperationalPage = OPERATIONAL_ONLY_PATHS.some((p) => path === p || path.startsWith(p + "/"));
+      if (isOperationalPage) {
+        navigate("/setup", { replace: true });
+      }
+      return;
+    }
+
+    if (readiness.status === "operational") {
+      if (path === "/setup" || path.startsWith("/setup/")) {
+        navigate("/timeline", { replace: true });
+      }
+      // Redirect old root (index) to timeline
+      if (path === "/" || path === "") {
+        navigate("/timeline", { replace: true });
+      }
+    }
+  }, [readiness.status, location.pathname, navigate]);
 
   // SSE toast notifications for real-time reservation events
   useReservationEvents({
@@ -111,10 +154,10 @@ export function DashboardLayout() {
     [navigate, signOut]
   );
 
-  // Build a Tools section with Copilot toggle appended to sections
+  // Build dynamic nav sections from readiness state + copilot tool
   const sectionsWithCopilot = useMemo(
     () => [
-      ...NAV_SECTIONS,
+      ...buildNavSections(readiness),
       {
         label: "Tools" as const,
         items: [
@@ -126,7 +169,7 @@ export function DashboardLayout() {
         ],
       },
     ],
-    []
+    [readiness]
   );
 
   // Custom navigate that handles copilot toggle
@@ -141,10 +184,7 @@ export function DashboardLayout() {
     [handleNavigate]
   );
 
-  // Copilot is "active" when open — map its sentinel path to current location
-  const activePath = copilotOpen && location.pathname === location.pathname
-    ? location.pathname
-    : location.pathname;
+  const activePath = location.pathname;
 
   // Build breadcrumb items from current route
   const breadcrumbs = useMemo((): BreadcrumbItem[] => {
@@ -153,14 +193,14 @@ export function DashboardLayout() {
     const path = pathname.replace(/^\/hospitality/, "").replace(/^\//, "");
     const segments = path.split("/").filter(Boolean);
 
-    // On home page, just show "Home" as current (no link)
+    // On home/timeline page, just show "Timeline" as current (no link)
     if (segments.length === 0) {
-      return [{ label: "Home" }];
+      return [{ label: "Timeline" }];
     }
 
-    // Always start with a clickable Home
+    // Always start with a clickable Timeline (new home)
     const items: BreadcrumbItem[] = [
-      { label: "Home", onClick: () => navigate("/") },
+      { label: "Timeline", onClick: () => navigate("/timeline") },
     ];
 
     // Build intermediate + final crumbs
@@ -230,6 +270,9 @@ export function DashboardLayout() {
             extraItems={extraItems}
             isMobileOpen={isMobileMenuOpen}
             onMobileClose={handleMobileClose}
+            headerSlot={
+              <VenueSwitcher onNavigate={handleNavigate} />
+            }
           />
           <button
             type="button"
@@ -243,7 +286,7 @@ export function DashboardLayout() {
           </button>
         </div>
 
-        <main id="main-content" tabIndex={-1} className={styles.content}>
+        <main id="main-content" tabIndex={-1} className={styles.content} style={{ outline: "none" }}>
           <div className={styles.breadcrumbBar}>
             <Breadcrumb items={breadcrumbs} />
           </div>
@@ -271,9 +314,7 @@ export function DashboardLayout() {
               </div>
             }
           >
-            <VenueProvider>
-              <Outlet />
-            </VenueProvider>
+            <Outlet />
           </ErrorBoundary>
         </main>
       </div>
@@ -289,5 +330,17 @@ export function DashboardLayout() {
         />
       )}
     </div>
+  );
+}
+
+/**
+ * Outer shell: wraps VenueProvider around DashboardLayoutInner so that
+ * useVenueReadiness (which calls useVenue) can be used inside the layout.
+ */
+export function DashboardLayout() {
+  return (
+    <VenueProvider>
+      <DashboardLayoutInner />
+    </VenueProvider>
   );
 }

--- a/apps/hospitality/src/components/DashboardSidebar.module.css
+++ b/apps/hospitality/src/components/DashboardSidebar.module.css
@@ -153,6 +153,24 @@
   background: var(--rialto-accent-muted);
 }
 
+/* ── Disabled nav item ───────────────────────── */
+
+.navLinkDisabled {
+  pointer-events: none;
+  opacity: 0.45;
+  cursor: default;
+}
+
+/* ── Step status icon ────────────────────────── */
+
+.stepIcon {
+  display: inline-block;
+  vertical-align: middle;
+  flex-shrink: 0;
+  margin-inline-end: var(--rialto-space-xs);
+  color: currentColor;
+}
+
 /* ── Mobile backdrop overlay ─────────────────── */
 
 .backdrop {

--- a/apps/hospitality/src/components/DashboardSidebar.tsx
+++ b/apps/hospitality/src/components/DashboardSidebar.tsx
@@ -1,6 +1,66 @@
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect, useRef, type ReactNode } from "react";
 import type { NavSection, NavItem } from "../nav-sections.js";
 import styles from "./DashboardSidebar.module.css";
+
+/* ── Step status icons ───────────────────────── */
+
+function CompletedIcon() {
+  return (
+    <svg
+      className={styles.stepIcon}
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+function CurrentIcon() {
+  return (
+    <svg
+      className={styles.stepIcon}
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <polyline points="9 18 15 12 9 6" />
+    </svg>
+  );
+}
+
+function LockedIcon() {
+  return (
+    <svg
+      className={styles.stepIcon}
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+      <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+    </svg>
+  );
+}
 
 /* ── Constants ───────────────────────────────── */
 
@@ -63,6 +123,8 @@ export interface DashboardSidebarProps {
   isMobileOpen?: boolean;
   /** Called when the mobile drawer should close */
   onMobileClose?: () => void;
+  /** Optional slot rendered above all nav sections (e.g. VenueSwitcher) */
+  headerSlot?: ReactNode;
 }
 
 /* ── Component ───────────────────────────────── */
@@ -74,6 +136,7 @@ export function DashboardSidebar({
   extraItems,
   isMobileOpen = false,
   onMobileClose,
+  headerSlot,
 }: DashboardSidebarProps) {
   const [collapsed, setCollapsed] = useState<Set<string>>(loadCollapsed);
   const sidebarRef = useRef<HTMLElement>(null);
@@ -151,6 +214,7 @@ export function DashboardSidebar({
         className={rootClassName}
         aria-label="Dashboard navigation"
       >
+        {headerSlot}
         <div className={styles.sections}>
           {sections.map((section, sectionIndex) => {
             const sectionKey = section.label ?? `section-${String(sectionIndex)}`;
@@ -168,14 +232,20 @@ export function DashboardSidebar({
                   <ul className={styles.sectionItemsFlat}>
                     {sectionItems.map((item) => {
                       const active = isItemActive(item);
+                      const isDisabled = item.disabled === true;
                       return (
                         <li key={item.id} className={styles.navItem}>
                           <button
-                            className={`${styles.navLink} ${active ? styles.navLinkActive : ""}`}
-                            onClick={() => handleItemClick(item.path)}
+                            className={`${styles.navLink} ${active ? styles.navLinkActive : ""} ${isDisabled ? styles.navLinkDisabled : ""}`}
+                            onClick={isDisabled ? undefined : () => handleItemClick(item.path)}
                             aria-current={active ? "page" : undefined}
+                            aria-disabled={isDisabled ? "true" : undefined}
                             type="button"
+                            tabIndex={isDisabled ? -1 : undefined}
                           >
+                            {item.stepStatus === "completed" && <CompletedIcon />}
+                            {item.stepStatus === "current" && <CurrentIcon />}
+                            {item.stepStatus === "locked" && <LockedIcon />}
                             {item.label}
                           </button>
                         </li>
@@ -209,14 +279,20 @@ export function DashboardSidebar({
                   <ul className={styles.sectionItems}>
                     {sectionItems.map((item) => {
                       const active = isItemActive(item);
+                      const isDisabled = item.disabled === true;
                       return (
                         <li key={item.id} className={styles.navItem}>
                           <button
-                            className={`${styles.navLink} ${active ? styles.navLinkActive : ""}`}
-                            onClick={() => handleItemClick(item.path)}
+                            className={`${styles.navLink} ${active ? styles.navLinkActive : ""} ${isDisabled ? styles.navLinkDisabled : ""}`}
+                            onClick={isDisabled ? undefined : () => handleItemClick(item.path)}
                             aria-current={active ? "page" : undefined}
+                            aria-disabled={isDisabled ? "true" : undefined}
                             type="button"
+                            tabIndex={isDisabled ? -1 : undefined}
                           >
+                            {item.stepStatus === "completed" && <CompletedIcon />}
+                            {item.stepStatus === "current" && <CurrentIcon />}
+                            {item.stepStatus === "locked" && <LockedIcon />}
                             {item.label}
                           </button>
                         </li>

--- a/apps/hospitality/src/components/VenueSwitcher.module.css
+++ b/apps/hospitality/src/components/VenueSwitcher.module.css
@@ -1,0 +1,155 @@
+/* ── VenueSwitcher ───────────────────────────── */
+
+.root {
+  position: relative;
+  padding: var(--rialto-space-sm);
+  border-block-end: 1px solid var(--rialto-border);
+}
+
+/* ── Trigger button ──────────────────────────── */
+
+.trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--rialto-space-xs) var(--rialto-space-sm);
+  background: var(--rialto-surface-recessed);
+  border: 1px solid var(--rialto-border);
+  border-radius: var(--rialto-radius-default);
+  color: var(--rialto-text-primary);
+  font-family: var(--rialto-font-sans);
+  font-size: var(--rialto-text-sm);
+  font-weight: var(--rialto-weight-medium);
+  cursor: default;
+  text-align: start;
+}
+
+.triggerInteractive {
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.triggerInteractive:hover {
+  background: var(--rialto-surface-matte);
+}
+
+.triggerInteractive:focus-visible {
+  outline: none;
+  box-shadow: var(--rialto-shadow-focus);
+}
+
+/* ── Venue name ──────────────────────────────── */
+
+.venueName {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ── Chevron icon ────────────────────────────── */
+
+.chevron {
+  flex-shrink: 0;
+  color: var(--rialto-text-tertiary);
+  transition: transform 0.2s ease;
+  margin-inline-start: var(--rialto-space-xs);
+}
+
+.chevronOpen {
+  transform: rotate(180deg);
+}
+
+/* ── Dropdown ────────────────────────────────── */
+
+.dropdown {
+  position: absolute;
+  inset-inline-start: var(--rialto-space-sm);
+  inset-inline-end: var(--rialto-space-sm);
+  inset-block-start: calc(100% - var(--rialto-space-xs));
+  z-index: 100;
+  background: var(--rialto-surface-elevated);
+  border: 1px solid var(--rialto-border);
+  border-radius: var(--rialto-radius-default);
+  box-shadow: var(--rialto-shadow-md, 0 4px 12px rgba(0, 0, 0, 0.15));
+  overflow: hidden;
+}
+
+/* ── Option ──────────────────────────────────── */
+
+.option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--rialto-space-xs) var(--rialto-space-sm);
+  background: transparent;
+  border: none;
+  color: var(--rialto-text-secondary);
+  font-family: var(--rialto-font-sans);
+  font-size: var(--rialto-text-sm);
+  text-align: start;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.option:hover {
+  background: var(--rialto-surface-recessed);
+  color: var(--rialto-text-primary);
+}
+
+.option:focus-visible {
+  outline: none;
+  box-shadow: var(--rialto-shadow-focus);
+  position: relative;
+  z-index: 1;
+}
+
+.optionSelected {
+  color: var(--rialto-accent);
+  font-weight: var(--rialto-weight-medium);
+}
+
+.checkmark {
+  flex-shrink: 0;
+  color: var(--rialto-accent);
+}
+
+/* ── Divider ─────────────────────────────────── */
+
+.divider {
+  height: 1px;
+  background: var(--rialto-border);
+  margin-block: var(--rialto-space-2xs);
+}
+
+/* ── Add Venue action ────────────────────────── */
+
+.addVenue {
+  display: flex;
+  align-items: center;
+  gap: var(--rialto-space-xs);
+  width: 100%;
+  padding: var(--rialto-space-xs) var(--rialto-space-sm);
+  background: transparent;
+  border: none;
+  color: var(--rialto-text-tertiary);
+  font-family: var(--rialto-font-sans);
+  font-size: var(--rialto-text-sm);
+  text-align: start;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.addVenue:hover {
+  background: var(--rialto-surface-recessed);
+  color: var(--rialto-text-primary);
+}
+
+.addVenue:focus-visible {
+  outline: none;
+  box-shadow: var(--rialto-shadow-focus);
+  position: relative;
+  z-index: 1;
+}

--- a/apps/hospitality/src/components/VenueSwitcher.tsx
+++ b/apps/hospitality/src/components/VenueSwitcher.tsx
@@ -1,0 +1,148 @@
+import { useState, useRef, useEffect, useCallback } from "react";
+import { useVenue } from "../contexts/VenueContext.js";
+import styles from "./VenueSwitcher.module.css";
+
+interface VenueSwitcherProps {
+  onNavigate: (path: string) => void;
+}
+
+export function VenueSwitcher({ onNavigate }: VenueSwitcherProps) {
+  const { venues, selectedVenue, setVenueId, isMultiVenue } = useVenue();
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleToggle = useCallback(() => {
+    if (isMultiVenue) {
+      setIsOpen((prev) => !prev);
+    }
+  }, [isMultiVenue]);
+
+  const handleSelect = useCallback(
+    (id: string) => {
+      setVenueId(id);
+      setIsOpen(false);
+    },
+    [setVenueId]
+  );
+
+  const handleAddVenue = useCallback(() => {
+    setIsOpen(false);
+    onNavigate("/onboarding");
+  }, [onNavigate]);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleOutsideClick = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleOutsideClick);
+    return () => document.removeEventListener("mousedown", handleOutsideClick);
+  }, [isOpen]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setIsOpen(false);
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen]);
+
+  if (!selectedVenue) return null;
+
+  return (
+    <div ref={containerRef} className={styles.root}>
+      <button
+        type="button"
+        className={`${styles.trigger} ${isMultiVenue ? styles.triggerInteractive : ""}`}
+        onClick={handleToggle}
+        aria-haspopup={isMultiVenue ? "listbox" : undefined}
+        aria-expanded={isMultiVenue ? isOpen : undefined}
+        aria-label={isMultiVenue ? `Current venue: ${selectedVenue.name}. Click to switch` : selectedVenue.name}
+      >
+        <span className={styles.venueName}>{selectedVenue.name}</span>
+        {isMultiVenue && (
+          <svg
+            className={`${styles.chevron} ${isOpen ? styles.chevronOpen : ""}`}
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <polyline points="6 9 12 15 18 9" />
+          </svg>
+        )}
+      </button>
+
+      {isOpen && (
+        <div className={styles.dropdown} role="listbox" aria-label="Select venue">
+          {venues.map((venue) => (
+            <button
+              key={venue.id}
+              type="button"
+              role="option"
+              aria-selected={venue.id === selectedVenue.id}
+              className={`${styles.option} ${venue.id === selectedVenue.id ? styles.optionSelected : ""}`}
+              onClick={() => handleSelect(venue.id)}
+            >
+              {venue.name}
+              {venue.id === selectedVenue.id && (
+                <svg
+                  className={styles.checkmark}
+                  width="12"
+                  height="12"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <polyline points="20 6 9 17 4 12" />
+                </svg>
+              )}
+            </button>
+          ))}
+          <div className={styles.divider} aria-hidden="true" />
+          <button
+            type="button"
+            className={styles.addVenue}
+            onClick={handleAddVenue}
+          >
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <line x1="12" y1="5" x2="12" y2="19" />
+              <line x1="5" y1="12" x2="19" y2="12" />
+            </svg>
+            Add Venue
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+VenueSwitcher.displayName = "VenueSwitcher";

--- a/apps/hospitality/src/hooks/useVenueReadiness.ts
+++ b/apps/hospitality/src/hooks/useVenueReadiness.ts
@@ -1,0 +1,131 @@
+import { useState, useEffect, useRef } from "react";
+import { createApiClient } from "@mbe/api-client";
+import { useAuth } from "@mbe/auth/react";
+import { useVenue } from "../contexts/VenueContext.js";
+
+export type SetupStep = "onboarding" | "operating-hours" | "floor-plan";
+
+export interface VenueReadiness {
+  status: "no-venue" | "setup" | "operational";
+  completedSteps: readonly SetupStep[];
+  nextStep: SetupStep | null;
+  progress: number; // 0–100
+}
+
+const READY: VenueReadiness = {
+  status: "operational",
+  completedSteps: ["onboarding", "operating-hours", "floor-plan"],
+  nextStep: null,
+  progress: 100,
+};
+
+const NO_VENUE: VenueReadiness = {
+  status: "no-venue",
+  completedSteps: [],
+  nextStep: "onboarding",
+  progress: 0,
+};
+
+interface FloorPlanState {
+  venueId: string;
+  hasFloorPlan: boolean;
+}
+
+export function useVenueReadiness(): VenueReadiness {
+  const { selectedVenue, selectedVenueId, isLoading } = useVenue();
+  const { accessToken } = useAuth();
+  // Tracks the last resolved floor-plan check result
+  const [floorPlanState, setFloorPlanState] = useState<FloorPlanState | null>(null);
+  const fetchingRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!selectedVenueId || !accessToken) return;
+    // Skip if we've already fetched or are currently fetching for this venue
+    if (fetchingRef.current === selectedVenueId) return;
+    if (floorPlanState?.venueId === selectedVenueId) return;
+
+    fetchingRef.current = selectedVenueId;
+
+    const api = createApiClient({
+      baseUrl: import.meta.env.VITE_API_URL ?? "",
+      getAccessToken: () => accessToken,
+    });
+
+    let cancelled = false;
+
+    api.floorPlans
+      .list({ venueId: selectedVenueId, limit: 10 })
+      .then((response) => {
+        if (cancelled) return;
+        const hasAtLeastOne = response.data.some(
+          (fp) => fp.tables !== undefined && fp.tables.length > 0
+        );
+        setFloorPlanState({ venueId: selectedVenueId, hasFloorPlan: hasAtLeastOne });
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setFloorPlanState({ venueId: selectedVenueId, hasFloorPlan: false });
+        }
+      })
+      .finally(() => {
+        if (fetchingRef.current === selectedVenueId) {
+          fetchingRef.current = null;
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedVenueId, accessToken, floorPlanState]);
+
+  if (isLoading) {
+    return { status: "setup", completedSteps: [], nextStep: "onboarding", progress: 0 };
+  }
+
+  if (!selectedVenue) {
+    return NO_VENUE;
+  }
+
+  // Evaluate gates
+  const onboardingComplete = true; // Venue exists = onboarding complete
+  const hasOperatingHours =
+    selectedVenue.operatingHours !== null &&
+    selectedVenue.operatingHours !== undefined &&
+    Object.values(selectedVenue.operatingHours).some(
+      (schedule) => schedule !== undefined
+    );
+
+  // Floor plan is current only if checked matches selected venue
+  const floorPlanReady =
+    floorPlanState !== null &&
+    floorPlanState.venueId === selectedVenueId &&
+    floorPlanState.hasFloorPlan;
+
+  const completedSteps: SetupStep[] = [];
+  if (onboardingComplete) completedSteps.push("onboarding");
+  if (hasOperatingHours) completedSteps.push("operating-hours");
+  if (floorPlanReady) completedSteps.push("floor-plan");
+
+  const allComplete = onboardingComplete && hasOperatingHours && floorPlanReady;
+
+  if (allComplete) return READY;
+
+  // Determine next step
+  let nextStep: SetupStep;
+  if (!onboardingComplete) {
+    nextStep = "onboarding";
+  } else if (!hasOperatingHours) {
+    nextStep = "operating-hours";
+  } else {
+    nextStep = "floor-plan";
+  }
+
+  const progress = Math.round((completedSteps.length / 3) * 100);
+
+  return {
+    status: "setup",
+    completedSteps,
+    nextStep,
+    progress,
+  };
+}

--- a/apps/hospitality/src/main.tsx
+++ b/apps/hospitality/src/main.tsx
@@ -21,14 +21,14 @@ initSentry({
 const DashboardLayout = lazy(() =>
   import("./components/DashboardLayout.js").then((m) => ({ default: m.DashboardLayout }))
 );
+const TimelinePage = lazy(() =>
+  import("./pages/TimelinePage.js").then((m) => ({ default: m.TimelinePage }))
+);
 const HomePage = lazy(() =>
   import("./pages/HomePage.js").then((m) => ({ default: m.HomePage }))
 );
 const ReservationsPage = lazy(() =>
   import("./pages/ReservationsPage.js").then((m) => ({ default: m.ReservationsPage }))
-);
-const TimelinePage = lazy(() =>
-  import("./pages/TimelinePage.js").then((m) => ({ default: m.TimelinePage }))
 );
 const GuestsPage = lazy(() =>
   import("./pages/GuestsPage.js").then((m) => ({ default: m.GuestsPage }))
@@ -54,6 +54,12 @@ const AdminPage = lazy(() =>
 const VenueOnboardingPage = lazy(() =>
   import("./pages/VenueOnboardingPage.js").then((m) => ({ default: m.VenueOnboardingPage }))
 );
+const SetupPage = lazy(() =>
+  import("./pages/SetupPage.js").then((m) => ({ default: m.SetupPage }))
+);
+const SetupHoursPage = lazy(() =>
+  import("./pages/SetupHoursPage.js").then((m) => ({ default: m.SetupHoursPage }))
+);
 
 // Validate auth config at startup — fail fast with a user-friendly error
 const authConfigResult = validateAuthConfig();
@@ -70,6 +76,10 @@ const authConfigResult = validateAuthConfig();
  * DashboardLayout so it doesn't compete with the pathless layout route —
  * React Router v7 can misroute when pathless layouts and named routes
  * coexist at the same level.
+ *
+ * Index route: TimelinePage (was HomePage/Dashboard).
+ * Dashboard moves to /dashboard.
+ * Setup pages: /setup, /setup/hours.
  */
 const router = createBrowserRouter(
   [
@@ -85,7 +95,25 @@ const router = createBrowserRouter(
           ),
           children: [
             {
+              // Index: Timeline is the default landing page in operational mode.
+              // DashboardLayout redirects to /setup for new venues or /timeline for operational ones.
               index: true,
+              element: (
+                <Suspense fallback={<LoadingPage />}>
+                  <TimelinePage />
+                </Suspense>
+              ),
+            },
+            {
+              path: "timeline",
+              element: (
+                <Suspense fallback={<LoadingPage />}>
+                  <TimelinePage />
+                </Suspense>
+              ),
+            },
+            {
+              path: "dashboard",
               element: (
                 <Suspense fallback={<LoadingPage />}>
                   <HomePage />
@@ -97,14 +125,6 @@ const router = createBrowserRouter(
               element: (
                 <Suspense fallback={<LoadingPage />}>
                   <ReservationsPage />
-                </Suspense>
-              ),
-            },
-            {
-              path: "timeline",
-              element: (
-                <Suspense fallback={<LoadingPage />}>
-                  <TimelinePage />
                 </Suspense>
               ),
             },
@@ -172,7 +192,23 @@ const router = createBrowserRouter(
                 </Suspense>
               ),
             },
-            { path: "*", element: <Navigate to="/" replace /> },
+            {
+              path: "setup",
+              element: (
+                <Suspense fallback={<LoadingPage />}>
+                  <SetupPage />
+                </Suspense>
+              ),
+            },
+            {
+              path: "setup/hours",
+              element: (
+                <Suspense fallback={<LoadingPage />}>
+                  <SetupHoursPage />
+                </Suspense>
+              ),
+            },
+            { path: "*", element: <Navigate to="/timeline" replace /> },
           ],
         },
       ],

--- a/apps/hospitality/src/nav-sections.ts
+++ b/apps/hospitality/src/nav-sections.ts
@@ -5,29 +5,22 @@
  * are top-level navigation (no collapsible header).
  */
 
+import type { VenueReadiness, SetupStep } from "./hooks/useVenueReadiness.js";
+
 export interface NavItem {
   id: string;
   label: string;
   path: string;
+  /** Setup step status — drives icon before the label */
+  stepStatus?: "completed" | "current" | "locked";
+  /** Prevents click and applies muted style */
+  disabled?: boolean;
 }
 
 export interface NavSection {
   label?: string;
   items: NavItem[];
 }
-
-/* ── Primary navigation ─────────────────────── */
-
-const PRIMARY: NavSection = {
-  items: [
-    { id: "home", label: "Home", path: "/" },
-    { id: "timeline", label: "Timeline", path: "/timeline" },
-    { id: "reservations", label: "Reservations", path: "/reservations" },
-    { id: "guests", label: "Guests", path: "/guests" },
-    { id: "floor-plans", label: "Floor Plans", path: "/floor-plans" },
-    { id: "onboarding", label: "New Venue", path: "/onboarding" },
-  ],
-};
 
 /* ── Account ────────────────────────────────── */
 
@@ -36,15 +29,6 @@ const ACCOUNT: NavSection = {
   items: [
     { id: "profile", label: "Profile", path: "/profile" },
     { id: "settings", label: "Settings", path: "/settings" },
-  ],
-};
-
-/* ── Developer ──────────────────────────────── */
-
-const DEVELOPER: NavSection = {
-  label: "Developer",
-  items: [
-    { id: "booking-widget", label: "Booking Widget", path: "/booking-widget" },
   ],
 };
 
@@ -57,6 +41,79 @@ const ADMIN: NavSection = {
   ],
 };
 
-/* ── Exports ────────────────────────────────── */
+/* ── Setup nav sections ─────────────────────── */
 
-export const NAV_SECTIONS: readonly NavSection[] = [PRIMARY, ACCOUNT, DEVELOPER, ADMIN];
+function buildSetupSections(readiness: VenueReadiness): readonly NavSection[] {
+  const STEP_ORDER: SetupStep[] = ["onboarding", "operating-hours", "floor-plan"];
+
+  const STEP_LABELS: Record<SetupStep, string> = {
+    "onboarding": "Venue Basics",
+    "operating-hours": "Set Operating Hours",
+    "floor-plan": "Create Floor Plan",
+  };
+
+  const STEP_PATHS: Record<SetupStep, string> = {
+    "onboarding": "/onboarding",
+    "operating-hours": "/setup/hours",
+    "floor-plan": "/floor-plans",
+  };
+
+  const items: NavItem[] = STEP_ORDER.map((step) => {
+    const isCompleted = readiness.completedSteps.includes(step);
+    const isCurrent = readiness.nextStep === step;
+    const isLocked = !isCompleted && !isCurrent;
+
+    return {
+      id: `setup-${step}`,
+      label: STEP_LABELS[step],
+      path: STEP_PATHS[step],
+      stepStatus: isCompleted ? "completed" : isCurrent ? "current" : "locked",
+      disabled: isLocked,
+    };
+  });
+
+  const setupSection: NavSection = {
+    label: "Get Started",
+    items,
+  };
+
+  return [setupSection, ACCOUNT, ADMIN];
+}
+
+/* ── Operational nav sections ───────────────── */
+
+function buildOperationalSections(): readonly NavSection[] {
+  const PRIMARY: NavSection = {
+    items: [
+      { id: "timeline", label: "Timeline", path: "/timeline" },
+      { id: "reservations", label: "Reservations", path: "/reservations" },
+      { id: "guests", label: "Guests", path: "/guests" },
+      { id: "home", label: "Dashboard", path: "/dashboard" },
+    ],
+  };
+
+  const MANAGE: NavSection = {
+    label: "Manage",
+    items: [
+      { id: "floor-plans", label: "Floor Plans", path: "/floor-plans" },
+      { id: "booking-widget", label: "Booking Widget", path: "/booking-widget" },
+    ],
+  };
+
+  return [PRIMARY, MANAGE, ACCOUNT, ADMIN];
+}
+
+/* ── Public API ─────────────────────────────── */
+
+export function buildNavSections(readiness: VenueReadiness): readonly NavSection[] {
+  if (readiness.status !== "operational") {
+    return buildSetupSections(readiness);
+  }
+  return buildOperationalSections();
+}
+
+/**
+ * @deprecated Use buildNavSections(readiness) instead.
+ * Kept for backwards compatibility during migration.
+ */
+export const NAV_SECTIONS: readonly NavSection[] = buildOperationalSections();

--- a/apps/hospitality/src/pages/SetupHoursPage.module.css
+++ b/apps/hospitality/src/pages/SetupHoursPage.module.css
@@ -1,0 +1,90 @@
+/* ── SetupHoursPage ──────────────────────────── */
+
+.root {
+  padding: var(--rialto-space-xl);
+  max-width: 560px;
+}
+
+/* ── Error banner ─────────────────────────────── */
+
+.errorBanner {
+  padding: var(--rialto-space-sm) var(--rialto-space-md);
+  background: var(--rialto-error-muted, #fee2e2);
+  color: var(--rialto-error, #dc2626);
+  border-radius: var(--rialto-radius-default);
+  font-family: var(--rialto-font-sans);
+  font-size: var(--rialto-text-sm);
+  margin-block-end: var(--rialto-space-lg);
+}
+
+/* ── Form wrapper ─────────────────────────────── */
+
+.form {
+  background: var(--rialto-surface-elevated);
+  border: 1px solid var(--rialto-border);
+  border-radius: var(--rialto-radius-default);
+  padding: var(--rialto-space-lg);
+  margin-block: var(--rialto-space-lg);
+}
+
+/* ── Actions ──────────────────────────────────── */
+
+.actions {
+  display: flex;
+  gap: var(--rialto-space-sm);
+  justify-content: flex-end;
+}
+
+.cancelButton {
+  padding: var(--rialto-space-xs) var(--rialto-space-md);
+  background: transparent;
+  color: var(--rialto-text-secondary);
+  border: 1px solid var(--rialto-border);
+  border-radius: var(--rialto-radius-default);
+  font-family: var(--rialto-font-sans);
+  font-size: var(--rialto-text-sm);
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.cancelButton:hover:not(:disabled) {
+  background: var(--rialto-surface-recessed);
+  color: var(--rialto-text-primary);
+}
+
+.cancelButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.cancelButton:focus-visible {
+  outline: none;
+  box-shadow: var(--rialto-shadow-focus);
+}
+
+.saveButton {
+  padding: var(--rialto-space-xs) var(--rialto-space-md);
+  background: var(--rialto-accent);
+  color: var(--rialto-text-on-accent, #fff);
+  border: none;
+  border-radius: var(--rialto-radius-default);
+  font-family: var(--rialto-font-sans);
+  font-size: var(--rialto-text-sm);
+  font-weight: var(--rialto-weight-medium);
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+
+.saveButton:hover:not(:disabled) {
+  opacity: 0.9;
+}
+
+.saveButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.saveButton:focus-visible {
+  outline: none;
+  box-shadow: var(--rialto-shadow-focus);
+}

--- a/apps/hospitality/src/pages/SetupHoursPage.tsx
+++ b/apps/hospitality/src/pages/SetupHoursPage.tsx
@@ -1,0 +1,84 @@
+import { useState, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "@mbe/auth/react";
+import { createApiClient } from "@mbe/api-client";
+import type { OperatingHours } from "@mbe/types";
+import { useVenue } from "../contexts/VenueContext.js";
+import { OperatingHoursStep } from "../components/venue-onboarding/OperatingHoursStep.js";
+import { PageHeader } from "../components/PageHeader.js";
+import styles from "./SetupHoursPage.module.css";
+
+export function SetupHoursPage() {
+  const navigate = useNavigate();
+  const { accessToken } = useAuth();
+  const { selectedVenue, selectedVenueId } = useVenue();
+
+  const [hours, setHours] = useState<OperatingHours>(
+    selectedVenue?.operatingHours ?? {}
+  );
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const api = useMemo(
+    () =>
+      createApiClient({
+        baseUrl: import.meta.env.VITE_API_URL ?? "",
+        getAccessToken: () => accessToken,
+      }),
+    [accessToken]
+  );
+
+  const handleSave = async () => {
+    if (!selectedVenueId) return;
+
+    setIsSaving(true);
+    setError(null);
+
+    try {
+      await api.venues.update(selectedVenueId, { operatingHours: hours });
+      navigate("/setup");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save operating hours.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className={styles.root}>
+      <PageHeader
+        title="Operating Hours"
+        description="Set the days and times your venue is open for reservations."
+      />
+
+      {error && (
+        <div className={styles.errorBanner} role="alert">
+          {error}
+        </div>
+      )}
+
+      <div className={styles.form}>
+        <OperatingHoursStep data={hours} onChange={setHours} />
+      </div>
+
+      <div className={styles.actions}>
+        <button
+          type="button"
+          className={styles.cancelButton}
+          onClick={() => navigate("/setup")}
+          disabled={isSaving}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          className={styles.saveButton}
+          onClick={handleSave}
+          disabled={isSaving}
+        >
+          {isSaving ? "Saving…" : "Save Hours"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/hospitality/src/pages/SetupPage.module.css
+++ b/apps/hospitality/src/pages/SetupPage.module.css
@@ -1,0 +1,158 @@
+/* ── SetupPage ────────────────────────────────── */
+
+.root {
+  padding: var(--rialto-space-xl);
+  max-width: 640px;
+}
+
+/* ── Progress ─────────────────────────────────── */
+
+.progressBar {
+  height: 6px;
+  background: var(--rialto-surface-recessed);
+  border-radius: var(--rialto-radius-pill);
+  margin-block: var(--rialto-space-lg) var(--rialto-space-xs);
+  overflow: hidden;
+}
+
+.progressFill {
+  height: 100%;
+  background: var(--rialto-accent);
+  border-radius: var(--rialto-radius-pill);
+  transition: width 0.4s ease;
+}
+
+.progressLabel {
+  font-family: var(--rialto-font-sans);
+  font-size: var(--rialto-text-sm);
+  color: var(--rialto-text-tertiary);
+  margin-block: 0 var(--rialto-space-xl);
+}
+
+/* ── Step list ────────────────────────────────── */
+
+.stepList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--rialto-space-md);
+}
+
+/* ── Step card ────────────────────────────────── */
+
+.step {
+  display: flex;
+  gap: var(--rialto-space-md);
+  padding: var(--rialto-space-md);
+  border-radius: var(--rialto-radius-default);
+  border: 1px solid var(--rialto-border);
+  background: var(--rialto-surface-elevated);
+}
+
+.stepCompleted {
+  border-color: var(--rialto-success, var(--rialto-accent));
+  opacity: 0.8;
+}
+
+.stepCurrent {
+  border-color: var(--rialto-accent);
+  background: var(--rialto-accent-muted, var(--rialto-surface-elevated));
+}
+
+.stepLocked {
+  opacity: 0.5;
+}
+
+/* ── Step icon ────────────────────────────────── */
+
+.stepIcon {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--rialto-radius-pill);
+  background: var(--rialto-surface-recessed);
+  color: var(--rialto-text-secondary);
+}
+
+.stepCompleted .stepIcon {
+  background: var(--rialto-success-muted, var(--rialto-accent-muted));
+  color: var(--rialto-success, var(--rialto-accent));
+}
+
+.stepCurrent .stepIcon {
+  background: var(--rialto-accent-muted);
+  color: var(--rialto-accent);
+}
+
+/* ── Step content ─────────────────────────────── */
+
+.stepContent {
+  flex: 1;
+  min-width: 0;
+}
+
+.stepTitle {
+  font-family: var(--rialto-font-sans);
+  font-size: var(--rialto-text-base);
+  font-weight: var(--rialto-weight-medium);
+  color: var(--rialto-text-primary);
+  margin: 0 0 var(--rialto-space-2xs);
+}
+
+.stepDescription {
+  font-family: var(--rialto-font-sans);
+  font-size: var(--rialto-text-sm);
+  color: var(--rialto-text-secondary);
+  margin: 0 0 var(--rialto-space-sm);
+}
+
+/* ── CTA buttons ─────────────────────────────── */
+
+.ctaButton {
+  padding: var(--rialto-space-xs) var(--rialto-space-md);
+  background: var(--rialto-accent);
+  color: var(--rialto-text-on-accent, #fff);
+  border: none;
+  border-radius: var(--rialto-radius-default);
+  font-family: var(--rialto-font-sans);
+  font-size: var(--rialto-text-sm);
+  font-weight: var(--rialto-weight-medium);
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+
+.ctaButton:hover {
+  opacity: 0.9;
+}
+
+.ctaButton:focus-visible {
+  outline: none;
+  box-shadow: var(--rialto-shadow-focus);
+}
+
+.reviewButton {
+  padding: var(--rialto-space-xs) var(--rialto-space-md);
+  background: transparent;
+  color: var(--rialto-text-secondary);
+  border: 1px solid var(--rialto-border);
+  border-radius: var(--rialto-radius-default);
+  font-family: var(--rialto-font-sans);
+  font-size: var(--rialto-text-sm);
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.reviewButton:hover {
+  background: var(--rialto-surface-recessed);
+  color: var(--rialto-text-primary);
+}
+
+.reviewButton:focus-visible {
+  outline: none;
+  box-shadow: var(--rialto-shadow-focus);
+}

--- a/apps/hospitality/src/pages/SetupPage.tsx
+++ b/apps/hospitality/src/pages/SetupPage.tsx
@@ -1,0 +1,124 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useVenueReadiness } from "../hooks/useVenueReadiness.js";
+import { useVenue } from "../contexts/VenueContext.js";
+import { PageHeader } from "../components/PageHeader.js";
+import styles from "./SetupPage.module.css";
+
+const STEP_CONFIG = [
+  {
+    id: "onboarding" as const,
+    label: "Venue Basics",
+    description: "Set up your venue name, timezone, and currency.",
+    path: "/onboarding",
+    ctaLabel: "Review Venue Details",
+  },
+  {
+    id: "operating-hours" as const,
+    label: "Set Operating Hours",
+    description: "Configure which days and hours your venue is open.",
+    path: "/setup/hours",
+    ctaLabel: "Set Operating Hours",
+  },
+  {
+    id: "floor-plan" as const,
+    label: "Create Floor Plan",
+    description: "Add a floor plan with at least one table to enable reservations.",
+    path: "/floor-plans",
+    ctaLabel: "Create Floor Plan",
+  },
+];
+
+export function SetupPage() {
+  const navigate = useNavigate();
+  const readiness = useVenueReadiness();
+  const { selectedVenue } = useVenue();
+
+  // Auto-redirect to timeline when fully operational
+  useEffect(() => {
+    if (readiness.status === "operational") {
+      navigate("/timeline", { replace: true });
+    }
+  }, [readiness.status, navigate]);
+
+  const venueName = selectedVenue?.name ?? "your venue";
+
+  return (
+    <div className={styles.root}>
+      <PageHeader
+        title={`Welcome to ${venueName}`}
+        description="Complete a few setup steps to start taking reservations."
+      />
+
+      <div className={styles.progressBar} role="progressbar" aria-valuenow={readiness.progress} aria-valuemin={0} aria-valuemax={100}>
+        <div className={styles.progressFill} style={{ width: `${readiness.progress}%` }} />
+      </div>
+      <p className={styles.progressLabel}>{readiness.progress}% complete</p>
+
+      <ol className={styles.stepList} aria-label="Setup steps">
+        {STEP_CONFIG.map((step) => {
+          const isCompleted = readiness.completedSteps.includes(step.id);
+          const isCurrent = readiness.nextStep === step.id;
+
+          let statusLabel: string;
+          let stepClass: string;
+          if (isCompleted) {
+            statusLabel = "Completed";
+            stepClass = styles.stepCompleted;
+          } else if (isCurrent) {
+            statusLabel = "Current step";
+            stepClass = styles.stepCurrent;
+          } else {
+            statusLabel = "Not yet available";
+            stepClass = styles.stepLocked;
+          }
+
+          return (
+            <li key={step.id} className={`${styles.step} ${stepClass}`} aria-label={`${step.label} — ${statusLabel}`}>
+              <div className={styles.stepIcon} aria-hidden="true">
+                {isCompleted ? (
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                ) : isCurrent ? (
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <polyline points="9 18 15 12 9 6" />
+                  </svg>
+                ) : (
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+                    <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+                  </svg>
+                )}
+              </div>
+
+              <div className={styles.stepContent}>
+                <h2 className={styles.stepTitle}>{step.label}</h2>
+                <p className={styles.stepDescription}>{step.description}</p>
+
+                {isCurrent && (
+                  <button
+                    type="button"
+                    className={styles.ctaButton}
+                    onClick={() => navigate(step.path)}
+                  >
+                    {step.ctaLabel}
+                  </button>
+                )}
+                {isCompleted && (
+                  <button
+                    type="button"
+                    className={styles.reviewButton}
+                    onClick={() => navigate(step.path)}
+                  >
+                    Review
+                  </button>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </div>
+  );
+}

--- a/apps/hospitality/src/pages/TimelinePage.tsx
+++ b/apps/hospitality/src/pages/TimelinePage.tsx
@@ -2,13 +2,14 @@ import { useState, useEffect, useMemo, useCallback } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useAuth } from "@mbe/auth/react";
 import { createApiClient } from "@mbe/api-client";
-import { Drawer, Select } from "@mbe/rialto";
-import type { Reservation, Table, Venue, TableStatus, UpdateReservationRequest } from "@mbe/types";
+import { Drawer } from "@mbe/rialto";
+import type { Reservation, Table, TableStatus, UpdateReservationRequest } from "@mbe/types";
 import { TimelineGrid } from "../components/timeline";
 import { CancelReservationDialog } from "../components/timeline/CancelReservationDialog";
 import { EditReservationDrawer } from "../components/timeline/EditReservationDrawer";
 import { WalkInDialog } from "../components/timeline/WalkInDialog";
 import { useReservationEvents } from "../hooks/useReservationEvents";
+import { useVenue } from "../contexts/VenueContext.js";
 import { PageHeader } from "../components/PageHeader";
 import styles from "./TimelinePage.module.css";
 
@@ -159,9 +160,8 @@ function ReservationDetails({ reservation, onEdit, onSeat, onCancel }: Reservati
 
 export function TimelinePage() {
   const { accessToken } = useAuth();
+  const { selectedVenueId } = useVenue();
 
-  const [venues, setVenues] = useState<Venue[]>([]);
-  const [selectedVenueId, setSelectedVenueId] = useState<string | null>(null);
   const [tables, setTables] = useState<Table[]>([]);
   const [reservations, setReservations] = useState<Reservation[]>([]);
   const [searchParams, setSearchParams] = useSearchParams();
@@ -231,22 +231,6 @@ export function TimelinePage() {
       setTables((prev) => prev.map((t) => (t.id === table.id ? table : t)));
     }, []),
   });
-
-  // Fetch venues on mount
-  useEffect(() => {
-    async function fetchVenues() {
-      try {
-        const response = await api.venues.list({ limit: 50 });
-        setVenues(response.data);
-        if (response.data.length > 0) {
-          setSelectedVenueId(response.data[0].id);
-        }
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to load venues");
-      }
-    }
-    fetchVenues();
-  }, [api]);
 
   // Fetch tables and reservations when venue or date changes
   useEffect(() => {
@@ -387,27 +371,12 @@ export function TimelinePage() {
     return { confirmed, pending, totalCovers, total: reservations.length };
   }, [reservations]);
 
-  const venueOptions = useMemo(
-    () => venues.map((v) => ({ value: v.id, label: v.name })),
-    [venues]
-  );
-
   return (
     <div className={styles.root}>
       {/* Header */}
       <div className={styles.header}>
         <div className={styles.headerTop}>
           <PageHeader title="Timeline" description="Real-time reservation view" />
-
-          {/* Venue selector */}
-          {venues.length > 1 && (
-            <Select
-              label="Venue"
-              options={venueOptions}
-              value={selectedVenueId ?? ""}
-              onChange={(value) => setSelectedVenueId(value)}
-            />
-          )}
         </div>
 
         {/* Date navigation */}


### PR DESCRIPTION
## Summary

- Implements two-phase sidebar: setup mode (stepper-gated) and operational mode (daily workflow nav) based on venue readiness
- New `useVenueReadiness` hook derives status from venue + operating hours + floor plan gates
- `VenueSwitcher` replaces per-page venue selectors — always visible in sidebar header
- New `/setup` and `/setup/hours` routes for guided venue configuration
- Timeline is now the default landing page; Dashboard moves to `/dashboard`
- Redirect guards in `DashboardLayout`: no-venue → `/onboarding`, setup + operational page → `/setup`, operational + setup URL → `/timeline`

## Test plan

- [ ] New venue (no operating hours, no floor plan): sidebar shows stepper, navigating to `/timeline` redirects to `/setup`
- [ ] After setting operating hours: second step shows checkmark, floor plan step becomes current
- [ ] After creating floor plan with tables: sidebar transitions to operational nav, redirects to `/timeline`
- [ ] Operational venue: Timeline is default landing, Dashboard at `/dashboard`, VenueSwitcher visible in sidebar
- [ ] Multi-venue user: VenueSwitcher dropdown lists venues, switching updates data
- [ ] Single-venue user: VenueSwitcher shows name only (no dropdown)
- [ ] `/setup` redirects to `/timeline` when already operational
- [ ] `pnpm typecheck` and `pnpm lint` pass with no errors

Closes #168

https://claude.ai/code/session_0168LngjRQV1A3FDtpbWNMHy