### PR TITLE
fix(services): integrate request ID middleware for distributed tracing

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,16 +45,16 @@
   },
   "lint-staged": {
     "apps/**/*.{ts,tsx}": [
-      "eslint --fix --flag v10_config_lookup_from_file"
+      "eslint --fix"
     ],
     "packages/**/*.{ts,tsx}": [
-      "eslint --fix --flag v10_config_lookup_from_file"
+      "eslint --fix"
     ],
     "services/**/*.{ts,tsx}": [
-      "eslint --fix --flag v10_config_lookup_from_file"
+      "eslint --fix"
     ],
     "tools/**/*.{ts,tsx}": [
-      "eslint --fix --flag v10_config_lookup_from_file"
+      "eslint --fix"
     ]
   },
   "pnpm": {

--- a/packages/observability/src/request-id.ts
+++ b/packages/observability/src/request-id.ts
@@ -1,4 +1,6 @@
 import { randomUUID } from "crypto";
+import type { FastifyInstance } from "fastify";
+import fp from "fastify-plugin";
 
 export interface RequestIdOptions {
   headerName?: string;
@@ -13,12 +15,19 @@ const DEFAULT_OPTIONS: Required<RequestIdOptions> = {
 export function createRequestIdMiddleware(options: RequestIdOptions = {}) {
   const { headerName, generator } = { ...DEFAULT_OPTIONS, ...options };
 
-  return function requestIdHook(fastify: { addHook: (name: string, fn: (req: { headers: Record<string, string>; id: string }) => void) => void }) {
-    fastify.addHook("onRequest", async (request) => {
-      const clientRequestId = request.headers[headerName];
-      request.id = clientRequestId || generator();
-    });
-  };
+  return fp(
+    async function requestIdPlugin(fastify: FastifyInstance) {
+      fastify.addHook("onRequest", async (request) => {
+        const clientRequestId = request.headers[headerName];
+        if (typeof clientRequestId === "string" && clientRequestId.length > 0) {
+          request.id = clientRequestId;
+        } else {
+          request.id = generator();
+        }
+      });
+    },
+    { name: "request-id-middleware" },
+  );
 }
 
 export function getRequestId(request: { id?: string }): string {

--- a/services/agent/src/app.ts
+++ b/services/agent/src/app.ts
@@ -5,6 +5,7 @@ import swagger from "@fastify/swagger";
 import swaggerUi from "@fastify/swagger-ui";
 import ScalarApiReference from "@scalar/fastify-api-reference";
 import { authPlugin, getAuthPluginOptionsFromEnv } from "@mbe/auth/fastify";
+import { createRequestIdMiddleware } from "@mbe/observability";
 import { sentryFastifyPlugin } from "@mbe/sentry/node";
 import { apiVersioningPlugin } from "@mbe/api-versioning/fastify";
 import { registerSchemas } from "./schemas/index.js";
@@ -48,6 +49,9 @@ export async function buildApp(options: AppOptions = {}): Promise<FastifyInstanc
     allowedHeaders: ["Content-Type", "Authorization"],
     methods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
   });
+
+  // Propagate X-Request-ID from edge router for distributed tracing
+  await fastify.register(createRequestIdMiddleware());
 
   await fastify.register(rateLimit, {
     max: 100,

--- a/services/reservations/src/app.ts
+++ b/services/reservations/src/app.ts
@@ -5,6 +5,7 @@ import swagger from "@fastify/swagger";
 import swaggerUi from "@fastify/swagger-ui";
 import ScalarApiReference from "@scalar/fastify-api-reference";
 import { authPlugin, getAuthPluginOptionsFromEnv } from "@mbe/auth/fastify";
+import { createRequestIdMiddleware } from "@mbe/observability";
 import { sentryFastifyPlugin } from "@mbe/sentry/node";
 import { apiVersioningPlugin } from "@mbe/api-versioning/fastify";
 import { registerSchemas } from "./schemas/index.js";
@@ -47,6 +48,9 @@ export async function buildApp(options: AppOptions = {}): Promise<FastifyInstanc
     allowedHeaders: ["Content-Type", "Authorization"],
     methods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
   });
+
+  // Propagate X-Request-ID from edge router for distributed tracing
+  await fastify.register(createRequestIdMiddleware());
 
   await fastify.register(rateLimit, {
     max: 100,

--- a/services/users/src/app.ts
+++ b/services/users/src/app.ts
@@ -5,6 +5,7 @@ import swagger from "@fastify/swagger";
 import swaggerUi from "@fastify/swagger-ui";
 import ScalarApiReference from "@scalar/fastify-api-reference";
 import { authPlugin, getAuthPluginOptionsFromEnv } from "@mbe/auth/fastify";
+import { createRequestIdMiddleware } from "@mbe/observability";
 import { sentryFastifyPlugin } from "@mbe/sentry/node";
 import { apiVersioningPlugin } from "@mbe/api-versioning/fastify";
 import { registerSchemas } from "./schemas/index.js";
@@ -42,6 +43,9 @@ export async function buildApp(options: AppOptions = {}): Promise<FastifyInstanc
     allowedHeaders: ["Content-Type", "Authorization"],
     methods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
   });
+
+  // Propagate X-Request-ID from edge router for distributed tracing
+  await fastify.register(createRequestIdMiddleware());
 
   await fastify.register(rateLimit, {
     max: 100,


### PR DESCRIPTION
## Summary
- Registered `createRequestIdMiddleware()` from `@mbe/observability` in all 3 services
- Rewrote middleware to be a proper Fastify plugin (using `fastify-plugin`)
- Sentry error tags now include real request IDs instead of "unknown"
- Also fixed deprecated ESLint flag in lint-staged config

## Changes
- `packages/observability/src/request-id.ts` — Rewritten as proper Fastify plugin with correct types
- `services/users/src/app.ts` — Added middleware registration
- `services/reservations/src/app.ts` — Added middleware registration  
- `services/agent/src/app.ts` — Added middleware registration

## Test plan
- [x] `pnpm typecheck` passes for all services
- [x] Observability package tests pass (9/9)
- [ ] CI passes

Closes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)