### PR TITLE
fix: 33 bug fixes, security hardening, and UX improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Generate Prisma client
-        run: pnpm --filter @mbe/users-service db:generate
+        run: pnpm --filter @mbe/users-service db:generate && pnpm --filter @mbe/reservations-service db:generate && pnpm --filter @mbe/agent-service db:generate
 
       - name: Lint
         run: pnpm lint
@@ -58,7 +58,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Generate Prisma client
-        run: pnpm --filter @mbe/users-service db:generate
+        run: pnpm --filter @mbe/users-service db:generate && pnpm --filter @mbe/reservations-service db:generate && pnpm --filter @mbe/agent-service db:generate
 
       - name: Typecheck
         run: pnpm typecheck
@@ -85,10 +85,16 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Generate Prisma client
-        run: pnpm --filter @mbe/users-service db:generate
+        run: pnpm --filter @mbe/users-service db:generate && pnpm --filter @mbe/reservations-service db:generate && pnpm --filter @mbe/agent-service db:generate
 
       - name: Build all packages
         run: pnpm build
+
+      - name: Check circular dependencies
+        run: node scripts/check-circular-deps.js
+
+      - name: Audit dependencies for vulnerabilities
+        run: pnpm audit --audit-level=high || echo "::warning::Dependency audit found high/critical vulnerabilities — see output above"
 
       - name: Check Dockerfile dependencies
         run: node scripts/check-dockerfile-deps.js
@@ -127,7 +133,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Generate Prisma client
-        run: pnpm --filter @mbe/users-service db:generate
+        run: pnpm --filter @mbe/users-service db:generate && pnpm --filter @mbe/reservations-service db:generate && pnpm --filter @mbe/agent-service db:generate
 
       - name: Run tests with coverage
         run: pnpm turbo test:coverage
@@ -175,13 +181,29 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Apply migrations
+      - name: Check for destructive migrations
+        run: node scripts/check-destructive-migrations.js
+
+      - name: Apply migrations (users)
         run: pnpm --filter @mbe/users-service db:migrate:deploy
         env:
           DATABASE_URL: postgresql://test:test@localhost:5432/test
 
+      - name: Apply migrations (reservations)
+        run: pnpm --filter @mbe/reservations-service db:migrate:deploy
+        env:
+          DATABASE_URL: postgresql://test:test@localhost:5432/test
+
+      - name: Apply migrations (agent)
+        run: pnpm --filter @mbe/agent-service db:migrate:deploy
+        env:
+          DATABASE_URL: postgresql://test:test@localhost:5432/test
+
       - name: Verify schema is in sync
-        run: pnpm --filter @mbe/users-service db:migrate:status
+        run: |
+          pnpm --filter @mbe/users-service db:migrate:status
+          pnpm --filter @mbe/reservations-service db:migrate:status
+          pnpm --filter @mbe/agent-service db:migrate:status
         env:
           DATABASE_URL: postgresql://test:test@localhost:5432/test
 

--- a/.github/workflows/deploy-services.yml
+++ b/.github/workflows/deploy-services.yml
@@ -17,8 +17,22 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Wait for CI to pass before deploying
+  ci-gate:
+    name: Wait for CI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for CI workflow
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.sha }}
+          check-name: "Build"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+
   deploy:
     name: Deploy API Services
+    needs: [ci-gate]
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,15 @@
 pnpm lint-staged
 pnpm turbo typecheck --filter='...[HEAD]'
+
+# Check generated files are up to date (~4s total)
+pnpm --filter @mbe/rialto build:registry --silent
+if ! git diff --quiet packages/rialto/registry.json 2>/dev/null; then
+  echo "ERROR: packages/rialto/registry.json is stale. Run 'pnpm --filter @mbe/rialto build:registry' and stage the result."
+  exit 1
+fi
+
+pnpm --filter @mbe/rialto-catalog generate --silent
+if ! git diff --quiet packages/rialto-catalog/src/generated-schemas.ts 2>/dev/null; then
+  echo "ERROR: packages/rialto-catalog/src/generated-schemas.ts is stale. Run 'pnpm --filter @mbe/rialto-catalog generate' and stage the result."
+  exit 1
+fi

--- a/apps/hospitality/package.json
+++ b/apps/hospitality/package.json
@@ -40,6 +40,6 @@
     "typescript": "^5.9.3",
     "vite": "^7.0.0",
     "vite-plugin-pwa": "^1.2.0",
-    "vitest": "^3.2.1"
+    "vitest": "^4.0.18"
   }
 }

--- a/apps/hospitality/src/components/DashboardLayout.module.css
+++ b/apps/hospitality/src/components/DashboardLayout.module.css
@@ -109,6 +109,10 @@
 /* ── Breadcrumb bar ─────────────────────────── */
 
 .breadcrumbBar {
+  /* Pull out to the edges of .content's padding so the bar spans full width,
+     then re-apply the same inline padding to align text with page content. */
+  margin-inline: calc(-1 * var(--rialto-space-lg));
+  margin-block-start: calc(-1 * var(--rialto-space-lg));
   padding-inline: var(--rialto-space-lg);
   padding-block: var(--rialto-space-sm);
   border-block-end: 1px solid var(--rialto-border);
@@ -135,6 +139,12 @@
 
   .content {
     padding: var(--rialto-space-md);
+  }
+
+  .breadcrumbBar {
+    margin-inline: calc(-1 * var(--rialto-space-md));
+    margin-block-start: calc(-1 * var(--rialto-space-md));
+    padding-inline: var(--rialto-space-md);
   }
 
   .commandHint {

--- a/apps/hospitality/src/components/dashboard/ReservationList.tsx
+++ b/apps/hospitality/src/components/dashboard/ReservationList.tsx
@@ -11,6 +11,11 @@ const STATUS_VARIANT: Record<string, "neutral" | "success" | "warning" | "error"
 };
 
 function formatTime(time: string): string {
+  const date = new Date(time);
+  if (!isNaN(date.getTime())) {
+    return date.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
+  }
+  // Fallback for plain HH:mm strings
   const [hours, minutes] = time.split(":");
   const h = parseInt(hours, 10);
   const suffix = h >= 12 ? "pm" : "am";

--- a/apps/hospitality/src/components/venue-onboarding/BasicInfoStep.tsx
+++ b/apps/hospitality/src/components/venue-onboarding/BasicInfoStep.tsx
@@ -12,9 +12,11 @@ interface BasicInfoStepProps {
   data: BasicInfoData;
   errors: Partial<Record<keyof BasicInfoData, string>>;
   onChange: (data: BasicInfoData) => void;
+  onValidate?: () => void;
+  slugStatus?: "idle" | "checking" | "available" | "taken";
 }
 
-export function BasicInfoStep({ data, errors, onChange }: BasicInfoStepProps) {
+export function BasicInfoStep({ data, errors, onChange, onValidate, slugStatus }: BasicInfoStepProps) {
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     const currentSlugIsAuto = data.slug === generateSlug(data.name);
@@ -30,6 +32,18 @@ export function BasicInfoStep({ data, errors, onChange }: BasicInfoStepProps) {
     onChange({ ...data, venueGroupId: e.target.value });
   };
 
+  const slugHint =
+    slugStatus === "checking"
+      ? "Checking availability..."
+      : slugStatus === "available"
+        ? "Slug is available"
+        : slugStatus === "taken"
+          ? undefined // shown as error instead
+          : "URL-friendly identifier (auto-generated from name)";
+
+  const slugHintColor =
+    slugStatus === "available" ? "primary" : "secondary";
+
   return (
     <div className={styles.stepContainer}>
       <Stack gap="md">
@@ -44,6 +58,7 @@ export function BasicInfoStep({ data, errors, onChange }: BasicInfoStepProps) {
             placeholder="e.g. The Grand Ballroom"
             value={data.name}
             onChange={handleNameChange}
+            onBlur={onValidate}
             aria-label="Venue Name"
           />
           {errors.name && <span className={styles.errorText}>{errors.name}</span>}
@@ -60,11 +75,14 @@ export function BasicInfoStep({ data, errors, onChange }: BasicInfoStepProps) {
             placeholder="e.g. the-grand-ballroom"
             value={data.slug}
             onChange={handleSlugChange}
+            onBlur={onValidate}
             aria-label="Slug"
           />
-          <Text variant="caption" color="secondary">
-            URL-friendly identifier (auto-generated from name)
-          </Text>
+          {slugHint && (
+            <Text variant="caption" color={slugHintColor}>
+              {slugHint}
+            </Text>
+          )}
           {errors.slug && <span className={styles.errorText}>{errors.slug}</span>}
         </div>
 

--- a/apps/hospitality/src/components/venue-onboarding/LocationTimeStep.tsx
+++ b/apps/hospitality/src/components/venue-onboarding/LocationTimeStep.tsx
@@ -10,9 +10,10 @@ interface LocationTimeStepProps {
   data: LocationTimeData;
   errors: Partial<Record<keyof LocationTimeData, string>>;
   onChange: (data: LocationTimeData) => void;
+  onValidate?: () => void;
 }
 
-const TIMEZONE_OPTIONS = [
+export const TIMEZONE_OPTIONS = [
   { value: "America/New_York", label: "Eastern Time (America/New_York)" },
   { value: "America/Chicago", label: "Central Time (America/Chicago)" },
   { value: "America/Denver", label: "Mountain Time (America/Denver)" },
@@ -39,7 +40,7 @@ const CURRENCY_OPTIONS = [
   { value: "AED", label: "AED - UAE Dirham" },
 ];
 
-export function LocationTimeStep({ data, errors, onChange }: LocationTimeStepProps) {
+export function LocationTimeStep({ data, errors, onChange, onValidate }: LocationTimeStepProps) {
   return (
     <div className={styles.stepContainer}>
       <Stack gap="md">
@@ -52,6 +53,7 @@ export function LocationTimeStep({ data, errors, onChange }: LocationTimeStepPro
             className={styles.select}
             value={data.ianaTimezone}
             onChange={(e) => onChange({ ...data, ianaTimezone: e.target.value })}
+            onBlur={onValidate}
           >
             <option value="">Select a timezone...</option>
             {TIMEZONE_OPTIONS.map((tz) => (
@@ -77,6 +79,7 @@ export function LocationTimeStep({ data, errors, onChange }: LocationTimeStepPro
             className={styles.select}
             value={data.currencyCode}
             onChange={(e) => onChange({ ...data, currencyCode: e.target.value })}
+            onBlur={onValidate}
           >
             {CURRENCY_OPTIONS.map((c) => (
               <option key={c.value} value={c.value}>

--- a/apps/hospitality/src/components/venue-onboarding/SettingsStep.tsx
+++ b/apps/hospitality/src/components/venue-onboarding/SettingsStep.tsx
@@ -11,9 +11,10 @@ interface SettingsStepProps {
   data: SettingsData;
   errors: Partial<Record<keyof SettingsData, string>>;
   onChange: (data: SettingsData) => void;
+  onValidate?: () => void;
 }
 
-export function SettingsStep({ data, errors, onChange }: SettingsStepProps) {
+export function SettingsStep({ data, errors, onChange, onValidate }: SettingsStepProps) {
   return (
     <div className={styles.stepContainer}>
       <Text variant="caption" color="secondary">
@@ -33,6 +34,7 @@ export function SettingsStep({ data, errors, onChange }: SettingsStepProps) {
             onChange={(e) =>
               onChange({ ...data, defaultReservationDuration: e.target.value })
             }
+            onBlur={onValidate}
             placeholder="90"
             min="1"
           />
@@ -51,6 +53,7 @@ export function SettingsStep({ data, errors, onChange }: SettingsStepProps) {
             className={styles.numberInput}
             value={data.maxPartySize}
             onChange={(e) => onChange({ ...data, maxPartySize: e.target.value })}
+            onBlur={onValidate}
             placeholder="12"
             min="1"
           />
@@ -71,6 +74,7 @@ export function SettingsStep({ data, errors, onChange }: SettingsStepProps) {
             onChange={(e) =>
               onChange({ ...data, advanceBookingDays: e.target.value })
             }
+            onBlur={onValidate}
             placeholder="30"
             min="1"
           />

--- a/apps/hospitality/src/components/venue-onboarding/StepIndicator.tsx
+++ b/apps/hospitality/src/components/venue-onboarding/StepIndicator.tsx
@@ -5,15 +5,17 @@ const STEP_LABELS = ["Info", "Location", "Hours", "Settings", "Review"];
 interface StepIndicatorProps {
   currentStep: number;
   totalSteps: number;
+  onStepClick?: (step: number) => void;
 }
 
-export function StepIndicator({ currentStep, totalSteps }: StepIndicatorProps) {
+export function StepIndicator({ currentStep, totalSteps, onStepClick }: StepIndicatorProps) {
   return (
     <div className={styles.stepIndicator} role="navigation" aria-label="Wizard progress">
       {Array.from({ length: totalSteps }, (_, i) => {
         const stepNumber = i + 1;
         const isActive = stepNumber === currentStep;
         const isCompleted = stepNumber < currentStep;
+        const isClickable = isCompleted && onStepClick;
 
         const dotClass = isActive
           ? styles.stepDotActive
@@ -21,12 +23,28 @@ export function StepIndicator({ currentStep, totalSteps }: StepIndicatorProps) {
             ? styles.stepDotCompleted
             : styles.stepDotPending;
 
+        const dotProps = isClickable
+          ? {
+              role: "link" as const,
+              tabIndex: 0,
+              onClick: () => onStepClick(stepNumber),
+              onKeyDown: (e: React.KeyboardEvent) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  onStepClick(stepNumber);
+                }
+              },
+              style: { cursor: "pointer" },
+            }
+          : {};
+
         return (
           <span key={stepNumber} style={{ display: "contents" }}>
             <span
               className={`${styles.stepDot} ${dotClass}`}
               aria-current={isActive ? "step" : undefined}
-              aria-label={`Step ${stepNumber}: ${STEP_LABELS[i] ?? ""}`}
+              aria-label={`Step ${stepNumber}: ${STEP_LABELS[i] ?? ""}${isClickable ? " (click to edit)" : ""}`}
+              {...dotProps}
             >
               {isCompleted ? "\u2713" : stepNumber}
             </span>

--- a/apps/hospitality/src/components/venue-onboarding/venue-onboarding.module.css
+++ b/apps/hospitality/src/components/venue-onboarding/venue-onboarding.module.css
@@ -75,7 +75,7 @@
 }
 
 .timeInput {
-  width: 7rem;
+  width: 10rem;
   padding-inline: var(--rialto-space-sm);
   padding-block: var(--rialto-space-xs);
   border: 1px solid var(--rialto-border);
@@ -179,6 +179,10 @@
   background: var(--rialto-accent);
   color: var(--rialto-text-on-accent);
   opacity: 0.7;
+}
+
+.stepDotCompleted:hover {
+  opacity: 1;
 }
 
 .stepDotPending {

--- a/apps/hospitality/src/contexts/VenueContext.tsx
+++ b/apps/hospitality/src/contexts/VenueContext.tsx
@@ -3,6 +3,7 @@ import {
   useContext,
   useState,
   useEffect,
+  useRef,
   useMemo,
   useCallback,
   type ReactNode,
@@ -18,6 +19,7 @@ interface VenueContextValue {
   setVenueId: (id: string) => void;
   isLoading: boolean;
   isMultiVenue: boolean;
+  refetchVenues: () => Promise<void>;
 }
 
 export type { VenueContextValue };
@@ -63,52 +65,48 @@ export function VenueProvider({ children }: VenueProviderProps) {
     readStoredVenueId
   );
   const [isLoading, setIsLoading] = useState(true);
+  const fetchVersionRef = useRef(0);
+
+  const fetchVenuesInner = useCallback(async () => {
+    const version = ++fetchVersionRef.current;
+    setIsLoading(true);
+    try {
+      const response = await api.venues.list({ limit: 100 });
+      if (version !== fetchVersionRef.current) return;
+
+      const fetched: readonly Venue[] = response.data;
+      setVenues(fetched);
+
+      // Auto-select logic: use stored ID if it matches a fetched venue,
+      // otherwise fall back to the first venue
+      const storedId = readStoredVenueId();
+      const storedExists = fetched.some((v) => v.id === storedId);
+
+      if (storedExists) {
+        setSelectedVenueId(storedId);
+      } else if (fetched.length > 0) {
+        const firstId = fetched[0].id;
+        setSelectedVenueId(firstId);
+        storeVenueId(firstId);
+      } else {
+        setSelectedVenueId(null);
+      }
+    } catch {
+      if (version === fetchVersionRef.current) {
+        setVenues([]);
+        setSelectedVenueId(null);
+      }
+    } finally {
+      if (version === fetchVersionRef.current) {
+        setIsLoading(false);
+      }
+    }
+  }, [api]);
 
   // Fetch venues on mount
   useEffect(() => {
-    let cancelled = false;
-
-    async function fetchVenues() {
-      setIsLoading(true);
-      try {
-        const response = await api.venues.list({ limit: 100 });
-        if (cancelled) return;
-
-        const fetched: readonly Venue[] = response.data;
-        setVenues(fetched);
-
-        // Auto-select logic: use stored ID if it matches a fetched venue,
-        // otherwise fall back to the first venue
-        const storedId = readStoredVenueId();
-        const storedExists = fetched.some((v) => v.id === storedId);
-
-        if (storedExists) {
-          setSelectedVenueId(storedId);
-        } else if (fetched.length > 0) {
-          const firstId = fetched[0].id;
-          setSelectedVenueId(firstId);
-          storeVenueId(firstId);
-        } else {
-          setSelectedVenueId(null);
-        }
-      } catch {
-        if (!cancelled) {
-          setVenues([]);
-          setSelectedVenueId(null);
-        }
-      } finally {
-        if (!cancelled) {
-          setIsLoading(false);
-        }
-      }
-    }
-
-    fetchVenues();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [api]);
+    fetchVenuesInner();
+  }, [fetchVenuesInner]);
 
   const setVenueId = useCallback(
     (id: string) => {
@@ -135,8 +133,9 @@ export function VenueProvider({ children }: VenueProviderProps) {
       setVenueId,
       isLoading,
       isMultiVenue,
+      refetchVenues: fetchVenuesInner,
     }),
-    [venues, selectedVenueId, selectedVenue, setVenueId, isLoading, isMultiVenue]
+    [venues, selectedVenueId, selectedVenue, setVenueId, isLoading, isMultiVenue, fetchVenuesInner]
   );
 
   return (

--- a/apps/hospitality/src/pages/AdminPage.tsx
+++ b/apps/hospitality/src/pages/AdminPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect, useMemo, useCallback, Fragment } from "react";
 import { useAuth } from "@mbe/auth/react";
 import {
   Alert,
@@ -277,9 +277,8 @@ export function AdminPage() {
             </thead>
             <tbody>
               {filteredUsers.map((user, index) => (
-                <>
+                <Fragment key={user.id}>
                   <tr
-                    key={user.id}
                     className={[
                       styles.row,
                       index % 2 === 1 ? styles.rowAlt : "",
@@ -335,7 +334,7 @@ export function AdminPage() {
                   {expandedUserId === user.id && (
                     <UserDetailRow key={`${user.id}-detail`} user={user} />
                   )}
-                </>
+                </Fragment>
               ))}
             </tbody>
           </table>

--- a/apps/hospitality/src/pages/GuestsPage.tsx
+++ b/apps/hospitality/src/pages/GuestsPage.tsx
@@ -652,6 +652,15 @@ export function GuestsPage() {
                         .filter(Boolean)
                         .join(" ")}
                       onClick={() => handleRowClick(guest.id)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          handleRowClick(guest.id);
+                        }
+                      }}
+                      tabIndex={0}
+                      role="button"
+                      aria-label={`View details for ${guest.name}`}
                     >
                       <td className={styles.td}>
                         <Text variant="body" color="primary" className={styles.guestName}>

--- a/apps/hospitality/src/pages/ReservationsPage.tsx
+++ b/apps/hospitality/src/pages/ReservationsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams, useNavigate } from "react-router-dom";
 import { useAuth } from "@mbe/auth/react";
 import { createApiClient } from "@mbe/api-client";
 import {
@@ -76,13 +76,14 @@ function formatRelativeTime(date: Date): string {
 /* ── Main component ─────────────────────────── */
 
 export function ReservationsPage() {
+  const navigate = useNavigate();
   const { accessToken } = useAuth();
   const { selectedVenueId } = useVenue();
   const [reservations, setReservations] = useState<Reservation[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [searchParams, setSearchParams] = useSearchParams();
-  const selectedDate = searchParams.get("date") ?? new Date().toISOString().split("T")[0];
+  const selectedDate = searchParams.get("date") ?? new Date().toLocaleDateString("en-CA");
   const statusFilter = searchParams.get("status") ?? "all";
   const [searchQuery, setSearchQuery] = useState("");
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
@@ -301,7 +302,20 @@ export function ReservationsPage() {
               </thead>
               <tbody className={styles.tbody}>
                 {filteredReservations.map((reservation) => (
-                  <tr key={reservation.id}>
+                  <tr
+                    key={reservation.id}
+                    onClick={() => navigate(`/timeline?date=${reservation.date}`)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        navigate(`/timeline?date=${reservation.date}`);
+                      }
+                    }}
+                    tabIndex={0}
+                    role="button"
+                    aria-label={`View ${reservation.guestName ?? "Guest"} reservation on timeline`}
+                    style={{ cursor: "pointer" }}
+                  >
                     <td className={styles.td}>
                       {formatTime(reservation.startTime)} - {formatTime(reservation.endTime)}
                     </td>

--- a/apps/hospitality/src/pages/TimelinePage.tsx
+++ b/apps/hospitality/src/pages/TimelinePage.tsx
@@ -165,7 +165,7 @@ export function TimelinePage() {
   const [tables, setTables] = useState<Table[]>([]);
   const [reservations, setReservations] = useState<Reservation[]>([]);
   const [searchParams, setSearchParams] = useSearchParams();
-  const selectedDate = searchParams.get("date") ?? new Date().toISOString().split("T")[0];
+  const selectedDate = searchParams.get("date") ?? new Date().toLocaleDateString("en-CA");
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedReservation, setSelectedReservation] = useState<Reservation | null>(null);
@@ -269,9 +269,9 @@ export function TimelinePage() {
   }, [api, selectedVenueId, selectedDate]);
 
   const handlePreviousDay = useCallback(() => {
-    const prev = new Date(selectedDate);
+    const prev = new Date(selectedDate + "T00:00:00");
     prev.setDate(prev.getDate() - 1);
-    const newDate = prev.toISOString().split("T")[0];
+    const newDate = prev.toLocaleDateString("en-CA");
     setSearchParams((p) => {
       const next = new URLSearchParams(p);
       next.set("date", newDate);
@@ -280,9 +280,9 @@ export function TimelinePage() {
   }, [selectedDate, setSearchParams]);
 
   const handleNextDay = useCallback(() => {
-    const next = new Date(selectedDate);
+    const next = new Date(selectedDate + "T00:00:00");
     next.setDate(next.getDate() + 1);
-    const newDate = next.toISOString().split("T")[0];
+    const newDate = next.toLocaleDateString("en-CA");
     setSearchParams((p) => {
       const params = new URLSearchParams(p);
       params.set("date", newDate);
@@ -293,7 +293,7 @@ export function TimelinePage() {
   const handleToday = useCallback(() => {
     setSearchParams((p) => {
       const next = new URLSearchParams(p);
-      next.set("date", new Date().toISOString().split("T")[0]);
+      next.set("date", new Date().toLocaleDateString("en-CA"));
       return next;
     });
   }, [setSearchParams]);
@@ -303,34 +303,48 @@ export function TimelinePage() {
   }, []);
 
   const handleSeat = async (reservation: Reservation) => {
-    const updated = await api.reservations.update(reservation.id, { status: "CONFIRMED" });
-    await api.tables.updateStatus(reservation.tableId, "OCCUPIED");
-    setReservations((prev) => prev.map((r) => (r.id === reservation.id ? updated : r)));
-    setTables((prev) =>
-      prev.map((t) => (t.id === reservation.tableId ? { ...t, status: "OCCUPIED" as const } : t))
-    );
-    setSelectedReservation(null);
+    try {
+      const updated = await api.reservations.update(reservation.id, { status: "CONFIRMED" });
+      await api.tables.updateStatus(reservation.tableId, "OCCUPIED");
+      setReservations((prev) => prev.map((r) => (r.id === reservation.id ? updated : r)));
+      setTables((prev) =>
+        prev.map((t) =>
+          t.id === reservation.tableId ? { ...t, status: "OCCUPIED" as const } : t
+        )
+      );
+      setSelectedReservation(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to seat guest");
+    }
   };
 
   const handleCancel = async (reason: string, note: string) => {
     if (!selectedReservation) return;
-    await api.reservations.cancelWithReason(selectedReservation.id, {
-      cancellationReason: reason,
-      cancellationNote: note,
-    });
-    setReservations((prev) =>
-      prev.map((r) =>
-        r.id === selectedReservation.id ? { ...r, status: "CANCELLED" as const } : r
-      )
-    );
-    setShowCancelDialog(false);
-    setSelectedReservation(null);
+    try {
+      await api.reservations.cancelWithReason(selectedReservation.id, {
+        cancellationReason: reason,
+        cancellationNote: note,
+      });
+      setReservations((prev) =>
+        prev.map((r) =>
+          r.id === selectedReservation.id ? { ...r, status: "CANCELLED" as const } : r
+        )
+      );
+      setShowCancelDialog(false);
+      setSelectedReservation(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to cancel reservation");
+    }
   };
 
   const handleEdit = async (id: string, data: UpdateReservationRequest) => {
-    const updated = await api.reservations.update(id, data);
-    setReservations((prev) => prev.map((r) => (r.id === id ? updated : r)));
-    setSelectedReservation(updated);
+    try {
+      const updated = await api.reservations.update(id, data);
+      setReservations((prev) => prev.map((r) => (r.id === id ? updated : r)));
+      setSelectedReservation(updated);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update reservation");
+    }
   };
 
   const handleWalkIn = async (data: {
@@ -339,11 +353,15 @@ export function TimelinePage() {
     venueId: string;
     guestName?: string;
   }) => {
-    const reservation = await api.reservations.walkIn(data);
-    setReservations((prev) => [...prev, reservation]);
-    setTables((prev) =>
-      prev.map((t) => (t.id === data.tableId ? { ...t, status: "OCCUPIED" as const } : t))
-    );
+    try {
+      const reservation = await api.reservations.walkIn(data);
+      setReservations((prev) => [...prev, reservation]);
+      setTables((prev) =>
+        prev.map((t) => (t.id === data.tableId ? { ...t, status: "OCCUPIED" as const } : t))
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create walk-in");
+    }
   };
 
   const handleTableStatusChange = async (tableId: string, status: TableStatus) => {
@@ -359,7 +377,7 @@ export function TimelinePage() {
     year: "numeric",
   });
 
-  const isToday = selectedDate === new Date().toISOString().split("T")[0];
+  const isToday = selectedDate === new Date().toLocaleDateString("en-CA");
 
   // Stats
   const stats = useMemo(() => {

--- a/apps/hospitality/src/pages/VenueOnboardingPage.test.tsx
+++ b/apps/hospitality/src/pages/VenueOnboardingPage.test.tsx
@@ -30,8 +30,18 @@ vi.mock("@mbe/api-client", () => ({
   })),
 }));
 
+const mockRefetchVenues = vi.fn().mockResolvedValue(undefined);
+vi.mock("../contexts/VenueContext.js", () => ({
+  useVenue: () => ({
+    refetchVenues: mockRefetchVenues,
+  }),
+}));
+
+const mockToast = vi.fn();
+
 // Mock Rialto components to simplify testing
 vi.mock("@mbe/rialto", () => ({
+  useToast: () => ({ toast: mockToast, dismiss: vi.fn() }),
   Button: ({
     children,
     onClick,
@@ -169,6 +179,8 @@ describe("VenueOnboardingPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCreate.mockReset();
+    mockRefetchVenues.mockReset().mockResolvedValue(undefined);
+    mockToast.mockReset();
   });
 
   it("should render step 1 (Basic Info) by default", () => {
@@ -223,6 +235,10 @@ describe("VenueOnboardingPage", () => {
     const nameInput = screen.getByLabelText("Venue Name") as HTMLInputElement;
     fireEvent.change(nameInput, { target: { value: "My Venue" } });
     fireEvent.click(screen.getByText("Next"));
+
+    // Clear the timezone (may be auto-detected from the environment)
+    const timezoneSelect = screen.getByLabelText("Timezone") as HTMLSelectElement;
+    fireEvent.change(timezoneSelect, { target: { value: "" } });
 
     // Try to proceed without selecting timezone
     fireEvent.click(screen.getByText("Next"));
@@ -308,7 +324,7 @@ describe("VenueOnboardingPage", () => {
     expect(payload.currencyCode).toBe("USD");
   });
 
-  it("should show success state after venue creation", async () => {
+  it("should show toast and redirect to /setup after venue creation", async () => {
     mockCreate.mockResolvedValueOnce({ id: "venue-456", name: "My Venue" });
 
     renderPage();
@@ -327,10 +343,16 @@ describe("VenueOnboardingPage", () => {
     fireEvent.click(screen.getByText("Create Venue"));
 
     await waitFor(() => {
-      expect(screen.getByText("Success!")).toBeTruthy();
+      expect(mockRefetchVenues).toHaveBeenCalledOnce();
     });
 
-    expect(screen.getByText(/venue-456/)).toBeTruthy();
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Venue created",
+        variant: "success",
+      })
+    );
+    expect(mockNavigate).toHaveBeenCalledWith("/setup", { replace: true });
   });
 
   it("should show error when API call fails", async () => {

--- a/apps/hospitality/src/pages/VenueOnboardingPage.tsx
+++ b/apps/hospitality/src/pages/VenueOnboardingPage.tsx
@@ -1,9 +1,10 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "@mbe/auth/react";
-import { Button, Card, Text, Stack } from "@mbe/rialto";
+import { Button, Card, Text, Stack, useToast } from "@mbe/rialto";
 import { ApiClient, VenuesClient } from "@mbe/api-client";
 import type { OperatingHours, CreateVenueRequest, VenueSettings } from "@mbe/types";
+import { useVenue } from "../contexts/VenueContext.js";
 import { PageHeader } from "../components/PageHeader";
 import { StepIndicator } from "../components/venue-onboarding/StepIndicator";
 import { BasicInfoStep } from "../components/venue-onboarding/BasicInfoStep";
@@ -13,6 +14,7 @@ import { SettingsStep } from "../components/venue-onboarding/SettingsStep";
 import { ConfirmationStep } from "../components/venue-onboarding/ConfirmationStep";
 import type { BasicInfoData } from "../components/venue-onboarding/BasicInfoStep";
 import type { LocationTimeData } from "../components/venue-onboarding/LocationTimeStep";
+import { TIMEZONE_OPTIONS } from "../components/venue-onboarding/LocationTimeStep";
 import type { SettingsData } from "../components/venue-onboarding/SettingsStep";
 import styles from "./VenueOnboardingPage.module.css";
 
@@ -24,8 +26,19 @@ const INITIAL_BASIC_INFO: BasicInfoData = {
   venueGroupId: "",
 };
 
+/** Use the browser's timezone as the default, only if it's in the supported options list. */
+function detectTimezone(): string {
+  try {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const supported = TIMEZONE_OPTIONS.map((o) => o.value);
+    return supported.includes(tz) ? tz : "";
+  } catch {
+    return "";
+  }
+}
+
 const INITIAL_LOCATION_TIME: LocationTimeData = {
-  ianaTimezone: "",
+  ianaTimezone: detectTimezone(),
   currencyCode: "USD",
 };
 
@@ -45,11 +58,12 @@ function isValidSlug(slug: string): boolean {
 export function VenueOnboardingPage() {
   const navigate = useNavigate();
   const { accessToken } = useAuth();
+  const { refetchVenues } = useVenue();
+  const { toast } = useToast();
 
   const [currentStep, setCurrentStep] = useState(1);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
-  const [createdVenueId, setCreatedVenueId] = useState<string | null>(null);
 
   // Step data — each piece of state is immutable (replaced, never mutated)
   const [basicInfo, setBasicInfo] = useState<BasicInfoData>(INITIAL_BASIC_INFO);
@@ -68,6 +82,48 @@ export function VenueOnboardingPage() {
     Partial<Record<keyof SettingsData, string>>
   >({});
 
+  // Slug uniqueness check (debounced)
+  const [slugStatus, setSlugStatus] = useState<"idle" | "checking" | "available" | "taken">("idle");
+  const slugCheckTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  useEffect(() => {
+    const slug = basicInfo.slug.trim();
+
+    // Reset if empty or invalid format
+    if (!slug || !isValidSlug(slug)) {
+      setSlugStatus("idle");
+      return;
+    }
+
+    // Debounce: wait 500ms after last change
+    clearTimeout(slugCheckTimerRef.current);
+    setSlugStatus("checking");
+
+    slugCheckTimerRef.current = setTimeout(async () => {
+      if (!accessToken) return;
+      try {
+        const apiClient = new ApiClient({
+          baseUrl: import.meta.env.VITE_API_URL ?? "",
+          getAccessToken: () => accessToken,
+        });
+        const venuesClient = new VenuesClient(apiClient);
+        await venuesClient.getBySlug(slug);
+        // If it returns successfully, the slug is taken
+        setSlugStatus("taken");
+        setBasicInfoErrors((prev) => ({ ...prev, slug: "A venue with this slug already exists" }));
+      } catch {
+        // 404 means slug is available
+        setSlugStatus("available");
+        setBasicInfoErrors((prev) => {
+          const { slug: _removed, ...rest } = prev;
+          return rest;
+        });
+      }
+    }, 500);
+
+    return () => clearTimeout(slugCheckTimerRef.current);
+  }, [basicInfo.slug, accessToken]);
+
   const validateBasicInfo = useCallback((): boolean => {
     const errors: Partial<Record<keyof BasicInfoData, string>> = {};
 
@@ -80,11 +136,13 @@ export function VenueOnboardingPage() {
       errors.slug = "Slug is required";
     } else if (!isValidSlug(slug)) {
       errors.slug = "Slug must be URL-safe (lowercase letters, numbers, hyphens)";
+    } else if (slugStatus === "taken") {
+      errors.slug = "A venue with this slug already exists";
     }
 
     setBasicInfoErrors(errors);
     return Object.keys(errors).length === 0;
-  }, [basicInfo]);
+  }, [basicInfo, slugStatus]);
 
   const validateLocationTime = useCallback((): boolean => {
     const errors: Partial<Record<keyof LocationTimeData, string>> = {};
@@ -205,8 +263,15 @@ export function VenueOnboardingPage() {
         getAccessToken: () => accessToken,
       });
       const venuesClient = new VenuesClient(apiClient);
-      const venue = await venuesClient.create(buildPayload());
-      setCreatedVenueId(venue.id);
+      await venuesClient.create(buildPayload());
+      await refetchVenues();
+      toast({
+        title: "Venue created",
+        description: `"${basicInfo.name.trim()}" is ready for setup`,
+        variant: "success",
+        duration: 5000,
+      });
+      navigate("/setup", { replace: true });
     } catch (err) {
       setSubmitError(
         err instanceof Error ? err.message : "Failed to create venue. Please try again."
@@ -216,34 +281,16 @@ export function VenueOnboardingPage() {
     }
   };
 
-  // Success state
-  if (createdVenueId) {
-    return (
-      <div>
-        <PageHeader title="Venue Created" description="Your new venue is ready" />
-        <Card>
-          <Stack gap="md" align="center">
-            <Text variant="label" color="primary">
-              Success!
-            </Text>
-            <Text variant="body" color="secondary">
-              Venue &quot;{basicInfo.name}&quot; has been created (ID: {createdVenueId}).
-            </Text>
-            <Button variant="primary" onClick={() => navigate("/")}>
-              Go to Dashboard
-            </Button>
-          </Stack>
-        </Card>
-      </div>
-    );
-  }
-
   return (
     <div>
       <PageHeader title="New Venue" description="Set up your venue in a few steps" />
 
       <div className={styles.wizardContainer}>
-        <StepIndicator currentStep={currentStep} totalSteps={TOTAL_STEPS} />
+        <StepIndicator
+          currentStep={currentStep}
+          totalSteps={TOTAL_STEPS}
+          onStepClick={(step) => setCurrentStep(step)}
+        />
 
         <Card>
           <Stack gap="lg">
@@ -256,6 +303,8 @@ export function VenueOnboardingPage() {
                   data={basicInfo}
                   errors={basicInfoErrors}
                   onChange={setBasicInfo}
+                  onValidate={validateBasicInfo}
+                  slugStatus={slugStatus}
                 />
               </>
             )}
@@ -269,6 +318,7 @@ export function VenueOnboardingPage() {
                   data={locationTime}
                   errors={locationTimeErrors}
                   onChange={setLocationTime}
+                  onValidate={validateLocationTime}
                 />
               </>
             )}
@@ -291,6 +341,7 @@ export function VenueOnboardingPage() {
                   data={settings}
                   errors={settingsErrors}
                   onChange={setSettings}
+                  onValidate={validateSettings}
                 />
               </>
             )}

--- a/apps/marketing/index.html
+++ b/apps/marketing/index.html
@@ -34,7 +34,9 @@
     <meta name="twitter:title" content="Matt Butler Engineering" />
     <meta name="twitter:description" content="Software engineering solutions for hospitality and beyond" />
     <meta name="twitter:image" content="https://mattbutlerengineering.com/og-image.png" />
-    <meta name="theme-color" content="#1a1a1a" />
+    <meta name="robots" content="index, follow" />
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/docs/superpowers/specs/2026-04-03-harness-engineering-design.md
+++ b/docs/superpowers/specs/2026-04-03-harness-engineering-design.md
@@ -47,6 +47,34 @@ Cross-app/service imports are already prevented by pnpm strict mode.
 
 Turbo-powered typecheck scoped to changed packages + dependents. Runs in ~12s with cache, catches type errors before they reach CI.
 
+### 4. Circular Dependency Detection (Feedback)
+
+**File:** `scripts/check-circular-deps.js`
+
+Walks all workspace `package.json` files and detects `@mbe/*` dependency cycles. Zero external dependencies — pure graph traversal. Runs in CI build job and available as `pnpm check:circular-deps`.
+
+### 5. Dependency Security Audit (Feedback)
+
+**CI step** in build job. Runs `pnpm audit --audit-level=high` as a non-blocking warning. Surfaces known CVEs in dependencies without breaking builds on low-severity issues.
+
+### 6. Destructive Migration Guard (Feedforward)
+
+**File:** `scripts/check-destructive-migrations.js`
+
+Scans new Prisma migration SQL files for `DROP TABLE`, `DROP COLUMN`, `TRUNCATE`, `DELETE FROM`. Runs in CI migrations job before applying migrations. Escape hatch: add `-- DESTRUCTIVE: <reason>` comment to the SQL file for intentional destructive changes.
+
+### 7. Service Layer Enforcement (Feedforward)
+
+**File:** `packages/config/eslint/node.js`
+
+Route files cannot import `**/services/database` or `@prisma/client` directly — must go through the service layer (e.g., `userService`, `reservationService`). Health routes and test files are exempt since they need direct DB access for connectivity checks.
+
+### 8. Generated Code Staleness Check (Temporal Shift)
+
+**File:** `.husky/pre-commit`
+
+Pre-commit hook regenerates `registry.json` and `generated-schemas.ts`, then checks for uncommitted diff. Takes ~4s total. Prevents the "CI fails 5 minutes later" loop when agents or developers forget to regenerate after source changes.
+
 ## Package Classification
 
 | Category | Packages |

--- a/infrastructure/worker/edge-router.js
+++ b/infrastructure/worker/edge-router.js
@@ -16,6 +16,7 @@ const SECURITY_HEADERS = {
   "X-Frame-Options": "DENY",
   "X-Content-Type-Options": "nosniff",
   "Referrer-Policy": "strict-origin-when-cross-origin",
+  "Permissions-Policy": "camera=(), microphone=(), geolocation=(), payment=()",
   "Content-Security-Policy": [
     "default-src 'self'",
     "script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com",
@@ -222,9 +223,39 @@ function computeSystemStatus(services, staticSites, ci, deploys) {
 }
 
 /**
- * Handle GET /health/system — aggregate all subsystem health.
+ * Check whether the request carries a valid health token.
+ * Returns true only when HEALTH_TOKEN is configured and the request
+ * includes a matching `Authorization: Bearer <token>` header.
  */
-async function handleHealthSystem(env) {
+function isHealthAuthorized(request, env) {
+  if (!env.HEALTH_TOKEN) return false;
+  return request.headers.get("Authorization") === `Bearer ${env.HEALTH_TOKEN}`;
+}
+
+/**
+ * Return a coarse health response with no infrastructure details.
+ */
+function coarseHealthResponse(status, timestamp) {
+  return new Response(JSON.stringify({ status, timestamp }), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+}
+
+/**
+ * Handle GET /health/system — aggregate all subsystem health.
+ *
+ * Unauthenticated requests receive only a coarse { status, timestamp }
+ * response.  Detailed subsystem data (service names, latencies, commit
+ * SHAs, CI status) requires a valid Bearer token matching HEALTH_TOKEN.
+ * If HEALTH_TOKEN is not configured, all requests get the coarse response
+ * (safe by default).
+ */
+async function handleHealthSystem(request, env) {
   const now = Date.now();
 
   // Fan out all checks in parallel
@@ -265,11 +296,17 @@ async function handleHealthSystem(env) {
   );
 
   const status = computeSystemStatus(services, staticSites, ci, deploys);
+  const timestamp = new Date(now).toISOString();
+
+  // Gate detailed output behind token auth (safe by default)
+  if (!isHealthAuthorized(request, env)) {
+    return coarseHealthResponse(status, timestamp);
+  }
 
   return new Response(
     JSON.stringify({
       status,
-      timestamp: new Date(now).toISOString(),
+      timestamp,
       subsystems: { services, static_sites: staticSites, ci, deploys },
     }),
     {
@@ -289,7 +326,7 @@ export default {
 
     // ── Health aggregation endpoint ───────────────────────────────────
     if (url.pathname === "/health/system") {
-      return handleHealthSystem(env);
+      return handleHealthSystem(request, env);
     }
 
     // Redirect www → non-www
@@ -322,6 +359,7 @@ export default {
       const headers = new Headers(request.headers);
       headers.set("Host", target.host);
       headers.set("X-Forwarded-Host", url.host);
+      headers.set("X-Forwarded-For", request.headers.get("CF-Connecting-IP") ?? "");
 
       return fetch(
         new Request(target, {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "dev:local": "docker compose -f infrastructure/docker-compose.yml up postgres -d --wait && pnpm env:init && pnpm db:push && turbo run dev",
     "env:init": "pnpm --filter './services/*' exec sh -c '[ -f .env ] || cp .env.example .env'",
     "db:push": "pnpm --filter './services/*' exec prisma db push --skip-generate",
+    "check:circular-deps": "node scripts/check-circular-deps.js",
+    "check:destructive-migrations": "node scripts/check-destructive-migrations.js",
     "check:dockerfiles": "node scripts/check-dockerfile-deps.js",
     "build": "turbo run build",
     "test": "turbo run test",

--- a/packages/agent-core/src/__tests__/session-runner.test.ts
+++ b/packages/agent-core/src/__tests__/session-runner.test.ts
@@ -12,6 +12,7 @@ vi.mock("../worktree-manager.js", () => ({
   pushBranch: vi.fn(),
   hasChanges: vi.fn(),
   removeWorktree: vi.fn(),
+  runVerification: vi.fn(),
 }));
 
 vi.mock("../pr-creator.js", () => ({
@@ -25,6 +26,14 @@ vi.mock("../success-evaluator.js", () => ({
   evaluateSuccess: vi.fn(),
   getGitDiff: vi.fn(),
   shouldEvaluate: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock("../diff-reviewer.js", () => ({
+  reviewDiff: vi.fn(),
+}));
+
+vi.mock("../feedback-loop.js", () => ({
+  runFeedbackLoop: vi.fn(),
 }));
 
 vi.mock("../failure-memory.js", () => ({
@@ -49,9 +58,12 @@ import {
   pushBranch,
   hasChanges,
   removeWorktree,
+  runVerification,
 } from "../worktree-manager.js";
 import { createPullRequest, buildPrTitle, buildPrBody } from "../pr-creator.js";
 import { evaluateSuccess, getGitDiff } from "../success-evaluator.js";
+import { reviewDiff } from "../diff-reviewer.js";
+import { runFeedbackLoop } from "../feedback-loop.js";
 import { loadMemory, queryPastFailures, buildFailureContext } from "../failure-memory.js";
 import { buildSystemPrompt } from "../prompt-builder.js";
 import { createToolPermissionHandler } from "../tool-permissions.js";
@@ -116,6 +128,16 @@ describe("runSession", () => {
     vi.mocked(loadMemory).mockResolvedValue({ records: [] });
     vi.mocked(queryPastFailures).mockReturnValue([]);
     vi.mocked(buildFailureContext).mockReturnValue("");
+
+    vi.mocked(runVerification).mockResolvedValue({
+      passed: true,
+      lintOk: true,
+      typecheckOk: true,
+      testsOk: true,
+    });
+
+    vi.mocked(reviewDiff).mockResolvedValue({ approved: true, issues: [] });
+    vi.mocked(runFeedbackLoop).mockResolvedValue({ resolved: false, retriesUsed: 0 });
 
     vi.mocked(getGitDiff).mockResolvedValue("diff --git a/file.ts\n+change");
     vi.mocked(evaluateSuccess).mockResolvedValue({

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -34,8 +34,9 @@ export {
   commitChanges,
   pushBranch,
   hasChanges,
+  runVerification,
 } from "./worktree-manager.js";
-export type { CreateWorktreeOptions } from "./worktree-manager.js";
+export type { CreateWorktreeOptions, VerificationResult as PrePushVerification } from "./worktree-manager.js";
 
 // PR creation
 export {
@@ -180,6 +181,15 @@ export type {
 } from "./task-decomposer.js";
 
 export { DEFAULT_ORCHESTRATOR_CONFIG } from "./task-decomposer.js";
+
+// Task intelligence (source files, budget, model, PR examples)
+export {
+  resolveSourceFiles,
+  resolveBudget,
+  resolveModel,
+  fetchRecentPrExamples,
+  formatPrExamples,
+} from "./task-intelligence.js";
 
 // Intent extraction
 export { extractIssueIntent, IssueIntentSchema } from "./intent-extractor.js";

--- a/packages/agent-core/src/prompt-builder.ts
+++ b/packages/agent-core/src/prompt-builder.ts
@@ -58,7 +58,8 @@ function formatSourceFileSection(entries: readonly SourceFileEntry[]): string {
 
 export function buildSystemPrompt(
   taskDescription: string,
-  sourceFileEntries?: readonly SourceFileEntry[]
+  sourceFileEntries?: readonly SourceFileEntry[],
+  prExamplesSection?: string
 ): string {
   const base = [
     "You are an autonomous coding agent. Complete the following task in a single session.",
@@ -86,7 +87,7 @@ export function buildSystemPrompt(
     ? formatSourceFileSection(sourceFileEntries)
     : "";
 
-  return base + sourceSection;
+  return base + sourceSection + (prExamplesSection ?? "");
 }
 
 export async function loadProjectContext(repoPath: string): Promise<string | null> {

--- a/packages/agent-core/src/session-runner.ts
+++ b/packages/agent-core/src/session-runner.ts
@@ -32,6 +32,11 @@ import { evaluateSuccess, getGitDiff, shouldEvaluate } from "./success-evaluator
 import type { EvaluationResult } from "./success-evaluator.js";
 import { reviewDiff } from "./diff-reviewer.js";
 import type { ReviewResult } from "./diff-reviewer.js";
+import {
+  resolveSourceFiles,
+  fetchRecentPrExamples,
+  formatPrExamples,
+} from "./task-intelligence.js";
 import { mapSdkMessage } from "./event-mapper.js";
 import {
   recordFailure,
@@ -97,15 +102,23 @@ export async function runSession(
           wtSpan.end();
         }
 
-        // 2. Build system prompt with failure context and source files
+        // 2. Build system prompt with failure context, source files, and PR examples
         const failureMemory = await loadMemory(config.repoPath);
         const pastFailures = queryPastFailures(failureMemory, config.taskDescription);
         const failureContext = buildFailureContext(pastFailures);
-        const sourceFileEntries = config.sourceFiles
-          ? await loadSourceFiles(config.sourceFiles)
+
+        // Auto-resolve source files from task description if none provided
+        const resolvedSourcePaths = config.sourceFiles ?? resolveSourceFiles(config.taskDescription);
+        const sourceFileEntries = resolvedSourcePaths.length > 0
+          ? await loadSourceFiles(resolvedSourcePaths)
           : undefined;
+
+        // Fetch recent successful PRs as examples (non-blocking)
+        const prExamples = await fetchRecentPrExamples(config.repoPath).catch(() => []);
+        const prExamplesSection = formatPrExamples(prExamples);
+
         const systemPrompt =
-          buildSystemPrompt(config.taskDescription, sourceFileEntries) + failureContext;
+          buildSystemPrompt(config.taskDescription, sourceFileEntries, prExamplesSection) + failureContext;
 
         // 3. Run the agent via SDK query()
         emitEvent(onEvent, "session:start", {

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -10,7 +10,7 @@ export interface FeedbackLoopConfig {
 }
 
 export const DEFAULT_FEEDBACK_LOOP_CONFIG: FeedbackLoopConfig = {
-  enabled: false,
+  enabled: true,
   maxRetries: 2,
   pollIntervalMs: 30_000,
   pollTimeoutMs: 300_000,

--- a/packages/api-client/src/availability.ts
+++ b/packages/api-client/src/availability.ts
@@ -80,9 +80,9 @@ export class HoldsClient {
    * Create a hold on a time slot
    */
   async create(data: CreateHoldRequest): Promise<{ hold: ReservationHold; sessionId: string }> {
-    const headers: Record<string, string> = {};
-    if (this.sessionId) {
-      headers["x-session-id"] = this.sessionId;
+    // Generate session ID before the request so create and confirm use the same ID
+    if (!this.sessionId) {
+      this.sessionId = crypto.randomUUID();
     }
 
     const response = await this.client.request<ApiResponse<ReservationHold>>(
@@ -90,16 +90,13 @@ export class HoldsClient {
       {
         method: "POST",
         body: JSON.stringify(data),
-        headers,
+        headers: {
+          "x-session-id": this.sessionId,
+        },
       }
     );
 
-    // The session ID may be returned in the response headers
-    // For now, use the one we have or generate one client-side
-    const newSessionId = this.sessionId ?? crypto.randomUUID();
-    this.sessionId = newSessionId;
-
-    return { hold: response.data, sessionId: newSessionId };
+    return { hold: response.data, sessionId: this.sessionId };
   }
 
   /**

--- a/packages/api-client/src/reservations.ts
+++ b/packages/api-client/src/reservations.ts
@@ -85,7 +85,7 @@ export class ReservationsClient {
    * Cancel a reservation
    */
   async cancel(id: string): Promise<Reservation> {
-    const response = await this.client.delete(`/api/v1/reservations/${id}`) as unknown as ApiResponse<Reservation>;
+    const response = await this.client.request<ApiResponse<Reservation>>(`/api/v1/reservations/${id}`, { method: "DELETE" });
     return response.data;
   }
 

--- a/packages/auth/src/react/hooks.ts
+++ b/packages/auth/src/react/hooks.ts
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useAuth as useOIDCAuth } from "react-oidc-context";
 import type { AuthUser, JWTPayload } from "../types/index.js";
 
@@ -54,9 +55,11 @@ export function useAccessToken(): string | null {
 export function useRequireAuth() {
   const auth = useAuth();
 
-  if (!auth.isLoading && !auth.isAuthenticated) {
-    auth.signIn();
-  }
+  useEffect(() => {
+    if (!auth.isLoading && !auth.isAuthenticated) {
+      auth.signIn();
+    }
+  }, [auth.isLoading, auth.isAuthenticated, auth.signIn]);
 
   return auth;
 }

--- a/packages/config/eslint/node.js
+++ b/packages/config/eslint/node.js
@@ -31,4 +31,45 @@ export default [
       ],
     },
   },
+  // Service layer enforcement — routes must not import database directly (go through service layer).
+  // Health routes are exempt since they need direct DB access for connectivity checks.
+  {
+    files: ["**/routes/**/*.ts"],
+    ignores: ["**/routes/health.ts", "**/routes/health.test.ts", "**/routes/**/*.test.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["@mbe/rialto", "@mbe/rialto/*"],
+              message: "Frontend-only package. Cannot import in backend services.",
+            },
+            {
+              group: ["@mbe/api-client", "@mbe/api-client/*"],
+              message: "Frontend-only package. Cannot import in backend services.",
+            },
+            {
+              group: ["@mbe/auth/react"],
+              message: "Frontend entrypoint. Use @mbe/auth/fastify in backend services.",
+            },
+            {
+              group: ["@mbe/sentry/react"],
+              message: "Frontend entrypoint. Use @mbe/sentry/node in backend services.",
+            },
+            {
+              group: ["**/services/database", "**/services/database.js"],
+              message:
+                "Routes must not import database directly. Use the service layer instead (e.g., userService, reservationService).",
+            },
+            {
+              group: ["@prisma/client", "@prisma/client/*"],
+              message:
+                "Routes must not import Prisma directly. Use the service layer instead.",
+            },
+          ],
+        },
+      ],
+    },
+  },
 ];

--- a/packages/rialto/src/components/Dialog/Dialog.tsx
+++ b/packages/rialto/src/components/Dialog/Dialog.tsx
@@ -114,12 +114,13 @@ export const Dialog = forwardRef<HTMLDivElement, DialogProps>(
               className={styles.panel}
               role="dialog"
               aria-modal
-              aria-label={title}
+              aria-labelledby={title ? "rialto-dialog-title" : undefined}
+              aria-label={title ? undefined : "Dialog"}
               transition={shouldReduceMotion ? { duration: 0 } : springGentle}
               {...motionProps}
             >
               <div className={styles.header}>
-                {title && <h2 className={styles.title}>{title}</h2>}
+                {title && <h2 id="rialto-dialog-title" className={styles.title}>{title}</h2>}
                 <button className={styles.close} onClick={onClose} aria-label="Close dialog">
                   <svg
                     width="14"

--- a/packages/rialto/src/components/Drawer/Drawer.tsx
+++ b/packages/rialto/src/components/Drawer/Drawer.tsx
@@ -154,7 +154,8 @@ export const Drawer = forwardRef<HTMLDivElement, DrawerProps>(function Drawer(
               className={panelClasses}
               role="dialog"
               aria-modal="true"
-              aria-label={title}
+              aria-labelledby={title ? "rialto-drawer-title" : undefined}
+              aria-label={title ? undefined : "Drawer"}
               initial={slideHidden}
               animate={slideOpen[side]}
               exit={slideHidden}
@@ -164,7 +165,7 @@ export const Drawer = forwardRef<HTMLDivElement, DrawerProps>(function Drawer(
               {(title || description) && (
                 <div className={styles.header}>
                   <div className={styles.headerContent}>
-                    {title && <h2 className={styles.title}>{title}</h2>}
+                    {title && <h2 id="rialto-drawer-title" className={styles.title}>{title}</h2>}
                     {description && <p className={styles.description}>{description}</p>}
                   </div>
                   <button

--- a/packages/rialto/src/components/Input/Input.module.css
+++ b/packages/rialto/src/components/Input/Input.module.css
@@ -39,7 +39,7 @@
   border-color: var(--rialto-accent);
 }
 
-.input[aria-disabled="true"] {
+.input:disabled {
   filter: saturate(0.6) brightness(0.95);
   cursor: not-allowed;
 }

--- a/packages/rialto/src/components/Input/Input.tsx
+++ b/packages/rialto/src/components/Input/Input.tsx
@@ -81,11 +81,11 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
               ref={ref}
               id={inputId}
               className={inputClass}
-              aria-disabled={disabled || undefined}
+              disabled={disabled || undefined}
               aria-invalid={error || undefined}
               aria-describedby={hint ? `${inputId}-hint` : undefined}
               required={required}
-              readOnly={disabled || readOnly}
+              readOnly={readOnly}
               {...props}
             />
             {endIcon && (

--- a/packages/rialto/src/components/interactions.test.tsx
+++ b/packages/rialto/src/components/interactions.test.tsx
@@ -65,11 +65,10 @@ describe("Interaction tests", () => {
     expect(screen.getByRole("button", { name: /third/i })).toHaveFocus();
   });
 
-  it("Input with disabledReason renders aria-disabled and readOnly", () => {
+  it("Input with disabledReason renders native disabled attribute", () => {
     render(<Input label="Email" disabled disabledReason="Account locked" />);
     const input = screen.getByLabelText("Email");
-    expect(input).toHaveAttribute("aria-disabled", "true");
-    expect(input).toHaveAttribute("readOnly");
+    expect(input).toBeDisabled();
   });
 
   it("Checkbox toggles on click", async () => {

--- a/services/agent/src/routes/remediation.ts
+++ b/services/agent/src/routes/remediation.ts
@@ -1,4 +1,5 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
+import { Readable } from "node:stream";
 import type { FastifyPluginAsync } from "fastify";
 import { z } from "zod";
 import type { ApiError } from "@mbe/types";
@@ -26,7 +27,7 @@ type AlertPayload = z.infer<typeof AlertPayloadSchema>;
 // ── Signature verification ───────────────────────────────────────────
 
 function verifyRemediationSignature(
-  payload: string,
+  payload: Buffer,
   signature: string | undefined,
   secret: string
 ): boolean {
@@ -41,6 +42,19 @@ function verifyRemediationSignature(
 // ── Route ────────────────────────────────────────────────────────────
 
 export const remediationRoutes: FastifyPluginAsync = async (fastify) => {
+  // Capture raw request body before Fastify parses JSON.
+  // Webhook senders sign the original bytes; re-serializing via JSON.stringify
+  // can produce a different byte sequence and break HMAC verification.
+  fastify.addHook("preParsing", async (request, _reply, payload) => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of payload) {
+      chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : (chunk as Buffer));
+    }
+    const rawBody = Buffer.concat(chunks);
+    (request as unknown as Record<string, unknown>).rawBody = rawBody;
+    return Readable.from(rawBody);
+  });
+
   fastify.post<{
     Body: unknown;
     Reply: { sessionId: string } | ApiError;
@@ -77,8 +91,9 @@ export const remediationRoutes: FastifyPluginAsync = async (fastify) => {
         });
       }
 
+      // Verify signature against the original raw bytes (not re-serialized JSON)
       const signature = request.headers["x-remediation-signature"] as string | undefined;
-      const rawBody = JSON.stringify(request.body);
+      const rawBody = (request as unknown as Record<string, unknown>).rawBody as Buffer;
 
       if (!verifyRemediationSignature(rawBody, signature, secret)) {
         return reply.code(401).send({

--- a/services/agent/src/routes/webhooks.ts
+++ b/services/agent/src/routes/webhooks.ts
@@ -1,4 +1,5 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
+import { Readable } from "node:stream";
 import type { FastifyPluginAsync } from "fastify";
 import type { ApiError } from "@mbe/types";
 import { extractIssueIntent } from "@mbe/agent-core";
@@ -61,7 +62,7 @@ interface GitHubCheckRunEvent {
 // ── Signature verification ───────────────────────────────────────────
 
 function verifySignature(
-  payload: string,
+  payload: Buffer,
   signature: string | undefined,
   secret: string
 ): boolean {
@@ -89,6 +90,19 @@ const AGENT_BRANCH_PREFIX = "agent/";
 // ── Routes ───────────────────────────────────────────────────────────
 
 export const webhookRoutes: FastifyPluginAsync = async (fastify) => {
+  // Capture raw request body before Fastify parses JSON.
+  // GitHub signs the original bytes; re-serializing via JSON.stringify
+  // can produce a different byte sequence and break HMAC verification.
+  fastify.addHook("preParsing", async (request, _reply, payload) => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of payload) {
+      chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : (chunk as Buffer));
+    }
+    const rawBody = Buffer.concat(chunks);
+    (request as unknown as Record<string, unknown>).rawBody = rawBody;
+    return Readable.from(rawBody);
+  });
+
   // POST /v1/webhooks/github — Handle GitHub webhook events
   fastify.post<{
     Body: unknown;
@@ -123,9 +137,9 @@ export const webhookRoutes: FastifyPluginAsync = async (fastify) => {
         });
       }
 
-      // Verify signature
+      // Verify signature against the original raw bytes (not re-serialized JSON)
       const signature = request.headers["x-hub-signature-256"] as string | undefined;
-      const rawBody = JSON.stringify(request.body);
+      const rawBody = (request as unknown as Record<string, unknown>).rawBody as Buffer;
 
       if (!verifySignature(rawBody, signature, secret)) {
         return reply.code(401).send({

--- a/services/agent/src/services/database.ts
+++ b/services/agent/src/services/database.ts
@@ -1,6 +1,20 @@
 import { PrismaClient } from "../generated/prisma/index.js";
 
-export const prisma = new PrismaClient();
+// Cap Prisma's internal connection pool to avoid exceeding PgBouncer's
+// session-mode pool_size. DigitalOcean managed Postgres defaults to ~25
+// total connections; with 3 services sharing the pooler, each gets ~7.
+const CONNECTION_LIMIT = parseInt(process.env.PRISMA_CONNECTION_LIMIT ?? "5", 10);
+
+export const prisma = new PrismaClient({
+  datasourceUrl: appendConnectionLimit(process.env.DATABASE_URL, CONNECTION_LIMIT),
+});
+
+function appendConnectionLimit(url: string | undefined, limit: number): string | undefined {
+  if (!url) return undefined;
+  const separator = url.includes("?") ? "&" : "?";
+  if (url.includes("connection_limit=")) return url;
+  return `${url}${separator}connection_limit=${limit}`;
+}
 
 process.on("beforeExit", async () => {
   await prisma.$disconnect();

--- a/services/reservations/src/routes/holds.test.ts
+++ b/services/reservations/src/routes/holds.test.ts
@@ -394,7 +394,7 @@ describe("Hold Routes", () => {
     it("should return 404 for expired hold", async () => {
       vi.mocked(holdService.convertToReservation).mockResolvedValue({
         success: false,
-        error: "Hold not found or expired",
+        error: "Hold has expired",
       });
 
       const response = await app.inject({
@@ -411,6 +411,51 @@ describe("Hold Routes", () => {
       expect(response.statusCode).toBe(404);
       const body = JSON.parse(response.body);
       expect(body.error).toBe("Not Found");
+      expect(body.message).toBe("Hold has expired");
+    });
+
+    it("should return 404 for nonexistent hold", async () => {
+      vi.mocked(holdService.convertToReservation).mockResolvedValue({
+        success: false,
+        error: "Hold not found",
+      });
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/v1/holds/hold-123/confirm",
+        headers: {
+          "x-session-id": "session-abc",
+        },
+        payload: {
+          guestName: "John Doe",
+        },
+      });
+
+      expect(response.statusCode).toBe(404);
+      const body = JSON.parse(response.body);
+      expect(body.message).toBe("Hold not found");
+    });
+
+    it("should return 403 for session ID mismatch", async () => {
+      vi.mocked(holdService.convertToReservation).mockResolvedValue({
+        success: false,
+        error: "Session ID does not match the hold",
+      });
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/v1/holds/hold-123/confirm",
+        headers: {
+          "x-session-id": "wrong-session",
+        },
+        payload: {
+          guestName: "John Doe",
+        },
+      });
+
+      expect(response.statusCode).toBe(403);
+      const body = JSON.parse(response.body);
+      expect(body.error).toBe("Forbidden");
     });
 
     it("should return 409 when slot no longer available", async () => {

--- a/services/reservations/src/routes/holds.ts
+++ b/services/reservations/src/routes/holds.ts
@@ -351,14 +351,24 @@ export const holdRoutes: FastifyPluginAsync = async (fastify) => {
       );
 
       if (!result.success) {
-        const isNotFound =
-          result.error?.includes("not found") ||
-          result.error?.includes("expired");
-        const statusCode = isNotFound ? 404 : 409;
+        const error = result.error ?? "Failed to confirm hold";
+        let statusCode: number;
+        let errorLabel: string;
+
+        if (error.includes("not found") || error.includes("expired")) {
+          statusCode = 404;
+          errorLabel = "Not Found";
+        } else if (error.includes("Session ID")) {
+          statusCode = 403;
+          errorLabel = "Forbidden";
+        } else {
+          statusCode = 409;
+          errorLabel = "Conflict";
+        }
 
         return reply.code(statusCode).send({
-          error: isNotFound ? "Not Found" : "Conflict",
-          message: result.error ?? "Failed to confirm hold",
+          error: errorLabel,
+          message: error,
           statusCode,
         });
       }

--- a/services/reservations/src/routes/reservations.test.ts
+++ b/services/reservations/src/routes/reservations.test.ts
@@ -575,7 +575,10 @@ describe("Reservation Routes", () => {
         status: "CONFIRMED" as const,
         guestName: "Walk-in",
       };
-      vi.mocked(reservationService.createWalkIn).mockResolvedValueOnce(walkInReservation);
+      vi.mocked(reservationService.createWalkIn).mockResolvedValueOnce({
+        success: true,
+        reservation: walkInReservation,
+      });
       vi.mocked(tableService.updateStatus).mockResolvedValueOnce({
         ...mockTable,
         status: "OCCUPIED" as const,
@@ -617,7 +620,10 @@ describe("Reservation Routes", () => {
         status: "CONFIRMED" as const,
         guestName: "Jane Smith",
       };
-      vi.mocked(reservationService.createWalkIn).mockResolvedValueOnce(walkInReservation);
+      vi.mocked(reservationService.createWalkIn).mockResolvedValueOnce({
+        success: true,
+        reservation: walkInReservation,
+      });
       vi.mocked(tableService.updateStatus).mockResolvedValueOnce({
         ...mockTable,
         status: "OCCUPIED" as const,

--- a/services/reservations/src/routes/reservations.ts
+++ b/services/reservations/src/routes/reservations.ts
@@ -226,6 +226,10 @@ export const reservationRoutes: FastifyPluginAsync = async (fastify) => {
             description: "Authentication required",
             $ref: "Error#",
           },
+          409: {
+            description: "Table is not available",
+            $ref: "Error#",
+          },
           500: {
             description: "Internal server error",
             $ref: "Error#",
@@ -235,13 +239,20 @@ export const reservationRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (request, reply) => {
       const userId = request.user?.id;
-      const reservation = await reservationService.createWalkIn(request.body, userId);
+      const result = await reservationService.createWalkIn(request.body, userId);
+      if (!result.success || !result.reservation) {
+        return reply.code(409).send({
+          error: "Conflict",
+          message: result.error ?? "Table is not available",
+          statusCode: 409,
+        });
+      }
       const updatedTable = await tableService.updateStatus(request.body.tableId, "OCCUPIED");
-      emitReservationCreated(reservation);
+      emitReservationCreated(result.reservation);
       if (updatedTable) {
         emitTableUpdated(updatedTable);
       }
-      return reply.code(201).send({ data: reservation });
+      return reply.code(201).send({ data: result.reservation });
     }
   );
 

--- a/services/reservations/src/services/availability.ts
+++ b/services/reservations/src/services/availability.ts
@@ -221,7 +221,6 @@ export async function getAvailableDates(
   endDate: string,
   partySize: number
 ): Promise<DateAvailability[]> {
-  const results: DateAvailability[] = [];
   const start = new Date(startDate);
   const end = new Date(endDate);
 
@@ -234,15 +233,97 @@ export async function getAvailableDates(
     start.getTime() + Math.min(daysDiff, maxDays) * 24 * 60 * 60 * 1000
   );
 
+  // Hoist venue + tables queries outside the loop (same for every date)
+  const [prismaVenue, suitableTables] = await Promise.all([
+    prisma.venue.findUnique({ where: { id: venueId } }),
+    findSuitableTables(venueId, partySize),
+  ]);
+
+  if (!prismaVenue || suitableTables.length === 0) {
+    // No venue or no tables — every date is unavailable
+    const results: DateAvailability[] = [];
+    for (let d = new Date(start); d <= actualEnd; d.setDate(d.getDate() + 1)) {
+      results.push({ date: d.toISOString().split("T")[0], hasAvailability: false, slotCount: 0 });
+    }
+    return results;
+  }
+
+  const venue: VenueWithSettings = {
+    id: prismaVenue.id,
+    name: prismaVenue.name,
+    slug: prismaVenue.slug,
+    ianaTimezone: prismaVenue.ianaTimezone,
+    settings: prismaVenue.settings as VenueSettings | null,
+    operatingHours: prismaVenue.operatingHours as OperatingHours | null,
+  };
+
+  // Bulk-fetch reservations and holds for the entire date range (2 queries total)
+  const [allReservations, allHolds] = await Promise.all([
+    prisma.reservation.findMany({
+      where: {
+        venueId,
+        date: { gte: start, lte: actualEnd },
+        status: { notIn: ["CANCELLED", "NO_SHOW"] },
+      },
+      select: { id: true, tableId: true, startTime: true, endTime: true, partySize: true },
+    }),
+    prisma.reservationHold.findMany({
+      where: {
+        venueId,
+        date: { gte: start, lte: actualEnd },
+        expiresAt: { gt: new Date() },
+      },
+      select: { id: true, tableId: true, startTime: true, endTime: true, partySize: true, expiresAt: true },
+    }),
+  ]);
+
+  const settings = venue.settings;
+  const slotInterval = settings?.slotIntervalMinutes ?? DEFAULT_SLOT_INTERVAL;
+  const lastSeatingBuffer = settings?.lastSeatingBuffer ?? DEFAULT_LAST_SEATING_BUFFER;
+  const duration = estimateDuration(partySize, settings);
+
+  const results: DateAvailability[] = [];
+
   for (let d = new Date(start); d <= actualEnd; d.setDate(d.getDate() + 1)) {
     const dateStr = d.toISOString().split("T")[0];
-    const slots = await generateTimeSlots(venueId, dateStr, partySize);
-    const availableSlots = slots.filter((s) => s.available);
+    const schedule = getDaySchedule(venue.operatingHours, d);
+
+    if (!schedule) {
+      results.push({ date: dateStr, hasAvailability: false, slotCount: 0 });
+      continue;
+    }
+
+    // Filter reservations and holds for this specific date
+    const dateReservations = allReservations.filter(
+      (r) => r.startTime.toISOString().split("T")[0] === dateStr
+    );
+    const dateHolds = allHolds.filter(
+      (h) => h.startTime.toISOString().split("T")[0] === dateStr
+    );
+
+    const openMinutes = parseTimeToMinutes(schedule.open);
+    const closeMinutes = parseTimeToMinutes(schedule.close);
+    const lastSeatingMinutes = closeMinutes - lastSeatingBuffer;
+
+    let availableCount = 0;
+
+    for (let minutes = openMinutes; minutes <= lastSeatingMinutes; minutes += slotInterval) {
+      const slotStart = createDateTimeFromMinutes(dateStr, minutes, venue.ianaTimezone);
+      const slotEnd = new Date(slotStart.getTime() + duration * 60 * 1000);
+
+      const hasAvailableTable = suitableTables.some(
+        (table) => !checkTableConflict(table.id, slotStart, slotEnd, dateReservations, dateHolds)
+      );
+
+      if (hasAvailableTable) {
+        availableCount++;
+      }
+    }
 
     results.push({
       date: dateStr,
-      hasAvailability: availableSlots.length > 0,
-      slotCount: availableSlots.length,
+      hasAvailability: availableCount > 0,
+      slotCount: availableCount,
     });
   }
 

--- a/services/reservations/src/services/database.ts
+++ b/services/reservations/src/services/database.ts
@@ -1,6 +1,21 @@
 import { PrismaClient } from "../generated/prisma/index.js";
 
-export const prisma = new PrismaClient();
+// Cap Prisma's internal connection pool to avoid exceeding PgBouncer's
+// session-mode pool_size. DigitalOcean managed Postgres defaults to ~25
+// total connections; with 3 services sharing the pooler, each gets ~7.
+const CONNECTION_LIMIT = parseInt(process.env.PRISMA_CONNECTION_LIMIT ?? "5", 10);
+
+export const prisma = new PrismaClient({
+  datasourceUrl: appendConnectionLimit(process.env.DATABASE_URL, CONNECTION_LIMIT),
+});
+
+function appendConnectionLimit(url: string | undefined, limit: number): string | undefined {
+  if (!url) return undefined;
+  const separator = url.includes("?") ? "&" : "?";
+  // Don't override if already set in the URL
+  if (url.includes("connection_limit=")) return url;
+  return `${url}${separator}connection_limit=${limit}`;
+}
 
 // Graceful shutdown
 process.on("beforeExit", async () => {

--- a/services/reservations/src/services/floor-plan.ts
+++ b/services/reservations/src/services/floor-plan.ts
@@ -173,17 +173,21 @@ export const floorPlanService = {
 
   async setActive(id: string, venueId: string): Promise<FloorPlan | null> {
     try {
-      // Deactivate all other floor plans for this venue
-      await prisma.floorPlan.updateMany({
-        where: { venueId, isActive: true },
-        data: { isActive: false },
-      });
+      // Wrap both writes in a transaction so a crash between them
+      // cannot leave the venue with no active floor plan
+      const floorPlan = await prisma.$transaction(async (tx) => {
+        // Deactivate all other floor plans for this venue
+        await tx.floorPlan.updateMany({
+          where: { venueId, isActive: true },
+          data: { isActive: false },
+        });
 
-      // Activate the specified floor plan
-      const floorPlan = await prisma.floorPlan.update({
-        where: { id },
-        data: { isActive: true },
-        include: { tables: true },
+        // Activate the specified floor plan
+        return tx.floorPlan.update({
+          where: { id },
+          data: { isActive: true },
+          include: { tables: true },
+        });
       });
       return mapPrismaFloorPlan(floorPlan);
     } catch {

--- a/services/reservations/src/services/guest.ts
+++ b/services/reservations/src/services/guest.ts
@@ -237,12 +237,16 @@ export const guestService = {
     const where: Prisma.GuestWhereInput = { venueId };
 
     // Text search on name, email, phone
+    const conditions: Record<string, unknown>[] = [];
+
     if (query) {
-      where.OR = [
-        { name: { contains: query, mode: "insensitive" } },
-        { email: { contains: query, mode: "insensitive" } },
-        { phone: { contains: query } },
-      ];
+      conditions.push({
+        OR: [
+          { name: { contains: query, mode: "insensitive" } },
+          { email: { contains: query, mode: "insensitive" } },
+          { phone: { contains: query } },
+        ],
+      });
     }
 
     // Filter by tags (JSON array contains)
@@ -254,10 +258,16 @@ export const guestService = {
     if (hasNotVisitedInDays) {
       const cutoffDate = new Date();
       cutoffDate.setDate(cutoffDate.getDate() - hasNotVisitedInDays);
-      where.OR = [
-        { lastVisit: { lt: cutoffDate } },
-        { lastVisit: null },
-      ];
+      conditions.push({
+        OR: [
+          { lastVisit: { lt: cutoffDate } },
+          { lastVisit: null },
+        ],
+      });
+    }
+
+    if (conditions.length > 0) {
+      where.AND = conditions;
     }
 
     // Filter by visit count

--- a/services/reservations/src/services/hold.ts
+++ b/services/reservations/src/services/hold.ts
@@ -69,7 +69,7 @@ export const holdService = {
     const endTime = new Date(startTime.getTime() + duration * 60 * 1000);
     const expiresAt = new Date(Date.now() + holdDuration * 60 * 1000);
 
-    // Find or validate table
+    // Find or validate table (pre-check outside transaction for auto-assign)
     let selectedTableId = tableId;
     if (!selectedTableId) {
       // Auto-assign a table
@@ -86,7 +86,7 @@ export const holdService = {
       }
       selectedTableId = table.id;
     } else {
-      // Verify provided table is available
+      // Pre-check: verify provided table is available
       const conflict = await availabilityService.checkConflict(
         selectedTableId!,
         date,
@@ -99,7 +99,7 @@ export const holdService = {
       }
     }
 
-    // Check pacing limits
+    // Check pacing limits (pre-check)
     const pacingCheck = await availabilityService.checkPacing(
       venueId,
       startTime,
@@ -114,26 +114,73 @@ export const holdService = {
       };
     }
 
-    // Release any existing holds for this session at this venue
-    await prisma.reservationHold.deleteMany({
-      where: { sessionId, venueId },
+    // Wrap conflict re-check + hold creation in a transaction to prevent
+    // concurrent requests from both passing the check
+    const txResult = await prisma.$transaction(async (tx) => {
+      // Re-check for conflicting reservations inside the transaction
+      const conflictingReservation = await tx.reservation.findFirst({
+        where: {
+          tableId: selectedTableId,
+          date: new Date(date),
+          status: { notIn: ["CANCELLED", "NO_SHOW"] },
+          AND: [
+            { startTime: { lt: endTime } },
+            { endTime: { gt: startTime } },
+          ],
+        },
+        select: { id: true },
+      });
+
+      if (conflictingReservation) {
+        return { conflict: true as const };
+      }
+
+      // Re-check for conflicting holds inside the transaction
+      const conflictingHold = await tx.reservationHold.findFirst({
+        where: {
+          tableId: selectedTableId,
+          date: new Date(date),
+          expiresAt: { gt: new Date() },
+          sessionId: { not: sessionId }, // Don't conflict with own session
+          AND: [
+            { startTime: { lt: endTime } },
+            { endTime: { gt: startTime } },
+          ],
+        },
+        select: { id: true },
+      });
+
+      if (conflictingHold) {
+        return { conflict: true as const };
+      }
+
+      // Release any existing holds for this session at this venue
+      await tx.reservationHold.deleteMany({
+        where: { sessionId, venueId },
+      });
+
+      // Create the hold
+      const hold = await tx.reservationHold.create({
+        data: {
+          venueId,
+          tableId: selectedTableId,
+          date: new Date(date),
+          startTime,
+          endTime,
+          partySize,
+          sessionId,
+          expiresAt,
+        },
+      });
+
+      return { conflict: false as const, hold };
     });
 
-    // Create the hold
-    const hold = await prisma.reservationHold.create({
-      data: {
-        venueId,
-        tableId: selectedTableId,
-        date: new Date(date),
-        startTime,
-        endTime,
-        partySize,
-        sessionId,
-        expiresAt,
-      },
-    });
+    if (txResult.conflict) {
+      return { success: false, error: "Table is not available for this time slot" };
+    }
 
-    return { success: true, hold: mapPrismaHold(hold) };
+    return { success: true, hold: mapPrismaHold(txResult.hold) };
   },
 
   /**
@@ -197,17 +244,23 @@ export const holdService = {
     guestDetails: ConfirmHoldRequest,
     userId?: string
   ): Promise<ConfirmHoldResult> {
-    // Get the hold
-    const hold = await prisma.reservationHold.findFirst({
-      where: {
-        id: holdId,
-        sessionId,
-        expiresAt: { gt: new Date() },
-      },
+    // Look up the hold by ID first, then diagnose failure separately
+    const hold = await prisma.reservationHold.findUnique({
+      where: { id: holdId },
     });
 
     if (!hold) {
-      return { success: false, error: "Hold not found or expired" };
+      return { success: false, error: "Hold not found" };
+    }
+
+    if (hold.expiresAt < new Date()) {
+      // Clean up the expired hold
+      await prisma.reservationHold.delete({ where: { id: holdId } }).catch(() => {});
+      return { success: false, error: "Hold has expired" };
+    }
+
+    if (hold.sessionId !== sessionId) {
+      return { success: false, error: "Session ID does not match the hold" };
     }
 
     // Check conflict + create reservation + delete hold atomically in a transaction

--- a/services/reservations/src/services/reservation.ts
+++ b/services/reservations/src/services/reservation.ts
@@ -338,7 +338,10 @@ export const reservationService = {
     return { success: true, reservation };
   },
 
-  async createWalkIn(data: WalkInRequest, userId?: string): Promise<Reservation> {
+  async createWalkIn(
+    data: WalkInRequest,
+    userId?: string
+  ): Promise<CreateReservationResult> {
     const now = new Date();
     const durationMinutes = data.durationMinutes ?? 90;
     const endTime = new Date(now.getTime() + durationMinutes * 60 * 1000);
@@ -348,25 +351,68 @@ export const reservationService = {
       Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
     );
 
-    const reservation = await prisma.reservation.create({
-      data: {
-        date: dateOnly,
-        startTime: now,
-        endTime,
-        partySize: data.partySize,
-        tableId: data.tableId,
-        status: "CONFIRMED",
-        guestName: data.guestName ?? "Walk-in",
-        guestEmail: null,
-        guestPhone: null,
-        guestId: null,
-        userId: userId ?? null,
-        venueId: data.venueId ?? null,
-        notes: null,
-      },
-      include: { table: true },
+    const dateStr = dateOnly.toISOString().split("T")[0];
+
+    // Conflict check + creation inside a transaction to prevent TOCTOU races
+    const conflict = await availabilityService.checkConflict(
+      data.tableId,
+      dateStr,
+      now,
+      endTime
+    );
+
+    if (conflict.hasConflict) {
+      return {
+        success: false,
+        error: "Table is not available",
+        conflict,
+      };
+    }
+
+    const reservation = await prisma.$transaction(async (tx) => {
+      // Re-check for conflicting reservations inside the transaction
+      const conflicting = await tx.reservation.findFirst({
+        where: {
+          tableId: data.tableId,
+          date: dateOnly,
+          status: { notIn: ["CANCELLED", "NO_SHOW"] },
+          AND: [{ startTime: { lt: endTime } }, { endTime: { gt: now } }],
+        },
+        select: { id: true },
+      });
+
+      if (conflicting) {
+        return null;
+      }
+
+      return tx.reservation.create({
+        data: {
+          date: dateOnly,
+          startTime: now,
+          endTime,
+          partySize: data.partySize,
+          tableId: data.tableId,
+          status: "CONFIRMED",
+          guestName: data.guestName ?? "Walk-in",
+          guestEmail: null,
+          guestPhone: null,
+          guestId: null,
+          userId: userId ?? null,
+          venueId: data.venueId ?? null,
+          notes: null,
+        },
+        include: { table: true },
+      });
     });
-    return mapPrismaReservation(reservation);
+
+    if (!reservation) {
+      return {
+        success: false,
+        error: "Table is not available",
+      };
+    }
+
+    return { success: true, reservation: mapPrismaReservation(reservation) };
   },
 
   async cancel(

--- a/services/users/src/routes/users.test.ts
+++ b/services/users/src/routes/users.test.ts
@@ -9,6 +9,7 @@ vi.mock("../services/user.js", () => ({
     getById: vi.fn(),
     getByEmail: vi.fn(),
     create: vi.fn(),
+    findOrCreate: vi.fn(),
     update: vi.fn(),
     delete: vi.fn(),
   },
@@ -243,7 +244,7 @@ describe("User Routes", () => {
 
   describe("DELETE /api/v1/users/:id", () => {
     it("deletes user and returns 204", async () => {
-      vi.mocked(userService.delete).mockResolvedValueOnce(undefined);
+      vi.mocked(userService.delete).mockResolvedValueOnce(true);
 
       const response = await app.inject({
         method: "DELETE",
@@ -283,7 +284,7 @@ describe("GET /api/v1/users/me", () => {
       protectedHeader: { alg: "RS256" },
     } as never);
 
-    vi.mocked(userService.getByEmail).mockResolvedValueOnce(mockUser);
+    vi.mocked(userService.findOrCreate).mockResolvedValueOnce(mockUser);
 
     const response = await app.inject({
       method: "GET",
@@ -296,8 +297,11 @@ describe("GET /api/v1/users/me", () => {
     expect(response.statusCode).toBe(200);
     const body = JSON.parse(response.body);
     expect(body.data.email).toBe("test@example.com");
-    expect(userService.getByEmail).toHaveBeenCalledWith("test@example.com");
-    expect(userService.create).not.toHaveBeenCalled();
+    expect(userService.findOrCreate).toHaveBeenCalledWith({
+      email: "test@example.com",
+      name: "Test User",
+      picture: "https://example.com/pic.jpg",
+    });
   });
 
   it("creates user and returns data for valid token with new user", async () => {
@@ -306,8 +310,7 @@ describe("GET /api/v1/users/me", () => {
       protectedHeader: { alg: "RS256" },
     } as never);
 
-    vi.mocked(userService.getByEmail).mockResolvedValueOnce(null);
-    vi.mocked(userService.create).mockResolvedValueOnce(mockUser);
+    vi.mocked(userService.findOrCreate).mockResolvedValueOnce(mockUser);
 
     const response = await app.inject({
       method: "GET",
@@ -320,8 +323,7 @@ describe("GET /api/v1/users/me", () => {
     expect(response.statusCode).toBe(200);
     const body = JSON.parse(response.body);
     expect(body.data.email).toBe("test@example.com");
-    expect(userService.getByEmail).toHaveBeenCalledWith("test@example.com");
-    expect(userService.create).toHaveBeenCalledWith({
+    expect(userService.findOrCreate).toHaveBeenCalledWith({
       email: "test@example.com",
       name: "Test User",
       picture: "https://example.com/pic.jpg",

--- a/services/users/src/routes/users.ts
+++ b/services/users/src/routes/users.ts
@@ -294,7 +294,14 @@ export const userRoutes: FastifyPluginAsync = async (fastify) => {
       },
     },
     async (request, reply) => {
-      await userService.delete(request.params.id);
+      const deleted = await userService.delete(request.params.id);
+      if (!deleted) {
+        return reply.code(404).send({
+          error: "Not Found",
+          message: "User not found",
+          statusCode: 404,
+        });
+      }
       return reply.code(204).send();
     }
   );
@@ -342,15 +349,13 @@ export const userRoutes: FastifyPluginAsync = async (fastify) => {
         });
       }
 
-      let user = await userService.getByEmail(authUser.email);
-      if (!user) {
-        // Auto-create user on first login
-        user = await userService.create({
-          email: authUser.email,
-          name: authUser.name,
-          picture: authUser.picture,
-        });
-      }
+      // Use findOrCreate (upsert) to prevent race conditions when two
+      // concurrent first-login requests both try to create the same user
+      const user = await userService.findOrCreate({
+        email: authUser.email,
+        name: authUser.name,
+        picture: authUser.picture,
+      });
       return { data: user };
     }
   );

--- a/services/users/src/services/database.ts
+++ b/services/users/src/services/database.ts
@@ -1,6 +1,20 @@
 import { PrismaClient } from "../generated/prisma/index.js";
 
-export const prisma = new PrismaClient();
+// Cap Prisma's internal connection pool to avoid exceeding PgBouncer's
+// session-mode pool_size. DigitalOcean managed Postgres defaults to ~25
+// total connections; with 3 services sharing the pooler, each gets ~7.
+const CONNECTION_LIMIT = parseInt(process.env.PRISMA_CONNECTION_LIMIT ?? "5", 10);
+
+export const prisma = new PrismaClient({
+  datasourceUrl: appendConnectionLimit(process.env.DATABASE_URL, CONNECTION_LIMIT),
+});
+
+function appendConnectionLimit(url: string | undefined, limit: number): string | undefined {
+  if (!url) return undefined;
+  const separator = url.includes("?") ? "&" : "?";
+  if (url.includes("connection_limit=")) return url;
+  return `${url}${separator}connection_limit=${limit}`;
+}
 
 // Graceful shutdown
 process.on("beforeExit", async () => {

--- a/services/users/src/services/user.ts
+++ b/services/users/src/services/user.ts
@@ -79,6 +79,24 @@ export const userService = {
     return mapPrismaUser(user);
   },
 
+  /**
+   * Finds a user by email or creates one if not found.
+   * Uses upsert to prevent race conditions when two concurrent
+   * first-login requests arrive for the same email.
+   */
+  async findOrCreate(data: CreateUserRequest): Promise<User> {
+    const user = await prisma.user.upsert({
+      where: { email: data.email },
+      update: {}, // No-op if user already exists
+      create: {
+        email: data.email,
+        name: data.name ?? null,
+        picture: data.picture ?? null,
+      },
+    });
+    return mapPrismaUser(user);
+  },
+
   async update(id: string, data: UpdateUserRequest): Promise<User | null> {
     try {
       const user = await prisma.user.update({
@@ -94,11 +112,16 @@ export const userService = {
     }
   },
 
-  async delete(id: string): Promise<void> {
+  async delete(id: string): Promise<boolean> {
     try {
       await prisma.user.delete({ where: { id } });
-    } catch {
-      // User not found, no-op
+      return true;
+    } catch (err: unknown) {
+      // Prisma P2025 = record not found
+      if (err && typeof err === "object" && "code" in err && err.code === "P2025") {
+        return false;
+      }
+      throw err;
     }
   },
 

--- a/tools/cli/src/commands/agent.ts
+++ b/tools/cli/src/commands/agent.ts
@@ -1,7 +1,13 @@
 import { Command } from "commander";
 import { resolve } from "node:path";
 import type { SessionConfig, SessionEvent } from "@mbe/agent-core";
-import { runSession, DEFAULT_SESSION_CONFIG } from "@mbe/agent-core";
+import {
+  runSession,
+  DEFAULT_SESSION_CONFIG,
+  DEFAULT_FEEDBACK_LOOP_CONFIG,
+  resolveBudget,
+  resolveModel,
+} from "@mbe/agent-core";
 import type {
   AgentSession,
   ApiResponse,
@@ -180,15 +186,24 @@ agentCommand
     ) => {
       const repoPath = resolve(process.cwd());
 
+      // Use task intelligence for smart defaults when user doesn't override
+      const smartBudget = resolveBudget(task);
+      const smartModel = resolveModel(task);
+
+      const isDefaultModel = options.model === DEFAULT_SESSION_CONFIG.model;
+      const isDefaultBudget = options.maxBudget === String(DEFAULT_SESSION_CONFIG.maxBudgetUsd);
+      const isDefaultTurns = options.maxTurns === String(DEFAULT_SESSION_CONFIG.maxTurns);
+
       const config: SessionConfig = {
         taskDescription: task,
         repoPath,
         baseBranch: options.baseBranch,
-        model: options.model,
-        maxTurns: parseInt(options.maxTurns, 10),
-        maxBudgetUsd: parseFloat(options.maxBudget),
+        model: isDefaultModel ? smartModel : options.model,
+        maxTurns: isDefaultTurns ? smartBudget.maxTurns : parseInt(options.maxTurns, 10),
+        maxBudgetUsd: isDefaultBudget ? smartBudget.budgetUsd : parseFloat(options.maxBudget),
         allowedTools: [...DEFAULT_SESSION_CONFIG.allowedTools],
         createPr: options.pr,
+        feedbackLoop: DEFAULT_FEEDBACK_LOOP_CONFIG,
       };
 
       console.log("Agent Session (local)");


### PR DESCRIPTION
## Summary

Comprehensive sweep fixing 33 GitHub issues across backend, frontend, design system, infrastructure, and the coding agent pipeline. 54 files changed, +1050/-286 lines.

### Backend (10 fixes)
- **#176** Fix hold confirmation session ID mismatch
- **#175** Cap Prisma connection pool to prevent DB exhaustion
- **#181** Wrap hold creation in transaction
- **#185** Atomic floor plan activation
- **#182** Fix /users/me race condition with upsert
- **#179** Add walk-in conflict check
- **#180** Fix guest search filter
- **#203** DELETE /users returns 404 for missing users
- **#202** Webhook HMAC raw body verification
- **#194** Optimize getAvailableDates N+1 queries

### Frontend (13 fixes)
- **#172** Inline validation with slug uniqueness
- **#173** Breadcrumb alignment
- **#174** Wizard step deep links
- **#177** Default timezone detection
- **#184** Fix useRequireAuth render side effect
- **#191** AdminPage fragment key
- **#192** Local date instead of UTC
- **#190** Timeline error handling
- **#183** Fix api-client cancel()
- **#208** Fix formatTime for ISO strings
- **#193** Keyboard accessible guest rows
- **#204** Clickable reservation rows

### Design System (2 fixes)
- **#195** Native disabled on Input
- **#207** aria-labelledby on Dialog/Drawer

### Infra & CI (7 fixes)
- **#186** Permissions-Policy header
- **#206** X-Forwarded-For forwarding
- **#205** Health endpoint auth gating
- **#187** Prisma generate for all services in CI
- **#188** CI gate before deploys
- **#209** Marketing robots meta
- **#210** Responsive theme-color

### Agent Pipeline
- Pre-push lint + typecheck + test verification gate
- AI security review on diffs
- Draft PR on gate failure

## Test plan
- [ ] All typecheck tasks pass (verified by pre-commit hook)
- [ ] All test suites pass (969+ tests)
- [ ] Verify hold create/confirm flow
- [ ] Verify venue wizard inline validation
- [ ] Verify edge router health endpoint auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)