### PR TITLE
docs: add CLAUDE.md for mcp-server, feature-flags, and CLI

### DIFF
--- a/packages/feature-flags/CLAUDE.md
+++ b/packages/feature-flags/CLAUDE.md
@@ -1,0 +1,63 @@
+# @mbe/feature-flags
+
+Lightweight feature flag evaluation library. Flags are stored in Cloudflare KV (managed by the edge router) and injected into service requests via the `X-Feature-Flags` header.
+
+## Structure
+
+```
+src/
+└── index.ts   # Types, evaluation functions, header parsing
+```
+
+## API
+
+### Types
+
+```typescript
+interface FeatureFlag {
+  enabled: boolean;
+  percentage: number;  // 0-100 rollout percentage
+}
+
+type FeatureFlagMap = Record<string, FeatureFlag>;
+```
+
+### Functions
+
+| Function | Signature | Purpose |
+|----------|-----------|---------|
+| `isEnabled` | `(flags, flagName) => boolean` | Check if flag is enabled (100% rollout only) |
+| `isEnabledForSeed` | `(flags, flagName, seed) => boolean` | Check with percentage rollout using consistent hashing |
+| `parseFeatureFlags` | `(header) => FeatureFlagMap` | Parse `X-Feature-Flags` JSON header (safe, returns `{}` on failure) |
+
+### Percentage Rollout
+
+Uses a deterministic hash of the seed string (typically user IP or ID) to decide inclusion. The same seed always gets the same result for a given percentage, ensuring consistent user experience.
+
+## Usage
+
+### In Fastify services
+
+```typescript
+import { parseFeatureFlags, isEnabled } from "@mbe/feature-flags";
+
+const flags = parseFeatureFlags(request.headers["x-feature-flags"]);
+if (isEnabled(flags, "new-booking-flow")) {
+  // New behavior
+}
+```
+
+### Flag lifecycle
+
+1. **Create/update**: `PUT /api/flags/<name>` on the edge router (requires `ADMIN_TOKEN`)
+2. **Storage**: Cloudflare KV (`HEALTH_STATE` namespace, key `flags/all`)
+3. **Distribution**: Edge router reads KV, evaluates per-request, sets `X-Feature-Flags` header
+4. **Consumption**: Services parse header with `parseFeatureFlags()`
+
+## Commands
+
+```bash
+pnpm build       # Compile TypeScript
+pnpm lint        # ESLint
+pnpm typecheck   # Type check
+```

--- a/packages/mcp-server/CLAUDE.md
+++ b/packages/mcp-server/CLAUDE.md
@@ -1,0 +1,65 @@
+# @mbe/mcp-server
+
+Infrastructure MCP server that gives Claude Code access to live system state via stdio transport.
+
+## Structure
+
+```
+src/
+├── index.ts              # Server setup, tool registry, request handler
+└── tools/
+    ├── ci.ts             # ci_run_status — GitHub Actions workflow status
+    ├── database.ts       # db_list_tables, db_migration_status — Postgres introspection
+    ├── deploy_status.ts  # deploy_status — DigitalOcean App Platform status
+    ├── git.ts            # git_workflow_status — branch, uncommitted changes, CI
+    ├── health.ts         # service_health_check — backend service health
+    └── pulumi.ts         # pulumi_stack_outputs — Pulumi stack exports
+```
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `pulumi_stack_outputs` | List all outputs from the Pulumi production stack |
+| `service_health_check` | Check health of users, reservations, agent services |
+| `ci_run_status` | Get latest GitHub Actions run status for all workflows |
+| `deploy_status` | Get current DigitalOcean App Platform deployment status |
+| `git_workflow_status` | Current branch, uncommitted changes, CI status |
+| `db_list_tables` | List all tables in the database |
+| `db_migration_status` | Show applied Prisma migrations |
+
+## Transport
+
+Uses `StdioServerTransport` from `@modelcontextprotocol/sdk`. Configured in `.mcp.json` at repo root:
+
+```json
+{
+  "mcpServers": {
+    "mbe-infra": {
+      "command": "npx",
+      "args": ["tsx", "packages/mcp-server/src/index.ts"]
+    }
+  }
+}
+```
+
+## Adding a New Tool
+
+1. Create tool implementation in `src/tools/<name>.ts` — export an async function returning a string
+2. Add tool definition to the `TOOLS` array in `src/index.ts` (name, description, inputSchema)
+3. Add handler case in the `CallToolRequestSchema` handler
+
+## Dependencies
+
+- `@modelcontextprotocol/sdk` — MCP protocol implementation
+- `pg` — Direct Postgres access for database tools
+- `zod` — Schema validation
+
+## Commands
+
+```bash
+pnpm build       # Compile TypeScript
+pnpm lint        # ESLint
+pnpm typecheck   # Type check
+pnpm start       # Run server (stdio)
+```

--- a/tools/cli/CLAUDE.md
+++ b/tools/cli/CLAUDE.md
@@ -1,0 +1,100 @@
+# @mbe/cli (`mbe`)
+
+Monorepo CLI for development, agent orchestration, and infrastructure management. Installed as `mbe` via workspace bin.
+
+## Structure
+
+```
+src/
+├── index.ts           # Commander program setup, command registration
+├── api.ts             # API client for agent service (localhost:3003)
+├── config.ts          # CLI configuration (auth tokens, API URLs)
+├── commands/
+│   ├── agent.ts       # agent run/start/list/status/logs/cancel/delete/orchestrate
+│   ├── adr.ts         # check-adr — validate Architecture Decision Records
+│   ├── check-deps.ts  # check-deps — dependency version enforcement
+│   ├── cleanup-worktrees.ts  # cleanup-worktrees — remove stale git worktrees
+│   ├── generate.ts    # generate — scaffold code from templates
+│   ├── login.ts       # login — authenticate with Auth0
+│   ├── logout.ts      # logout — clear local tokens
+│   ├── loop.ts        # loop — run command repeatedly on interval
+│   ├── mcp.ts         # mcp — start MCP server
+│   ├── new.ts         # new — scaffold new packages/services
+│   ├── pack.ts        # pack/pack-changed — generate llms.txt context files
+│   ├── prime.ts       # prime — prepare repo context for AI agents
+│   ├── stats.ts       # stats/log-session/audit-perf — agent performance metrics
+│   ├── sync-rules.ts  # sync-rules — sync Claude rules across packages
+│   ├── up.ts          # up — start dev servers
+│   ├── users.ts       # users — API user management
+│   ├── visual.ts      # visual — UI development tools
+│   ├── wave.ts        # wave — parallel agent execution
+│   └── whoami.ts      # whoami — show current user
+└── __tests__/         # Test files
+```
+
+## Key Commands
+
+### Agent (local mode — runs via @mbe/agent-core)
+
+```bash
+mbe agent run "Fix the login bug"    # Create worktree, run Claude, get PR
+  --model <model>                    # default: claude-sonnet-4-6
+  --max-budget <usd>                 # default: 1.00
+  --max-turns <n>                    # default: 50
+  --no-pr                            # skip PR, keep worktree
+  -v, --verbose                      # stream agent events
+```
+
+### Agent (API mode — requires agent service on :3003)
+
+```bash
+mbe agent start "task"     # Create session via API
+mbe agent list             # List all sessions
+mbe agent status <id>      # Get session details
+mbe agent logs <id>        # Stream SSE events
+mbe agent cancel <id>      # Cancel running session
+mbe agent orchestrate "task"  # Decompose → parallel sessions → PRs
+```
+
+### Context Management
+
+```bash
+mbe pack <package>         # Generate llms.txt for a package
+mbe pack-changed           # Regenerate llms.txt for changed packages (git hook)
+mbe prime                  # Prepare full repo context for agents
+mbe sync-rules             # Sync Claude rules across packages
+```
+
+### Development
+
+```bash
+mbe up                     # Start dev servers
+mbe new <type> <name>      # Scaffold new package/service
+mbe generate <template>    # Generate code from templates
+mbe check-adr --staged     # Validate staged changes against ADRs
+mbe check-deps             # Enforce dependency version constraints
+mbe cleanup-worktrees      # Remove stale agent worktrees
+```
+
+### Observability
+
+```bash
+mbe stats                  # Agent performance metrics
+mbe log-session            # Log a session for tracking
+mbe audit-perf             # Audit agent performance trends
+```
+
+## Adding a New Command
+
+1. Create `src/commands/<name>.ts` — export a `Command` instance
+2. Import and register in `src/index.ts` via `program.addCommand()`
+3. Add tests in `src/__tests__/`
+
+## Commands
+
+```bash
+pnpm build       # Compile TypeScript
+pnpm lint        # ESLint
+pnpm typecheck   # Type check
+pnpm test        # Run tests
+```


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` for `packages/mcp-server` — 7 MCP tools, stdio transport, adding-new-tool guide
- Adds `CLAUDE.md` for `packages/feature-flags` — flag evaluation API, percentage rollout, flag lifecycle
- Adds `CLAUDE.md` for `tools/cli` — all 20+ commands grouped by category, adding-new-command guide

Completes the documentation effort started in PRs #466/#467/#468. All packages now have CLAUDE.md.

## Test plan
- [x] Files follow existing CLAUDE.md conventions (see services/agent/CLAUDE.md)
- [ ] Verify AI agents can use docs to navigate these packages

Closes #363