### PR TITLE
feat(marketing): add copy-to-clipboard for email

### DIFF
--- a/apps/marketing/src/components/ContactSection.tsx
+++ b/apps/marketing/src/components/ContactSection.tsx
@@ -1,10 +1,33 @@
-import { Stack, useScrollReveal, staggerReveal, boop } from "@mbe/rialto";
+import { useState } from "react";
+import { Stack, useScrollReveal, staggerReveal, boop, useToast } from "@mbe/rialto";
 import { motion, useReducedMotion } from "framer-motion";
 import styles from "../pages/HomePage.module.css";
+
+const EMAIL = "mattbutlerengineering+webapp@gmail.com";
+
+const EXTERNAL_LINKS = [
+  { href: "https://github.com/mattbutlerengineering", label: "GitHub" },
+  { href: "https://www.linkedin.com/in/matt-butler-66496a68/", label: "LinkedIn" },
+] as const;
 
 export function ContactSection() {
   const { ref, controls } = useScrollReveal();
   const shouldReduceMotion = useReducedMotion();
+  const { toast } = useToast();
+  const [copied, setCopied] = useState(false);
+
+  const handleCopyEmail = async () => {
+    try {
+      await navigator.clipboard.writeText(EMAIL);
+      toast({ title: "Email copied!", variant: "success", duration: 2000 });
+    } catch {
+      toast({ title: "Could not copy — try selecting the address manually", variant: "error", duration: 3000 });
+    }
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const hoverEffect = shouldReduceMotion ? undefined : { scale: boop.scale };
 
   return (
     <section id="contact" className={styles.section}>
@@ -18,25 +41,45 @@ export function ContactSection() {
             animate={controls}
           >
             <Stack direction="row" gap="md" wrap>
-              {[
-                { href: "https://github.com/mattbutlerengineering", label: "GitHub", external: true },
-                { href: "https://www.linkedin.com/in/matt-butler-66496a68/", label: "LinkedIn", external: true },
-                { href: "mailto:mattbutlerengineering+webapp@gmail.com", label: "Email", external: false },
-              ].map((link) => (
+              {EXTERNAL_LINKS.map((link) => (
                 <motion.a
                   key={link.label}
                   href={link.href}
-                  target={link.external ? "_blank" : undefined}
-                  rel={link.external ? "noopener noreferrer" : undefined}
-                  aria-label={link.external ? `${link.label} (opens in new tab)` : undefined}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={`${link.label} (opens in new tab)`}
                   className={styles.contactLink}
                   variants={staggerReveal.item}
-                  whileHover={shouldReduceMotion ? undefined : { scale: boop.scale }}
+                  whileHover={hoverEffect}
                   transition={boop.transition}
                 >
                   {link.label}
                 </motion.a>
               ))}
+
+              <motion.span
+                className={styles.contactEmailGroup}
+                variants={staggerReveal.item}
+              >
+                <motion.a
+                  href={`mailto:${EMAIL}`}
+                  className={styles.contactLink}
+                  whileHover={hoverEffect}
+                  transition={boop.transition}
+                >
+                  Email
+                </motion.a>
+                <motion.button
+                  type="button"
+                  onClick={handleCopyEmail}
+                  aria-label="Copy email address to clipboard"
+                  className={styles.copyEmailButton}
+                  whileHover={hoverEffect}
+                  transition={boop.transition}
+                >
+                  {copied ? "Copied!" : "Copy"}
+                </motion.button>
+              </motion.span>
             </Stack>
           </motion.div>
         </Stack>

--- a/apps/marketing/src/main.tsx
+++ b/apps/marketing/src/main.tsx
@@ -4,7 +4,7 @@ import "./global.css";
 import { StrictMode, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
-import { RialtoProvider, ErrorBoundary } from "@mbe/rialto";
+import { RialtoProvider, ErrorBoundary, ToastProvider } from "@mbe/rialto";
 import { initSentry, handleErrorBoundary } from "@mbe/sentry/react";
 import { App } from "./App";
 
@@ -66,11 +66,13 @@ function Root() {
   return (
     // RialtoProvider MUST wrap BrowserRouter (outside it)
     <RialtoProvider theme={resolved}>
-      <ErrorBoundary onError={handleErrorBoundary}>
-        <BrowserRouter>
-          <App theme={resolved} onThemeToggle={handleThemeToggle} />
-        </BrowserRouter>
-      </ErrorBoundary>
+      <ToastProvider>
+        <ErrorBoundary onError={handleErrorBoundary}>
+          <BrowserRouter>
+            <App theme={resolved} onThemeToggle={handleThemeToggle} />
+          </BrowserRouter>
+        </ErrorBoundary>
+      </ToastProvider>
     </RialtoProvider>
   );
 }

--- a/apps/marketing/src/pages/HomePage.module.css
+++ b/apps/marketing/src/pages/HomePage.module.css
@@ -58,6 +58,37 @@
   border-color: var(--rialto-border-strong);
 }
 
+.contactEmailGroup {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--rialto-space-xs);
+}
+
+.copyEmailButton {
+  color: var(--rialto-text-secondary);
+  background: transparent;
+  font-size: var(--rialto-text-sm);
+  font-weight: var(--rialto-weight-medium);
+  font-family: var(--rialto-font-sans);
+  padding-block: var(--rialto-space-xs);
+  padding-inline: var(--rialto-space-sm);
+  border: 1px solid var(--rialto-border);
+  border-radius: var(--rialto-radius-default);
+  cursor: pointer;
+  transition: color 150ms var(--rialto-ease-precision),
+              border-color 150ms var(--rialto-ease-precision);
+}
+
+.copyEmailButton:hover {
+  color: var(--rialto-text-primary);
+  border-color: var(--rialto-border-strong);
+}
+
+.copyEmailButton:focus-visible {
+  outline: none;
+  box-shadow: var(--rialto-shadow-focus);
+}
+
 @media (max-width: 640px) {
   .projectGrid {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
- Adds a "Copy" button next to the Email link in ContactSection
- Uses `navigator.clipboard.writeText()` with error handling for unsupported browsers
- Leverages Rialto's `ToastProvider` + `useToast` for "Copied!" / error feedback
- Wraps app in `ToastProvider` in main.tsx (enables toast usage throughout the app)

## Changes
- `apps/marketing/src/main.tsx` — add `ToastProvider` wrapper
- `apps/marketing/src/components/ContactSection.tsx` — copy button + toast feedback
- `apps/marketing/src/pages/HomePage.module.css` — `.contactEmailGroup` and `.copyEmailButton` styles

## Test plan
- [ ] Click "Copy" button — email copied to clipboard, success toast appears
- [ ] Click "Email" link — mailto: still works as before
- [ ] Test in browser without clipboard API — error toast shown gracefully
- [ ] Verify button text shows "Copied!" for 2 seconds then reverts

Closes #330