### PR TITLE
fix(reservations): set maxListeners on SSE event emitter

### DIFF
--- a/services/reservations/src/routes/events.ts
+++ b/services/reservations/src/routes/events.ts
@@ -67,12 +67,19 @@ export async function eventRoutes(fastify: FastifyInstance): Promise<void> {
 
       // Subscribe to events
       reservationEvents.onChange(handleEvent);
+      fastify.log.info(
+        { connections: reservationEvents.getConnectionCount() },
+        "SSE client connected"
+      );
 
       // Cleanup on disconnect
       request.raw.on("close", () => {
         clearInterval(pingInterval);
         reservationEvents.offChange(handleEvent);
-        fastify.log.info("SSE client disconnected");
+        fastify.log.info(
+          { connections: reservationEvents.getConnectionCount() },
+          "SSE client disconnected"
+        );
       });
 
       // Don't end the response - keep the connection open

--- a/services/reservations/src/services/events.ts
+++ b/services/reservations/src/services/events.ts
@@ -17,16 +17,44 @@ export interface ReservationEvent {
   data: Reservation | Table | ReservationHold;
 }
 
+/** Maximum concurrent SSE connections before Node emits a warning. */
+const MAX_SSE_LISTENERS = 100;
+
+/** Threshold (percentage of MAX_SSE_LISTENERS) at which we log a warning. */
+const LISTENER_WARNING_THRESHOLD = 0.8;
+
 class ReservationEventEmitter extends EventEmitter {
+  private connectionCount = 0;
+
+  constructor() {
+    super();
+    this.setMaxListeners(MAX_SSE_LISTENERS);
+  }
+
+  /** Current number of active SSE connections. */
+  getConnectionCount(): number {
+    return this.connectionCount;
+  }
+
   emitChange(payload: ReservationEvent): boolean {
     return super.emit("change", payload);
   }
 
   onChange(listener: (payload: ReservationEvent) => void): this {
+    this.connectionCount += 1;
+
+    if (this.connectionCount >= MAX_SSE_LISTENERS * LISTENER_WARNING_THRESHOLD) {
+      // Use process.stderr so this surfaces even without a logger instance
+      process.stderr.write(
+        `[reservationEvents] WARNING: ${this.connectionCount}/${MAX_SSE_LISTENERS} SSE listeners active — approaching limit\n`
+      );
+    }
+
     return super.on("change", listener);
   }
 
   offChange(listener: (payload: ReservationEvent) => void): this {
+    this.connectionCount = Math.max(0, this.connectionCount - 1);
     return super.off("change", listener);
   }
 }


### PR DESCRIPTION
## Summary
- Set `maxListeners(100)` on EventEmitter to prevent memory leak warnings
- Added connection count tracking with warning at 80% capacity
- Verified listener cleanup uses correct function references

## Test plan
- [x] Typecheck passes
- [ ] CI passes

Closes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)