### PR TITLE
feat: dependency graph visualization + schema backward compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,12 @@ jobs:
           git diff --exit-code packages/rialto-catalog/src/generated-schemas.ts || \
             (echo "ERROR: generated-schemas.ts is stale. Run 'pnpm --filter @mbe/rialto-catalog generate' locally and commit the result." && exit 1)
 
+      - name: Check dependency graph drift
+        run: |
+          pnpm graph
+          git diff --exit-code docs/architecture/dependency-graph.md || \
+            (echo "ERROR: dependency-graph.md is stale. Run 'pnpm graph' locally and commit the result." && exit 1)
+
       - name: Record bundle sizes
         if: github.ref == 'refs/heads/main'
         run: node scripts/record-bundle-sizes.js --output bundle-sizes.json

--- a/docs/architecture/dependency-graph.md
+++ b/docs/architecture/dependency-graph.md
@@ -1,0 +1,134 @@
+# Dependency Graph
+
+> **Auto-generated** — do not edit manually.
+> Regenerate with `pnpm graph`.
+
+Inter-workspace dependency relationships between `@mbe/*` packages.
+
+```mermaid
+flowchart TD
+  subgraph apps["Frontend Apps"]
+    gen["gen"]
+    hospitality["hospitality"]
+    marketing["marketing"]
+    rialto_web["rialto-web"]
+  end
+  subgraph services["Backend Services"]
+    agent_service["agent"]
+    reservations_service["reservations"]
+    users_service["users"]
+  end
+  subgraph packages["Shared Packages"]
+    agent_core["agent-core"]
+    api_client["api-client"]
+    api_versioning["api-versioning"]
+    auth["auth"]
+    config["config"]
+    feature_flags["feature-flags"]
+    mcp_server["mcp-server"]
+    observability["observability"]
+    rialto["rialto"]
+    rialto_catalog["rialto-catalog"]
+    rialto_plugin["rialto-plugin"]
+    sentry["sentry"]
+    types["types"]
+  end
+  subgraph tools["Developer Tools"]
+    cli["cli"]
+  end
+
+  gen --> auth
+  gen --> rialto
+  gen --> rialto_catalog
+  gen --> config
+  hospitality --> api_client
+  hospitality --> auth
+  hospitality --> rialto
+  hospitality --> rialto_catalog
+  hospitality --> sentry
+  hospitality --> types
+  hospitality --> config
+  marketing --> rialto
+  marketing --> sentry
+  marketing --> config
+  rialto_web --> rialto
+  rialto_web --> sentry
+  rialto_web --> config
+  agent_service --> agent_core
+  agent_service --> api_versioning
+  agent_service --> auth
+  agent_service --> observability
+  agent_service --> rialto_catalog
+  agent_service --> sentry
+  agent_service --> types
+  agent_service --> config
+  reservations_service --> api_versioning
+  reservations_service --> auth
+  reservations_service --> observability
+  reservations_service --> sentry
+  reservations_service --> types
+  reservations_service --> config
+  users_service --> api_versioning
+  users_service --> auth
+  users_service --> observability
+  users_service --> sentry
+  users_service --> types
+  users_service --> config
+  agent_core --> types
+  agent_core --> config
+  api_client --> types
+  api_client --> config
+  api_versioning --> config
+  auth --> types
+  auth --> config
+  feature_flags --> config
+  mcp_server --> config
+  observability --> types
+  observability --> config
+  rialto --> config
+  rialto_catalog --> rialto
+  rialto_catalog --> config
+  rialto_plugin --> rialto
+  rialto_plugin --> config
+  sentry --> types
+  sentry --> config
+  types --> config
+  cli --> agent_core
+  cli --> types
+  cli --> config
+
+  classDef frontend fill:#e0f2fe,stroke:#0284c7
+  classDef backend fill:#fef3c7,stroke:#d97706
+  classDef shared fill:#e0e7ff,stroke:#4f46e5
+  classDef tooling fill:#f0fdf4,stroke:#16a34a
+  class gen frontend
+  class hospitality frontend
+  class marketing frontend
+  class rialto_web frontend
+  class agent_service backend
+  class reservations_service backend
+  class users_service backend
+  class agent_core shared
+  class api_client shared
+  class api_versioning shared
+  class auth shared
+  class config shared
+  class feature_flags shared
+  class mcp_server shared
+  class observability shared
+  class rialto shared
+  class rialto_catalog shared
+  class rialto_plugin shared
+  class sentry shared
+  class types shared
+  class cli tooling
+```
+
+## Legend
+
+| Color | Category |
+|-------|----------|
+| Blue | Frontend Apps (`apps/*`) |
+| Amber | Backend Services (`services/*`) |
+| Indigo | Shared Packages (`packages/*`) |
+| Green | Developer Tools (`tools/*`) |

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "check:destructive-migrations": "node scripts/check-destructive-migrations.js",
     "check:dockerfiles": "node scripts/check-dockerfile-deps.js",
     "check:env-sync": "node scripts/check-env-sync.js",
+    "graph": "node scripts/generate-dep-graph.js",
     "build": "turbo run build",
     "test": "turbo run test",
     "test:contract": "turbo run test:contract",

--- a/scripts/generate-dep-graph.js
+++ b/scripts/generate-dep-graph.js
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+
+/**
+ * Generates a Mermaid dependency graph of workspace packages.
+ *
+ * Reads every package.json in the monorepo, extracts inter-workspace
+ * dependencies, and writes a Mermaid flowchart to
+ * docs/architecture/dependency-graph.md.
+ *
+ * Usage: node scripts/generate-dep-graph.js
+ */
+
+import { readFileSync, readdirSync, writeFileSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, "..");
+
+const WORKSPACE_DIRS = ["apps", "services", "packages", "tools"];
+
+const CLASSIFICATION_LABELS = {
+  apps: "Frontend Apps",
+  services: "Backend Services",
+  packages: "Shared Packages",
+  tools: "Developer Tools",
+};
+
+function discoverPackages() {
+  const packages = new Map();
+
+  for (const dir of WORKSPACE_DIRS) {
+    const fullDir = join(root, dir);
+    if (!existsSync(fullDir)) continue;
+
+    for (const entry of readdirSync(fullDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const pkgPath = join(fullDir, entry.name, "package.json");
+      if (!existsSync(pkgPath)) continue;
+
+      const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+      if (!pkg.name) continue;
+
+      const mbeDeps = Object.keys({
+        ...pkg.dependencies,
+        ...pkg.devDependencies,
+      }).filter((name) => name.startsWith("@mbe/"));
+
+      packages.set(pkg.name, {
+        deps: mbeDeps,
+        dir: `${dir}/${entry.name}`,
+        category: dir,
+        shortName: entry.name,
+      });
+    }
+  }
+
+  return packages;
+}
+
+function toMermaidId(name) {
+  return name.replace("@mbe/", "").replace(/-/g, "_");
+}
+
+function generateMermaid(packages) {
+  const lines = ["flowchart TD"];
+
+  // Group packages by category into subgraphs
+  for (const dir of WORKSPACE_DIRS) {
+    const members = [...packages.entries()].filter(
+      ([, info]) => info.category === dir
+    );
+    if (members.length === 0) continue;
+
+    lines.push(`  subgraph ${dir}["${CLASSIFICATION_LABELS[dir]}"]`);
+    for (const [name, info] of members) {
+      lines.push(`    ${toMermaidId(name)}["${info.shortName}"]`);
+    }
+    lines.push("  end");
+  }
+
+  lines.push("");
+
+  // Add edges
+  for (const [name, info] of packages) {
+    for (const dep of info.deps) {
+      if (!packages.has(dep)) continue;
+      lines.push(`  ${toMermaidId(name)} --> ${toMermaidId(dep)}`);
+    }
+  }
+
+  // Add styling
+  lines.push("");
+  lines.push("  classDef frontend fill:#e0f2fe,stroke:#0284c7");
+  lines.push("  classDef backend fill:#fef3c7,stroke:#d97706");
+  lines.push("  classDef shared fill:#e0e7ff,stroke:#4f46e5");
+  lines.push("  classDef tooling fill:#f0fdf4,stroke:#16a34a");
+
+  for (const [name, info] of packages) {
+    const classMap = {
+      apps: "frontend",
+      services: "backend",
+      packages: "shared",
+      tools: "tooling",
+    };
+    lines.push(`  class ${toMermaidId(name)} ${classMap[info.category]}`);
+  }
+
+  return lines.join("\n");
+}
+
+function generateMarkdown(mermaid) {
+  return `# Dependency Graph
+
+> **Auto-generated** — do not edit manually.
+> Regenerate with \`pnpm graph\`.
+
+Inter-workspace dependency relationships between \`@mbe/*\` packages.
+
+\`\`\`mermaid
+${mermaid}
+\`\`\`
+
+## Legend
+
+| Color | Category |
+|-------|----------|
+| Blue | Frontend Apps (\`apps/*\`) |
+| Amber | Backend Services (\`services/*\`) |
+| Indigo | Shared Packages (\`packages/*\`) |
+| Green | Developer Tools (\`tools/*\`) |
+`;
+}
+
+// Run
+const packages = discoverPackages();
+const mermaid = generateMermaid(packages);
+const markdown = generateMarkdown(mermaid);
+const outputPath = join(root, "docs", "architecture", "dependency-graph.md");
+
+writeFileSync(outputPath, markdown);
+console.log(
+  `Generated dependency graph with ${packages.size} packages → ${outputPath}`
+);


### PR DESCRIPTION
## Summary

Two harness engineering improvements:

### 1. Dependency Graph Visualization (Closes #201)
- Generate Mermaid diagram of all 21 workspace packages with color-coded subgraphs
- `pnpm graph` script + CI drift check

### 2. API Backward Compatibility Checks (Closes #215)
- `compareSchema()` in `@mbe/types/schema-compat` classifies schema changes
- Breaking (fail): field removal, type narrowing, new required fields
- Non-breaking (pass): optional field additions, description changes
- Baseline JSON files + compat tests for all 3 services
- `pnpm schema:baseline` to regenerate baselines

## Test plan
- [x] pnpm graph generates diagram idempotently
- [x] Schema compat tests pass for all 3 services (20 new tests)
- [x] Pre-existing snapshot mismatch auto-passes compat check
- [ ] CI drift check catches stale graph
- [ ] Breaking schema change fails compat test

Closes #201
Closes #215