### PR TITLE
docs: add CLAUDE.md for observability and sentry packages

### DIFF
--- a/packages/observability/CLAUDE.md
+++ b/packages/observability/CLAUDE.md
@@ -1,0 +1,70 @@
+# @mbe/observability
+
+OpenTelemetry SDK wrapper for Node.js services. Provides tracing, metrics, request ID propagation, and agent baggage context.
+
+## SDK Initialization
+
+`initTelemetry({ serviceName, serviceVersion? })` creates a `NodeSDK` instance with OTLP/HTTP exporters. Must be called **before** importing Fastify or HTTP modules (the SDK monkey-patches Node's HTTP stack).
+
+Instrumentations: `http`, `fastify`, `pino` only. No auto-instrumentation suite (avoids DNS/net/fs noise and ~8 MB heap overhead). Uses OTLP/HTTP, not gRPC (saves 8-12 MB from `@grpc/grpc-js`).
+
+Resource attributes: service name, version, deployment environment, `deploy.sha`, `deploy.pr_number`, `deploy.author`.
+
+### Filtered Paths
+
+`shouldIgnoreRequest` excludes `/health`, `/docs`, `/reference` (and sub-paths) from tracing. Application routes like `/api/v1/*` are always traced.
+
+## Request ID Middleware
+
+`createRequestIdMiddleware(options?)` is a Fastify plugin that:
+- Reads `x-request-id` header from incoming requests (or generates a UUID)
+- Sets `request.id` for downstream logging and tracing
+
+Helpers: `getRequestId(request)` extracts the ID; `logWithRequestId(logger, id, msg, ctx)` adds it to structured logs.
+
+## Baggage Context
+
+Propagates agent metadata through the OTel W3C Baggage format across service boundaries.
+
+```typescript
+import { createBaggageContext, extractAgentBaggage, BAGGAGE_KEYS } from "@mbe/observability/baggage";
+
+// Attach baggage to outbound requests
+const ctx = createBaggageContext({ sessionId: "abc", prNumber: "42" });
+context.with(ctx, () => { /* HTTP calls carry baggage headers */ });
+
+// Extract baggage in receiving service
+const bag = extractAgentBaggage(); // { sessionId, prNumber, issueNumber, deploySha }
+```
+
+Baggage keys: `agent.session_id`, `agent.pr_number`, `agent.issue_number`, `deploy.sha`.
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Grafana Cloud OTLP gateway URL |
+| `OTEL_EXPORTER_OTLP_HEADERS` | `Authorization=Basic <base64>` |
+| `OTEL_SDK_DISABLED` | Set `"true"` to disable (tests, local dev) |
+| `NODE_ENV` | Maps to `deployment.environment` resource attribute |
+| `DEPLOY_SHA` | Git SHA of current deploy |
+| `DEPLOY_PR_NUMBER` | PR number that triggered deploy |
+| `DEPLOY_AUTHOR` | Author of the deploy |
+
+## Package Exports
+
+- `@mbe/observability` — main entry (initTelemetry, request ID, baggage)
+- `@mbe/observability/baggage` — baggage utilities only (lighter import for non-Node contexts)
+
+## Service Integration Pattern
+
+```typescript
+// src/telemetry.ts — must be first import in entry point
+import { initTelemetry } from "@mbe/observability";
+const sdk = initTelemetry({ serviceName: "reservations" });
+sdk.start();
+
+// src/app.ts
+import { createRequestIdMiddleware } from "@mbe/observability";
+app.register(createRequestIdMiddleware());
+```

--- a/packages/sentry/CLAUDE.md
+++ b/packages/sentry/CLAUDE.md
@@ -1,0 +1,65 @@
+# @mbe/sentry
+
+Sentry error monitoring wrapper with separate entry points for Node.js services and React apps.
+
+## Entry Points
+
+| Import | Platform | Use |
+|--------|----------|-----|
+| `@mbe/sentry` | Universal | Config types and `resolveConfig` only |
+| `@mbe/sentry/node` | Node.js | `initSentry`, `sentryFastifyPlugin` |
+| `@mbe/sentry/react` | Browser | `initSentry`, `handleErrorBoundary` |
+
+## Config Resolution
+
+`resolveConfig(dsn)` returns `SentryConfig` with:
+- `enabled`: `true` only when DSN is a non-empty string
+- `environment`: `SENTRY_ENVIRONMENT` > `NODE_ENV` > `"development"`
+- `release`: `SENTRY_RELEASE` > `npm_package_version`
+
+Works in both Node and browser (guards `process` access). No DSN = Sentry fully disabled.
+
+## Node.js — Fastify Plugin
+
+`initSentry({ serviceName })` initializes the SDK. Disables OTel integration (`skipOpenTelemetrySetup: true`) since `@mbe/observability` handles tracing separately. Traces sample rate is 0 (traces come from OTel).
+
+`sentryFastifyPlugin` registers two hooks:
+
+1. **Error handler** — captures thrown exceptions with request context (method, URL, requestId, user). Returns RFC 9457 Problem Details via `createProblemDetails`. Flags the reply with `__sentryErrorCaptured` to prevent double-capture. 500s return generic "Internal Server Error" to clients.
+
+2. **onResponse hook** — catches status-based errors not thrown as exceptions:
+   - **5xx**: captured as errors (unless already caught by error handler)
+   - **409, 422, 429**: captured as warnings (notable client errors)
+   - **400, 401, 403, 404**: silently ignored (expected client errors)
+
+User context is extracted from `request.user` (set by `@mbe/auth` plugin) without importing auth types directly.
+
+## React — Error Boundary
+
+`initSentry({ appName, dsn })` initializes with:
+- Session replay on errors only (`replaysOnErrorSampleRate: 1.0`)
+- No session replay sampling in normal sessions
+- App name tagged for filtering
+
+`handleErrorBoundary(error, errorInfo)` captures React error boundary crashes with `componentStack` as extra context. Wire it to your error boundary's `onError` prop.
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `SENTRY_DSN` | DSN string; empty/missing disables Sentry entirely |
+| `SENTRY_ENVIRONMENT` | Override environment (falls back to `NODE_ENV`) |
+| `SENTRY_RELEASE` | Release version (falls back to `npm_package_version`) |
+
+## Integration Pattern
+
+```typescript
+// Node service entry point
+import { initSentry, sentryFastifyPlugin } from "@mbe/sentry/node";
+initSentry({ serviceName: "reservations" });
+app.register(sentryFastifyPlugin);
+
+// React app entry point
+import { initSentry, handleErrorBoundary } from "@mbe/sentry/react";
+initSentry({ appName: "hospitality", dsn: import.meta.env.VITE_SENTRY_DSN });
+```


### PR DESCRIPTION
## Summary
- `packages/observability/CLAUDE.md` (2.9KB) — OTEL init, request ID, baggage context, trace filtering
- `packages/sentry/CLAUDE.md` (2.8KB) — Dual entry points, Fastify plugin with dedup, error boundary

## Test plan
- [x] Typecheck passes
- [ ] CI passes

Partial fix for #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)