### PR TITLE
feat: create @mbe/agent-test-utils package for cost-free agent development (#366)

### DIFF
--- a/packages/agent-test-utils/README.md
+++ b/packages/agent-test-utils/README.md
@@ -1,0 +1,250 @@
+# @mbe/agent-test-utils
+
+Testing utilities for `@mbe/agent-core` that eliminate live API calls and their associated costs. Use these in unit and integration tests to get fast, deterministic, reproducible results.
+
+## Installation
+
+This is a private workspace package. Import it from other packages in this monorepo:
+
+```json
+{
+  "devDependencies": {
+    "@mbe/agent-test-utils": "workspace:*"
+  }
+}
+```
+
+## Modules
+
+### 1. Mock Claude Client
+
+Drop-in replacement for the `query` function from `@anthropic-ai/claude-agent-sdk`.
+
+#### Deterministic mode (default)
+
+Returns a predictable success result for every call — no network, no cost.
+
+```ts
+import { createMockClaudeClient } from "@mbe/agent-test-utils";
+
+const client = createMockClaudeClient({
+  deterministicCostUsd: 0.05,
+  deterministicTokens: { input: 5000, output: 1000 },
+});
+
+for await (const msg of client.query({ prompt: "Fix the bug", model: "claude-sonnet-4-6" })) {
+  console.log(msg); // { type: "result", subtype: "success", total_cost_usd: 0.05, ... }
+}
+
+console.log(client.calls);          // [{ callIndex: 1, prompt: "Fix the bug", ... }]
+console.log(client.totalCostUsd()); // 0.05
+```
+
+#### Replay mode
+
+Record real API responses to JSON files and replay them in tests.
+
+```ts
+const client = createMockClaudeClient({
+  mode: "replay",
+  fixtures: [
+    // Load from a file: JSON.parse(readFileSync("fixtures/session-1.json", "utf-8"))
+    [
+      { type: "system", subtype: "init" },
+      { type: "result", subtype: "success", total_cost_usd: 0.12, /* ... */ },
+    ],
+  ],
+});
+```
+
+#### Error injection
+
+Test retry and error-handling paths without hitting rate limits.
+
+```ts
+const client = createMockClaudeClient({
+  errorOnCall: 2,
+  errorToInject: new Error("Rate limit exceeded"),
+});
+
+// Call 1: succeeds
+// Call 2: throws "Rate limit exceeded"
+```
+
+---
+
+### 2. Session Event Fixtures
+
+Pre-built `SessionEvent[]` sequences that mirror real agent output.
+
+```ts
+import {
+  buildMinimalSuccessFixture,
+  buildBugFixFixture,
+  buildFailureFixture,
+  createFixturePlayer,
+  extractToolCalls,
+  compareToolCalls,
+} from "@mbe/agent-test-utils";
+
+// Minimal: start + assistant + result
+const simple = buildMinimalSuccessFixture({ sessionId: "test-123", costUsd: 0.02 });
+
+// Full bug-fix: includes Read, Grep, Edit, Bash tool calls
+const bugFix = buildBugFixFixture();
+
+// Error path: includes session:error + failed result
+const failure = buildFailureFixture();
+```
+
+#### Step-through player
+
+```ts
+const player = createFixturePlayer(buildBugFixFixture());
+
+while (player.hasMore()) {
+  const event = player.next();
+  // process event one at a time
+}
+
+player.reset(); // rewind to beginning
+```
+
+#### Tool call comparison
+
+```ts
+const events = buildBugFixFixture();
+const actual = extractToolCalls(events);
+
+const expected = [
+  { toolName: "Read", input: {} },
+  { toolName: "Edit", input: {} },
+];
+
+const diff = compareToolCalls(expected, actual);
+if (!diff.passed) {
+  console.log("Missing tools:", diff.missing);
+  console.log("Unexpected tools:", diff.unexpected);
+}
+```
+
+#### Save/load fixtures from files
+
+```ts
+import { serializeFixture, loadFixtureFromFile } from "@mbe/agent-test-utils";
+import { writeFileSync } from "node:fs";
+
+// Save a fixture (e.g. recorded from a real run)
+writeFileSync("fixtures/bug-fix.json", serializeFixture(buildBugFixFixture()));
+
+// Load it back
+const events = loadFixtureFromFile("fixtures/bug-fix.json");
+```
+
+---
+
+### 3. Worktree Simulation
+
+In-memory git operation mocks with three pre-built repo states.
+
+```ts
+import {
+  createWorktreeSimulator,
+  assertOperationCalled,
+  assertOperationNotCalled,
+} from "@mbe/agent-test-utils";
+
+// Clean repo: hasChanges = false, verification passes
+const sim = createWorktreeSimulator({ state: "clean" });
+
+// Dirty repo: hasChanges = true, verification passes
+const dirty = createWorktreeSimulator({ state: "dirty" });
+
+// Conflicted: hasChanges = true, verification FAILS
+const conflicted = createWorktreeSimulator({ state: "conflicted" });
+```
+
+#### Simulating failures
+
+```ts
+// createWorktree always throws
+const failCreate = createWorktreeSimulator({ failOnCreate: true });
+
+// pushBranch fails N times then succeeds (for retry testing)
+const retryPush = createWorktreeSimulator({ failOnPush: true, pushFailCount: 2 });
+```
+
+#### Using as vitest mocks
+
+```ts
+import { createWorktreeMocks, createWorktreeSimulator } from "@mbe/agent-test-utils";
+import { vi } from "vitest";
+
+const sim = createWorktreeSimulator({ state: "dirty" });
+
+vi.mock("../worktree-manager.js", () => createWorktreeMocks(sim));
+
+// In your test:
+await runSession(config);
+assertOperationCalled(sim, "commitChanges");
+assertOperationNotCalled(sim, "removeWorktree");
+```
+
+---
+
+### 4. Cost Estimation
+
+Calculate costs and estimate session budgets without API calls.
+
+```ts
+import {
+  calculateCost,
+  estimateSessionCost,
+  createCostProfiler,
+  wouldExceedBudget,
+  estimateTokenCount,
+} from "@mbe/agent-test-utils";
+
+// Estimate token count from text
+const tokens = estimateTokenCount("Fix the authentication bug in the login flow");
+
+// Calculate cost for known token usage
+const cost = calculateCost(
+  { inputTokens: 50_000, outputTokens: 5_000 },
+  "claude-sonnet-4-6"
+);
+console.log(`Estimated cost: $${cost.totalCostUsd.toFixed(4)}`);
+
+// Budget planning before running a session
+const estimate = estimateSessionCost("Implement OAuth2 login", {
+  model: "claude-haiku-4-5",
+  numTurns: 10,
+  expectedOutputTokens: 800,
+});
+console.log(`Estimated: $${estimate.totalCostUsd.toFixed(4)}`);
+
+// Guard: would this session exceed budget?
+const tooExpensive = wouldExceedBudget("Rewrite entire codebase", 0.50, {
+  numTurns: 100,
+});
+```
+
+#### Profile costs across multiple sessions
+
+```ts
+const profiler = createCostProfiler();
+
+profiler.record("session-1", { inputTokens: 5000, outputTokens: 1000 }, 3000);
+profiler.record("session-2", { inputTokens: 8000, outputTokens: 1500 }, 5000);
+
+const summary = profiler.summary();
+console.log(`Total cost: $${summary.totalCostUsd.toFixed(4)}`);
+console.log(`Most expensive: ${summary.mostExpensiveSession?.sessionId}`);
+```
+
+## Running Tests
+
+```bash
+pnpm --filter @mbe/agent-test-utils test
+pnpm --filter @mbe/agent-test-utils test:coverage
+```

--- a/packages/agent-test-utils/package.json
+++ b/packages/agent-test-utils/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@mbe/agent-test-utils",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "production": "./dist/index.js",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "lint": "eslint src/",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.92",
+    "@mbe/agent-core": "workspace:*",
+    "@mbe/types": "workspace:*"
+  },
+  "devDependencies": {
+    "@mbe/config": "workspace:*",
+    "@types/node": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/agent-test-utils/src/__tests__/cost-estimator.test.ts
+++ b/packages/agent-test-utils/src/__tests__/cost-estimator.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect } from "vitest";
+import {
+  estimateTokenCount,
+  estimatePromptTokens,
+  calculateCost,
+  estimateSessionCost,
+  createCostProfiler,
+  wouldExceedBudget,
+  estimateLatency,
+  MODEL_PRICING,
+  DEFAULT_LATENCY_PROFILE,
+} from "../cost-estimator.js";
+
+describe("estimateTokenCount", () => {
+  it("returns 0 for empty string", () => {
+    expect(estimateTokenCount("")).toBe(0);
+  });
+
+  it("estimates ~4 chars per token", () => {
+    const text = "a".repeat(400);
+    expect(estimateTokenCount(text)).toBe(100);
+  });
+
+  it("rounds up for partial tokens", () => {
+    expect(estimateTokenCount("abc")).toBe(1); // 3 chars → ceil(3/4) = 1
+  });
+});
+
+describe("estimatePromptTokens", () => {
+  it("adds system prompt overhead to task estimate", () => {
+    const task = "Fix the login bug"; // ~5 tokens
+    const result = estimatePromptTokens(task, 2000);
+    expect(result).toBeGreaterThan(2000);
+  });
+
+  it("uses default overhead of 2000", () => {
+    const result = estimatePromptTokens("x");
+    expect(result).toBeGreaterThanOrEqual(2000);
+  });
+});
+
+describe("calculateCost", () => {
+  it("calculates cost for sonnet", () => {
+    const cost = calculateCost({ inputTokens: 1_000_000, outputTokens: 0 });
+    expect(cost.inputCostUsd).toBeCloseTo(3.0);
+    expect(cost.model).toBe("claude-sonnet-4-6");
+  });
+
+  it("calculates output cost separately", () => {
+    const cost = calculateCost({ inputTokens: 0, outputTokens: 1_000_000 });
+    expect(cost.outputCostUsd).toBeCloseTo(15.0);
+  });
+
+  it("includes cache write cost when provided", () => {
+    const cost = calculateCost({
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheWriteTokens: 1_000_000,
+    });
+    expect(cost.cacheWriteCostUsd).toBeCloseTo(3.75);
+  });
+
+  it("includes cache read cost when provided", () => {
+    const cost = calculateCost({
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 1_000_000,
+    });
+    expect(cost.cacheReadCostUsd).toBeCloseTo(0.3);
+  });
+
+  it("uses haiku pricing when specified", () => {
+    const cost = calculateCost({ inputTokens: 1_000_000, outputTokens: 0 }, "claude-haiku-4-5");
+    expect(cost.inputCostUsd).toBeCloseTo(0.8);
+    expect(cost.model).toBe("claude-haiku-4-5");
+  });
+
+  it("falls back to sonnet for unknown model", () => {
+    const cost = calculateCost({ inputTokens: 1_000_000, outputTokens: 0 }, "unknown-model");
+    expect(cost.model).toBe("claude-sonnet-4-6");
+  });
+
+  it("totalCostUsd is sum of all components", () => {
+    const cost = calculateCost({
+      inputTokens: 100_000,
+      outputTokens: 10_000,
+      cacheWriteTokens: 50_000,
+      cacheReadTokens: 200_000,
+    });
+    const expected =
+      cost.inputCostUsd + cost.outputCostUsd + cost.cacheWriteCostUsd + cost.cacheReadCostUsd;
+    expect(cost.totalCostUsd).toBeCloseTo(expected);
+  });
+});
+
+describe("estimateSessionCost", () => {
+  it("returns a cost breakdown", () => {
+    const cost = estimateSessionCost("Fix the login bug");
+    expect(cost.totalCostUsd).toBeGreaterThan(0);
+    expect(cost.model).toBe("claude-sonnet-4-6");
+  });
+
+  it("respects custom turn count (more turns = more cost)", () => {
+    const low = estimateSessionCost("task", { numTurns: 1 });
+    const high = estimateSessionCost("task", { numTurns: 10 });
+    expect(high.totalCostUsd).toBeGreaterThan(low.totalCostUsd);
+  });
+
+  it("respects custom model", () => {
+    const haiku = estimateSessionCost("task", { model: "claude-haiku-4-5" });
+    const sonnet = estimateSessionCost("task", { model: "claude-sonnet-4-6" });
+    expect(sonnet.totalCostUsd).toBeGreaterThan(haiku.totalCostUsd);
+  });
+});
+
+describe("createCostProfiler", () => {
+  it("records a session profile", () => {
+    const profiler = createCostProfiler();
+    profiler.record("sess-1", { inputTokens: 5000, outputTokens: 1000 }, 3000);
+    expect(profiler.profiles()).toHaveLength(1);
+    expect(profiler.profiles()[0].sessionId).toBe("sess-1");
+  });
+
+  it("summary returns zero values when empty", () => {
+    const profiler = createCostProfiler();
+    const s = profiler.summary();
+    expect(s.totalSessions).toBe(0);
+    expect(s.totalCostUsd).toBe(0);
+    expect(s.mostExpensiveSession).toBeNull();
+  });
+
+  it("aggregates costs across sessions", () => {
+    const profiler = createCostProfiler();
+    profiler.record("s1", { inputTokens: 10000, outputTokens: 2000 }, 2000);
+    profiler.record("s2", { inputTokens: 20000, outputTokens: 5000 }, 5000);
+    const s = profiler.summary();
+    expect(s.totalSessions).toBe(2);
+    expect(s.totalCostUsd).toBeGreaterThan(0);
+    expect(s.totalInputTokens).toBe(30000);
+    expect(s.totalOutputTokens).toBe(7000);
+  });
+
+  it("identifies most and least expensive sessions", () => {
+    const profiler = createCostProfiler();
+    profiler.record("cheap", { inputTokens: 100, outputTokens: 10 }, 100);
+    profiler.record("expensive", { inputTokens: 1_000_000, outputTokens: 200_000 }, 10000);
+    const s = profiler.summary();
+    expect(s.mostExpensiveSession?.sessionId).toBe("expensive");
+    expect(s.cheapestSession?.sessionId).toBe("cheap");
+  });
+
+  it("reset clears all profiles", () => {
+    const profiler = createCostProfiler();
+    profiler.record("s1", { inputTokens: 100, outputTokens: 10 }, 100);
+    profiler.reset();
+    expect(profiler.profiles()).toHaveLength(0);
+    expect(profiler.summary().totalSessions).toBe(0);
+  });
+});
+
+describe("wouldExceedBudget", () => {
+  it("returns false for very generous budget", () => {
+    const result = wouldExceedBudget("Fix a small bug", 100);
+    expect(result).toBe(false);
+  });
+
+  it("returns true for impossibly tight budget", () => {
+    const result = wouldExceedBudget("Fix a small bug", 0.000001);
+    expect(result).toBe(true);
+  });
+});
+
+describe("estimateLatency", () => {
+  it("returns positive value for non-zero token usage", () => {
+    const ms = estimateLatency({ inputTokens: 5000, outputTokens: 1000 });
+    expect(ms).toBeGreaterThan(0);
+  });
+
+  it("uses base latency as minimum", () => {
+    const ms = estimateLatency(
+      { inputTokens: 0, outputTokens: 0 },
+      { ...DEFAULT_LATENCY_PROFILE, jitterMs: 0 }
+    );
+    expect(ms).toBe(DEFAULT_LATENCY_PROFILE.baseMs);
+  });
+
+  it("more tokens means more latency", () => {
+    const low = estimateLatency({ inputTokens: 100, outputTokens: 50 });
+    const high = estimateLatency({ inputTokens: 100000, outputTokens: 50000 });
+    expect(high).toBeGreaterThan(low);
+  });
+});
+
+describe("MODEL_PRICING", () => {
+  it("contains entries for all main models", () => {
+    expect(MODEL_PRICING["claude-sonnet-4-6"]).toBeDefined();
+    expect(MODEL_PRICING["claude-haiku-4-5"]).toBeDefined();
+    expect(MODEL_PRICING["claude-opus-4-5"]).toBeDefined();
+  });
+
+  it("opus is most expensive model", () => {
+    const sonnet = MODEL_PRICING["claude-sonnet-4-6"].inputCostPer1MTokens;
+    const opus = MODEL_PRICING["claude-opus-4-5"].inputCostPer1MTokens;
+    const haiku = MODEL_PRICING["claude-haiku-4-5"].inputCostPer1MTokens;
+    expect(opus).toBeGreaterThan(sonnet);
+    expect(sonnet).toBeGreaterThan(haiku);
+  });
+});

--- a/packages/agent-test-utils/src/__tests__/mock-claude-client.test.ts
+++ b/packages/agent-test-utils/src/__tests__/mock-claude-client.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from "vitest";
+import { createMockClaudeClient } from "../mock-claude-client.js";
+
+async function drainGenerator(
+  gen: AsyncGenerator<unknown>
+): Promise<unknown[]> {
+  const results: unknown[] = [];
+  for await (const item of gen) {
+    results.push(item);
+  }
+  return results;
+}
+
+describe("createMockClaudeClient", () => {
+  describe("deterministic mode", () => {
+    it("returns a result message for every call", async () => {
+      const client = createMockClaudeClient();
+      const messages = await drainGenerator(client.query({ prompt: "Fix the bug" }));
+      expect(messages).toHaveLength(1);
+      const msg = messages[0] as { type: string; subtype: string };
+      expect(msg.type).toBe("result");
+      expect(msg.subtype).toBe("success");
+    });
+
+    it("records call history", async () => {
+      const client = createMockClaudeClient();
+      await drainGenerator(client.query({ prompt: "Task one", model: "claude-haiku-4-5" }));
+      await drainGenerator(client.query({ prompt: "Task two" }));
+
+      expect(client.calls).toHaveLength(2);
+      expect(client.calls[0].prompt).toBe("Task one");
+      expect(client.calls[0].model).toBe("claude-haiku-4-5");
+      expect(client.calls[1].prompt).toBe("Task two");
+    });
+
+    it("accumulates total cost across calls", async () => {
+      const client = createMockClaudeClient({ deterministicCostUsd: 0.05 });
+      await drainGenerator(client.query({ prompt: "call 1" }));
+      await drainGenerator(client.query({ prompt: "call 2" }));
+
+      expect(client.totalCostUsd()).toBeCloseTo(0.10);
+    });
+
+    it("accumulates total token usage across calls", async () => {
+      const client = createMockClaudeClient({
+        deterministicTokens: { input: 1000, output: 200 },
+      });
+      await drainGenerator(client.query({ prompt: "a" }));
+      await drainGenerator(client.query({ prompt: "b" }));
+
+      const usage = client.totalTokenUsage();
+      expect(usage.input).toBe(2000);
+      expect(usage.output).toBe(400);
+    });
+
+    it("uses custom token counts in result message", async () => {
+      const client = createMockClaudeClient({
+        deterministicTokens: { input: 500, output: 100 },
+        deterministicCostUsd: 0.002,
+      });
+      const messages = await drainGenerator(client.query({ prompt: "task" }));
+      const result = messages[0] as {
+        total_cost_usd: number;
+        usage: { input_tokens: number; output_tokens: number };
+      };
+      expect(result.total_cost_usd).toBeCloseTo(0.002);
+      expect(result.usage.input_tokens).toBe(500);
+      expect(result.usage.output_tokens).toBe(100);
+    });
+  });
+
+  describe("replay mode", () => {
+    it("yields messages from fixture sequences in order", async () => {
+      const fixture1 = [
+        { type: "system", subtype: "init" },
+        {
+          type: "result",
+          subtype: "success",
+          uuid: "u1",
+          session_id: "s1",
+          duration_ms: 1000,
+          duration_api_ms: 900,
+          is_error: false,
+          num_turns: 2,
+          result: "done",
+          stop_reason: "end_turn",
+          total_cost_usd: 0.01,
+          usage: {
+            input_tokens: 500,
+            output_tokens: 100,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+          },
+          modelUsage: {},
+          permission_denials: [],
+        },
+      ];
+
+      const client = createMockClaudeClient({ mode: "replay", fixtures: [fixture1] });
+      const messages = await drainGenerator(client.query({ prompt: "replay test" }));
+
+      expect(messages).toHaveLength(2);
+      expect((messages[0] as { type: string }).type).toBe("system");
+      expect((messages[1] as { type: string }).type).toBe("result");
+    });
+
+    it("cycles through fixtures when exhausted", async () => {
+      const fixture = [
+        {
+          type: "result",
+          subtype: "success",
+          uuid: "u",
+          session_id: "s",
+          duration_ms: 100,
+          duration_api_ms: 90,
+          is_error: false,
+          num_turns: 1,
+          result: "ok",
+          stop_reason: "end_turn",
+          total_cost_usd: 0.001,
+          usage: {
+            input_tokens: 10,
+            output_tokens: 5,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+          },
+          modelUsage: {},
+          permission_denials: [],
+        },
+      ];
+      const client = createMockClaudeClient({ mode: "replay", fixtures: [fixture] });
+
+      await drainGenerator(client.query({ prompt: "call 1" }));
+      await drainGenerator(client.query({ prompt: "call 2" }));
+
+      // Both calls should have succeeded (fixture cycled)
+      expect(client.calls).toHaveLength(2);
+    });
+  });
+
+  describe("error injection", () => {
+    it("throws on the specified call number", async () => {
+      const client = createMockClaudeClient({
+        errorOnCall: 2,
+        errorToInject: new Error("Rate limit exceeded"),
+      });
+
+      // First call should succeed
+      await drainGenerator(client.query({ prompt: "call 1" }));
+
+      // Second call should throw
+      await expect(
+        drainGenerator(client.query({ prompt: "call 2" }))
+      ).rejects.toThrow("Rate limit exceeded");
+    });
+
+    it("throws immediately when errorOnCall is 1", async () => {
+      const client = createMockClaudeClient({
+        errorOnCall: 1,
+        errorToInject: new Error("Connection timeout"),
+      });
+
+      await expect(
+        drainGenerator(client.query({ prompt: "will fail" }))
+      ).rejects.toThrow("Connection timeout");
+    });
+  });
+
+  describe("reset", () => {
+    it("clears call history and resets counters", async () => {
+      const client = createMockClaudeClient({ deterministicCostUsd: 0.05 });
+      await drainGenerator(client.query({ prompt: "call before reset" }));
+
+      expect(client.calls).toHaveLength(1);
+      expect(client.totalCostUsd()).toBeCloseTo(0.05);
+
+      client.reset();
+
+      expect(client.calls).toHaveLength(0);
+      expect(client.totalCostUsd()).toBe(0);
+    });
+  });
+});

--- a/packages/agent-test-utils/src/__tests__/session-fixtures.test.ts
+++ b/packages/agent-test-utils/src/__tests__/session-fixtures.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildMinimalSuccessFixture,
+  buildBugFixFixture,
+  buildFailureFixture,
+  createFixturePlayer,
+  extractToolCalls,
+  compareToolCalls,
+  serializeFixture,
+} from "../session-fixtures.js";
+import type { SessionEvent } from "@mbe/agent-core";
+
+describe("buildMinimalSuccessFixture", () => {
+  it("returns at least start and result events", () => {
+    const events = buildMinimalSuccessFixture();
+    expect(events.length).toBeGreaterThanOrEqual(2);
+    expect(events[0].type).toBe("session:start");
+    expect(events[events.length - 1].type).toBe("session:result");
+  });
+
+  it("uses provided session options", () => {
+    const events = buildMinimalSuccessFixture({ sessionId: "my-session", numTurns: 10 });
+    const result = events[events.length - 1];
+    const data = result.data as { num_turns: number; session_id: string };
+    expect(data.num_turns).toBe(10);
+    expect(data.session_id).toBe("my-session");
+  });
+
+  it("all events have timestamps", () => {
+    const events = buildMinimalSuccessFixture();
+    for (const event of events) {
+      expect(event.timestamp).toBeTruthy();
+      expect(() => new Date(event.timestamp)).not.toThrow();
+    }
+  });
+});
+
+describe("buildBugFixFixture", () => {
+  it("includes tool_use and tool_result events", () => {
+    const events = buildBugFixFixture();
+    const toolUseEvents = events.filter((e) => e.type === "session:tool_use");
+    const toolResultEvents = events.filter((e) => e.type === "session:tool_result");
+    expect(toolUseEvents.length).toBeGreaterThan(0);
+    expect(toolResultEvents.length).toBeGreaterThan(0);
+  });
+
+  it("starts with session:start and ends with session:result", () => {
+    const events = buildBugFixFixture();
+    expect(events[0].type).toBe("session:start");
+    expect(events[events.length - 1].type).toBe("session:result");
+  });
+
+  it("allows customizing tool calls", () => {
+    const events = buildBugFixFixture({
+      toolCalls: [
+        { toolName: "Bash", input: { command: "ls" }, output: "file.ts" },
+      ],
+    });
+    const toolUseEvents = events.filter((e) => e.type === "session:tool_use");
+    expect(toolUseEvents).toHaveLength(1);
+  });
+});
+
+describe("buildFailureFixture", () => {
+  it("includes session:error event", () => {
+    const events = buildFailureFixture();
+    const errorEvents = events.filter((e) => e.type === "session:error");
+    expect(errorEvents.length).toBeGreaterThan(0);
+  });
+
+  it("ends with a result event with is_error=true", () => {
+    const events = buildFailureFixture();
+    const last = events[events.length - 1];
+    expect(last.type).toBe("session:result");
+    const data = last.data as { is_error: boolean };
+    expect(data.is_error).toBe(true);
+  });
+});
+
+describe("createFixturePlayer", () => {
+  it("steps through events one at a time", () => {
+    const events = buildMinimalSuccessFixture();
+    const player = createFixturePlayer(events);
+
+    expect(player.hasMore()).toBe(true);
+    const first = player.next();
+    expect(first?.type).toBe("session:start");
+    expect(player.position()).toBe(1);
+  });
+
+  it("returns undefined when exhausted", () => {
+    const events: SessionEvent[] = [];
+    const player = createFixturePlayer(events);
+    expect(player.hasMore()).toBe(false);
+    expect(player.next()).toBeUndefined();
+  });
+
+  it("drainAll returns remaining events", () => {
+    const events = buildMinimalSuccessFixture();
+    const player = createFixturePlayer(events);
+    player.next(); // consume first
+
+    const remaining = player.drainAll();
+    expect(remaining.length).toBe(events.length - 1);
+    expect(player.hasMore()).toBe(false);
+  });
+
+  it("reset returns to position 0", () => {
+    const events = buildMinimalSuccessFixture();
+    const player = createFixturePlayer(events);
+    player.drainAll();
+
+    expect(player.hasMore()).toBe(false);
+    player.reset();
+    expect(player.hasMore()).toBe(true);
+    expect(player.position()).toBe(0);
+  });
+});
+
+describe("extractToolCalls", () => {
+  it("extracts tool names from tool_use events", () => {
+    const events = buildBugFixFixture();
+    const calls = extractToolCalls(events);
+    expect(calls.length).toBeGreaterThan(0);
+    const toolNames = calls.map((c) => c.toolName);
+    expect(toolNames).toContain("Read");
+  });
+
+  it("returns empty array when no tool_use events", () => {
+    const events = buildMinimalSuccessFixture();
+    const calls = extractToolCalls(events);
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe("compareToolCalls", () => {
+  it("identifies matched calls", () => {
+    const expected = [{ toolName: "Read", input: {} }];
+    const actual = [
+      { toolName: "Read", input: { file_path: "/foo.ts" } },
+      { toolName: "Bash", input: { command: "ls" } },
+    ];
+    const diff = compareToolCalls(expected, actual);
+    expect(diff.matched).toHaveLength(1);
+    expect(diff.matched[0].toolName).toBe("Read");
+  });
+
+  it("identifies missing calls", () => {
+    const expected = [
+      { toolName: "Read", input: {} },
+      { toolName: "Write", input: {} },
+    ];
+    const actual = [{ toolName: "Read", input: {} }];
+    const diff = compareToolCalls(expected, actual);
+    expect(diff.missing).toHaveLength(1);
+    expect(diff.missing[0].toolName).toBe("Write");
+    expect(diff.passed).toBe(false);
+  });
+
+  it("identifies unexpected calls", () => {
+    const expected = [{ toolName: "Read", input: {} }];
+    const actual = [
+      { toolName: "Read", input: {} },
+      { toolName: "Bash", input: {} },
+    ];
+    const diff = compareToolCalls(expected, actual);
+    expect(diff.unexpected).toHaveLength(1);
+    expect(diff.unexpected[0].toolName).toBe("Bash");
+    expect(diff.passed).toBe(false);
+  });
+
+  it("passes when expected and actual match exactly", () => {
+    const calls = [{ toolName: "Grep", input: { pattern: "foo" } }];
+    const diff = compareToolCalls(calls, calls);
+    expect(diff.passed).toBe(true);
+    expect(diff.missing).toHaveLength(0);
+    expect(diff.unexpected).toHaveLength(0);
+  });
+});
+
+describe("serializeFixture", () => {
+  it("serializes to valid JSON", () => {
+    const events = buildMinimalSuccessFixture();
+    const json = serializeFixture(events);
+    expect(() => JSON.parse(json)).not.toThrow();
+  });
+
+  it("round-trips fixture data", () => {
+    const events = buildMinimalSuccessFixture({ sessionId: "round-trip-test" });
+    const json = serializeFixture(events);
+    const parsed = JSON.parse(json) as SessionEvent[];
+    expect(parsed[0].type).toBe("session:start");
+  });
+});

--- a/packages/agent-test-utils/src/__tests__/worktree-simulator.test.ts
+++ b/packages/agent-test-utils/src/__tests__/worktree-simulator.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from "vitest";
+import {
+  createWorktreeSimulator,
+  assertOperationCalled,
+  assertOperationNotCalled,
+  CLEAN_REPO_FILES,
+  DIRTY_REPO_FILES,
+  CONFLICTED_REPO_FILES,
+} from "../worktree-simulator.js";
+
+describe("createWorktreeSimulator", () => {
+  describe("default (clean) state", () => {
+    it("createWorktree returns a WorktreeInfo", async () => {
+      const sim = createWorktreeSimulator({ repoPath: "/repo" });
+      const info = await sim.createWorktree("/repo", "fix bug");
+      expect(info.path).toContain("/repo");
+      expect(info.branchName).toBeTruthy();
+      expect(info.mode).toBe("full");
+    });
+
+    it("hasChanges returns false for clean repo", async () => {
+      const sim = createWorktreeSimulator({ state: "clean" });
+      const result = await sim.hasChanges("/repo/worktree");
+      expect(result).toBe(false);
+    });
+
+    it("runVerification passes for clean repo", async () => {
+      const sim = createWorktreeSimulator({ state: "clean" });
+      const result = await sim.runVerification("/repo/worktree");
+      expect(result.passed).toBe(true);
+      expect(result.lintOk).toBe(true);
+      expect(result.typecheckOk).toBe(true);
+      expect(result.testsOk).toBe(true);
+    });
+
+    it("provides CLEAN_REPO_FILES by default", () => {
+      const sim = createWorktreeSimulator({ state: "clean" });
+      expect(sim.files()).toBe(CLEAN_REPO_FILES);
+    });
+  });
+
+  describe("dirty state", () => {
+    it("hasChanges returns true", async () => {
+      const sim = createWorktreeSimulator({ state: "dirty" });
+      expect(await sim.hasChanges("/repo/worktree")).toBe(true);
+    });
+
+    it("runVerification passes for dirty repo", async () => {
+      const sim = createWorktreeSimulator({ state: "dirty" });
+      const result = await sim.runVerification("/repo/worktree");
+      expect(result.passed).toBe(true);
+    });
+
+    it("provides DIRTY_REPO_FILES", () => {
+      const sim = createWorktreeSimulator({ state: "dirty" });
+      expect(sim.files()).toBe(DIRTY_REPO_FILES);
+    });
+  });
+
+  describe("conflicted state", () => {
+    it("hasChanges returns true", async () => {
+      const sim = createWorktreeSimulator({ state: "conflicted" });
+      expect(await sim.hasChanges("/repo/worktree")).toBe(true);
+    });
+
+    it("runVerification fails for conflicted repo", async () => {
+      const sim = createWorktreeSimulator({ state: "conflicted" });
+      const result = await sim.runVerification("/repo/worktree");
+      expect(result.passed).toBe(false);
+      expect(result.lintOk).toBe(false);
+    });
+
+    it("provides CONFLICTED_REPO_FILES", () => {
+      const sim = createWorktreeSimulator({ state: "conflicted" });
+      expect(sim.files()).toBe(CONFLICTED_REPO_FILES);
+    });
+  });
+
+  describe("commitChanges", () => {
+    it("returns a deterministic commit sha", async () => {
+      const sim = createWorktreeSimulator();
+      const sha = await sim.commitChanges("/repo/worktree");
+      expect(sha).toBeTruthy();
+      expect(typeof sha).toBe("string");
+    });
+  });
+
+  describe("pushBranch", () => {
+    it("succeeds by default", async () => {
+      const sim = createWorktreeSimulator();
+      await expect(sim.pushBranch("/repo", "agent/fix-bug")).resolves.toBeUndefined();
+    });
+
+    it("throws when failOnPush is true", async () => {
+      const sim = createWorktreeSimulator({ failOnPush: true, pushFailCount: 10 });
+      await expect(sim.pushBranch("/repo", "agent/fix-bug")).rejects.toThrow("push failed");
+    });
+
+    it("fails for pushFailCount times then succeeds", async () => {
+      const sim = createWorktreeSimulator({ failOnPush: true, pushFailCount: 2 });
+
+      // First two attempts fail
+      await expect(sim.pushBranch("/repo", "branch")).rejects.toThrow();
+      await expect(sim.pushBranch("/repo", "branch")).rejects.toThrow();
+      // Third succeeds
+      await expect(sim.pushBranch("/repo", "branch")).resolves.toBeUndefined();
+    });
+  });
+
+  describe("failOnCreate", () => {
+    it("throws when creating worktree", async () => {
+      const sim = createWorktreeSimulator({ failOnCreate: true });
+      await expect(sim.createWorktree("/repo", "task")).rejects.toThrow("git worktree add failed");
+    });
+  });
+
+  describe("call recording", () => {
+    it("records all operations in order", async () => {
+      const sim = createWorktreeSimulator({ state: "dirty" });
+      await sim.createWorktree("/repo", "task");
+      await sim.hasChanges("/repo/wt");
+      await sim.commitChanges("/repo/wt");
+      await sim.pushBranch("/repo", "branch");
+      await sim.removeWorktree("/repo", "/repo/wt");
+
+      const calls = sim.calls();
+      expect(calls.map((c) => c.operation)).toEqual([
+        "createWorktree",
+        "hasChanges",
+        "commitChanges",
+        "pushBranch",
+        "removeWorktree",
+      ]);
+    });
+
+    it("reset clears call history", async () => {
+      const sim = createWorktreeSimulator();
+      await sim.createWorktree("/repo", "task");
+      expect(sim.calls()).toHaveLength(1);
+
+      sim.reset();
+      expect(sim.calls()).toHaveLength(0);
+    });
+  });
+
+  describe("worktreeInfo", () => {
+    it("returns consistent info matching createWorktree result", async () => {
+      const sim = createWorktreeSimulator({ branchName: "agent/my-task" });
+      const created = await sim.createWorktree("/repo", "task");
+      const info = sim.worktreeInfo();
+      expect(created.path).toBe(info.path);
+      expect(created.branchName).toBe(info.branchName);
+    });
+  });
+});
+
+describe("assertOperationCalled", () => {
+  it("does not throw when operation was called", async () => {
+    const sim = createWorktreeSimulator();
+    await sim.createWorktree("/repo", "task");
+    expect(() => assertOperationCalled(sim, "createWorktree")).not.toThrow();
+  });
+
+  it("throws when operation was not called", () => {
+    const sim = createWorktreeSimulator();
+    expect(() => assertOperationCalled(sim, "pushBranch")).toThrow(
+      'Expected worktree operation "pushBranch" to have been called'
+    );
+  });
+});
+
+describe("assertOperationNotCalled", () => {
+  it("does not throw when operation was not called", () => {
+    const sim = createWorktreeSimulator();
+    expect(() => assertOperationNotCalled(sim, "removeWorktree")).not.toThrow();
+  });
+
+  it("throws when operation was called", async () => {
+    const sim = createWorktreeSimulator();
+    await sim.removeWorktree("/repo", "/repo/wt");
+    expect(() => assertOperationNotCalled(sim, "removeWorktree")).toThrow(
+      'Expected worktree operation "removeWorktree" NOT to have been called'
+    );
+  });
+});

--- a/packages/agent-test-utils/src/cost-estimator.ts
+++ b/packages/agent-test-utils/src/cost-estimator.ts
@@ -1,0 +1,316 @@
+/**
+ * Cost estimation utilities for agent sessions without live API calls.
+ *
+ * Provides:
+ * - Token counting estimation based on text length
+ * - Cost calculation using model pricing tables
+ * - Session cost profiling across multiple runs
+ * - Latency simulation with configurable delays
+ */
+
+// ── Pricing tables ────────────────────────────────────────────────────
+
+export interface ModelPricing {
+  readonly model: string;
+  /** Cost per 1M input tokens in USD */
+  readonly inputCostPer1MTokens: number;
+  /** Cost per 1M output tokens in USD */
+  readonly outputCostPer1MTokens: number;
+  /** Cost per 1M cache-write tokens in USD */
+  readonly cacheWritePer1MTokens?: number;
+  /** Cost per 1M cache-read tokens in USD */
+  readonly cacheReadPer1MTokens?: number;
+}
+
+/** Pricing as of early 2026 — update as Anthropic changes rates. */
+export const MODEL_PRICING: Record<string, ModelPricing> = {
+  "claude-sonnet-4-6": {
+    model: "claude-sonnet-4-6",
+    inputCostPer1MTokens: 3.0,
+    outputCostPer1MTokens: 15.0,
+    cacheWritePer1MTokens: 3.75,
+    cacheReadPer1MTokens: 0.3,
+  },
+  "claude-haiku-4-5": {
+    model: "claude-haiku-4-5",
+    inputCostPer1MTokens: 0.8,
+    outputCostPer1MTokens: 4.0,
+    cacheWritePer1MTokens: 1.0,
+    cacheReadPer1MTokens: 0.08,
+  },
+  "claude-opus-4-5": {
+    model: "claude-opus-4-5",
+    inputCostPer1MTokens: 15.0,
+    outputCostPer1MTokens: 75.0,
+    cacheWritePer1MTokens: 18.75,
+    cacheReadPer1MTokens: 1.5,
+  },
+} as const;
+
+const DEFAULT_MODEL = "claude-sonnet-4-6";
+
+// ── Token estimation ──────────────────────────────────────────────────
+
+/**
+ * Rough token count estimate based on character count.
+ * Uses the ~4 chars/token heuristic for English prose/code.
+ * Not suitable for precise billing — use for test budget calculations.
+ */
+export function estimateTokenCount(text: string): number {
+  if (text.length === 0) return 0;
+  return Math.ceil(text.length / 4);
+}
+
+/**
+ * Estimates input tokens for a typical agent prompt including system prompt overhead.
+ */
+export function estimatePromptTokens(
+  taskDescription: string,
+  systemPromptOverhead = 2000
+): number {
+  return estimateTokenCount(taskDescription) + systemPromptOverhead;
+}
+
+// ── Cost calculation ──────────────────────────────────────────────────
+
+export interface TokenUsageInput {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cacheWriteTokens?: number;
+  readonly cacheReadTokens?: number;
+}
+
+export interface CostBreakdown {
+  readonly model: string;
+  readonly inputCostUsd: number;
+  readonly outputCostUsd: number;
+  readonly cacheWriteCostUsd: number;
+  readonly cacheReadCostUsd: number;
+  readonly totalCostUsd: number;
+}
+
+/**
+ * Calculates the cost for a given token usage without any API calls.
+ */
+export function calculateCost(
+  usage: TokenUsageInput,
+  model = DEFAULT_MODEL
+): CostBreakdown {
+  const pricing = MODEL_PRICING[model] ?? MODEL_PRICING[DEFAULT_MODEL];
+
+  const inputCostUsd = (usage.inputTokens / 1_000_000) * pricing.inputCostPer1MTokens;
+  const outputCostUsd = (usage.outputTokens / 1_000_000) * pricing.outputCostPer1MTokens;
+  const cacheWriteCostUsd =
+    usage.cacheWriteTokens !== undefined && pricing.cacheWritePer1MTokens !== undefined
+      ? (usage.cacheWriteTokens / 1_000_000) * pricing.cacheWritePer1MTokens
+      : 0;
+  const cacheReadCostUsd =
+    usage.cacheReadTokens !== undefined && pricing.cacheReadPer1MTokens !== undefined
+      ? (usage.cacheReadTokens / 1_000_000) * pricing.cacheReadPer1MTokens
+      : 0;
+
+  const totalCostUsd = inputCostUsd + outputCostUsd + cacheWriteCostUsd + cacheReadCostUsd;
+
+  return {
+    model: pricing.model,
+    inputCostUsd,
+    outputCostUsd,
+    cacheWriteCostUsd,
+    cacheReadCostUsd,
+    totalCostUsd,
+  };
+}
+
+/**
+ * Estimates the cost of a session given a task description and expected output size.
+ * Useful for budget planning before running real sessions.
+ */
+export function estimateSessionCost(
+  taskDescription: string,
+  options: {
+    readonly model?: string;
+    readonly expectedOutputTokens?: number;
+    readonly numTurns?: number;
+    readonly systemPromptOverhead?: number;
+  } = {}
+): CostBreakdown {
+  const {
+    model = DEFAULT_MODEL,
+    expectedOutputTokens = 500,
+    numTurns = 5,
+    systemPromptOverhead = 2000,
+  } = options;
+
+  const inputTokens = estimatePromptTokens(taskDescription, systemPromptOverhead) * numTurns;
+  const outputTokens = expectedOutputTokens * numTurns;
+
+  return calculateCost({ inputTokens, outputTokens }, model);
+}
+
+// ── Session cost profiler ─────────────────────────────────────────────
+
+export interface SessionCostProfile {
+  readonly sessionId: string;
+  readonly model: string;
+  readonly usage: TokenUsageInput;
+  readonly breakdown: CostBreakdown;
+  readonly durationMs: number;
+  readonly timestamp: string;
+}
+
+export interface CostProfilerSummary {
+  readonly totalSessions: number;
+  readonly totalCostUsd: number;
+  readonly averageCostUsd: number;
+  readonly totalInputTokens: number;
+  readonly totalOutputTokens: number;
+  readonly mostExpensiveSession: SessionCostProfile | null;
+  readonly cheapestSession: SessionCostProfile | null;
+}
+
+export interface CostProfiler {
+  readonly record: (
+    sessionId: string,
+    usage: TokenUsageInput,
+    durationMs: number,
+    model?: string
+  ) => SessionCostProfile;
+  readonly summary: () => CostProfilerSummary;
+  readonly profiles: () => readonly SessionCostProfile[];
+  readonly reset: () => void;
+}
+
+/**
+ * Creates a session cost profiler for tracking usage across multiple test runs.
+ */
+export function createCostProfiler(): CostProfiler {
+  const profileLog: SessionCostProfile[] = [];
+
+  function record(
+    sessionId: string,
+    usage: TokenUsageInput,
+    durationMs: number,
+    model = DEFAULT_MODEL
+  ): SessionCostProfile {
+    const breakdown = calculateCost(usage, model);
+    const profile: SessionCostProfile = {
+      sessionId,
+      model,
+      usage,
+      breakdown,
+      durationMs,
+      timestamp: new Date().toISOString(),
+    };
+    profileLog.push(profile);
+    return profile;
+  }
+
+  function summary(): CostProfilerSummary {
+    if (profileLog.length === 0) {
+      return {
+        totalSessions: 0,
+        totalCostUsd: 0,
+        averageCostUsd: 0,
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        mostExpensiveSession: null,
+        cheapestSession: null,
+      };
+    }
+
+    const totalCostUsd = profileLog.reduce((sum, p) => sum + p.breakdown.totalCostUsd, 0);
+    const totalInputTokens = profileLog.reduce((sum, p) => sum + p.usage.inputTokens, 0);
+    const totalOutputTokens = profileLog.reduce((sum, p) => sum + p.usage.outputTokens, 0);
+
+    const sorted = [...profileLog].sort(
+      (a, b) => b.breakdown.totalCostUsd - a.breakdown.totalCostUsd
+    );
+
+    return {
+      totalSessions: profileLog.length,
+      totalCostUsd,
+      averageCostUsd: totalCostUsd / profileLog.length,
+      totalInputTokens,
+      totalOutputTokens,
+      mostExpensiveSession: sorted[0] ?? null,
+      cheapestSession: sorted[sorted.length - 1] ?? null,
+    };
+  }
+
+  return {
+    record,
+    summary,
+    profiles(): readonly SessionCostProfile[] {
+      return [...profileLog];
+    },
+    reset(): void {
+      profileLog.length = 0;
+    },
+  };
+}
+
+// ── Budget guard ──────────────────────────────────────────────────────
+
+/**
+ * Returns true if the estimated cost of a session would exceed the budget.
+ * Use this in tests to assert that sessions stay within budget bounds.
+ */
+export function wouldExceedBudget(
+  taskDescription: string,
+  maxBudgetUsd: number,
+  options: {
+    readonly model?: string;
+    readonly expectedOutputTokens?: number;
+    readonly numTurns?: number;
+  } = {}
+): boolean {
+  const estimate = estimateSessionCost(taskDescription, options);
+  return estimate.totalCostUsd > maxBudgetUsd;
+}
+
+// ── Latency simulation ────────────────────────────────────────────────
+
+export interface LatencyProfile {
+  /** Base latency in ms per API call. */
+  readonly baseMs: number;
+  /** Additional ms per 1000 input tokens. */
+  readonly msPerKInputTokens: number;
+  /** Additional ms per 100 output tokens. */
+  readonly msPerHundredOutputTokens: number;
+  /** Random jitter range in ms (±jitterMs). */
+  readonly jitterMs: number;
+}
+
+export const DEFAULT_LATENCY_PROFILE: LatencyProfile = {
+  baseMs: 500,
+  msPerKInputTokens: 100,
+  msPerHundredOutputTokens: 50,
+  jitterMs: 200,
+};
+
+/**
+ * Estimates the expected latency for a given token usage.
+ */
+export function estimateLatency(
+  usage: TokenUsageInput,
+  profile: LatencyProfile = DEFAULT_LATENCY_PROFILE
+): number {
+  const inputLatency = (usage.inputTokens / 1000) * profile.msPerKInputTokens;
+  const outputLatency = (usage.outputTokens / 100) * profile.msPerHundredOutputTokens;
+  return profile.baseMs + inputLatency + outputLatency;
+}
+
+/**
+ * Simulates latency with optional jitter. Returns a promise that resolves after
+ * the simulated delay — use in test helpers to pace async sequences.
+ */
+export async function simulateLatency(
+  usage: TokenUsageInput,
+  profile: LatencyProfile = DEFAULT_LATENCY_PROFILE
+): Promise<number> {
+  const base = estimateLatency(usage, profile);
+  const jitter = (Math.random() * 2 - 1) * profile.jitterMs;
+  const total = Math.max(0, Math.round(base + jitter));
+  await new Promise<void>((resolve) => setTimeout(resolve, total));
+  return total;
+}

--- a/packages/agent-test-utils/src/index.ts
+++ b/packages/agent-test-utils/src/index.ts
@@ -1,0 +1,72 @@
+// Mock Claude client
+export {
+  createMockClaudeClient,
+} from "./mock-claude-client.js";
+export type {
+  MockMode,
+  MockTokenUsage,
+  MockResultMessage,
+  MockClientOptions,
+  MockCallRecord,
+  MockClaudeClient,
+} from "./mock-claude-client.js";
+
+// Session event fixtures
+export {
+  buildMinimalSuccessFixture,
+  buildBugFixFixture,
+  buildFailureFixture,
+  createFixturePlayer,
+  extractToolCalls,
+  compareToolCalls,
+  loadFixtureFromFile,
+  serializeFixture,
+} from "./session-fixtures.js";
+export type {
+  ToolCallRecord,
+  FixtureOptions,
+  FixturePlayer,
+  ToolCallDiff,
+} from "./session-fixtures.js";
+
+// Worktree simulation
+export {
+  createWorktreeSimulator,
+  createWorktreeMocks,
+  assertOperationCalled,
+  assertOperationNotCalled,
+  CLEAN_REPO_FILES,
+  DIRTY_REPO_FILES,
+  CONFLICTED_REPO_FILES,
+} from "./worktree-simulator.js";
+export type {
+  RepoState,
+  SimulatedFile,
+  WorktreeSimulatorOptions,
+  WorktreeSimulator,
+  WorktreeCallRecord,
+  VerificationResult,
+} from "./worktree-simulator.js";
+
+// Cost estimation
+export {
+  estimateTokenCount,
+  estimatePromptTokens,
+  calculateCost,
+  estimateSessionCost,
+  createCostProfiler,
+  wouldExceedBudget,
+  estimateLatency,
+  simulateLatency,
+  MODEL_PRICING,
+  DEFAULT_LATENCY_PROFILE,
+} from "./cost-estimator.js";
+export type {
+  ModelPricing,
+  TokenUsageInput,
+  CostBreakdown,
+  SessionCostProfile,
+  CostProfilerSummary,
+  CostProfiler,
+  LatencyProfile,
+} from "./cost-estimator.js";

--- a/packages/agent-test-utils/src/mock-claude-client.ts
+++ b/packages/agent-test-utils/src/mock-claude-client.ts
@@ -1,0 +1,257 @@
+/**
+ * Mock Claude client for cost-free agent testing.
+ *
+ * Supports two modes:
+ * - replay: return pre-recorded fixture responses in sequence
+ * - deterministic: generate predictable responses based on input
+ *
+ * Also supports error injection for testing error-handling paths.
+ */
+
+import type { SDKMessage, SDKResultMessage } from "@anthropic-ai/claude-agent-sdk";
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export type MockMode = "replay" | "deterministic";
+
+export interface MockTokenUsage {
+  readonly input_tokens: number;
+  readonly output_tokens: number;
+  readonly cache_creation_input_tokens: number;
+  readonly cache_read_input_tokens: number;
+}
+
+export interface MockResultMessage {
+  readonly type: "result";
+  readonly subtype: "success" | "error_max_turns" | "error_during_turn";
+  readonly uuid: string;
+  readonly session_id: string;
+  readonly duration_ms: number;
+  readonly duration_api_ms: number;
+  readonly is_error: boolean;
+  readonly num_turns: number;
+  readonly result: string;
+  readonly stop_reason: string;
+  readonly total_cost_usd: number;
+  readonly usage: MockTokenUsage;
+  readonly modelUsage: Record<string, unknown>;
+  readonly permission_denials: unknown[];
+  readonly errors?: readonly string[];
+}
+
+export interface MockClientOptions {
+  /**
+   * Mode of operation.
+   * - "replay": returns messages from `fixtures` in order, cycling back if exhausted
+   * - "deterministic": generates a minimal success result for every call
+   */
+  readonly mode?: MockMode;
+
+  /**
+   * Pre-recorded message sequences to replay. Each call to `query()` consumes
+   * the next sequence. Sequences cycle once exhausted.
+   */
+  readonly fixtures?: readonly (readonly SDKMessage[])[];
+
+  /**
+   * When set, inject this error on the Nth call (1-based). Useful for testing
+   * retry and error-handling paths.
+   */
+  readonly errorOnCall?: number;
+
+  /**
+   * Error to throw when `errorOnCall` is triggered.
+   */
+  readonly errorToInject?: Error;
+
+  /**
+   * Simulated latency in milliseconds per yielded message. Default: 0.
+   */
+  readonly simulatedLatencyMs?: number;
+
+  /**
+   * Token counts for deterministic mode. Defaults to 1000 input / 200 output.
+   */
+  readonly deterministicTokens?: Readonly<{ input: number; output: number }>;
+
+  /**
+   * Cost per call in deterministic mode. Default: 0.01.
+   */
+  readonly deterministicCostUsd?: number;
+}
+
+export interface MockCallRecord {
+  readonly callIndex: number;
+  readonly prompt: string;
+  readonly model: string;
+  readonly timestamp: string;
+}
+
+// ── Default deterministic result ─────────────────────────────────────
+
+function buildDeterministicResult(
+  callIndex: number,
+  tokens: Readonly<{ input: number; output: number }>,
+  costUsd: number
+): MockResultMessage {
+  return {
+    type: "result",
+    subtype: "success",
+    uuid: `mock-uuid-${callIndex}`,
+    session_id: `mock-session-${callIndex}`,
+    duration_ms: 1000,
+    duration_api_ms: 900,
+    is_error: false,
+    num_turns: 3,
+    result: `Mock task completed successfully (call ${callIndex})`,
+    stop_reason: "end_turn",
+    total_cost_usd: costUsd,
+    usage: {
+      input_tokens: tokens.input,
+      output_tokens: tokens.output,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+    },
+    modelUsage: {},
+    permission_denials: [],
+  };
+}
+
+// ── Mock client factory ───────────────────────────────────────────────
+
+export interface MockClaudeClient {
+  /**
+   * Drop-in replacement for the `query` function from `@anthropic-ai/claude-agent-sdk`.
+   * Returns an async generator that yields SDKMessages.
+   */
+  readonly query: (options: {
+    prompt: string;
+    model?: string;
+    [key: string]: unknown;
+  }) => AsyncGenerator<SDKMessage | SDKResultMessage>;
+
+  /**
+   * History of all calls made to `query`.
+   */
+  readonly calls: readonly MockCallRecord[];
+
+  /**
+   * Reset call history and fixture cursor.
+   */
+  readonly reset: () => void;
+
+  /**
+   * Total simulated cost across all calls.
+   */
+  readonly totalCostUsd: () => number;
+
+  /**
+   * Total simulated token usage across all calls.
+   */
+  readonly totalTokenUsage: () => Readonly<{ input: number; output: number }>;
+}
+
+export function createMockClaudeClient(options: MockClientOptions = {}): MockClaudeClient {
+  const {
+    mode = "deterministic",
+    fixtures = [],
+    errorOnCall,
+    errorToInject = new Error("Injected mock error"),
+    simulatedLatencyMs = 0,
+    deterministicTokens = { input: 1000, output: 200 },
+    deterministicCostUsd = 0.01,
+  } = options;
+
+  let callCount = 0;
+  let fixtureIndex = 0;
+  const callHistory: MockCallRecord[] = [];
+  const costHistory: number[] = [];
+  const tokenHistory: Array<Readonly<{ input: number; output: number }>> = [];
+
+  async function* query(queryOptions: {
+    prompt: string;
+    model?: string;
+    [key: string]: unknown;
+  }): AsyncGenerator<SDKMessage | SDKResultMessage> {
+    callCount += 1;
+    const currentCall = callCount;
+
+    callHistory.push({
+      callIndex: currentCall,
+      prompt: queryOptions.prompt,
+      model: queryOptions.model ?? "unknown",
+      timestamp: new Date().toISOString(),
+    });
+
+    // Inject error if configured
+    if (errorOnCall !== undefined && currentCall === errorOnCall) {
+      throw errorToInject;
+    }
+
+    if (simulatedLatencyMs > 0) {
+      await new Promise<void>((resolve) => setTimeout(resolve, simulatedLatencyMs));
+    }
+
+    if (mode === "replay" && fixtures.length > 0) {
+      // Cycle through fixtures
+      const sequence = fixtures[fixtureIndex % fixtures.length];
+      fixtureIndex += 1;
+
+      for (const message of sequence) {
+        if (simulatedLatencyMs > 0) {
+          await new Promise<void>((resolve) => setTimeout(resolve, simulatedLatencyMs));
+        }
+        yield message;
+      }
+
+      // Track cost from result message if present
+      const resultMsg = sequence.find(
+        (m): m is SDKResultMessage => m.type === "result"
+      );
+      const cost = (resultMsg as SDKResultMessage | undefined)?.total_cost_usd ?? 0;
+      const inputTokens = (resultMsg as SDKResultMessage | undefined)?.usage?.input_tokens ?? 0;
+      const outputTokens = (resultMsg as SDKResultMessage | undefined)?.usage?.output_tokens ?? 0;
+      costHistory.push(cost);
+      tokenHistory.push({ input: inputTokens, output: outputTokens });
+    } else {
+      // Deterministic mode: yield a single success result
+      const result = buildDeterministicResult(
+        currentCall,
+        deterministicTokens,
+        deterministicCostUsd
+      );
+      costHistory.push(deterministicCostUsd);
+      tokenHistory.push({ input: deterministicTokens.input, output: deterministicTokens.output });
+      yield result as unknown as SDKMessage;
+    }
+  }
+
+  function reset(): void {
+    callCount = 0;
+    fixtureIndex = 0;
+    callHistory.length = 0;
+    costHistory.length = 0;
+    tokenHistory.length = 0;
+  }
+
+  function totalCostUsd(): number {
+    return costHistory.reduce((sum, c) => sum + c, 0);
+  }
+
+  function totalTokenUsage(): Readonly<{ input: number; output: number }> {
+    return tokenHistory.reduce(
+      (acc, t) => ({ input: acc.input + t.input, output: acc.output + t.output }),
+      { input: 0, output: 0 }
+    );
+  }
+
+  return {
+    query,
+    get calls(): readonly MockCallRecord[] {
+      return [...callHistory];
+    },
+    reset,
+    totalCostUsd,
+    totalTokenUsage,
+  };
+}

--- a/packages/agent-test-utils/src/session-fixtures.ts
+++ b/packages/agent-test-utils/src/session-fixtures.ts
@@ -1,0 +1,357 @@
+/**
+ * Session event fixtures for testing agent-core without live API calls.
+ *
+ * Provides:
+ * - Pre-built realistic SessionEvent sequences
+ * - Step-through mode for testing event processing
+ * - Fixture loading from JSON files
+ * - Expected vs actual tool call comparison
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { SessionEvent, SessionEventType } from "@mbe/agent-core";
+
+// ── Built-in fixture types ────────────────────────────────────────────
+
+export interface ToolCallRecord {
+  readonly toolName: string;
+  readonly input: Record<string, unknown>;
+  readonly output?: string;
+}
+
+export interface FixtureOptions {
+  readonly sessionId?: string;
+  readonly numTurns?: number;
+  readonly costUsd?: number;
+  readonly inputTokens?: number;
+  readonly outputTokens?: number;
+  readonly durationMs?: number;
+  readonly resultText?: string;
+  readonly toolCalls?: readonly ToolCallRecord[];
+}
+
+// ── Event builder helpers ─────────────────────────────────────────────
+
+function makeTimestamp(offsetMs = 0): string {
+  return new Date(Date.now() + offsetMs).toISOString();
+}
+
+function buildStartEvent(sessionId: string): SessionEvent {
+  return {
+    type: "session:start",
+    timestamp: makeTimestamp(),
+    data: { message: `Session ${sessionId} started` },
+  };
+}
+
+function buildAssistantEvent(text: string, offsetMs = 0): SessionEvent {
+  return {
+    type: "session:assistant",
+    timestamp: makeTimestamp(offsetMs),
+    data: {
+      type: "assistant",
+      message: {
+        id: `msg_${Math.random().toString(36).slice(2, 10)}`,
+        type: "message",
+        role: "assistant",
+        content: [{ type: "text", text }],
+        model: "claude-sonnet-4-6",
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 100, output_tokens: 50 },
+      },
+    } as unknown as SessionEvent["data"],
+  };
+}
+
+function buildToolUseEvent(call: ToolCallRecord, offsetMs = 0): SessionEvent {
+  return {
+    type: "session:tool_use",
+    timestamp: makeTimestamp(offsetMs),
+    data: {
+      type: "tool_use",
+      tool_use: {
+        id: `toolu_${Math.random().toString(36).slice(2, 10)}`,
+        name: call.toolName,
+        input: call.input,
+      },
+    } as unknown as SessionEvent["data"],
+  };
+}
+
+function buildToolResultEvent(call: ToolCallRecord, offsetMs = 0): SessionEvent {
+  return {
+    type: "session:tool_result",
+    timestamp: makeTimestamp(offsetMs),
+    data: {
+      type: "tool_result",
+      tool_use_id: `toolu_${Math.random().toString(36).slice(2, 10)}`,
+      content: call.output ?? "Tool executed successfully",
+    } as unknown as SessionEvent["data"],
+  };
+}
+
+function buildResultEvent(opts: Required<FixtureOptions>): SessionEvent {
+  return {
+    type: "session:result",
+    timestamp: makeTimestamp(opts.durationMs),
+    data: {
+      type: "result",
+      subtype: "success",
+      uuid: `uuid_${opts.sessionId}`,
+      session_id: opts.sessionId,
+      duration_ms: opts.durationMs,
+      duration_api_ms: Math.floor(opts.durationMs * 0.9),
+      is_error: false,
+      num_turns: opts.numTurns,
+      result: opts.resultText,
+      stop_reason: "end_turn",
+      total_cost_usd: opts.costUsd,
+      usage: {
+        input_tokens: opts.inputTokens,
+        output_tokens: opts.outputTokens,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+      modelUsage: {},
+      permission_denials: [],
+    } as unknown as SessionEvent["data"],
+  };
+}
+
+// ── Pre-built fixture sequences ───────────────────────────────────────
+
+const DEFAULT_OPTS: Required<FixtureOptions> = {
+  sessionId: "fixture-session-001",
+  numTurns: 5,
+  costUsd: 0.05,
+  inputTokens: 5000,
+  outputTokens: 1000,
+  durationMs: 3000,
+  resultText: "Task completed successfully",
+  toolCalls: [],
+};
+
+/**
+ * A minimal fixture: just start + result, no tool calls.
+ * Good for testing the happy path of session completion.
+ */
+export function buildMinimalSuccessFixture(opts: FixtureOptions = {}): readonly SessionEvent[] {
+  const o = { ...DEFAULT_OPTS, ...opts };
+  return [
+    buildStartEvent(o.sessionId),
+    buildAssistantEvent("I'll help you with that task."),
+    buildResultEvent(o),
+  ];
+}
+
+/**
+ * A fixture that includes typical Read/Edit/Bash tool calls.
+ * Mirrors what a real agent session looks like when fixing a bug.
+ */
+export function buildBugFixFixture(opts: FixtureOptions = {}): readonly SessionEvent[] {
+  const o = {
+    ...DEFAULT_OPTS,
+    numTurns: 8,
+    costUsd: 0.12,
+    inputTokens: 10000,
+    outputTokens: 2500,
+    durationMs: 8000,
+    resultText: "Fixed the bug by updating the validation logic",
+    toolCalls: [
+      { toolName: "Read", input: { file_path: "/repo/src/auth.ts" }, output: "export function validate() {...}" },
+      { toolName: "Grep", input: { pattern: "validateToken", path: "/repo/src" }, output: "src/auth.ts:12: validateToken" },
+      { toolName: "Edit", input: { file_path: "/repo/src/auth.ts", old_string: "if (token)", new_string: "if (token && token.length > 0)" }, output: "File updated" },
+      { toolName: "Bash", input: { command: "cd /repo && pnpm test --filter auth" }, output: "All 12 tests passed" },
+    ] as ToolCallRecord[],
+    ...opts,
+  };
+
+  const events: SessionEvent[] = [buildStartEvent(o.sessionId)];
+  let offset = 500;
+
+  for (const call of o.toolCalls) {
+    events.push(buildAssistantEvent(`Let me ${call.toolName.toLowerCase()} the relevant files.`, offset));
+    offset += 200;
+    events.push(buildToolUseEvent(call, offset));
+    offset += 100;
+    events.push(buildToolResultEvent(call, offset));
+    offset += 100;
+  }
+
+  events.push(buildAssistantEvent("All changes are complete and tests pass.", offset));
+  events.push(buildResultEvent(o));
+
+  return events;
+}
+
+/**
+ * A fixture representing a failed session (error during turn).
+ */
+export function buildFailureFixture(opts: FixtureOptions = {}): readonly SessionEvent[] {
+  const o = {
+    ...DEFAULT_OPTS,
+    numTurns: 2,
+    costUsd: 0.02,
+    inputTokens: 2000,
+    outputTokens: 300,
+    durationMs: 1500,
+    resultText: "",
+    ...opts,
+  };
+
+  return [
+    buildStartEvent(o.sessionId),
+    buildAssistantEvent("I'll try to complete the task."),
+    {
+      type: "session:error" as SessionEventType,
+      timestamp: makeTimestamp(1000),
+      data: { message: "Rate limit exceeded. Please try again later." },
+    },
+    {
+      type: "session:result",
+      timestamp: makeTimestamp(o.durationMs),
+      data: {
+        type: "result",
+        subtype: "error_during_turn",
+        uuid: `uuid_${o.sessionId}`,
+        session_id: o.sessionId,
+        duration_ms: o.durationMs,
+        duration_api_ms: Math.floor(o.durationMs * 0.9),
+        is_error: true,
+        num_turns: o.numTurns,
+        result: "",
+        stop_reason: "error",
+        total_cost_usd: o.costUsd,
+        usage: {
+          input_tokens: o.inputTokens,
+          output_tokens: o.outputTokens,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+        modelUsage: {},
+        permission_denials: [],
+        errors: ["Rate limit exceeded. Please try again later."],
+      } as unknown as SessionEvent["data"],
+    },
+  ];
+}
+
+// ── Step-through player ───────────────────────────────────────────────
+
+export interface FixturePlayer {
+  /** Returns the next event, or undefined if exhausted. */
+  readonly next: () => SessionEvent | undefined;
+  /** Returns true if there are more events. */
+  readonly hasMore: () => boolean;
+  /** Resets to the beginning of the fixture. */
+  readonly reset: () => void;
+  /** Returns all remaining events at once. */
+  readonly drainAll: () => readonly SessionEvent[];
+  /** Number of events already consumed. */
+  readonly position: () => number;
+}
+
+/**
+ * Creates a step-through player for a fixture sequence.
+ * Useful for testing event-by-event processing logic.
+ */
+export function createFixturePlayer(events: readonly SessionEvent[]): FixturePlayer {
+  let cursor = 0;
+
+  return {
+    next(): SessionEvent | undefined {
+      if (cursor >= events.length) return undefined;
+      const event = events[cursor];
+      cursor += 1;
+      return event;
+    },
+    hasMore(): boolean {
+      return cursor < events.length;
+    },
+    reset(): void {
+      cursor = 0;
+    },
+    drainAll(): readonly SessionEvent[] {
+      const remaining = events.slice(cursor);
+      cursor = events.length;
+      return remaining;
+    },
+    position(): number {
+      return cursor;
+    },
+  };
+}
+
+// ── Tool call comparison ──────────────────────────────────────────────
+
+export interface ToolCallDiff {
+  readonly matched: readonly ToolCallRecord[];
+  readonly missing: readonly ToolCallRecord[];
+  readonly unexpected: readonly ToolCallRecord[];
+  readonly passed: boolean;
+}
+
+/**
+ * Extracts tool_use events from a fixture sequence.
+ */
+export function extractToolCalls(events: readonly SessionEvent[]): readonly ToolCallRecord[] {
+  return events
+    .filter((e) => e.type === "session:tool_use")
+    .map((e) => {
+      const data = e.data as { tool_use?: { name: string; input: Record<string, unknown> } };
+      return {
+        toolName: data.tool_use?.name ?? "unknown",
+        input: data.tool_use?.input ?? {},
+      };
+    });
+}
+
+/**
+ * Compares expected vs actual tool calls.
+ * Matching is by toolName only — use for asserting that specific tools were invoked.
+ */
+export function compareToolCalls(
+  expected: readonly ToolCallRecord[],
+  actual: readonly ToolCallRecord[]
+): ToolCallDiff {
+  const actualNames = actual.map((c) => c.toolName);
+  const expectedNames = expected.map((c) => c.toolName);
+
+  const matched = expected.filter((e) => actualNames.includes(e.toolName));
+  const missing = expected.filter((e) => !actualNames.includes(e.toolName));
+  const unexpected = actual.filter((a) => !expectedNames.includes(a.toolName));
+
+  return {
+    matched,
+    missing,
+    unexpected,
+    passed: missing.length === 0 && unexpected.length === 0,
+  };
+}
+
+// ── JSON fixture loading ──────────────────────────────────────────────
+
+/**
+ * Loads a session fixture from a JSON file on disk.
+ * Useful for recording real API responses and replaying them.
+ */
+export function loadFixtureFromFile(filePath: string): readonly SessionEvent[] {
+  const absolutePath = resolve(filePath);
+  const raw = readFileSync(absolutePath, "utf-8");
+  const parsed = JSON.parse(raw) as unknown;
+
+  if (!Array.isArray(parsed)) {
+    throw new TypeError(`Fixture file must contain a JSON array: ${absolutePath}`);
+  }
+
+  return parsed as SessionEvent[];
+}
+
+/**
+ * Serializes a fixture sequence to a JSON string suitable for saving.
+ */
+export function serializeFixture(events: readonly SessionEvent[]): string {
+  return JSON.stringify(events, null, 2);
+}

--- a/packages/agent-test-utils/src/worktree-simulator.ts
+++ b/packages/agent-test-utils/src/worktree-simulator.ts
@@ -1,0 +1,254 @@
+/**
+ * Worktree simulation helpers for cost-free agent testing.
+ *
+ * Provides in-memory git operation mocks with predictable return values.
+ * Three pre-built repo states: clean, dirty (uncommitted changes), conflicted.
+ */
+
+import type { WorktreeInfo } from "@mbe/agent-core";
+
+// ── Repo state types ──────────────────────────────────────────────────
+
+export type RepoState = "clean" | "dirty" | "conflicted";
+
+export interface SimulatedFile {
+  readonly path: string;
+  readonly content: string;
+  readonly status?: "modified" | "added" | "deleted" | "conflicted";
+}
+
+export interface WorktreeSimulatorOptions {
+  readonly repoPath?: string;
+  readonly baseBranch?: string;
+  readonly branchName?: string;
+  readonly state?: RepoState;
+  readonly files?: readonly SimulatedFile[];
+  /** Simulate a failure on createWorktree. */
+  readonly failOnCreate?: boolean;
+  /** Simulate a failure on pushBranch. */
+  readonly failOnPush?: boolean;
+  /** Number of times push should fail before succeeding (for retry testing). */
+  readonly pushFailCount?: number;
+}
+
+export interface VerificationResult {
+  readonly passed: boolean;
+  readonly lintOk: boolean;
+  readonly typecheckOk: boolean;
+  readonly testsOk: boolean;
+}
+
+// ── Default repo fixtures ─────────────────────────────────────────────
+
+export const CLEAN_REPO_FILES: readonly SimulatedFile[] = [
+  { path: "src/index.ts", content: 'export const version = "1.0.0";', status: "modified" },
+  { path: "src/utils.ts", content: "export function identity<T>(x: T): T { return x; }" },
+  { path: "package.json", content: '{"name": "test-repo", "version": "1.0.0"}' },
+];
+
+export const DIRTY_REPO_FILES: readonly SimulatedFile[] = [
+  ...CLEAN_REPO_FILES,
+  { path: "src/new-feature.ts", content: "export function newFeature() {}", status: "added" },
+  { path: "src/old-code.ts", content: "", status: "deleted" },
+];
+
+export const CONFLICTED_REPO_FILES: readonly SimulatedFile[] = [
+  {
+    path: "src/index.ts",
+    content: [
+      "<<<<<<< HEAD",
+      'export const version = "2.0.0";',
+      "=======",
+      'export const version = "1.5.0";',
+      ">>>>>>> feature-branch",
+    ].join("\n"),
+    status: "conflicted",
+  },
+  { path: "src/utils.ts", content: "export function identity<T>(x: T): T { return x; }" },
+];
+
+function getDefaultFiles(state: RepoState): readonly SimulatedFile[] {
+  if (state === "dirty") return DIRTY_REPO_FILES;
+  if (state === "conflicted") return CONFLICTED_REPO_FILES;
+  return CLEAN_REPO_FILES;
+}
+
+// ── Simulator interface ───────────────────────────────────────────────
+
+export interface WorktreeCallRecord {
+  readonly operation: string;
+  readonly args: readonly unknown[];
+  readonly timestamp: string;
+}
+
+export interface WorktreeSimulator {
+  /** Simulates `createWorktree`. Returns a WorktreeInfo or throws if failOnCreate. */
+  readonly createWorktree: (repoPath: string, taskDescription: string) => Promise<WorktreeInfo>;
+  /** Simulates `removeWorktree`. */
+  readonly removeWorktree: (repoPath: string, worktreePath: string) => Promise<void>;
+  /** Simulates `hasChanges`. Returns true for dirty/conflicted repos. */
+  readonly hasChanges: (worktreePath: string) => Promise<boolean>;
+  /** Simulates `commitChanges`. Returns a deterministic commit sha. */
+  readonly commitChanges: (worktreePath: string, message?: string) => Promise<string>;
+  /** Simulates `pushBranch`. May fail based on failOnPush / pushFailCount. */
+  readonly pushBranch: (repoPath: string, branchName: string) => Promise<void>;
+  /** Simulates `runVerification`. Returns passed:true for clean/dirty repos. */
+  readonly runVerification: (worktreePath: string) => Promise<VerificationResult>;
+  /** Returns all recorded operation calls. */
+  readonly calls: () => readonly WorktreeCallRecord[];
+  /** Resets call history and push failure counter. */
+  readonly reset: () => void;
+  /** Returns the current state of simulated files. */
+  readonly files: () => readonly SimulatedFile[];
+  /** Returns the WorktreeInfo for the simulated worktree. */
+  readonly worktreeInfo: () => WorktreeInfo;
+}
+
+// ── Factory ───────────────────────────────────────────────────────────
+
+export function createWorktreeSimulator(options: WorktreeSimulatorOptions = {}): WorktreeSimulator {
+  const {
+    repoPath = "/mock-repo",
+    branchName = "agent/mock-task-abc123",
+    state = "clean",
+    files = getDefaultFiles(state),
+    failOnCreate = false,
+    failOnPush = false,
+    pushFailCount = 0,
+  } = options;
+
+  const worktreePath = `${repoPath}/.agent-worktrees/${branchName.replace(/\//g, "-")}`;
+  const callLog: WorktreeCallRecord[] = [];
+  let pushAttempts = 0;
+
+  function record(operation: string, ...args: unknown[]): void {
+    callLog.push({
+      operation,
+      args: args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))),
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  const info: WorktreeInfo = {
+    path: worktreePath,
+    branchName,
+    mode: "full",
+  };
+
+  return {
+    async createWorktree(rp: string, taskDesc: string): Promise<WorktreeInfo> {
+      record("createWorktree", rp, taskDesc);
+      if (failOnCreate) {
+        throw new Error("git worktree add failed: no space left on device");
+      }
+      return info;
+    },
+
+    async removeWorktree(rp: string, wp: string): Promise<void> {
+      record("removeWorktree", rp, wp);
+    },
+
+    async hasChanges(wp: string): Promise<boolean> {
+      record("hasChanges", wp);
+      return state !== "clean";
+    },
+
+    async commitChanges(wp: string, message?: string): Promise<string> {
+      record("commitChanges", wp, message ?? "chore: agent changes");
+      return "abc1234def5678";
+    },
+
+    async pushBranch(rp: string, bn: string): Promise<void> {
+      record("pushBranch", rp, bn);
+      pushAttempts += 1;
+
+      if (failOnPush && pushAttempts <= pushFailCount) {
+        throw new Error(`push failed (attempt ${pushAttempts}/${pushFailCount}): connection reset`);
+      }
+    },
+
+    async runVerification(wp: string): Promise<VerificationResult> {
+      record("runVerification", wp);
+      const hasConflicts = state === "conflicted";
+      return {
+        passed: !hasConflicts,
+        lintOk: !hasConflicts,
+        typecheckOk: !hasConflicts,
+        testsOk: !hasConflicts,
+      };
+    },
+
+    calls(): readonly WorktreeCallRecord[] {
+      return [...callLog];
+    },
+
+    reset(): void {
+      callLog.length = 0;
+      pushAttempts = 0;
+    },
+
+    files(): readonly SimulatedFile[] {
+      return files;
+    },
+
+    worktreeInfo(): WorktreeInfo {
+      return info;
+    },
+  };
+}
+
+// ── Vitest-compatible mock factory ───────────────────────────────────
+
+/**
+ * Returns a plain object of vi.fn() mocks shaped like the worktree-manager module.
+ * Use this when you want to `vi.mock("../worktree-manager.js", () => createWorktreeMocks())`.
+ */
+export function createWorktreeMocks(
+  simulator: WorktreeSimulator = createWorktreeSimulator()
+): Record<string, (...args: unknown[]) => unknown> {
+  return {
+    createWorktree: (...args: unknown[]) =>
+      simulator.createWorktree(args[0] as string, args[1] as string),
+    removeWorktree: (...args: unknown[]) =>
+      simulator.removeWorktree(args[0] as string, args[1] as string),
+    hasChanges: (...args: unknown[]) => simulator.hasChanges(args[0] as string),
+    commitChanges: (...args: unknown[]) =>
+      simulator.commitChanges(args[0] as string, args[1] as string | undefined),
+    pushBranch: (...args: unknown[]) =>
+      simulator.pushBranch(args[0] as string, args[1] as string),
+    runVerification: (...args: unknown[]) => simulator.runVerification(args[0] as string),
+  };
+}
+
+// ── Test assertion helpers ────────────────────────────────────────────
+
+/**
+ * Asserts that a specific worktree operation was called at least once.
+ */
+export function assertOperationCalled(
+  simulator: WorktreeSimulator,
+  operation: string
+): void {
+  const found = simulator.calls().some((c) => c.operation === operation);
+  if (!found) {
+    throw new Error(
+      `Expected worktree operation "${operation}" to have been called, but it was not.\n` +
+      `Actual calls: ${simulator.calls().map((c) => c.operation).join(", ") || "(none)"}`
+    );
+  }
+}
+
+/**
+ * Asserts that a specific worktree operation was NOT called.
+ */
+export function assertOperationNotCalled(
+  simulator: WorktreeSimulator,
+  operation: string
+): void {
+  const found = simulator.calls().some((c) => c.operation === operation);
+  if (found) {
+    throw new Error(
+      `Expected worktree operation "${operation}" NOT to have been called, but it was.`
+    );
+  }
+}

--- a/packages/agent-test-utils/tsconfig.json
+++ b/packages/agent-test-utils/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@mbe/config/typescript/node",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/agent-test-utils/vitest.config.ts
+++ b/packages/agent-test-utils/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts", "src/index.ts"],
+      thresholds: {
+        lines: 80,
+        branches: 80,
+        functions: 80,
+        statements: 80,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -411,6 +411,34 @@ importers:
         specifier: 'catalog:'
         version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(jsdom@29.0.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
+  packages/agent-test-utils:
+    dependencies:
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.2.92
+        version: 0.2.92(zod@4.3.6)
+      '@mbe/agent-core':
+        specifier: workspace:*
+        version: link:../agent-core
+      '@mbe/types':
+        specifier: workspace:*
+        version: link:../types
+    devDependencies:
+      '@mbe/config':
+        specifier: workspace:*
+        version: link:../config
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.5.2
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.2(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(jsdom@29.0.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(jsdom@29.0.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/api-client:
     dependencies:
       '@mbe/types':
@@ -1227,11 +1255,6 @@ packages:
     resolution: {integrity: sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.28.6':
-    resolution: {integrity: sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   '@babel/parser@7.29.2':
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
@@ -1658,10 +1681,6 @@ packages:
 
   '@babel/traverse@7.29.0':
     resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.28.6':
-    resolution: {integrity: sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
@@ -8413,8 +8432,8 @@ snapshots:
 
   '@babel/generator@7.28.6':
     dependencies:
-      '@babel/parser': 7.28.6
-      '@babel/types': 7.28.6
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -8482,7 +8501,7 @@ snapshots:
   '@babel/helper-module-imports@7.28.6':
     dependencies:
       '@babel/traverse': 7.28.6
-      '@babel/types': 7.28.6
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8543,11 +8562,7 @@ snapshots:
   '@babel/helpers@7.28.6':
     dependencies:
       '@babel/template': 7.28.6
-      '@babel/types': 7.28.6
-
-  '@babel/parser@7.28.6':
-    dependencies:
-      '@babel/types': 7.28.6
+      '@babel/types': 7.29.0
 
   '@babel/parser@7.29.2':
     dependencies:
@@ -9075,17 +9090,17 @@ snapshots:
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.28.6
-      '@babel/parser': 7.28.6
-      '@babel/types': 7.28.6
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
 
   '@babel/traverse@7.28.6':
     dependencies:
       '@babel/code-frame': 7.28.6
       '@babel/generator': 7.28.6
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.6
+      '@babel/parser': 7.29.2
       '@babel/template': 7.28.6
-      '@babel/types': 7.28.6
+      '@babel/types': 7.29.0
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -9101,11 +9116,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.28.6':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.29.0':
     dependencies:


### PR DESCRIPTION
Closes #366

## Summary
- Scaffolded `packages/agent-test-utils` as a private ESM workspace package (`@mbe/agent-test-utils`)
- Mock Claude client with deterministic mode, record/replay mode, error injection (rate limits, timeouts), and call history tracking
- Session event fixtures with pre-built sequences (minimal success, bug-fix with tool calls, failure), step-through player, and tool call diff comparison
- Worktree simulator with clean/dirty/conflicted repo states, failure injection, and a vitest mock factory
- Cost estimator with model pricing tables, token estimation, session budget guards, cost profiler, and latency simulation
- README with usage examples for all four modules

## Test plan
- [x] 79 unit tests covering all four modules
- [x] TypeScript strict typecheck passes
- [x] ESLint passes with no errors
- [x] 80% coverage thresholds configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)