### PR TITLE
fix(rialto): accessibility improvements for Toast, Table, and Button spinner

### DIFF
--- a/packages/rialto/src/components/Button/Button.module.css
+++ b/packages/rialto/src/components/Button/Button.module.css
@@ -151,6 +151,12 @@
   }
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation: none;
+  }
+}
+
 .contentHidden {
   opacity: 0.8;
 }

--- a/packages/rialto/src/components/Table/Table.tsx
+++ b/packages/rialto/src/components/Table/Table.tsx
@@ -192,7 +192,7 @@ function TableInner<T extends Record<string, unknown>>(
                       ? "none"
                       : undefined
                 }
-                role={col.sortable ? "columnheader" : undefined}
+                role="columnheader"
               >
                 {col.header}
                 {col.sortable && (

--- a/packages/rialto/src/components/Toast/Toast.tsx
+++ b/packages/rialto/src/components/Toast/Toast.tsx
@@ -157,7 +157,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
           </AnimatePresence>
         </div>
         {/* Assertive region — error (interrupts user immediately) */}
-        <div aria-live="assertive" aria-atomic="true">
+        <div aria-live="assertive" aria-atomic="false">
           <AnimatePresence mode="popLayout">
             {assertiveToasts.map((t) => (
               <ToastItem key={t.id} toast={t} onDismiss={dismiss} />


### PR DESCRIPTION
## Summary
- **Toast**: `aria-atomic="false"` on assertive region — prevents full re-announcement
- **Table**: all `<th>` elements get `role="columnheader"`, not just sortable ones
- **Button**: spinner animation respects `prefers-reduced-motion`
- **Skeleton**: already had reduced motion support (verified, no change needed)

## Test plan
- [x] Typecheck passes
- [x] All 218 Rialto tests pass
- [ ] CI passes

Closes #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)