### PR TITLE
ci: consolidate install and prisma generate into preparation job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
-    name: Lint
+  prepare:
+    name: Prepare
     runs-on: ubuntu-latest
 
     steps:
@@ -37,13 +37,61 @@ jobs:
           node-version: 22
           cache: "pnpm"
 
-      - run: pnpm install --frozen-lockfile
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Cache Prisma clients
+        id: cache-prisma
+        uses: actions/cache@v4
+        with:
+          path: |
+            services/users/src/generated
+            services/reservations/src/generated
+            services/agent/src/generated
+          key: prisma-clients-${{ hashFiles('services/users/prisma/schema.prisma', 'services/reservations/prisma/schema.prisma', 'services/agent/prisma/schema.prisma') }}
+
+      - name: Generate Prisma clients
+        if: steps.cache-prisma.outputs.cache-hit != 'true'
+        run: |
+          pnpm --filter @mbe/users-service db:generate
+          pnpm --filter @mbe/reservations-service db:generate
+          pnpm --filter @mbe/agent-service db:generate
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    needs: [prepare]
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Restore node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('pnpm-lock.yaml') }}
 
       - run: pnpm lint
 
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest
+    needs: [prepare]
 
     steps:
       - uses: actions/checkout@v5
@@ -55,13 +103,20 @@ jobs:
           node-version: 22
           cache: "pnpm"
 
-      - run: pnpm install --frozen-lockfile
+      - name: Restore node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('pnpm-lock.yaml') }}
 
-      - name: Generate Prisma clients
-        run: |
-          pnpm --filter @mbe/users-service db:generate
-          pnpm --filter @mbe/reservations-service db:generate
-          pnpm --filter @mbe/agent-service db:generate
+      - name: Restore Prisma clients
+        uses: actions/cache@v4
+        with:
+          path: |
+            services/users/src/generated
+            services/reservations/src/generated
+            services/agent/src/generated
+          key: prisma-clients-${{ hashFiles('services/users/prisma/schema.prisma', 'services/reservations/prisma/schema.prisma', 'services/agent/prisma/schema.prisma') }}
 
       - name: Typecheck
         env:
@@ -84,13 +139,20 @@ jobs:
           node-version: 22
           cache: "pnpm"
 
-      - run: pnpm install --frozen-lockfile
+      - name: Restore node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('pnpm-lock.yaml') }}
 
-      - name: Generate Prisma clients
-        run: |
-          pnpm --filter @mbe/users-service db:generate
-          pnpm --filter @mbe/reservations-service db:generate
-          pnpm --filter @mbe/agent-service db:generate
+      - name: Restore Prisma clients
+        uses: actions/cache@v4
+        with:
+          path: |
+            services/users/src/generated
+            services/reservations/src/generated
+            services/agent/src/generated
+          key: prisma-clients-${{ hashFiles('services/users/prisma/schema.prisma', 'services/reservations/prisma/schema.prisma', 'services/agent/prisma/schema.prisma') }}
 
       - name: Build all packages
         env:
@@ -140,13 +202,20 @@ jobs:
           node-version: 22
           cache: "pnpm"
 
-      - run: pnpm install --frozen-lockfile
+      - name: Restore node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('pnpm-lock.yaml') }}
 
-      - name: Generate Prisma clients
-        run: |
-          pnpm --filter @mbe/users-service db:generate
-          pnpm --filter @mbe/reservations-service db:generate
-          pnpm --filter @mbe/agent-service db:generate
+      - name: Restore Prisma clients
+        uses: actions/cache@v4
+        with:
+          path: |
+            services/users/src/generated
+            services/reservations/src/generated
+            services/agent/src/generated
+          key: prisma-clients-${{ hashFiles('services/users/prisma/schema.prisma', 'services/reservations/prisma/schema.prisma', 'services/agent/prisma/schema.prisma') }}
 
       - name: Run tests with coverage
         env:
@@ -191,13 +260,20 @@ jobs:
           node-version: 22
           cache: "pnpm"
 
-      - run: pnpm install --frozen-lockfile
+      - name: Restore node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('pnpm-lock.yaml') }}
 
-      - name: Generate Prisma clients
-        run: |
-          pnpm --filter @mbe/users-service db:generate
-          pnpm --filter @mbe/reservations-service db:generate
-          pnpm --filter @mbe/agent-service db:generate
+      - name: Restore Prisma clients
+        uses: actions/cache@v4
+        with:
+          path: |
+            services/users/src/generated
+            services/reservations/src/generated
+            services/agent/src/generated
+          key: prisma-clients-${{ hashFiles('services/users/prisma/schema.prisma', 'services/reservations/prisma/schema.prisma', 'services/agent/prisma/schema.prisma') }}
 
       - name: Check for destructive migrations
         run: node scripts/check-destructive-migrations.js


### PR DESCRIPTION
## Summary
- Adds a `prepare` job that runs `pnpm install` and `prisma generate` once, caching results
- All downstream jobs (lint, typecheck, build, test, migrations) restore from cache
- Eliminates 4 redundant `pnpm install` and 12 redundant `prisma generate` invocations per CI run
- Cache keys are content-based: `pnpm-lock.yaml` hash for node_modules, schema file hashes for Prisma

## Impact
- **Before:** 5x `pnpm install`, 4x `prisma generate` (12 total generate calls)
- **After:** 1x install, 1x generate — downstream jobs get instant cache hits
- Estimated savings: 3-5 minutes per CI run

## Test plan
- [ ] CI passes on this PR (self-validating)
- [ ] Cache hits work on subsequent pushes to same branch
- [ ] Cache invalidates correctly when pnpm-lock.yaml or schema files change
- [ ] All existing checks (circular deps, service bindings, env sync, etc.) still run

Closes #323