### PR TITLE
refactor: extract shared NDJSON streaming utility from duplicate hooks

### DIFF
--- a/apps/gen/package.json
+++ b/apps/gen/package.json
@@ -27,6 +27,7 @@
   ],
   "dependencies": {
     "@json-render/react": "^0.16.0",
+    "@mbe/api-client": "workspace:*",
     "@mbe/auth": "workspace:*",
     "@mbe/rialto": "workspace:*",
     "@mbe/rialto-catalog": "workspace:*",

--- a/apps/gen/src/hooks/useGenStream.ts
+++ b/apps/gen/src/hooks/useGenStream.ts
@@ -2,6 +2,7 @@ import { useState, useRef, useCallback } from "react";
 import { flatToTree } from "@json-render/react";
 import type { Spec } from "@json-render/react";
 import { useAuth } from "@mbe/auth/react";
+import { streamNDJSON } from "@mbe/api-client/streaming";
 
 // FlatElement is the element type consumed by flatToTree. We derive it from the
 // function signature rather than importing from @json-render/core (not a direct dep).
@@ -21,6 +22,26 @@ export interface UseGenStreamReturn {
   send: (prompt: string, context?: Record<string, unknown>) => Promise<void>;
   clear: () => void;
   stop: () => void;
+}
+
+/** Blocked prop keys for XSS prevention (CONTENT-01). */
+const BLOCKED_PROP_KEYS = new Set(["dangerouslySetInnerHTML", "ref"]);
+
+/**
+ * Sanitize parsed element props to prevent XSS (CONTENT-01).
+ * Returns a new object with dangerous keys removed.
+ */
+function sanitizeProps(parsed: Record<string, unknown>): Record<string, unknown> {
+  if (!parsed.props || typeof parsed.props !== "object") return parsed;
+
+  const props = parsed.props as Record<string, unknown>;
+  const safeProps: Record<string, unknown> = {};
+  for (const key of Object.keys(props)) {
+    if (!key.startsWith("on") && !BLOCKED_PROP_KEYS.has(key)) {
+      safeProps[key] = props[key];
+    }
+  }
+  return { ...parsed, props: safeProps };
 }
 
 /**
@@ -73,97 +94,24 @@ export function useGenStream({
       const accumulatedRawLines: string[] = [];
 
       try {
-        const response = await fetch(api, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
-          },
-          body: JSON.stringify({ prompt, context }),
+        const stream = streamNDJSON<Record<string, unknown>>({
+          url: api,
+          body: { prompt, context },
+          headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : undefined,
           signal: controller.signal,
         });
 
-        if (!response.ok) {
-          throw new Error(`Request failed: ${response.statusText}`);
-        }
+        for await (const parsed of stream) {
+          const sanitized = sanitizeProps(parsed);
+          const rawLine = JSON.stringify(sanitized);
 
-        if (!response.body) {
-          throw new Error("Response body is not readable");
-        }
+          accumulatedRawLines.push(rawLine);
+          setRawLines((prev) => [...prev, rawLine]);
 
-        const reader = response.body.getReader();
-        const decoder = new TextDecoder();
-        let buffer = "";
-
-        while (true) {
-          const { done, value } = await reader.read();
-
-          if (done) {
-            break;
-          }
-
-          buffer += decoder.decode(value, { stream: true });
-
-          // Process complete lines from the buffer
-          const lines = buffer.split("\n");
-          // Keep the last (possibly incomplete) chunk in the buffer
-          buffer = lines.pop() ?? "";
-
-          for (const line of lines) {
-            const trimmed = line.trim();
-            if (!trimmed) continue;
-
-            accumulatedRawLines.push(trimmed);
-            setRawLines((prev) => [...prev, trimmed]);
-
-            try {
-              const parsed = JSON.parse(trimmed) as Record<string, unknown>;
-
-              // CONTENT-01: Sanitize element props to prevent XSS
-              if (parsed.props && typeof parsed.props === "object") {
-                const props = parsed.props as Record<string, unknown>;
-                for (const key of Object.keys(props)) {
-                  // Block dangerous event handlers and internal React props
-                  if (key.startsWith("on") || key === "dangerouslySetInnerHTML" || key === "ref") {
-                    delete props[key];
-                  }
-                }
-              }
-
-              // Treat as a flat element; cast to FlatElement for spec assembly
-              accumulatedElements.push(parsed as unknown as FlatElement);
-              const updatedSpec = flatToTree([...accumulatedElements]);
-              setSpec(updatedSpec);
-            } catch {
-              // Skip malformed JSON lines
-            }
-          }
-        }
-
-        // Process any remaining buffered content
-        if (buffer.trim()) {
-          const trimmedBuffer = buffer.trim();
-          accumulatedRawLines.push(trimmedBuffer);
-          setRawLines((prev) => [...prev, trimmedBuffer]);
-          try {
-            const parsed = JSON.parse(trimmedBuffer) as Record<string, unknown>;
-
-            // CONTENT-01: Sanitize element props to prevent XSS
-            if (parsed.props && typeof parsed.props === "object") {
-              const props = parsed.props as Record<string, unknown>;
-              for (const key of Object.keys(props)) {
-                if (key.startsWith("on") || key === "dangerouslySetInnerHTML" || key === "ref") {
-                  delete props[key];
-                }
-              }
-            }
-
-            accumulatedElements.push(parsed as unknown as FlatElement);
-            const finalSpec = flatToTree([...accumulatedElements]);
-            setSpec(finalSpec);
-          } catch {
-            // Skip malformed JSON lines
-          }
+          // Treat as a flat element; cast to FlatElement for spec assembly
+          accumulatedElements.push(sanitized as unknown as FlatElement);
+          const updatedSpec = flatToTree([...accumulatedElements]);
+          setSpec(updatedSpec);
         }
 
         // Build the final spec and notify completion — pass local rawLines array

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
-    "./users": "./src/users.ts"
+    "./users": "./src/users.ts",
+    "./streaming": "./src/streaming.ts"
   },
   "scripts": {
     "lint": "eslint src/",

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -8,6 +8,7 @@ export { TablesClient, type ListTablesParams } from "./tables.js";
 export { GuestsClient, type ListGuestsParams, type SearchGuestsParams, type FindOrCreateGuestRequest } from "./guests.js";
 export { FloorPlansClient, type ListFloorPlansParams } from "./floor-plans.js";
 export { AvailabilityClient, HoldsClient, type GetTimeSlotsParams, type GetDatesParams } from "./availability.js";
+export { streamNDJSON, type StreamConfig } from "./streaming.js";
 
 import { ApiClient } from "./client.js";
 import { UsersClient } from "./users.js";

--- a/packages/api-client/src/streaming.ts
+++ b/packages/api-client/src/streaming.ts
@@ -1,0 +1,98 @@
+/**
+ * Shared NDJSON streaming utility.
+ *
+ * Handles raw fetch with ReadableStream, newline-delimited JSON parsing with
+ * buffer for incomplete chunks, and proper error propagation. Used by both
+ * useGenStream (apps/gen) and useGenCopilotStream (packages/rialto).
+ */
+
+export interface StreamConfig {
+  /** URL to POST to */
+  url: string;
+  /** Request body (will be JSON-stringified) */
+  body: unknown;
+  /** Extra headers merged with Content-Type and Authorization */
+  headers?: Record<string, string>;
+  /** AbortSignal for cancellation */
+  signal?: AbortSignal;
+}
+
+/**
+ * Stream NDJSON from a POST endpoint, yielding one parsed object per line.
+ *
+ * Callers are responsible for:
+ * - Building the request body
+ * - Handling AbortError (partial results are fine)
+ * - Domain-specific processing of each yielded object
+ *
+ * @example
+ * ```ts
+ * for await (const obj of streamNDJSON<MyType>({ url, body, signal })) {
+ *   // process each line
+ * }
+ * ```
+ */
+export async function* streamNDJSON<T>(config: StreamConfig): AsyncGenerator<T> {
+  const response = await fetch(config.url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...config.headers,
+    },
+    body: JSON.stringify(config.body),
+    signal: config.signal,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Request failed: ${response.statusText}`);
+  }
+
+  if (!response.body) {
+    throw new Error("Response body is not readable");
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+
+      if (done) {
+        break;
+      }
+
+      buffer += decoder.decode(value, { stream: true });
+
+      // Process complete lines from the buffer
+      const lines = buffer.split("\n");
+      // Keep the last (possibly incomplete) chunk in the buffer
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+
+        try {
+          const parsed = JSON.parse(trimmed) as T;
+          yield parsed;
+        } catch {
+          // Skip malformed JSON lines
+        }
+      }
+    }
+
+    // Process any remaining buffered content
+    if (buffer.trim()) {
+      try {
+        const parsed = JSON.parse(buffer.trim()) as T;
+        yield parsed;
+      } catch {
+        // Skip malformed JSON lines
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/packages/rialto/package.json
+++ b/packages/rialto/package.json
@@ -95,6 +95,7 @@
     }
   ],
   "dependencies": {
-    "@json-render/react": "^0.16.0"
+    "@json-render/react": "^0.16.0",
+    "@mbe/api-client": "workspace:*"
   }
 }

--- a/packages/rialto/src/components/GenCopilot/useGenCopilotStream.ts
+++ b/packages/rialto/src/components/GenCopilot/useGenCopilotStream.ts
@@ -1,6 +1,7 @@
 import { useState, useRef, useCallback } from "react";
 import { flatToTree } from "@json-render/react";
 import type { Spec } from "@json-render/react";
+import { streamNDJSON } from "@mbe/api-client/streaming";
 import type { DomainContext } from "./GenCopilot.js";
 
 // FlatElement is the element type consumed by flatToTree. We derive it from the
@@ -35,6 +36,26 @@ function buildPromptWithContext(userPrompt: string, domainContext: DomainContext
     .join("\n\n");
 
   return `You are generating UI for a hospitality management app. Use these data schemas:\n\n${schemasText}\n\nUser request: ${userPrompt}`;
+}
+
+/** Blocked prop keys for XSS prevention (CONTENT-01). */
+const BLOCKED_PROP_KEYS = new Set(["dangerouslySetInnerHTML", "ref"]);
+
+/**
+ * Sanitize parsed element props to prevent XSS (CONTENT-01).
+ * Returns a new object with dangerous keys removed.
+ */
+function sanitizeProps(parsed: Record<string, unknown>): Record<string, unknown> {
+  if (!parsed.props || typeof parsed.props !== "object") return parsed;
+
+  const props = parsed.props as Record<string, unknown>;
+  const safeProps: Record<string, unknown> = {};
+  for (const key of Object.keys(props)) {
+    if (!key.startsWith("on") && !BLOCKED_PROP_KEYS.has(key)) {
+      safeProps[key] = props[key];
+    }
+  }
+  return { ...parsed, props: safeProps };
 }
 
 /**
@@ -92,90 +113,20 @@ export function useGenCopilotStream({
         const token = await Promise.resolve(getAccessTokenRef.current());
         const prompt = buildPromptWithContext(userPrompt, domainContextRef.current);
 
-        const response = await fetch(api, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            ...(token ? { Authorization: `Bearer ${token}` } : {}),
-          },
-          body: JSON.stringify({ prompt }),
+        const stream = streamNDJSON<Record<string, unknown>>({
+          url: api,
+          body: { prompt },
+          headers: token ? { Authorization: `Bearer ${token}` } : undefined,
           signal: controller.signal,
         });
 
-        if (!response.ok) {
-          throw new Error(`Request failed: ${response.statusText}`);
-        }
+        for await (const parsed of stream) {
+          const sanitized = sanitizeProps(parsed);
 
-        if (!response.body) {
-          throw new Error("Response body is not readable");
-        }
-
-        const reader = response.body.getReader();
-        const decoder = new TextDecoder();
-        let buffer = "";
-
-        while (true) {
-          const { done, value } = await reader.read();
-
-          if (done) {
-            break;
-          }
-
-          buffer += decoder.decode(value, { stream: true });
-
-          // Process complete lines from the buffer
-          const lines = buffer.split("\n");
-          // Keep the last (possibly incomplete) chunk in the buffer
-          buffer = lines.pop() ?? "";
-
-          for (const line of lines) {
-            const trimmed = line.trim();
-            if (!trimmed) continue;
-
-            try {
-              const parsed = JSON.parse(trimmed) as Record<string, unknown>;
-
-              // CONTENT-01: Sanitize element props to prevent XSS
-              if (parsed.props && typeof parsed.props === "object") {
-                const props = parsed.props as Record<string, unknown>;
-                for (const key of Object.keys(props)) {
-                  if (key.startsWith("on") || key === "dangerouslySetInnerHTML" || key === "ref") {
-                    delete props[key];
-                  }
-                }
-              }
-
-              // Treat as a flat element; cast to FlatElement for spec assembly
-              accumulatedElements.push(parsed as unknown as FlatElement);
-              const updatedSpec = flatToTree([...accumulatedElements]);
-              setSpec(updatedSpec);
-            } catch {
-              // Skip malformed JSON lines
-            }
-          }
-        }
-
-        // Process any remaining buffered content
-        if (buffer.trim()) {
-          try {
-            const parsed = JSON.parse(buffer.trim()) as Record<string, unknown>;
-
-            // CONTENT-01: Sanitize element props to prevent XSS
-            if (parsed.props && typeof parsed.props === "object") {
-              const props = parsed.props as Record<string, unknown>;
-              for (const key of Object.keys(props)) {
-                if (key.startsWith("on") || key === "dangerouslySetInnerHTML" || key === "ref") {
-                  delete props[key];
-                }
-              }
-            }
-
-            accumulatedElements.push(parsed as unknown as FlatElement);
-            const finalSpec = flatToTree([...accumulatedElements]);
-            setSpec(finalSpec);
-          } catch {
-            // Skip malformed JSON lines
-          }
+          // Treat as a flat element; cast to FlatElement for spec assembly
+          accumulatedElements.push(sanitized as unknown as FlatElement);
+          const updatedSpec = flatToTree([...accumulatedElements]);
+          setSpec(updatedSpec);
         }
 
         // Build the final spec and notify completion

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       '@json-render/react':
         specifier: ^0.16.0
         version: 0.16.0(react@19.2.4)(zod@4.3.6)
+      '@mbe/api-client':
+        specifier: workspace:*
+        version: link:../../packages/api-client
       '@mbe/auth':
         specifier: workspace:*
         version: link:../../packages/auth
@@ -624,6 +627,9 @@ importers:
       '@json-render/react':
         specifier: ^0.16.0
         version: 0.16.0(react@19.2.4)(zod@4.3.6)
+      '@mbe/api-client':
+        specifier: workspace:*
+        version: link:../api-client
     devDependencies:
       '@mbe/config':
         specifier: workspace:*


### PR DESCRIPTION
## Summary
- Created `packages/api-client/src/streaming.ts` with `streamNDJSON<T>()` async generator
- Refactored `useGenStream.ts` and `useGenCopilotStream.ts` to use shared utility
- Eliminated 100+ lines of duplicated streaming logic

## Test plan
- [x] Typecheck passes
- [ ] CI passes

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)