### PR TITLE
fix(auth): add proactive token refresh in useAccessToken hook

### DIFF
--- a/packages/auth/src/react/hooks.ts
+++ b/packages/auth/src/react/hooks.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useAuth as useOIDCAuth } from "react-oidc-context";
 import type { AuthUser, JWTPayload } from "../types/index.js";
 
@@ -41,11 +41,26 @@ export function useAuth() {
 
 /**
  * Hook to get access token for API calls
- * Automatically handles token refresh
+ * Proactively refreshes token when within 5 minutes of expiry
  */
 export function useAccessToken(): string | null {
-  const { accessToken } = useAuth();
-  return accessToken;
+  const auth = useOIDCAuth();
+  const expiresAt = auth.user?.expires_at;
+  const signinSilent = auth.signinSilent;
+
+  useEffect(() => {
+    if (!expiresAt) return;
+
+    const msUntilExpiry = expiresAt * 1000 - Date.now();
+    // Proactively refresh when within 5 minutes of expiry
+    if (msUntilExpiry > 0 && msUntilExpiry < 5 * 60 * 1000) {
+      signinSilent().catch(() => {
+        // Silent refresh failed — token may have fully expired
+      });
+    }
+  }, [expiresAt, signinSilent]);
+
+  return auth.user?.access_token ?? null;
 }
 
 /**
@@ -54,12 +69,21 @@ export function useAccessToken(): string | null {
  */
 export function useRequireAuth() {
   const auth = useAuth();
+  const signInRef = useRef(auth.signIn);
+
+  useEffect(() => {
+    signInRef.current = auth.signIn;
+  }, [auth.signIn]);
+
+  const stableSignIn = useCallback(() => {
+    signInRef.current();
+  }, []);
 
   useEffect(() => {
     if (!auth.isLoading && !auth.isAuthenticated) {
-      auth.signIn();
+      stableSignIn();
     }
-  }, [auth.isLoading, auth.isAuthenticated, auth.signIn]);
+  }, [auth.isLoading, auth.isAuthenticated, stableSignIn]);
 
   return auth;
 }


### PR DESCRIPTION
## Summary
- `useAccessToken` now triggers `signinSilent()` when token is within 5 min of expiry
- `useRequireAuth` uses ref-based callback to prevent infinite redirect loop
- Prevents stale tokens from causing silent 401s

## Test plan
- [x] Typecheck passes
- [x] Lint passes
- [ ] CI passes

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)