### PR TITLE
fix(ci): fail CI on critical vulnerabilities, warn on high

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,9 @@ jobs:
         run: node scripts/check-env-sync.js
 
       - name: Audit dependencies for vulnerabilities
-        run: pnpm audit --audit-level=high || echo "::warning::Dependency audit found high/critical vulnerabilities — see output above"
+        run: |
+          pnpm audit --audit-level=critical || { echo "::error::Critical vulnerability found"; exit 1; }
+          pnpm audit --audit-level=high || echo "::warning::High-severity audit issues found — review before merging"
 
       - name: Check Dockerfile dependencies
         run: node scripts/check-dockerfile-deps.js


### PR DESCRIPTION
## Summary
- Critical vulnerabilities now fail CI immediately (exit 1)
- High-severity issues show as warnings (visible in PR checks but non-blocking)
- Previously all audit issues were warnings only

## Test plan
- [ ] CI passes
- [ ] Critical vuln would block merge
- [ ] High vuln shows warning annotation

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)