### PR TITLE
feat: add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-task.yml
+++ b/.github/ISSUE_TEMPLATE/agent-task.yml
@@ -1,0 +1,48 @@
+name: Agent Task
+description: Task for automated agent pickup (created by site-audit, decompose, ci-monitor)
+labels: ["ready"]
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What should the agent accomplish?
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: How do we know this is done?
+      placeholder: |
+        - [ ] Criterion 1
+        - [ ] Criterion 2
+    validations:
+      required: true
+
+  - type: dropdown
+    id: complexity
+    attributes:
+      label: Estimated complexity
+      options:
+        - "XS — < 1 hour, config change"
+        - "S — 1-2 hours, single file"
+        - "M — half day, multiple files"
+        - "L — full day, cross-cutting"
+        - "XL — multi-day, architectural"
+    validations:
+      required: true
+
+  - type: input
+    id: packages
+    attributes:
+      label: Affected packages
+      description: Comma-separated list of packages/services
+      placeholder: "services/users, packages/auth"
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Implementation hints
+      description: File paths, related issues, constraints

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened? What did you expect?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce the issue?
+      placeholder: |
+        1. Go to...
+        2. Click on...
+        3. See error...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - "Critical — blocks production"
+        - "High — major feature broken"
+        - "Medium — workaround exists"
+        - "Low — cosmetic or minor"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - "Marketing site"
+        - "Hospitality app"
+        - "Users service"
+        - "Reservations service"
+        - "Agent service"
+        - "Rialto design system"
+        - "Auth package"
+        - "CI/CD"
+        - "Other"
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Logs, screenshots, environment details

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions or discussion
+    url: https://github.com/mattbutlerengineering/mattbutlerengineering/discussions
+    about: Use discussions for questions, ideas, or general conversation

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,42 @@
+name: Enhancement
+description: Suggest a feature or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: What problem does this solve? Why is it needed?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How should this work?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other approaches did you consider?
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - "Marketing site"
+        - "Hospitality app"
+        - "Users service"
+        - "Reservations service"
+        - "Agent service"
+        - "Rialto design system"
+        - "CI/CD"
+        - "Developer experience"
+        - "Other"
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Summary
+
+<!-- What does this PR do and why? -->
+
+## Changes
+
+<!-- List key changes, one per line -->
+
+-
+
+## Test plan
+
+<!-- How was this tested? -->
+
+- [ ]
+
+## Checklist
+
+- [ ] `pnpm lint` passes
+- [ ] `pnpm typecheck` passes
+- [ ] `pnpm test` passes
+- [ ] No hardcoded secrets or credentials
+- [ ] Breaking changes documented (if any)


### PR DESCRIPTION
## Summary
- Bug report template (YAML form: severity dropdown, affected area, repro steps)
- Enhancement template (motivation, solution, alternatives)
- Agent task template (acceptance criteria, complexity estimate, affected packages) — designed for `/site-audit`, `/decompose`, `/ci-monitor`
- PR template (summary, test plan, pre-merge checklist)
- Blank issues disabled, links to discussions

## Why
Heavy automation (site-audit, decompose, issue-worker) creates issues/PRs with inconsistent structure. Templates ensure every issue has acceptance criteria and every PR has a test plan.

## Test plan
- [ ] Navigate to Issues → New Issue — see template chooser
- [ ] Create issue from each template — fields render correctly
- [ ] Create PR — template auto-populates

Closes #362