### PR TITLE
fix(services): stop swallowing Prisma errors in catch-all handlers

### DIFF
--- a/services/agent/src/services/session.ts
+++ b/services/agent/src/services/session.ts
@@ -2,6 +2,15 @@ import type { Prisma, Session, SessionEvent, SessionStatus } from "../generated/
 import type { AgentSession, AgentSessionEvent, Pagination } from "@mbe/types";
 import { prisma } from "./database.js";
 
+function isPrismaNotFound(err: unknown): boolean {
+  return (
+    err !== null &&
+    typeof err === "object" &&
+    "code" in err &&
+    (err as { code: string }).code === "P2025"
+  );
+}
+
 function mapPrismaSession(session: Session): AgentSession {
   return {
     id: session.id,
@@ -148,8 +157,9 @@ export const sessionService = {
         },
       });
       return mapPrismaSession(session);
-    } catch {
-      return null;
+    } catch (err: unknown) {
+      if (isPrismaNotFound(err)) return null;
+      throw err;
     }
   },
 
@@ -157,8 +167,9 @@ export const sessionService = {
     try {
       await prisma.session.delete({ where: { id } });
       return true;
-    } catch {
-      return false;
+    } catch (err: unknown) {
+      if (isPrismaNotFound(err)) return false;
+      throw err;
     }
   },
 

--- a/services/reservations/src/services/floor-plan.ts
+++ b/services/reservations/src/services/floor-plan.ts
@@ -11,6 +11,15 @@ import type {
 import { Prisma } from "../generated/prisma/index.js";
 import { prisma } from "./database.js";
 
+function isPrismaNotFound(err: unknown): boolean {
+  return (
+    err !== null &&
+    typeof err === "object" &&
+    "code" in err &&
+    (err as { code: string }).code === "P2025"
+  );
+}
+
 type PrismaFloorPlan = {
   id: string;
   venueId: string;
@@ -152,8 +161,9 @@ export const floorPlanService = {
         include: { tables: true },
       });
       return mapPrismaFloorPlan(floorPlan);
-    } catch {
-      return null;
+    } catch (err: unknown) {
+      if (isPrismaNotFound(err)) return null;
+      throw err;
     }
   },
 
@@ -166,8 +176,9 @@ export const floorPlanService = {
       });
       await prisma.floorPlan.delete({ where: { id } });
       return true;
-    } catch {
-      return false;
+    } catch (err: unknown) {
+      if (isPrismaNotFound(err)) return false;
+      throw err;
     }
   },
 
@@ -190,8 +201,9 @@ export const floorPlanService = {
         });
       });
       return mapPrismaFloorPlan(floorPlan);
-    } catch {
-      return null;
+    } catch (err: unknown) {
+      if (isPrismaNotFound(err)) return null;
+      throw err;
     }
   },
 
@@ -205,8 +217,9 @@ export const floorPlanService = {
         data: { shapeMetadata: shapeMetadata as unknown as Prisma.InputJsonValue },
       });
       return mapPrismaTable(table);
-    } catch {
-      return null;
+    } catch (err: unknown) {
+      if (isPrismaNotFound(err)) return null;
+      throw err;
     }
   },
 
@@ -244,8 +257,9 @@ export const floorPlanService = {
         },
       });
       return mapPrismaTable(table);
-    } catch {
-      return null;
+    } catch (err: unknown) {
+      if (isPrismaNotFound(err)) return null;
+      throw err;
     }
   },
 
@@ -259,8 +273,9 @@ export const floorPlanService = {
         },
       });
       return mapPrismaTable(table);
-    } catch {
-      return null;
+    } catch (err: unknown) {
+      if (isPrismaNotFound(err)) return null;
+      throw err;
     }
   },
 };

--- a/services/reservations/src/services/guest.ts
+++ b/services/reservations/src/services/guest.ts
@@ -9,6 +9,15 @@ import type {
 import type { Prisma } from "../generated/prisma/index.js";
 import { prisma } from "./database.js";
 
+function isPrismaNotFound(err: unknown): boolean {
+  return (
+    err !== null &&
+    typeof err === "object" &&
+    "code" in err &&
+    (err as { code: string }).code === "P2025"
+  );
+}
+
 function mapPrismaGuest(guest: {
   id: string;
   venueId: string;
@@ -189,8 +198,9 @@ export const guestService = {
         data: updateData,
       });
       return mapPrismaGuest(guest);
-    } catch {
-      return null;
+    } catch (err: unknown) {
+      if (isPrismaNotFound(err)) return null;
+      throw err;
     }
   },
 
@@ -198,8 +208,9 @@ export const guestService = {
     try {
       await prisma.guest.delete({ where: { id } });
       return true;
-    } catch {
-      return false;
+    } catch (err: unknown) {
+      if (isPrismaNotFound(err)) return false;
+      throw err;
     }
   },
 
@@ -223,8 +234,9 @@ export const guestService = {
         },
       });
       return mapPrismaGuest(guest);
-    } catch {
-      return null;
+    } catch (err: unknown) {
+      if (isPrismaNotFound(err)) return null;
+      throw err;
     }
   },
 

--- a/services/reservations/src/services/reservation.ts
+++ b/services/reservations/src/services/reservation.ts
@@ -15,6 +15,15 @@ import type { Reservation as PrismaReservation, Table as PrismaTable } from "../
 import { prisma } from "./database.js";
 import { availabilityService } from "./availability.js";
 
+function isPrismaNotFound(err: unknown): boolean {
+  return (
+    err !== null &&
+    typeof err === "object" &&
+    "code" in err &&
+    (err as { code: string }).code === "P2025"
+  );
+}
+
 type PrismaReservationWithTable = PrismaReservation & {
   table?: PrismaTable;
 };
@@ -273,8 +282,9 @@ export const reservationService = {
         include: { table: true },
       });
       return mapPrismaReservation(reservation);
-    } catch {
-      return null;
+    } catch (err: unknown) {
+      if (isPrismaNotFound(err)) return null;
+      throw err;
     }
   },
 
@@ -431,8 +441,9 @@ export const reservationService = {
         include: { table: true },
       });
       return mapPrismaReservation(reservation);
-    } catch {
-      return null;
+    } catch (err: unknown) {
+      if (isPrismaNotFound(err)) return null;
+      throw err;
     }
   },
 };

--- a/services/reservations/src/services/table.ts
+++ b/services/reservations/src/services/table.ts
@@ -9,6 +9,15 @@ import type {
 import { Prisma } from "../generated/prisma/index.js";
 import { prisma } from "./database.js";
 
+function isPrismaNotFound(err: unknown): boolean {
+  return (
+    err !== null &&
+    typeof err === "object" &&
+    "code" in err &&
+    (err as { code: string }).code === "P2025"
+  );
+}
+
 const VALID_TABLE_STATUSES: TableStatus[] = ["AVAILABLE", "OCCUPIED", "DIRTY", "READY"];
 
 function mapPrismaTable(table: {
@@ -133,8 +142,9 @@ export const tableService = {
         data: updateData,
       });
       return mapPrismaTable(table);
-    } catch {
-      return null;
+    } catch (err: unknown) {
+      if (isPrismaNotFound(err)) return null;
+      throw err;
     }
   },
 
@@ -148,8 +158,9 @@ export const tableService = {
         data: { status: status as TableStatus },
       });
       return mapPrismaTable(table);
-    } catch {
-      return null;
+    } catch (err: unknown) {
+      if (isPrismaNotFound(err)) return null;
+      throw err;
     }
   },
 
@@ -157,8 +168,9 @@ export const tableService = {
     try {
       await prisma.table.delete({ where: { id } });
       return true;
-    } catch {
-      return false;
+    } catch (err: unknown) {
+      if (isPrismaNotFound(err)) return false;
+      throw err;
     }
   },
 };

--- a/services/reservations/src/services/venue.ts
+++ b/services/reservations/src/services/venue.ts
@@ -10,6 +10,15 @@ import type {
 import type { Prisma } from "../generated/prisma/index.js";
 import { prisma } from "./database.js";
 
+function isPrismaNotFound(err: unknown): boolean {
+  return (
+    err !== null &&
+    typeof err === "object" &&
+    "code" in err &&
+    (err as { code: string }).code === "P2025"
+  );
+}
+
 function mapPrismaVenueGroup(group: {
   id: string;
   name: string;
@@ -121,8 +130,9 @@ export const venueGroupService = {
         data: updateData,
       });
       return mapPrismaVenueGroup(group);
-    } catch {
-      return null;
+    } catch (err: unknown) {
+      if (isPrismaNotFound(err)) return null;
+      throw err;
     }
   },
 
@@ -130,8 +140,9 @@ export const venueGroupService = {
     try {
       await prisma.venueGroup.delete({ where: { id } });
       return true;
-    } catch {
-      return false;
+    } catch (err: unknown) {
+      if (isPrismaNotFound(err)) return false;
+      throw err;
     }
   },
 };
@@ -228,8 +239,9 @@ export const venueService = {
         include: { venueGroup: true },
       });
       return mapPrismaVenue(venue);
-    } catch {
-      return null;
+    } catch (err: unknown) {
+      if (isPrismaNotFound(err)) return null;
+      throw err;
     }
   },
 
@@ -237,8 +249,9 @@ export const venueService = {
     try {
       await prisma.venue.delete({ where: { id } });
       return true;
-    } catch {
-      return false;
+    } catch (err: unknown) {
+      if (isPrismaNotFound(err)) return false;
+      throw err;
     }
   },
 };

--- a/services/users/src/services/user.ts
+++ b/services/users/src/services/user.ts
@@ -8,6 +8,15 @@ import type {
 } from "@mbe/types";
 import { prisma } from "./database.js";
 
+function isPrismaNotFound(err: unknown): boolean {
+  return (
+    err !== null &&
+    typeof err === "object" &&
+    "code" in err &&
+    (err as { code: string }).code === "P2025"
+  );
+}
+
 function mapPrismaUser(user: {
   id: string;
   email: string;
@@ -107,8 +116,9 @@ export const userService = {
         },
       });
       return mapPrismaUser(user);
-    } catch {
-      return null;
+    } catch (err: unknown) {
+      if (isPrismaNotFound(err)) return null;
+      throw err;
     }
   },
 
@@ -117,10 +127,7 @@ export const userService = {
       await prisma.user.delete({ where: { id } });
       return true;
     } catch (err: unknown) {
-      // Prisma P2025 = record not found
-      if (err && typeof err === "object" && "code" in err && err.code === "P2025") {
-        return false;
-      }
+      if (isPrismaNotFound(err)) return false;
       throw err;
     }
   },
@@ -141,8 +148,9 @@ export const userService = {
         data: { preferences: newPrefs },
       });
       return mapPrismaUser(updated);
-    } catch {
-      return null;
+    } catch (err: unknown) {
+      if (isPrismaNotFound(err)) return null;
+      throw err;
     }
   },
 };


### PR DESCRIPTION
## Summary
- Fixed 22 catch blocks across 7 files in all 3 services
- Added `isPrismaNotFound()` helper to each service
- Changed bare `catch { return null }` to only swallow P2025 (record not found), re-throw everything else
- Unique constraint violations, FK failures, and network errors are no longer silently swallowed

## Files Changed
- `services/reservations/src/services/table.ts` (3 catch blocks)
- `services/reservations/src/services/guest.ts` (3 catch blocks)
- `services/reservations/src/services/reservation.ts` (2 catch blocks)
- `services/reservations/src/services/floor-plan.ts` (6 catch blocks)
- `services/reservations/src/services/venue.ts` (4 catch blocks)
- `services/users/src/services/user.ts` (2 catch blocks)
- `services/agent/src/services/session.ts` (2 catch blocks)

## Test plan
- [x] `pnpm typecheck` passes for all 3 services
- [x] Users service tests: 26/26 pass
- [ ] CI passes

Closes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)