### PR TITLE
feat: add gitleaks secret scanning to pre-commit and CI

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,22 @@
+name: Secret Scan
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  gitleaks:
+    name: Gitleaks Secret Scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,34 @@
+# Gitleaks configuration — secret scanning for pre-commit and CI
+# https://github.com/gitleaks/gitleaks
+
+title = "mattbutlerengineering gitleaks config"
+
+[extend]
+# Use the default gitleaks rules as a base
+useDefault = true
+
+# Allowlist patterns that are not secrets
+[allowlist]
+  description = "Known non-secret patterns"
+
+  paths = [
+    '''node_modules''',
+    '''\.claude/worktrees''',
+    '''pnpm-lock\.yaml''',
+    '''coverage''',
+    '''dist''',
+    '''\.git''',
+  ]
+
+  regexTarget = "match"
+  regexes = [
+    # Auth0 domain (public, not a secret)
+    '''dev-[a-z0-9]+\.us\.auth0\.com''',
+    # Test/example values
+    '''test-api-key''',
+    '''example[-_]?(key|token|secret)''',
+    '''placeholder''',
+    '''your[-_]?(api[-_]?key|token|secret)''',
+    # Sentry DSN format (public DSN, not a secret)
+    '''https://[a-f0-9]+@o\d+\.ingest\.\w+\.sentry\.io/\d+''',
+  ]

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,3 +3,8 @@
 
 pnpm lint-staged
 pnpm --filter @mbe/cli start check-adr
+
+# Secret scanning — skip if gitleaks is not installed
+if command -v gitleaks >/dev/null 2>&1; then
+  gitleaks protect --staged --config .gitleaks.toml --verbose
+fi


### PR DESCRIPTION
## Summary
- Adds `.gitleaks.toml` config with allowlist for known non-secret patterns (Auth0 domains, Sentry DSNs, test values)
- Adds `secret-scan.yml` GitHub Actions workflow using official gitleaks-action
- Adds gitleaks to pre-commit hook (gracefully skips if not installed locally)

## Why
No secret scanning existed — a developer or AI agent could accidentally commit API keys, tokens, or passwords. This adds defense in depth at both commit-time and CI.

## Test plan
- [ ] CI: secret-scan workflow runs and passes on this PR
- [ ] Pre-commit: install gitleaks locally (`brew install gitleaks`), then `echo "AKIA..." > test-secret.txt && git add test-secret.txt` — should block
- [ ] Allowlist: verify Auth0 domain patterns are not flagged

Closes #258