### PR TITLE
feat(harness): add service binding consistency check to CI build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,9 @@ jobs:
       - name: Check circular dependencies
         run: node scripts/check-circular-deps.js
 
+      - name: Check service binding consistency
+        run: node scripts/check-service-bindings.js
+
       - name: Audit dependencies for vulnerabilities
         run: pnpm audit --audit-level=high || echo "::warning::Dependency audit found high/critical vulnerabilities — see output above"
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "env:init": "pnpm --filter './services/*' exec sh -c '[ -f .env ] || cp .env.example .env'",
     "db:push": "pnpm --filter './services/*' exec prisma db push --skip-generate",
     "check:circular-deps": "node scripts/check-circular-deps.js",
+    "check:service-bindings": "node scripts/check-service-bindings.js",
     "check:destructive-migrations": "node scripts/check-destructive-migrations.js",
     "check:dockerfiles": "node scripts/check-dockerfile-deps.js",
     "build": "turbo run build",


### PR DESCRIPTION
## Summary

- Adds `check-service-bindings.js` script to CI build job to catch service binding mismatches across wrangler.toml, edge-router.js, and pulumi/index.ts
- Adds `check:service-bindings` npm script for local execution
- Script was already present but not integrated into CI — now it runs on every build

## Testing

Verified script passes with current binding configuration:
```
wrangler.toml:   [GEN, HOSPITALITY, MARKETING, RIALTO]
edge-router.js:  [GEN, HOSPITALITY, MARKETING, RIALTO]
pulumi/index.ts: [GEN, HOSPITALITY, MARKETING, RIALTO]
```