### PR TITLE
feat: automated accessibility testing with axe-core in CI (#283)

### DIFF
--- a/apps/gen/e2e/a11y.test.ts
+++ b/apps/gen/e2e/a11y.test.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "@playwright/test";
+import { injectAxe } from "@axe-core/playwright";
+
+test.describe("Accessibility", () => {
+  test.beforeEach(async ({ page }) => {
+    await injectAxe(page);
+  });
+
+  test("homepage has no critical violations", async ({ page }) => {
+    const violations: string[] = [];
+
+    await page.goto("/");
+
+    await page.evaluate(() => {
+      // @ts-expect-error - axe is injected
+      window.axe.run(window.document, { runOnly: { type: "tag", values: ["wcag2aa"] } }).then((result: { violations: { impact: string; id: string }[] }) => {
+        result.violations.forEach((v) => {
+          if (v.impact === "critical" || v.impact === "serious") {
+            violations.push(`${v.id}: ${v.impact}`);
+          }
+        });
+      });
+    });
+
+    expect(violations).toHaveLength(0);
+  });
+});

--- a/apps/gen/package.json
+++ b/apps/gen/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "lint": "eslint src/",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:a11y": "playwright test --config playwright.config.ts e2e/a11y.test.ts"
   },
   "dependencies": {
     "@json-render/react": "^0.15.0",
@@ -20,7 +21,9 @@
     "react-router-dom": "^7.1.0"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.1",
     "@mbe/config": "workspace:*",
+    "@playwright/test": "^1.58.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^5.0.0",

--- a/apps/gen/playwright.config.ts
+++ b/apps/gen/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  outputDir: "./e2e/test-results",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? "github" : "list",
+
+  use: {
+    baseURL: "http://localhost:3005/gen/",
+    actionTimeout: 15_000,
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+      },
+    },
+  ],
+
+  webServer: {
+    command: "pnpm dev -- --port 3005 --strictPort",
+    url: "http://localhost:3005/gen/",
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+});

--- a/apps/hospitality/e2e/a11y.test.ts
+++ b/apps/hospitality/e2e/a11y.test.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "@playwright/test";
+import { injectAxe } from "@axe-core/playwright";
+
+test.describe("Accessibility", () => {
+  test.beforeEach(async ({ page }) => {
+    await injectAxe(page);
+  });
+
+  test("homepage has no critical violations", async ({ page }) => {
+    const violations: string[] = [];
+
+    await page.goto("/");
+
+    await page.evaluate(() => {
+      // @ts-expect-error - axe is injected
+      window.axe.run(window.document, { runOnly: { type: "tag", values: ["wcag2aa"] } }).then((result: { violations: { impact: string; id: string }[] }) => {
+        result.violations.forEach((v) => {
+          if (v.impact === "critical" || v.impact === "serious") {
+            violations.push(`${v.id}: ${v.impact}`);
+          }
+        });
+      });
+    });
+
+    expect(violations).toHaveLength(0);
+  });
+});

--- a/apps/hospitality/package.json
+++ b/apps/hospitality/package.json
@@ -11,7 +11,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:e2e": "playwright test --config playwright.config.ts"
+    "test:e2e": "playwright test --config playwright.config.ts",
+    "test:a11y": "playwright test --config playwright.config.ts e2e/a11y.test.ts"
   },
   "dependencies": {
     "@json-render/react": "^0.15.0",
@@ -28,6 +29,7 @@
     "react-router-dom": "^7.1.0"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.1",
     "@mbe/config": "workspace:*",
     "@sentry/vite-plugin": "^5.1.1",
     "@testing-library/jest-dom": "^6.6.3",

--- a/apps/marketing/e2e/a11y.test.ts
+++ b/apps/marketing/e2e/a11y.test.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "@playwright/test";
+import { injectAxe } from "@axe-core/playwright";
+
+test.describe("Accessibility", () => {
+  test.beforeEach(async ({ page }) => {
+    await injectAxe(page);
+  });
+
+  test("homepage has no critical violations", async ({ page }) => {
+    const violations: string[] = [];
+
+    await page.goto("/");
+
+    await page.evaluate(() => {
+      // @ts-expect-error - axe is injected
+      window.axe.run(window.document, { runOnly: { type: "tag", values: ["wcag2aa"] } }).then((result: { violations: { impact: string; id: string }[] }) => {
+        result.violations.forEach((v) => {
+          if (v.impact === "critical" || v.impact === "serious") {
+            violations.push(`${v.id}: ${v.impact}`);
+          }
+        });
+      });
+    });
+
+    expect(violations).toHaveLength(0);
+  });
+});

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "lint": "eslint src/",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:a11y": "playwright test --config playwright.config.ts e2e/a11y.test.ts"
   },
   "dependencies": {
     "@mbe/rialto": "workspace:*",
@@ -19,7 +20,9 @@
     "react-router-dom": "^7.1.0"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.1",
     "@mbe/config": "workspace:*",
+    "@playwright/test": "^1.58.2",
     "@sentry/vite-plugin": "^5.1.1",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/apps/marketing/playwright.config.ts
+++ b/apps/marketing/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  outputDir: "./e2e/test-results",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? "github" : "list",
+
+  use: {
+    baseURL: "http://localhost:3000",
+    actionTimeout: 15_000,
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+      },
+    },
+  ],
+
+  webServer: {
+    command: "pnpm dev -- --port 3000 --strictPort",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+});

--- a/apps/rialto-web/e2e/a11y.test.ts
+++ b/apps/rialto-web/e2e/a11y.test.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "@playwright/test";
+import { injectAxe } from "@axe-core/playwright";
+
+test.describe("Accessibility", () => {
+  test.beforeEach(async ({ page }) => {
+    await injectAxe(page);
+  });
+
+  test("homepage has no critical violations", async ({ page }) => {
+    const violations: string[] = [];
+
+    await page.goto("/");
+
+    await page.evaluate(() => {
+      // @ts-expect-error - axe is injected
+      window.axe.run(window.document, { runOnly: { type: "tag", values: ["wcag2aa"] } }).then((result: { violations: { impact: string; id: string }[] }) => {
+        result.violations.forEach((v) => {
+          if (v.impact === "critical" || v.impact === "serious") {
+            violations.push(`${v.id}: ${v.impact}`);
+          }
+        });
+      });
+    });
+
+    expect(violations).toHaveLength(0);
+  });
+});

--- a/apps/rialto-web/package.json
+++ b/apps/rialto-web/package.json
@@ -9,7 +9,8 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "lint": "eslint .",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:a11y": "playwright test --config playwright.config.ts e2e/a11y.test.ts"
   },
   "dependencies": {
     "@mbe/rialto": "workspace:*",
@@ -21,7 +22,9 @@
     "react-router-dom": "^7.13.0"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.1",
     "@mbe/config": "workspace:*",
+    "@playwright/test": "^1.58.2",
     "@sentry/vite-plugin": "^5.1.1",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,9 +89,15 @@ importers:
         specifier: ^7.1.0
         version: 7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.11.1
+        version: 4.11.1(playwright-core@1.58.2)
       '@mbe/config':
         specifier: workspace:*
         version: link:../../packages/config
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.58.2
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -147,6 +153,9 @@ importers:
         specifier: ^7.1.0
         version: 7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.11.1
+        version: 4.11.1(playwright-core@1.58.2)
       '@mbe/config':
         specifier: workspace:*
         version: link:../../packages/config
@@ -208,9 +217,15 @@ importers:
         specifier: ^7.1.0
         version: 7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.11.1
+        version: 4.11.1(playwright-core@1.58.2)
       '@mbe/config':
         specifier: workspace:*
         version: link:../../packages/config
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.58.2
       '@sentry/vite-plugin':
         specifier: ^5.1.1
         version: 5.1.1(encoding@0.1.13)(rollup@4.60.0)
@@ -254,9 +269,15 @@ importers:
         specifier: ^7.13.0
         version: 7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.11.1
+        version: 4.11.1(playwright-core@1.58.2)
       '@mbe/config':
         specifier: workspace:*
         version: link:../../packages/config
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.58.2
       '@sentry/vite-plugin':
         specifier: ^5.1.1
         version: 5.1.1(encoding@0.1.13)(rollup@4.60.0)
@@ -928,6 +949,11 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@axe-core/playwright@4.11.1':
+    resolution: {integrity: sha512-mKEfoUIB1MkVTht0BGZFXtSAEKXMJoDkyV5YZ9jbBmZCcWDz71tegNsdTkIN8zc/yMi5Gm2kx7Z5YQ9PfWNAWw==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.28.6':
     resolution: {integrity: sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==}
@@ -7555,6 +7581,11 @@ snapshots:
       lru-cache: 11.2.6
 
   '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@axe-core/playwright@4.11.1(playwright-core@1.58.2)':
+    dependencies:
+      axe-core: 4.11.1
+      playwright-core: 1.58.2
 
   '@babel/code-frame@7.28.6':
     dependencies:


### PR DESCRIPTION
## Summary

Implements automated accessibility testing with axe-core for all frontend apps.

## Changes

- Add `@axe-core/playwright` to marketing, hospitality, rialto-web, gen
- Add playwright config to apps without existing e2e setup
- Create `e2e/a11y.test.ts` for each app checking WCAG 2.1 AA compliance
- Fail on critical/serious violations, pass on moderate warnings
- Add `test:a11y` script to each app's package.json

## Pages Tested

- Marketing: `/`
- Hospitality: `/` (homepage)
- Rialto: `/` (homepage)
- Gen: `/` (homepage)

## Running Tests

```bash
# Run a11y tests for specific app
pnpm --filter @mbe/marketing test:a11y
pnpm --filter @mbe/hospitality test:a11y
pnpm --filter @mbe/rialto-web test:a11y
pnpm --filter @mbe/gen test:a11y
```

Closes #283