### PR TITLE
docs: add 5 Architecture Decision Records (ADR-002 through ADR-006)

### DIFF
--- a/docs/adr/ADR-002-api-error-format.md
+++ b/docs/adr/ADR-002-api-error-format.md
@@ -1,0 +1,23 @@
+# ADR-002: API Error Format (RFC 7807 Problem Details)
+
+**Status:** active
+**Date:** 2026-04-06
+
+## Context
+
+With three backend services (reservations, users, agent), each was returning errors in slightly different shapes. Frontend clients needed per-service error parsing logic, and debugging production issues required knowing which service format to expect. We needed a single, standards-based error envelope.
+
+## Decision
+
+All API errors use the `createProblemDetails()` helper from `@mbe/types`, which produces responses conforming to RFC 7807 (Problem Details for HTTP APIs). Every Fastify service registers a shared error handler that catches thrown errors and serializes them into this format with `type`, `title`, `status`, `detail`, and optional `instance` fields.
+
+## Consequences
+
+- **Enables:** Unified client-side error handling via one parser. Agents can programmatically interpret errors without heuristics.
+- **Constrains:** All new services must adopt the shared error handler; ad-hoc error shapes are prohibited.
+- **Trade-off:** Slightly more boilerplate per service vs. complete consistency across the API surface.
+
+## Alternatives Considered
+
+- **Custom JSON envelope** (`{ success, error, data }`): Simpler but non-standard; no ecosystem tooling support.
+- **GraphQL errors**: Would require migrating to GraphQL; overkill when REST serves current needs.

--- a/docs/adr/ADR-003-auth-architecture.md
+++ b/docs/adr/ADR-003-auth-architecture.md
@@ -1,0 +1,24 @@
+# ADR-003: Auth Architecture (Auth0 OIDC + Permissive Plugin)
+
+**Status:** active
+**Date:** 2026-04-06
+
+## Context
+
+The platform serves both public-facing pages (marketing, menu browsing) and authenticated flows (reservations, user profiles). Routes like `/api/reservations/availability` must work for anonymous visitors but return richer data for logged-in users. A strict auth-or-reject model would force endpoint duplication.
+
+## Decision
+
+Use Auth0 as the OIDC identity provider. On the backend, a custom Fastify plugin (`@mbe/auth`) validates JWTs when present but does not reject unauthenticated requests. Routes opt into protection via a `requireAuth` preHandler. The frontend uses `@auth0/auth0-react` with PKCE and stores tokens in memory (no localStorage).
+
+## Consequences
+
+- **Enables:** Single route definitions that serve both anonymous and authenticated users. Auth0 handles MFA, social login, and token rotation.
+- **Constrains:** Every protected route must explicitly add the `requireAuth` guard; forgetting it leaves the route open. Code review must check for this.
+- **Trade-off:** Permissive-by-default is riskier than strict-by-default, but matches the product's public-first design. The `requireAuth` guard is a one-liner, keeping the friction low.
+
+## Alternatives Considered
+
+- **Keycloak (self-hosted)**: Full control but significant ops burden for a small team.
+- **Firebase Auth**: Tightly coupled to GCP ecosystem; harder to use with non-Firebase backends.
+- **Strict-by-default plugin**: Would require `allowAnonymous` decorators on public routes, increasing boilerplate for the common case.

--- a/docs/adr/ADR-004-edge-routing.md
+++ b/docs/adr/ADR-004-edge-routing.md
@@ -1,0 +1,24 @@
+# ADR-004: Edge Routing (Cloudflare Workers + Service Bindings)
+
+**Status:** active
+**Date:** 2026-04-06
+
+## Context
+
+After deploying SPA updates, users received stale `index.html` from CDN cache, causing blank pages until the cache expired. The edge layer needed to serve fresh HTML on every navigation request while still caching static assets aggressively.
+
+## Decision
+
+A single Cloudflare Worker (`edge-router`) receives all requests for `mattbutlerengineering.com`. It dispatches to per-app Workers (marketing, hospitality, gen) via Service Bindings. HTML responses are served with `Cache-Control: no-store` to guarantee fresh content after deploys. Static assets (JS, CSS, images) use content-hashed filenames and long-lived cache headers.
+
+## Consequences
+
+- **Enables:** Zero-downtime deploys with no stale HTML. Per-app isolation means one app's Worker crash doesn't affect others. Sub-millisecond dispatch via Service Bindings (no network hop).
+- **Constrains:** All frontend apps must be deployed as Workers, not Pages. Routing logic lives in `edge-router` and must be updated when apps are added.
+- **Trade-off:** More operational complexity than a managed platform (Vercel/Netlify), but full control over caching and routing behavior.
+
+## Alternatives Considered
+
+- **Cloudflare Pages**: Simpler deploys but limited control over cache headers and routing; no Service Bindings support.
+- **Vercel/Netlify**: Managed platforms with opinionated caching; would require workarounds for the stale-HTML problem.
+- **Nginx reverse proxy**: Self-managed, no edge presence, higher latency for global users.

--- a/docs/adr/ADR-005-agent-worktree-isolation.md
+++ b/docs/adr/ADR-005-agent-worktree-isolation.md
@@ -1,0 +1,24 @@
+# ADR-005: Agent Worktree Isolation
+
+**Status:** active
+**Date:** 2026-04-06
+
+## Context
+
+AI agents (via `mbe agent run`) modify source code to implement features and fix bugs. Running agents in the main working directory risks conflicts with in-progress human work, corrupted state from partial agent failures, and inability to run multiple agents in parallel on different tasks.
+
+## Decision
+
+Each agent session creates a Git worktree under `.claude/worktrees/<session-id>`, branching from `main`. The agent operates entirely within this worktree. On success, the agent creates a PR from the worktree branch. On failure or cancellation, the worktree is cleaned up. Multiple agents can run concurrently on separate worktrees without interference.
+
+## Consequences
+
+- **Enables:** Parallel agent execution, safe failure recovery, and zero disruption to the developer's working directory. Agents can be aggressive with code changes knowing the blast radius is contained.
+- **Constrains:** Worktrees share the same Git object store, so very large parallel operations can contend on Git locks. Disk usage grows linearly with concurrent agents.
+- **Trade-off:** Worktrees are lighter than full clones (shared `.git`) but heavier than in-process sandboxing. The isolation-to-overhead ratio is the best fit for the current agent workload.
+
+## Alternatives Considered
+
+- **Docker containers**: Stronger isolation but significantly higher startup time and resource usage per agent session.
+- **Separate full clones**: Maximum isolation but wasteful disk and network usage; slow to set up.
+- **In-process sandboxing**: Lowest overhead but no filesystem isolation; one agent's changes would affect another's.

--- a/docs/adr/ADR-006-health-check-architecture.md
+++ b/docs/adr/ADR-006-health-check-architecture.md
@@ -1,0 +1,28 @@
+# ADR-006: Health Check Architecture
+
+**Status:** active
+**Date:** 2026-04-06
+
+## Context
+
+DigitalOcean App Platform requires a health endpoint for liveness probes, but we also need user-visible health status for debugging and transparency. A single endpoint cannot serve both: platform probes need fast, simple responses while public health pages benefit from dependency status and latency metrics.
+
+## Decision
+
+Each service exposes two health endpoints:
+
+- **`/health`** (platform probe): Returns 200 with `{ status: "ok" }`. No database queries, no external calls. Used by DO App Platform for restart decisions.
+- **`/api/<service>/health`** (public): Returns dependency status (database connectivity, external service reachability) and flags slow queries exceeding a configurable threshold. Used by the status page and agent diagnostics.
+
+Both endpoints are unauthenticated.
+
+## Consequences
+
+- **Enables:** Reliable platform health checks that never false-positive due to a slow downstream dependency. Public endpoint gives agents and developers actionable diagnostics without SSH access.
+- **Constrains:** Two endpoints to maintain per service; the public endpoint's dependency checks must be lightweight enough to not become a performance problem themselves.
+- **Trade-off:** Slight duplication vs. clear separation of concerns between infrastructure probes and observability.
+
+## Alternatives Considered
+
+- **Single `/health` endpoint with query params**: Mixes concerns; risk of platform probe hitting the slow path.
+- **External monitoring only** (e.g., UptimeRobot): No integration with platform auto-restart; adds a paid dependency for basic health visibility.


### PR DESCRIPTION
## Summary
5 ADRs covering API errors, auth, edge routing, agent isolation, health checks.

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)