### PR TITLE
fix(hospitality): sync SSE updates across pages via shared context

### DIFF
--- a/apps/hospitality/src/components/DashboardLayout.tsx
+++ b/apps/hospitality/src/components/DashboardLayout.tsx
@@ -1,18 +1,17 @@
 import { useState, useCallback, useMemo, useEffect } from "react";
 import { useNavigate, useLocation, Outlet } from "react-router-dom";
 import { useAuth } from "@mbe/auth/react";
-import { Breadcrumb, CommandPalette, ErrorBoundary, GenCopilot, Kbd, useToast } from "@mbe/rialto";
+import { Breadcrumb, CommandPalette, ErrorBoundary, GenCopilot, Kbd } from "@mbe/rialto";
 import type { BreadcrumbItem } from "@mbe/rialto";
 import { registry } from "@mbe/rialto-catalog";
-import type { Reservation } from "@mbe/types";
 import { HOSPITALITY_DOMAIN_CONTEXT } from "../constants/copilotContext.js";
 import { useCommandPalette } from "../hooks/use-command-palette.js";
-import { useReservationEvents } from "../hooks/useReservationEvents.js";
 import { useTheme, resolveTheme } from "../hooks/use-theme.js";
 import { useVenueReadiness } from "../hooks/useVenueReadiness.js";
 import { buildNavSections } from "../nav-sections.js";
 import type { NavItem } from "../nav-sections.js";
 import { VenueProvider } from "../contexts/VenueContext.js";
+import { ReservationDataProvider } from "../contexts/ReservationDataContext.js";
 import { DashboardSidebar } from "./DashboardSidebar.js";
 import { VenueSwitcher } from "./VenueSwitcher.js";
 import styles from "./DashboardLayout.module.css";
@@ -47,7 +46,6 @@ function DashboardLayoutInner() {
   const { theme, setTheme } = useTheme();
   const readiness = useVenueReadiness();
 
-  const { toast } = useToast();
   const [copilotOpen, setCopilotOpen] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
@@ -80,33 +78,6 @@ function DashboardLayoutInner() {
       }
     }
   }, [readiness.status, location.pathname, navigate]);
-
-  // SSE toast notifications for real-time reservation events
-  useReservationEvents({
-    enabled: true,
-    onReservationCreated: useCallback(
-      (reservation: Reservation) => {
-        toast({
-          title: "New reservation",
-          description: `${reservation.guestName ?? "Guest"} — ${new Date(reservation.startTime).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`,
-          variant: "accent",
-          duration: 5000,
-        });
-      },
-      [toast]
-    ),
-    onReservationCancelled: useCallback(
-      (reservation: Reservation) => {
-        toast({
-          title: "Reservation cancelled",
-          description: `${reservation.guestName ?? "Guest"}'s reservation was cancelled`,
-          variant: "error",
-          duration: 5000,
-        });
-      },
-      [toast]
-    ),
-  });
 
   // Toggle theme between light and dark
   const toggleTheme = useCallback(() => {
@@ -340,7 +311,9 @@ function DashboardLayoutInner() {
 export function DashboardLayout() {
   return (
     <VenueProvider>
-      <DashboardLayoutInner />
+      <ReservationDataProvider>
+        <DashboardLayoutInner />
+      </ReservationDataProvider>
     </VenueProvider>
   );
 }

--- a/apps/hospitality/src/contexts/ReservationDataContext.tsx
+++ b/apps/hospitality/src/contexts/ReservationDataContext.tsx
@@ -1,0 +1,178 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useRef,
+  useMemo,
+  type ReactNode,
+} from "react";
+import { useToast } from "@mbe/rialto";
+import type { Reservation } from "@mbe/types";
+import { useReservationEvents } from "../hooks/useReservationEvents.js";
+import { useVenue } from "./VenueContext.js";
+
+/* ── Toast rate limiter ────────────────────────── */
+
+const TOAST_WINDOW_MS = 10_000;
+const TOAST_MAX = 3;
+
+interface ToastRateLimiter {
+  readonly timestamps: readonly number[];
+}
+
+function canShowToast(limiter: ToastRateLimiter): {
+  allowed: boolean;
+  next: ToastRateLimiter;
+} {
+  const now = Date.now();
+  const recent = limiter.timestamps.filter((t) => now - t < TOAST_WINDOW_MS);
+  if (recent.length >= TOAST_MAX) {
+    return { allowed: false, next: { timestamps: recent } };
+  }
+  return { allowed: true, next: { timestamps: [...recent, now] } };
+}
+
+/* ── Context shape ─────────────────────────────── */
+
+interface ReservationDataContextValue {
+  readonly reservations: readonly Reservation[];
+  readonly isConnected: boolean;
+  readonly addReservation: (reservation: Reservation) => void;
+  readonly updateReservation: (reservation: Reservation) => void;
+  readonly removeReservation: (id: string) => void;
+  readonly setReservations: (reservations: Reservation[]) => void;
+}
+
+const ReservationDataContext =
+  createContext<ReservationDataContextValue | null>(null);
+
+/* ── Provider ──────────────────────────────────── */
+
+interface ReservationDataProviderProps {
+  readonly children: ReactNode;
+}
+
+export function ReservationDataProvider({
+  children,
+}: ReservationDataProviderProps) {
+  const { selectedVenueId } = useVenue();
+  const { toast } = useToast();
+  const [reservations, setReservationsState] = useState<Reservation[]>([]);
+  const toastLimiterRef = useRef<ToastRateLimiter>({ timestamps: [] });
+
+  const showRateLimitedToast = useCallback(
+    (opts: Parameters<typeof toast>[0]) => {
+      const { allowed, next } = canShowToast(toastLimiterRef.current);
+      toastLimiterRef.current = next;
+      if (allowed) {
+        toast(opts);
+      }
+    },
+    [toast]
+  );
+
+  const addReservation = useCallback((reservation: Reservation) => {
+    setReservationsState((prev) => {
+      const exists = prev.some((r) => r.id === reservation.id);
+      if (exists) {
+        return prev.map((r) => (r.id === reservation.id ? reservation : r));
+      }
+      return [...prev, reservation];
+    });
+  }, []);
+
+  const updateReservation = useCallback((reservation: Reservation) => {
+    setReservationsState((prev) =>
+      prev.map((r) => (r.id === reservation.id ? reservation : r))
+    );
+  }, []);
+
+  const removeReservation = useCallback((id: string) => {
+    setReservationsState((prev) => prev.filter((r) => r.id !== id));
+  }, []);
+
+  const setReservations = useCallback((next: Reservation[]) => {
+    setReservationsState(next);
+  }, []);
+
+  /* ── SSE subscription ────────────────────────── */
+
+  const handleCreated = useCallback(
+    (reservation: Reservation) => {
+      addReservation(reservation);
+      showRateLimitedToast({
+        title: "New reservation",
+        description: `${reservation.guestName ?? "Guest"} — ${new Date(reservation.startTime).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`,
+        variant: "accent",
+        duration: 5000,
+      });
+    },
+    [addReservation, showRateLimitedToast]
+  );
+
+  const handleUpdated = useCallback(
+    (reservation: Reservation) => {
+      updateReservation(reservation);
+    },
+    [updateReservation]
+  );
+
+  const handleCancelled = useCallback(
+    (reservation: Reservation) => {
+      updateReservation(reservation);
+      showRateLimitedToast({
+        title: "Reservation cancelled",
+        description: `${reservation.guestName ?? "Guest"}'s reservation was cancelled`,
+        variant: "error",
+        duration: 5000,
+      });
+    },
+    [updateReservation, showRateLimitedToast]
+  );
+
+  const { isConnected } = useReservationEvents({
+    venueId: selectedVenueId ?? undefined,
+    enabled: !!selectedVenueId,
+    onReservationCreated: handleCreated,
+    onReservationUpdated: handleUpdated,
+    onReservationCancelled: handleCancelled,
+  });
+
+  const value = useMemo<ReservationDataContextValue>(
+    () => ({
+      reservations,
+      isConnected,
+      addReservation,
+      updateReservation,
+      removeReservation,
+      setReservations,
+    }),
+    [
+      reservations,
+      isConnected,
+      addReservation,
+      updateReservation,
+      removeReservation,
+      setReservations,
+    ]
+  );
+
+  return (
+    <ReservationDataContext.Provider value={value}>
+      {children}
+    </ReservationDataContext.Provider>
+  );
+}
+
+/* ── Hook ──────────────────────────────────────── */
+
+export function useReservationData(): ReservationDataContextValue {
+  const context = useContext(ReservationDataContext);
+  if (!context) {
+    throw new Error(
+      "useReservationData must be used within a ReservationDataProvider"
+    );
+  }
+  return context;
+}

--- a/apps/hospitality/src/pages/ReservationsPage.tsx
+++ b/apps/hospitality/src/pages/ReservationsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback, useRef } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
 import { useAuth } from "@mbe/auth/react";
 import { createApiClient } from "@mbe/api-client";
@@ -14,9 +14,9 @@ import {
   Stat,
   Text,
 } from "@mbe/rialto";
-import type { Reservation, ReservationStatus } from "@mbe/types";
+import type { ReservationStatus } from "@mbe/types";
 import { useVenue } from "../contexts/VenueContext.js";
-import { useReservationEvents } from "../hooks/useReservationEvents.js";
+import { useReservationData } from "../contexts/ReservationDataContext.js";
 import { PageHeader } from "../components/PageHeader";
 import styles from "./ReservationsPage.module.css";
 
@@ -79,7 +79,11 @@ export function ReservationsPage() {
   const navigate = useNavigate();
   const { accessToken } = useAuth();
   const { selectedVenueId } = useVenue();
-  const [reservations, setReservations] = useState<Reservation[]>([]);
+  const {
+    reservations: sharedReservations,
+    isConnected,
+    setReservations: setSharedReservations,
+  } = useReservationData();
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [searchParams, setSearchParams] = useSearchParams();
@@ -113,35 +117,11 @@ export function ReservationsPage() {
     return () => clearInterval(id);
   }, [lastUpdated]);
 
-  /* ── Real-time SSE updates ─────────────────── */
-
-  const handleCreated = useCallback(
-    (reservation: Reservation) => {
-      if (reservation.date === selectedDate) {
-        setReservations((prev) => [...prev, reservation]);
-        setLastUpdated(new Date());
-      }
-    },
-    [selectedDate]
+  // Filter shared reservations to the selected date
+  const reservations = useMemo(
+    () => sharedReservations.filter((r) => r.date === selectedDate),
+    [sharedReservations, selectedDate]
   );
-
-  const handleUpdated = useCallback((reservation: Reservation) => {
-    setReservations((prev) => prev.map((r) => (r.id === reservation.id ? reservation : r)));
-    setLastUpdated(new Date());
-  }, []);
-
-  const handleCancelled = useCallback((reservation: Reservation) => {
-    setReservations((prev) => prev.map((r) => (r.id === reservation.id ? reservation : r)));
-    setLastUpdated(new Date());
-  }, []);
-
-  const { isConnected } = useReservationEvents({
-    venueId: selectedVenueId ?? undefined,
-    enabled: true,
-    onReservationCreated: handleCreated,
-    onReservationUpdated: handleUpdated,
-    onReservationCancelled: handleCancelled,
-  });
 
   const stats = useMemo(() => {
     const confirmed = reservations.filter((r) => r.status === "CONFIRMED").length;
@@ -180,7 +160,7 @@ export function ReservationsPage() {
           limit: 50,
         });
 
-        setReservations(response.data);
+        setSharedReservations(response.data);
         setLastUpdated(new Date());
       } catch (err) {
         setError(err instanceof Error ? err.message : "Failed to load reservations");
@@ -190,7 +170,7 @@ export function ReservationsPage() {
     }
 
     fetchReservations();
-  }, [api, selectedDate, selectedVenueId]);
+  }, [api, selectedDate, selectedVenueId, setSharedReservations]);
 
   const formatTime = (isoString: string) => {
     return new Date(isoString).toLocaleTimeString([], {

--- a/apps/hospitality/src/pages/TimelinePage.tsx
+++ b/apps/hospitality/src/pages/TimelinePage.tsx
@@ -10,6 +10,7 @@ import { EditReservationDrawer } from "../components/timeline/EditReservationDra
 import { WalkInDialog } from "../components/timeline/WalkInDialog";
 import { useReservationEvents } from "../hooks/useReservationEvents";
 import { useVenue } from "../contexts/VenueContext.js";
+import { useReservationData } from "../contexts/ReservationDataContext.js";
 import { PageHeader } from "../components/PageHeader";
 import styles from "./TimelinePage.module.css";
 
@@ -161,9 +162,15 @@ function ReservationDetails({ reservation, onEdit, onSeat, onCancel }: Reservati
 export function TimelinePage() {
   const { accessToken } = useAuth();
   const { selectedVenueId } = useVenue();
+  const {
+    reservations: sharedReservations,
+    isConnected,
+    setReservations: setSharedReservations,
+    addReservation,
+    updateReservation,
+  } = useReservationData();
 
   const [tables, setTables] = useState<Table[]>([]);
-  const [reservations, setReservations] = useState<Reservation[]>([]);
   const [searchParams, setSearchParams] = useSearchParams();
   const selectedDate = searchParams.get("date") ?? new Date().toLocaleDateString("en-CA");
   const [isLoading, setIsLoading] = useState(true);
@@ -184,53 +191,28 @@ export function TimelinePage() {
     [accessToken]
   );
 
-  // Real-time updates via SSE
-  const { isConnected } = useReservationEvents({
+  // SSE for table updates and hold confirmations (reservation events handled by context)
+  useReservationEvents({
     venueId: selectedVenueId ?? undefined,
     enabled: !!selectedVenueId,
-    onReservationCreated: useCallback(
-      (reservation: Reservation) => {
-        // Only add if it matches our current date
-        if (reservation.date === selectedDate) {
-          setReservations((prev) => {
-            const exists = prev.some((r) => r.id === reservation.id);
-            if (exists) {
-              return prev.map((r) => (r.id === reservation.id ? reservation : r));
-            }
-            return [...prev, reservation];
-          });
-        }
-      },
-      [selectedDate]
-    ),
-    onReservationUpdated: useCallback((reservation: Reservation) => {
-      setReservations((prev) =>
-        prev.map((r) => (r.id === reservation.id ? reservation : r))
-      );
-    }, []),
-    onReservationCancelled: useCallback((reservation: Reservation) => {
-      setReservations((prev) =>
-        prev.map((r) => (r.id === reservation.id ? reservation : r))
-      );
-    }, []),
     onHoldConfirmed: useCallback(
       (reservation: Reservation) => {
         if (reservation.date === selectedDate) {
-          setReservations((prev) => {
-            const exists = prev.some((r) => r.id === reservation.id);
-            if (exists) {
-              return prev.map((r) => (r.id === reservation.id ? reservation : r));
-            }
-            return [...prev, reservation];
-          });
+          addReservation(reservation);
         }
       },
-      [selectedDate]
+      [selectedDate, addReservation]
     ),
     onTableUpdated: useCallback((table: Table) => {
       setTables((prev) => prev.map((t) => (t.id === table.id ? table : t)));
     }, []),
   });
+
+  // Filter shared reservations to the selected date
+  const reservations = useMemo(
+    () => sharedReservations.filter((r) => r.date === selectedDate),
+    [sharedReservations, selectedDate]
+  );
 
   // Fetch tables and reservations when venue or date changes
   useEffect(() => {
@@ -257,7 +239,7 @@ export function TimelinePage() {
         });
 
         setTables(sortedTables);
-        setReservations(reservationsResponse.data);
+        setSharedReservations(reservationsResponse.data);
       } catch (err) {
         setError(err instanceof Error ? err.message : "Failed to load data");
       } finally {
@@ -266,7 +248,7 @@ export function TimelinePage() {
     }
 
     fetchData();
-  }, [api, selectedVenueId, selectedDate]);
+  }, [api, selectedVenueId, selectedDate, setSharedReservations]);
 
   const handlePreviousDay = useCallback(() => {
     const prev = new Date(selectedDate + "T00:00:00");
@@ -306,7 +288,7 @@ export function TimelinePage() {
     try {
       const updated = await api.reservations.update(reservation.id, { status: "CONFIRMED" });
       await api.tables.updateStatus(reservation.tableId, "OCCUPIED");
-      setReservations((prev) => prev.map((r) => (r.id === reservation.id ? updated : r)));
+      updateReservation(updated);
       setTables((prev) =>
         prev.map((t) =>
           t.id === reservation.tableId ? { ...t, status: "OCCUPIED" as const } : t
@@ -325,11 +307,7 @@ export function TimelinePage() {
         cancellationReason: reason,
         cancellationNote: note,
       });
-      setReservations((prev) =>
-        prev.map((r) =>
-          r.id === selectedReservation.id ? { ...r, status: "CANCELLED" as const } : r
-        )
-      );
+      updateReservation({ ...selectedReservation, status: "CANCELLED" as const });
       setShowCancelDialog(false);
       setSelectedReservation(null);
     } catch (err) {
@@ -340,7 +318,7 @@ export function TimelinePage() {
   const handleEdit = async (id: string, data: UpdateReservationRequest) => {
     try {
       const updated = await api.reservations.update(id, data);
-      setReservations((prev) => prev.map((r) => (r.id === id ? updated : r)));
+      updateReservation(updated);
       setSelectedReservation(updated);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to update reservation");
@@ -355,7 +333,7 @@ export function TimelinePage() {
   }) => {
     try {
       const reservation = await api.reservations.walkIn(data);
-      setReservations((prev) => [...prev, reservation]);
+      addReservation(reservation);
       setTables((prev) =>
         prev.map((t) => (t.id === data.tableId ? { ...t, status: "OCCUPIED" as const } : t))
       );


### PR DESCRIPTION
## Summary
- Created `ReservationDataContext` — shared SSE subscription at DashboardLayout level
- Timeline and Reservations pages now share the same real-time data
- Dedup by ID prevents duplicate entries from optimistic update + SSE confirmation
- Toast rate limiting (max 3 per 10 seconds) prevents notification spam

## Changes
- **New**: `contexts/ReservationDataContext.tsx` — shared state + SSE subscription
- **Modified**: `DashboardLayout.tsx` — wraps children with provider, removed own SSE
- **Modified**: `TimelinePage.tsx` — consumes shared context, filters by date
- **Modified**: `ReservationsPage.tsx` — consumes shared context, filters by date

## Test plan
- [x] Typecheck passes
- [ ] CI passes
- [ ] Switching between Timeline and Reservations shows consistent data
- [ ] New reservation appears on both pages simultaneously

Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)