### PR TITLE
fix(agent): sanitize AI-generated output to prevent XSS

### DIFF
--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -242,6 +242,9 @@ export {
 } from "./retry.js";
 export type { RetryConfig, RetryResult } from "./retry.js";
 
+// Output sanitization (XSS prevention for AI-generated content)
+export { escapeHtml, sanitizeStreamChunk, createSanitizedStream } from "./sanitize-output.js";
+
 // Bundle size tracking
 export {
   measureAppBundleSize,

--- a/packages/agent-core/src/sanitize-output.test.ts
+++ b/packages/agent-core/src/sanitize-output.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "vitest";
+import { escapeHtml, sanitizeStreamChunk, createSanitizedStream } from "./sanitize-output.js";
+
+describe("escapeHtml", () => {
+  it("escapes < and > characters", () => {
+    expect(escapeHtml("<script>alert('xss')</script>")).toBe(
+      "&lt;script&gt;alert(&#x27;xss&#x27;)&lt;/script&gt;"
+    );
+  });
+
+  it("escapes ampersands", () => {
+    expect(escapeHtml("foo & bar")).toBe("foo &amp; bar");
+  });
+
+  it("escapes double quotes", () => {
+    expect(escapeHtml('a "quoted" value')).toBe("a &quot;quoted&quot; value");
+  });
+
+  it("escapes single quotes", () => {
+    expect(escapeHtml("it's")).toBe("it&#x27;s");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(escapeHtml("")).toBe("");
+  });
+
+  it("returns plain text unchanged", () => {
+    expect(escapeHtml("hello world 123")).toBe("hello world 123");
+  });
+
+  it("escapes nested tags", () => {
+    expect(escapeHtml("<div><img onerror=alert(1)></div>")).toBe(
+      "&lt;div&gt;&lt;img onerror=alert(1)&gt;&lt;/div&gt;"
+    );
+  });
+
+  it("escapes event handler attributes", () => {
+    expect(escapeHtml('<a onmouseover="steal()">link</a>')).toBe(
+      "&lt;a onmouseover=&quot;steal()&quot;&gt;link&lt;/a&gt;"
+    );
+  });
+
+  it("handles multiple entities in sequence", () => {
+    expect(escapeHtml("&<>\"'")).toBe("&amp;&lt;&gt;&quot;&#x27;");
+  });
+
+  it("does not double-escape already escaped entities", () => {
+    // If input already contains &amp; it should escape the & again
+    expect(escapeHtml("&amp;")).toBe("&amp;amp;");
+  });
+
+  it("handles unicode and emoji safely", () => {
+    expect(escapeHtml("hello 🌍 café")).toBe("hello 🌍 café");
+  });
+
+  it("escapes javascript: protocol in markup", () => {
+    expect(escapeHtml('<a href="javascript:alert(1)">click</a>')).toBe(
+      '&lt;a href=&quot;javascript:alert(1)&quot;&gt;click&lt;/a&gt;'
+    );
+  });
+});
+
+describe("sanitizeStreamChunk", () => {
+  it("escapes HTML in plain text chunks", () => {
+    expect(sanitizeStreamChunk("<b>bold</b>")).toBe("&lt;b&gt;bold&lt;/b&gt;");
+  });
+
+  it("sanitizes text fields in NDJSON chunks", () => {
+    const ndjson = JSON.stringify({ type: "text", text: "<script>xss</script>" });
+    const result = JSON.parse(sanitizeStreamChunk(ndjson));
+    expect(result.text).toBe("&lt;script&gt;xss&lt;/script&gt;");
+  });
+
+  it("preserves non-text fields in NDJSON", () => {
+    const ndjson = JSON.stringify({ type: "usage", inputTokens: 100 });
+    const result = JSON.parse(sanitizeStreamChunk(ndjson));
+    expect(result).toEqual({ type: "usage", inputTokens: 100 });
+  });
+
+  it("sanitizes nested content field in NDJSON", () => {
+    const ndjson = JSON.stringify({ type: "message", content: '<img onerror="alert(1)">' });
+    const result = JSON.parse(sanitizeStreamChunk(ndjson));
+    expect(result.content).toBe('&lt;img onerror=&quot;alert(1)&quot;&gt;');
+  });
+
+  it("handles empty string", () => {
+    expect(sanitizeStreamChunk("")).toBe("");
+  });
+
+  it("handles whitespace-only string", () => {
+    expect(sanitizeStreamChunk("  \n  ")).toBe("  \n  ");
+  });
+
+  it("falls back to escapeHtml for malformed JSON", () => {
+    const malformed = '{"broken: <script>';
+    expect(sanitizeStreamChunk(malformed)).toBe(
+      '{&quot;broken: &lt;script&gt;'
+    );
+  });
+
+  it("sanitizes message field in NDJSON", () => {
+    const ndjson = JSON.stringify({ type: "assistant", message: "<div>injected</div>" });
+    const result = JSON.parse(sanitizeStreamChunk(ndjson));
+    expect(result.message).toBe("&lt;div&gt;injected&lt;/div&gt;");
+  });
+});
+
+describe("createSanitizedStream", () => {
+  async function collectStream(stream: ReadableStream<string>): Promise<string[]> {
+    const reader = stream.getReader();
+    const chunks: string[] = [];
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+    }
+    return chunks;
+  }
+
+  it("escapes HTML entities in each chunk from a ReadableStream", async () => {
+    const source = new ReadableStream<string>({
+      start(controller) {
+        controller.enqueue("<script>");
+        controller.enqueue("alert('xss')");
+        controller.enqueue("</script>");
+        controller.close();
+      },
+    });
+
+    const chunks = await collectStream(createSanitizedStream(source));
+    expect(chunks).toEqual([
+      "&lt;script&gt;",
+      "alert(&#x27;xss&#x27;)",
+      "&lt;/script&gt;",
+    ]);
+  });
+
+  it("escapes HTML entities in each chunk from an AsyncIterable", async () => {
+    async function* generate(): AsyncIterable<string> {
+      yield "<b>bold</b>";
+      yield "safe text";
+    }
+
+    const chunks = await collectStream(createSanitizedStream(generate()));
+    expect(chunks).toEqual(["&lt;b&gt;bold&lt;/b&gt;", "safe text"]);
+  });
+
+  it("handles empty stream", async () => {
+    const source = new ReadableStream<string>({
+      start(controller) {
+        controller.close();
+      },
+    });
+
+    const chunks = await collectStream(createSanitizedStream(source));
+    expect(chunks).toEqual([]);
+  });
+});

--- a/packages/agent-core/src/sanitize-output.ts
+++ b/packages/agent-core/src/sanitize-output.ts
@@ -1,0 +1,120 @@
+/**
+ * HTML entity escaping and stream chunk sanitization for AI-generated output.
+ *
+ * Prevents XSS (OWASP LLM02) by escaping HTML entities in streamed text
+ * before it reaches clients.
+ */
+
+/** Fields in NDJSON objects that may contain AI-generated text needing sanitization. */
+const TEXT_FIELDS = ["text", "content", "message"] as const;
+
+/**
+ * Escape HTML entities in a string to prevent XSS when rendered in browsers.
+ *
+ * Escapes: & < > " '
+ */
+export function escapeHtml(text: string): string {
+  if (text.length === 0) return text;
+
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#x27;");
+}
+
+/**
+ * Sanitize a streamed chunk of AI output.
+ *
+ * - For NDJSON chunks (valid JSON lines): parses the JSON, escapes HTML in
+ *   known text fields (text, content, message), and re-serializes.
+ * - For plain text chunks: escapes all HTML entities.
+ *
+ * Returns a new string — never mutates the input.
+ */
+export function sanitizeStreamChunk(chunk: string): string {
+  if (chunk.length === 0) return chunk;
+
+  const trimmed = chunk.trim();
+
+  // Non-JSON content: escape the whole thing
+  if (trimmed.length === 0 || trimmed[0] !== "{") {
+    return escapeHtml(chunk);
+  }
+
+  // Attempt NDJSON parse
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(trimmed) as Record<string, unknown>;
+  } catch {
+    // Malformed JSON — fall back to full escaping
+    return escapeHtml(chunk);
+  }
+
+  // Build a new object with sanitized text fields (immutable pattern)
+  let changed = false;
+  const sanitized: Record<string, unknown> = {};
+
+  for (const key of Object.keys(parsed)) {
+    const value = parsed[key];
+    if (typeof value === "string" && TEXT_FIELDS.includes(key as (typeof TEXT_FIELDS)[number])) {
+      const escaped = escapeHtml(value);
+      sanitized[key] = escaped;
+      if (escaped !== value) changed = true;
+    } else {
+      sanitized[key] = value;
+    }
+  }
+
+  // If nothing changed, return original to avoid unnecessary serialization churn
+  if (!changed) return chunk;
+
+  return JSON.stringify(sanitized);
+}
+
+/**
+ * Create a TransformStream that sanitizes each text chunk passing through.
+ *
+ * Wraps an AI SDK textStream (or any ReadableStream<string>) so that every
+ * chunk is HTML-escaped before reaching the client.
+ */
+export function createSanitizedStream(
+  source: ReadableStream<string> | AsyncIterable<string>
+): ReadableStream<string> {
+  const reader =
+    "getReader" in source
+      ? source.getReader()
+      : readableStreamFromAsyncIterable(source).getReader();
+
+  return new ReadableStream<string>({
+    async pull(controller) {
+      const { value, done } = await reader.read();
+      if (done) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(escapeHtml(value));
+    },
+    cancel() {
+      reader.cancel();
+    },
+  });
+}
+
+/** Convert an AsyncIterable to a ReadableStream for uniform handling. */
+function readableStreamFromAsyncIterable(
+  iterable: AsyncIterable<string>
+): ReadableStream<string> {
+  const iterator = iterable[Symbol.asyncIterator]();
+  return new ReadableStream<string>({
+    async pull(controller) {
+      const { value, done } = await iterator.next();
+      if (done) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(value);
+    },
+  });
+}

--- a/packages/agent-core/src/session-runner.ts
+++ b/packages/agent-core/src/session-runner.ts
@@ -42,6 +42,7 @@ import {
 import { analyzeDiff } from "./diff-static-analyzer.js";
 import { mapSdkMessage } from "./event-mapper.js";
 import type { TurnMetricsEvent } from "./event-mapper.js";
+import { sanitizeStreamChunk } from "./sanitize-output.js";
 import {
   recordFailure,
   queryPastFailures,
@@ -286,8 +287,9 @@ export async function runSession(
             }
 
             // Emit typed events for observability (pass current turn index)
+            // Sanitize serialized event data to prevent XSS in AI-generated content (OWASP LLM02)
             for (const mapped of mapSdkMessage(message, turnIndex)) {
-              emitEvent(onEvent, mapped.type, { message: JSON.stringify(mapped) });
+              emitEvent(onEvent, mapped.type, { message: sanitizeStreamChunk(JSON.stringify(mapped)) });
 
               // Accumulate per-turn metrics
               if (mapped.type === "session:turn_metrics") {

--- a/services/agent/src/routes/gen-chat.ts
+++ b/services/agent/src/routes/gen-chat.ts
@@ -8,6 +8,7 @@ import { requireAuth } from "@mbe/auth/fastify";
 import { createProblemDetails } from "@mbe/types";
 // Import directly from catalog (not index) to avoid pulling in registry.tsx (browser-only)
 import { catalog } from "@mbe/rialto-catalog/catalog";
+import { createSanitizedStream } from "@mbe/agent-core";
 import { z } from "zod";
 
 // Memoize catalog prompt at module load — avoid re-generating per request
@@ -87,13 +88,14 @@ export const genChatRoutes: FastifyPluginAsync = async (fastify) => {
         },
       });
 
-      // GEN-07: SSE passthrough headers
-      reply.header("Content-Type", "application/x-ndjson");
+      // GEN-07: SSE passthrough headers — text/plain prevents browser HTML rendering
+      reply.header("Content-Type", "text/plain; charset=utf-8");
       reply.header("Cache-Control", "no-cache");
       reply.header("Connection", "keep-alive");
       reply.header("X-Accel-Buffering", "no");
 
-      return reply.send(result.textStream);
+      // Sanitize AI output to prevent XSS (OWASP LLM02)
+      return reply.send(createSanitizedStream(result.textStream));
     }
   );
 };

--- a/services/agent/src/routes/gen-ui.ts
+++ b/services/agent/src/routes/gen-ui.ts
@@ -8,6 +8,7 @@ import { requireAuth } from "@mbe/auth/fastify";
 import { createProblemDetails } from "@mbe/types";
 // Import directly from catalog (not index) to avoid pulling in registry.tsx (browser-only)
 import { catalog } from "@mbe/rialto-catalog/catalog";
+import { createSanitizedStream } from "@mbe/agent-core";
 import { z } from "zod";
 
 // Memoize catalog prompt at module load — avoid re-generating per request
@@ -92,13 +93,14 @@ export const genUiRoutes: FastifyPluginAsync = async (fastify) => {
         },
       });
 
-      // GEN-07: SSE passthrough headers
-      reply.header("Content-Type", "application/x-ndjson");
+      // GEN-07: SSE passthrough headers — text/plain prevents browser HTML rendering
+      reply.header("Content-Type", "text/plain; charset=utf-8");
       reply.header("Cache-Control", "no-cache");
       reply.header("Connection", "keep-alive");
       reply.header("X-Accel-Buffering", "no");
 
-      return reply.send(result.textStream);
+      // Sanitize AI output to prevent XSS (OWASP LLM02)
+      return reply.send(createSanitizedStream(result.textStream));
     }
   );
 };


### PR DESCRIPTION
## Summary
- Creates `packages/agent-core/src/sanitize-output.ts` with `escapeHtml()`, `sanitizeStreamChunk()`, and `createSanitizedStream()` utilities
- Wraps AI text streams in gen-ui and gen-chat routes with `createSanitizedStream()` and sets Content-Type to `text/plain`
- Applies `sanitizeStreamChunk()` to SSE event data in session-runner before emitting
- 23 new tests covering script tags, nested HTML, event handlers, unicode, malformed JSON, empty streams

Addresses OWASP LLM02 (Insecure Output Handling).

## Test plan
- [x] 23 new sanitization tests passing
- [x] 576 total agent-core tests passing
- [ ] Verify `<script>` tags in AI output render as escaped text in hospitality app
- [ ] Confirm Content-Type headers on streaming endpoints

Closes #374