### PR TITLE
feat(turbo): enable remote caching for CI/CD optimization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,19 @@ jobs:
           pnpm --filter @mbe/reservations-service db:generate
           pnpm --filter @mbe/agent-service db:generate
 
+      - name: Login to Turborepo Remote Cache
+        if: secrets.TURBO_TOKEN != ''
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+        run: pnpm turbo login --token "$TURBO_TOKEN"
+
+      - name: Link to Turborepo Remote Cache
+        if: secrets.TURBO_TOKEN != ''
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+        run: pnpm turbo link --team "$TURBO_TEAM" --token "$TURBO_TOKEN"
+
   hadolint:
     name: Dockerfile Lint
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ Use `mbe check-model "<directive>"` to verify the recommended tier before starti
 
 ## Performance Infrastructure
 The monorepo uses Turborepo for orchestration and caching. To maximize velocity:
-- **Remote Caching:** Run `npx turbo login` and `npx turbo link` to enable shared build artifacts. This prevents redundant compilation across local and CI environments.
+- **Remote Caching:** Configured via Vercel Remote Cache. See [docs/TURBO.md](docs/TURBO.md) for setup instructions. CI authenticates automatically using `TURBO_TOKEN` and `TURBO_TEAM` variables.
 - **Selective Typechecking:** Use `pnpm turbo typecheck --filter='...[HEAD]'` to only check packages affected by current changes.
 - **Autonomous Refresh:** The `post-commit` hook automatically runs `mbe pack` to keep AI context skeletons (`llms.txt`) updated.
 

--- a/docs/TURBO.md
+++ b/docs/TURBO.md
@@ -1,0 +1,122 @@
+# Turborepo Remote Cache
+
+This document describes the remote caching configuration for CI/CD optimization.
+
+## Overview
+
+Turborepo's remote cache stores build artifacts in Vercel's infrastructure, allowing:
+- **Faster CI builds**: Skip tasks already completed on other branches
+- **Shared caching**: Local `pnpm dev` can use CI cache
+- **Reduced compute costs**: Less time running redundant builds
+
+## Configuration
+
+### Repository Variables (GitHub Actions)
+
+| Variable | Value | Purpose |
+|----------|-------|---------|
+| `TURBO_TEAM` | `mattbutlerengineering` | Vercel team slug for cache namespace |
+
+### Repository Secrets (GitHub Actions)
+
+| Secret | Purpose |
+|--------|---------|
+| `TURBO_TOKEN` | Vercel API token for authentication |
+
+## Setup Instructions
+
+### 1. Create Vercel Account
+
+If you don't have a Vercel account:
+1. Sign up at [vercel.com](https://vercel.com)
+2. Create a team named `mattbutlerengineering` (or your preferred name)
+
+### 2. Generate Vercel API Token
+
+1. Go to [Vercel Dashboard > Settings > Tokens](https://vercel.com/dashboard/settings/tokens)
+2. Click "Create Token"
+3. Name: `turborepo-cache-ci`
+4. Scope: Select the `mattbutlerengineering` team
+5. Copy the generated token
+
+### 3. Add Secrets to GitHub
+
+```bash
+# Add TURBO_TOKEN secret
+gh secret set TURBO_TOKEN --body "<your-vercel-token>"
+
+# TURBO_TEAM is already set to mattbutlerengineering
+gh api repos/mattbutlerengineering/mattbutlerengineering/actions/variables/TURBO_TEAM
+```
+
+### 4. Verify Configuration
+
+The CI workflow automatically:
+1. Runs `turbo login --token` in the prepare job
+2. Links to the remote cache with `turbo link --team`
+3. Subsequent turbo commands use the cached artifacts
+
+## Local Setup
+
+To use remote cache locally:
+
+```bash
+# Login to Vercel
+npx turbo login
+
+# Link to the team
+npx turbo link --team mattbutlerengineering
+
+# Verify remote caching is enabled
+npx turbo remote cache ls
+```
+
+## CI Behavior
+
+Without `TURBO_TOKEN`:
+- CI runs with local caching only
+- Build times are unaffected
+- No errors occur
+
+With `TURBO_TOKEN`:
+- Turbo authenticates with Vercel Remote Cache
+- Build artifacts are fetched/stored remotely
+- Cache hits speed up builds significantly
+
+## Viewing Cache
+
+```bash
+# List cached artifacts
+npx turbo remote cache ls
+
+# Get details of a specific artifact
+npx turbo remote cache get <artifact-id>
+
+# Tag artifacts for organization
+npx turbo remote cache tag <artifact-id> <tag>
+```
+
+## Troubleshooting
+
+### "Invalid token" errors
+
+1. Verify `TURBO_TOKEN` is correctly set in GitHub secrets
+2. Ensure the token hasn't expired
+3. Check the token has team-level scope
+
+### Cache misses on main
+
+Expected when:
+- First push to a new team
+- Cache was cleared
+- Build configuration changed significantly
+
+### Local cache conflicts
+
+If local and remote caches conflict:
+
+```bash
+# Clear local cache
+pnpm turbo prune
+rm -rf node_modules/.cache/turbo
+```

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "remoteCache": {
+    "enabled": true
+  },
   "globalDependencies": [
     "pnpm-lock.yaml",
     "tsconfig.base.json",


### PR DESCRIPTION
## Summary
Enable Turborepo remote caching to optimize CI/CD builds by sharing build artifacts across branches and local development.

## Changes
- **turbo.json**: Add `remoteCache.enabled: true` configuration
- **ci.yml**: Add `turbo login` and `turbo link` steps in the prepare job for CI authentication
- **docs/TURBO.md**: Document setup instructions for remote caching
- **AGENTS.md**: Update Performance Infrastructure section with link to turbo docs

## Setup Required (Manual)
To complete the configuration, you need to:
1. Create a Vercel account at [vercel.com](https://vercel.com)
2. Create a team named `mattbutlerengineering` 
3. Generate a Vercel API token
4. Add `TURBO_TOKEN` as a GitHub secret

See [docs/TURBO.md](docs/TURBO.md) for detailed instructions.

## Closes
Closes #337