### PR TITLE
fix: correct invalid hook event name in project config

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,38 @@
+{
+  "hooks": {
+    "BeforeTool": [
+      {
+        "matcher": "write_file|replace_in_file",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/gsd-prompt-guard.js",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "AfterTool": [
+      {
+        "matcher": "write_file|replace_in_file|run_shell_command|agent|task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/gsd-context-monitor.js",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/gsd-check-update.js"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Creates `.gemini/settings.json` with Gemini CLI-compatible hook event names (`BeforeTool`/`AfterTool` instead of Claude's `PreToolUse`/`PostToolUse`)
- Resolves the `⚠ Invalid hook event name: 'PostToolUse' from project config. Skipping.` warning when starting Gemini CLI

## Why
Gemini CLI and Claude Code use different hook event names. Static JSON configs can't branch at runtime, so each CLI needs its own settings file with the correct event names.

## Test plan
- [ ] Start Gemini CLI — verify no `PostToolUse` warning
- [ ] Start Claude Code — verify hooks still fire correctly
- [ ] Verify GSD context-monitor hook works in both CLIs

Closes #332