### PR TITLE
fix(a11y): add reduced motion support and unique Dialog aria-labelledby

### DIFF
--- a/apps/gen/src/components/HistoryPanel.module.css
+++ b/apps/gen/src/components/HistoryPanel.module.css
@@ -403,6 +403,30 @@
   background-color: var(--rialto-surface-elevated);
 }
 
+/* ── Reduced motion ──────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .itemPrompt[data-tooltip]:hover::after {
+    animation: none;
+  }
+
+  .deleteConfirm {
+    animation: none;
+  }
+
+  .filterTab,
+  .item,
+  .starButton,
+  .replayButton,
+  .deleteButton,
+  .deleteConfirmYes,
+  .deleteConfirmNo,
+  .searchInput,
+  .searchClear,
+  .itemActions {
+    transition: none;
+  }
+}
+
 /* --- Search bar --- */
 
 .searchBar {

--- a/apps/gen/src/components/PreviewPane.module.css
+++ b/apps/gen/src/components/PreviewPane.module.css
@@ -196,6 +196,27 @@
   margin-inline-start: auto;
 }
 
+/* ── Reduced motion ──────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .suggestionCard {
+    animation: none;
+    transition: none;
+  }
+
+  .suggestionCard:hover {
+    transform: none;
+  }
+
+  .pulse {
+    animation: none;
+    opacity: 0.35;
+  }
+
+  .viewportFrame {
+    transition: none;
+  }
+}
+
 /* Error state */
 .errorState {
   display: flex;

--- a/apps/gen/src/pages/PlaygroundPage.module.css
+++ b/apps/gen/src/pages/PlaygroundPage.module.css
@@ -134,3 +134,15 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* ── Reduced motion ──────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .backdrop {
+    animation: none;
+  }
+
+  .overlayStart,
+  .overlayEnd {
+    animation: none;
+  }
+}

--- a/apps/hospitality/src/pages/FloorPlanEditorPage.module.css
+++ b/apps/hospitality/src/pages/FloorPlanEditorPage.module.css
@@ -28,6 +28,13 @@
   }
 }
 
+/* ── Reduced motion ──────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation: none;
+  }
+}
+
 /* Error state */
 .errorContainer {
   padding: var(--rialto-space-lg);

--- a/apps/hospitality/src/pages/HomePage.module.css
+++ b/apps/hospitality/src/pages/HomePage.module.css
@@ -151,6 +151,13 @@
   }
 }
 
+/* ── Reduced motion ──────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .connectingDot {
+    animation: none;
+  }
+}
+
 /* ── Skeleton Placeholders ─────────────────── */
 
 .skeletonStats {

--- a/apps/hospitality/src/pages/ReservationsPage.module.css
+++ b/apps/hospitality/src/pages/ReservationsPage.module.css
@@ -53,6 +53,13 @@
   color: var(--rialto-text-tertiary);
 }
 
+/* ── Reduced motion ──────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .liveDotConnected {
+    animation: none;
+  }
+}
+
 .statsRow {
   display: grid;
   grid-template-columns: repeat(4, 1fr);

--- a/apps/hospitality/src/pages/TimelinePage.module.css
+++ b/apps/hospitality/src/pages/TimelinePage.module.css
@@ -179,6 +179,17 @@
   }
 }
 
+/* ── Reduced motion ──────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .liveDotConnected {
+    animation: none;
+  }
+
+  .spinner {
+    animation: none;
+  }
+}
+
 .errorBox {
   background: var(--rialto-error-muted);
   color: var(--rialto-error);

--- a/packages/rialto/src/components/Dialog/Dialog.tsx
+++ b/packages/rialto/src/components/Dialog/Dialog.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, useRef, type ReactNode } from "react";
+import { forwardRef, useEffect, useId, useRef, type ReactNode } from "react";
 import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import { springGentle, precision } from "../../tokens/motion";
 import styles from "./Dialog.module.css";
@@ -28,6 +28,7 @@ export const Dialog = forwardRef<HTMLDivElement, DialogProps>(
     const shouldReduceMotion = useReducedMotion();
     const panelRef = useRef<HTMLDivElement>(null);
     const triggerRef = useRef<Element | null>(null);
+    const titleId = useId();
 
     // Capture trigger element on open; restore focus to it on close
     useEffect(() => {
@@ -114,13 +115,13 @@ export const Dialog = forwardRef<HTMLDivElement, DialogProps>(
               className={styles.panel}
               role="dialog"
               aria-modal
-              aria-labelledby={title ? "rialto-dialog-title" : undefined}
+              aria-labelledby={title ? titleId : undefined}
               aria-label={title ? undefined : "Dialog"}
               transition={shouldReduceMotion ? { duration: 0 } : springGentle}
               {...motionProps}
             >
               <div className={styles.header}>
-                {title && <h2 id="rialto-dialog-title" className={styles.title}>{title}</h2>}
+                {title && <h2 id={titleId} className={styles.title}>{title}</h2>}
                 <button className={styles.close} onClick={onClose} aria-label="Close dialog">
                   <svg
                     width="14"


### PR DESCRIPTION
## Summary
- Adds `prefers-reduced-motion: reduce` media queries to 7 CSS files with unguarded `@keyframes` animations (gen app + hospitality app pages)
- Fixes Dialog `aria-labelledby` to use React `useId()` so multiple simultaneous dialogs get unique references
- Verified: icon-only buttons already have `aria-label`, Toast already has proper ARIA attributes

## Changed files
- `packages/rialto/src/components/Dialog/Dialog.tsx` — unique `aria-labelledby` via `useId()`
- `apps/gen/src/pages/PlaygroundPage.module.css` — reduced motion for backdrop/overlay
- `apps/gen/src/components/PreviewPane.module.css` — reduced motion for card/loading animations
- `apps/gen/src/components/HistoryPanel.module.css` — reduced motion for tooltip/delete animations
- `apps/hospitality/src/pages/ReservationsPage.module.css` — reduced motion for live dot pulse
- `apps/hospitality/src/pages/FloorPlanEditorPage.module.css` — reduced motion for spinner
- `apps/hospitality/src/pages/TimelinePage.module.css` — reduced motion for pulse/spinner
- `apps/hospitality/src/pages/HomePage.module.css` — reduced motion for connecting dot

## Test plan
- [x] 218 Rialto tests passing
- [x] Typecheck and lint clean
- [ ] Manual: verify animations pause with `prefers-reduced-motion: reduce` enabled
- [ ] Manual: open multiple Dialogs simultaneously, verify unique aria-labelledby

Closes #405