### PR TITLE
refactor: extract toDateString utility, replace 14 unsafe date splits

### DIFF
--- a/apps/hospitality/src/components/booking-widget/DatePartySelector.tsx
+++ b/apps/hospitality/src/components/booking-widget/DatePartySelector.tsx
@@ -1,4 +1,5 @@
 import { Input, Button } from "@mbe/rialto";
+import { toDateString } from "@mbe/types";
 import styles from "./DatePartySelector.module.css";
 
 export interface DatePartySelectorProps {
@@ -25,13 +26,13 @@ export function DatePartySelector({
   maxPartySize = 8,
 }: DatePartySelectorProps) {
   // Default min date to today
-  const today = new Date().toISOString().split("T")[0];
+  const today = toDateString(new Date());
   const effectiveMinDate = minDate ?? today;
 
   // Default max date to 30 days from now
   const thirtyDaysFromNow = new Date();
   thirtyDaysFromNow.setDate(thirtyDaysFromNow.getDate() + 30);
-  const effectiveMaxDate = maxDate ?? thirtyDaysFromNow.toISOString().split("T")[0];
+  const effectiveMaxDate = maxDate ?? toDateString(thirtyDaysFromNow);
 
   const partySizes = PARTY_SIZE_OPTIONS.filter((size) => size <= maxPartySize);
 

--- a/apps/hospitality/src/components/timeline/TimelineGrid.tsx
+++ b/apps/hospitality/src/components/timeline/TimelineGrid.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, useEffect } from "react";
-import type { Reservation, Table, TableStatus } from "@mbe/types";
+import { toDateString, type Reservation, type Table, type TableStatus } from "@mbe/types";
 import { ReservationBlock } from "./ReservationBlock";
 import { TableStatusBadge } from "../TableStatusBadge.js";
 import styles from "./TimelineGrid.module.css";
@@ -77,7 +77,7 @@ export function TimelineGrid({
     return () => clearInterval(interval);
   }, []);
 
-  const isToday = date === currentTime.toISOString().split("T")[0];
+  const isToday = date === toDateString(currentTime);
   const currentTimeOffset = useMemo(() => {
     if (!isToday) return null;
     const minutes = currentTime.getHours() * 60 + currentTime.getMinutes();

--- a/apps/hospitality/src/hooks/useDashboardStats.ts
+++ b/apps/hospitality/src/hooks/useDashboardStats.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo, useCallback } from "react";
 import { createApiClient } from "@mbe/api-client";
 import { useAuth } from "@mbe/auth/react";
 import { useVenue } from "../contexts/VenueContext.js";
-import type { Reservation } from "@mbe/types";
+import { toDateString, type Reservation } from "@mbe/types";
 
 export interface DashboardStats {
   totalReservations: number;
@@ -29,7 +29,7 @@ const FALLBACK_STATS: DashboardStats = {
 };
 
 function getTodayString(): string {
-  return new Date().toISOString().split("T")[0];
+  return toDateString(new Date());
 }
 
 function computeUpcoming(reservations: readonly Reservation[]): number {

--- a/packages/rialto-plugin/scripts/generate-reference.ts
+++ b/packages/rialto-plugin/scripts/generate-reference.ts
@@ -201,7 +201,7 @@ function generate(): void {
   const header = [
     "# Rialto Component Reference",
     "",
-    `> Auto-generated from manifest v${manifest.version} on ${new Date().toISOString().split("T")[0]}`,
+    `> Auto-generated from manifest v${manifest.version} on ${new Date().toISOString().substring(0, 10)}`,
     "> Do not edit — run `pnpm generate` to regenerate.",
     "",
     "---",

--- a/packages/types/src/date.ts
+++ b/packages/types/src/date.ts
@@ -1,0 +1,4 @@
+/** Format a Date to YYYY-MM-DD string (e.g., "2026-04-05") */
+export function toDateString(date: Date): string {
+  return date.toISOString().substring(0, 10);
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -101,5 +101,8 @@ export type {
   BulkUpdateTablePositionsRequest,
 } from "./floor-plan.js";
 
+// Date utilities
+export { toDateString } from "./date.js";
+
 // Zod Schemas
 export * from "./schemas/index.js";

--- a/services/reservations/src/services/availability.ts
+++ b/services/reservations/src/services/availability.ts
@@ -1,13 +1,14 @@
-import type {
-  TimeSlot,
-  AvailableTable,
-  DateAvailability,
-  ConflictCheckResult,
-  PacingCheckResult,
-  VenueSettings,
-  OperatingHours,
-  DaySchedule,
-  DurationRule,
+import {
+  toDateString,
+  type TimeSlot,
+  type AvailableTable,
+  type DateAvailability,
+  type ConflictCheckResult,
+  type PacingCheckResult,
+  type VenueSettings,
+  type OperatingHours,
+  type DaySchedule,
+  type DurationRule,
 } from "@mbe/types";
 import type { Table } from "../generated/prisma/index.js";
 import { prisma } from "./database.js";
@@ -243,7 +244,7 @@ export async function getAvailableDates(
     // No venue or no tables — every date is unavailable
     const results: DateAvailability[] = [];
     for (let d = new Date(start); d <= actualEnd; d.setDate(d.getDate() + 1)) {
-      results.push({ date: d.toISOString().split("T")[0], hasAvailability: false, slotCount: 0 });
+      results.push({ date: toDateString(d), hasAvailability: false, slotCount: 0 });
     }
     return results;
   }
@@ -285,7 +286,7 @@ export async function getAvailableDates(
   const results: DateAvailability[] = [];
 
   for (let d = new Date(start); d <= actualEnd; d.setDate(d.getDate() + 1)) {
-    const dateStr = d.toISOString().split("T")[0];
+    const dateStr = toDateString(d);
     const schedule = getDaySchedule(venue.operatingHours, d);
 
     if (!schedule) {
@@ -295,10 +296,10 @@ export async function getAvailableDates(
 
     // Filter reservations and holds for this specific date
     const dateReservations = allReservations.filter(
-      (r) => r.startTime.toISOString().split("T")[0] === dateStr
+      (r) => toDateString(r.startTime) === dateStr
     );
     const dateHolds = allHolds.filter(
-      (h) => h.startTime.toISOString().split("T")[0] === dateStr
+      (h) => toDateString(h.startTime) === dateStr
     );
 
     const openMinutes = parseTimeToMinutes(schedule.open);
@@ -457,7 +458,7 @@ export async function checkPacing(
   // Define the time window
   const windowStart = startTime;
   const windowEnd = new Date(startTime.getTime() + windowMinutes * 60 * 1000);
-  const dateStr = startTime.toISOString().split("T")[0];
+  const dateStr = toDateString(startTime);
 
   // Count covers in reservations starting in this window
   const reservationCovers = await prisma.reservation.aggregate({

--- a/services/reservations/src/services/hold.ts
+++ b/services/reservations/src/services/hold.ts
@@ -1,11 +1,12 @@
-import type {
-  ReservationHold,
-  CreateHoldRequest,
-  ConfirmHoldRequest,
-  Reservation,
-  Table,
-  VenueSettings,
-  TableShapeMetadata,
+import {
+  toDateString,
+  type ReservationHold,
+  type CreateHoldRequest,
+  type ConfirmHoldRequest,
+  type Reservation,
+  type Table,
+  type VenueSettings,
+  type TableShapeMetadata,
 } from "@mbe/types";
 import type { ReservationHold as PrismaHold } from "../generated/prisma/index.js";
 import { prisma } from "./database.js";
@@ -19,7 +20,7 @@ function mapPrismaHold(hold: PrismaHold): ReservationHold {
     id: hold.id,
     venueId: hold.venueId,
     tableId: hold.tableId,
-    date: hold.date.toISOString().split("T")[0],
+    date: toDateString(hold.date),
     startTime: hold.startTime.toISOString(),
     endTime: hold.endTime.toISOString(),
     partySize: hold.partySize,
@@ -342,7 +343,7 @@ export const holdService = {
       success: true,
       reservation: {
         id: result.id,
-        date: result.date.toISOString().split("T")[0],
+        date: toDateString(result.date),
         startTime: result.startTime.toISOString(),
         endTime: result.endTime.toISOString(),
         partySize: result.partySize,

--- a/services/reservations/src/services/reservation.ts
+++ b/services/reservations/src/services/reservation.ts
@@ -1,15 +1,16 @@
-import type {
-  Reservation,
-  ReservationStatus,
-  Table,
-  CreateReservationRequest,
-  UpdateReservationRequest,
-  WalkInRequest,
-  PaginatedResponse,
-  ConflictCheckResult,
-  PacingCheckResult,
-  TableShapeMetadata,
-  VenueSettings,
+import {
+  toDateString,
+  type Reservation,
+  type ReservationStatus,
+  type Table,
+  type CreateReservationRequest,
+  type UpdateReservationRequest,
+  type WalkInRequest,
+  type PaginatedResponse,
+  type ConflictCheckResult,
+  type PacingCheckResult,
+  type TableShapeMetadata,
+  type VenueSettings,
 } from "@mbe/types";
 import type { Reservation as PrismaReservation, Table as PrismaTable } from "../generated/prisma/index.js";
 import { prisma } from "./database.js";
@@ -31,7 +32,7 @@ type PrismaReservationWithTable = PrismaReservation & {
 function mapPrismaReservation(reservation: PrismaReservationWithTable): Reservation {
   return {
     id: reservation.id,
-    date: reservation.date.toISOString().split("T")[0],
+    date: toDateString(reservation.date),
     startTime: reservation.startTime.toISOString(),
     endTime: reservation.endTime.toISOString(),
     partySize: reservation.partySize,
@@ -314,7 +315,7 @@ export const reservationService = {
 
     if (timeOrTableChanged) {
       // Build the final values for conflict check
-      const date = data.date ?? existing.date.toISOString().split("T")[0];
+      const date = data.date ?? toDateString(existing.date);
       const startTime = data.startTime
         ? new Date(data.startTime)
         : existing.startTime;
@@ -361,7 +362,7 @@ export const reservationService = {
       Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
     );
 
-    const dateStr = dateOnly.toISOString().split("T")[0];
+    const dateStr = toDateString(dateOnly);
 
     // Conflict check + creation inside a transaction to prevent TOCTOU races
     const conflict = await availabilityService.checkConflict(


### PR DESCRIPTION
## Summary
- Created `toDateString()` utility in `@mbe/types`
- Replaced 14 instances of `.toISOString().split("T")[0]` across 7 files
- Uses `.substring(0, 10)` — safer than array indexing from `.split()`

## Test plan
- [x] Typecheck passes (28/28 tasks)
- [ ] CI passes

Closes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)