### PR TITLE
fix(security): unify CORS origins across all services

### DIFF
--- a/services/agent/src/app.ts
+++ b/services/agent/src/app.ts
@@ -36,10 +36,14 @@ export async function buildApp(options: AppOptions = {}): Promise<FastifyInstanc
   // Core plugins
   const corsOrigins = process.env.CORS_ORIGINS?.split(",") || [
     "http://localhost:3000",
-    "http://localhost:3003",
     "http://localhost:3002",
+    "http://localhost:3003",
+    "http://localhost:3004",
+    "http://localhost:5173",
+    "http://localhost:5174",
     "https://mattbutlerengineering.com",
     "https://hospitality.mattbutlerengineering.com",
+    "https://gen.mattbutlerengineering.com",
   ];
 
   await fastify.register(cors, {

--- a/services/reservations/src/app.ts
+++ b/services/reservations/src/app.ts
@@ -35,10 +35,14 @@ export async function buildApp(options: AppOptions = {}): Promise<FastifyInstanc
   // Core plugins
   const corsOrigins = process.env.CORS_ORIGINS?.split(",") || [
     "http://localhost:3000",
-    "http://localhost:3004",
     "http://localhost:3002",
+    "http://localhost:3003",
+    "http://localhost:3004",
+    "http://localhost:5173",
+    "http://localhost:5174",
     "https://mattbutlerengineering.com",
     "https://hospitality.mattbutlerengineering.com",
+    "https://gen.mattbutlerengineering.com",
   ];
 
   await fastify.register(cors, {

--- a/services/users/src/app.ts
+++ b/services/users/src/app.ts
@@ -30,10 +30,14 @@ export async function buildApp(options: AppOptions = {}): Promise<FastifyInstanc
   // Core plugins
   const corsOrigins = process.env.CORS_ORIGINS?.split(",") || [
     "http://localhost:3000",
-    "http://localhost:3001",
     "http://localhost:3002",
+    "http://localhost:3003",
+    "http://localhost:3004",
+    "http://localhost:5173",
+    "http://localhost:5174",
     "https://mattbutlerengineering.com",
     "https://hospitality.mattbutlerengineering.com",
+    "https://gen.mattbutlerengineering.com",
   ];
 
   await fastify.register(cors, {


### PR DESCRIPTION
## Summary
- Standardized CORS origin whitelist across all three services (users, reservations, agent)
- Each service now uses the same unified list: all dev ports + all production domains
- Origins overridable via `CORS_ORIGINS` environment variable

## Changes
All three `app.ts` files now share:
```typescript
const corsOrigins = process.env.CORS_ORIGINS?.split(",") || [
  "http://localhost:3000", "http://localhost:3002",
  "http://localhost:3003", "http://localhost:3004",
  "http://localhost:5173", "http://localhost:5174",
  "https://mattbutlerengineering.com",
  "https://hospitality.mattbutlerengineering.com",
  "https://gen.mattbutlerengineering.com",
];
```

## Test plan
- [x] `pnpm typecheck` passes for all 3 services
- [ ] CI passes

Closes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)