### PR TITLE
feat(docker): use turbo prune for optimized Docker builds

### DIFF
--- a/services/agent/Dockerfile
+++ b/services/agent/Dockerfile
@@ -5,35 +5,21 @@ RUN corepack enable && corepack prepare pnpm@9.15.4 --activate
 
 WORKDIR /app
 
-# Copy workspace config
-COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+# Copy turbo.json for prune configuration
+COPY turbo.json ./
 
-# Copy package.json files for all workspace packages we depend on
-COPY packages/types/package.json ./packages/types/
-COPY packages/config/package.json ./packages/config/
-COPY packages/auth/package.json ./packages/auth/
-COPY packages/api-versioning/package.json ./packages/api-versioning/
-COPY packages/agent-core/package.json ./packages/agent-core/
-COPY packages/observability/package.json ./packages/observability/
-COPY packages/sentry/package.json ./packages/sentry/
-COPY packages/rialto/package.json ./packages/rialto/
-COPY packages/rialto-catalog/package.json ./packages/rialto-catalog/
-COPY services/agent/package.json ./services/agent/
+# Generate pruned monorepo for Docker (only includes dependencies needed for this service)
+RUN pnpm turbo prune --docker @mbe/agent-service
 
-# Install all dependencies
-RUN pnpm install --frozen-lockfile
+# Copy pruned workspace files from out/ directory
+COPY out/pnpm-lock.yaml ./
+COPY out/pnpm-workspace.yaml ./
+COPY out/package.json ./
+COPY out/packages ./packages
+COPY out/services ./services
 
 # Copy tsconfig files (needed for build, changes rarely)
-COPY packages/types/tsconfig.json ./packages/types/
 COPY packages/config/typescript ./packages/config/typescript
-COPY packages/auth/tsconfig.json ./packages/auth/
-COPY packages/api-versioning/tsconfig.json ./packages/api-versioning/
-COPY packages/agent-core/tsconfig.json ./packages/agent-core/
-COPY packages/observability/tsconfig.json ./packages/observability/
-COPY packages/sentry/tsconfig.json ./packages/sentry/
-COPY packages/rialto/tsconfig.json ./packages/rialto/
-COPY packages/rialto-catalog/tsconfig.json packages/rialto-catalog/tsconfig.build.json ./packages/rialto-catalog/
-COPY services/agent/tsconfig.json ./services/agent/
 
 # Copy Prisma schema (needed for db:generate)
 COPY services/agent/prisma ./services/agent/prisma
@@ -48,6 +34,9 @@ COPY packages/sentry/src ./packages/sentry/src
 COPY packages/rialto/src ./packages/rialto/src
 COPY packages/rialto-catalog/src ./packages/rialto-catalog/src
 COPY services/agent/src ./services/agent/src
+
+# Install all dependencies
+RUN pnpm install --frozen-lockfile
 
 # Build workspace packages and service in a single layer
 RUN pnpm --filter @mbe/types build && \
@@ -71,23 +60,15 @@ WORKDIR /app
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 app
 
-# Copy workspace config
-COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+# Copy pruned workspace files from builder stage
+COPY --from=builder /app/out/pnpm-lock.yaml ./
+COPY --from=builder /app/out/pnpm-workspace.yaml ./
+COPY --from=builder /app/out/package.json ./
+COPY --from=builder /app/out/packages ./packages
+COPY --from=builder /app/out/services ./services
 
-# Copy package.json files
-COPY packages/types/package.json ./packages/types/
-COPY packages/config/package.json ./packages/config/
-COPY packages/auth/package.json ./packages/auth/
-COPY packages/api-versioning/package.json ./packages/api-versioning/
-COPY packages/agent-core/package.json ./packages/agent-core/
-COPY packages/observability/package.json ./packages/observability/
-COPY packages/sentry/package.json ./packages/sentry/
-COPY packages/rialto/package.json ./packages/rialto/
-COPY packages/rialto-catalog/package.json ./packages/rialto-catalog/
-COPY services/agent/package.json ./services/agent/
-
-# Copy Prisma schema first (needed for generate)
-COPY services/agent/prisma ./services/agent/prisma
+# Copy Prisma schema (needed for generate)
+COPY --from=builder /app/services/agent/prisma ./services/agent/prisma
 
 # Install all dependencies (NODE_ENV unset to include devDeps for prisma CLI)
 RUN pnpm install --frozen-lockfile

--- a/services/reservations/Dockerfile
+++ b/services/reservations/Dockerfile
@@ -5,29 +5,21 @@ RUN corepack enable && corepack prepare pnpm@9.15.4 --activate
 
 WORKDIR /app
 
-# Copy workspace config
-COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+# Copy turbo.json for prune configuration
+COPY turbo.json ./
 
-# Copy package.json files for all workspace packages we depend on
-COPY packages/types/package.json ./packages/types/
-COPY packages/auth/package.json ./packages/auth/
-COPY packages/api-versioning/package.json ./packages/api-versioning/
-COPY packages/config/package.json ./packages/config/
-COPY packages/observability/package.json ./packages/observability/
-COPY packages/sentry/package.json ./packages/sentry/
-COPY services/reservations/package.json ./services/reservations/
+# Generate pruned monorepo for Docker (only includes dependencies needed for this service)
+RUN pnpm turbo prune --docker @mbe/reservations-service
 
-# Install all dependencies
-RUN pnpm install --frozen-lockfile
+# Copy pruned workspace files from out/ directory
+COPY out/pnpm-lock.yaml ./
+COPY out/pnpm-workspace.yaml ./
+COPY out/package.json ./
+COPY out/packages ./packages
+COPY out/services ./services
 
 # Copy tsconfig files (needed for build, changes rarely)
-COPY packages/types/tsconfig.json ./packages/types/
-COPY packages/auth/tsconfig.json ./packages/auth/
-COPY packages/api-versioning/tsconfig.json ./packages/api-versioning/
 COPY packages/config/typescript ./packages/config/typescript
-COPY packages/observability/tsconfig.json ./packages/observability/
-COPY packages/sentry/tsconfig.json ./packages/sentry/
-COPY services/reservations/tsconfig.json ./services/reservations/
 
 # Copy Prisma schema (needed for db:generate)
 COPY services/reservations/prisma ./services/reservations/prisma
@@ -39,6 +31,9 @@ COPY packages/api-versioning/src ./packages/api-versioning/src
 COPY packages/observability/src ./packages/observability/src
 COPY packages/sentry/src ./packages/sentry/src
 COPY services/reservations/src ./services/reservations/src
+
+# Install all dependencies
+RUN pnpm install --frozen-lockfile
 
 # Build workspace packages and service in a single layer
 RUN pnpm --filter @mbe/types build && \
@@ -60,19 +55,15 @@ WORKDIR /app
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 app
 
-# Copy workspace config
-COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+# Copy pruned workspace files from builder stage
+COPY --from=builder /app/out/pnpm-lock.yaml ./
+COPY --from=builder /app/out/pnpm-workspace.yaml ./
+COPY --from=builder /app/out/package.json ./
+COPY --from=builder /app/out/packages ./packages
+COPY --from=builder /app/out/services ./services
 
-# Copy package.json files
-COPY packages/types/package.json ./packages/types/
-COPY packages/auth/package.json ./packages/auth/
-COPY packages/api-versioning/package.json ./packages/api-versioning/
-COPY packages/observability/package.json ./packages/observability/
-COPY packages/sentry/package.json ./packages/sentry/
-COPY services/reservations/package.json ./services/reservations/
-
-# Copy Prisma schema first (needed for generate)
-COPY services/reservations/prisma ./services/reservations/prisma
+# Copy Prisma schema (needed for generate)
+COPY --from=builder /app/services/reservations/prisma ./services/reservations/prisma
 
 # Install all dependencies (NODE_ENV unset to include devDeps for prisma CLI)
 RUN pnpm install --frozen-lockfile

--- a/services/users/Dockerfile
+++ b/services/users/Dockerfile
@@ -5,29 +5,21 @@ RUN corepack enable && corepack prepare pnpm@9.15.4 --activate
 
 WORKDIR /app
 
-# Copy workspace config
-COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+# Copy turbo.json for prune configuration
+COPY turbo.json ./
 
-# Copy package.json files for all workspace packages we depend on
-COPY packages/types/package.json ./packages/types/
-COPY packages/auth/package.json ./packages/auth/
-COPY packages/api-versioning/package.json ./packages/api-versioning/
-COPY packages/config/package.json ./packages/config/
-COPY packages/observability/package.json ./packages/observability/
-COPY packages/sentry/package.json ./packages/sentry/
-COPY services/users/package.json ./services/users/
+# Generate pruned monorepo for Docker (only includes dependencies needed for this service)
+RUN pnpm turbo prune --docker @mbe/users-service
 
-# Install all dependencies
-RUN pnpm install --frozen-lockfile
+# Copy pruned workspace files from out/ directory
+COPY out/pnpm-lock.yaml ./
+COPY out/pnpm-workspace.yaml ./
+COPY out/package.json ./
+COPY out/packages ./packages
+COPY out/services ./services
 
 # Copy tsconfig files (needed for build, changes rarely)
-COPY packages/types/tsconfig.json ./packages/types/
-COPY packages/auth/tsconfig.json ./packages/auth/
-COPY packages/api-versioning/tsconfig.json ./packages/api-versioning/
 COPY packages/config/typescript ./packages/config/typescript
-COPY packages/observability/tsconfig.json ./packages/observability/
-COPY packages/sentry/tsconfig.json ./packages/sentry/
-COPY services/users/tsconfig.json ./services/users/
 
 # Copy Prisma schema (needed for db:generate)
 COPY services/users/prisma ./services/users/prisma
@@ -39,6 +31,9 @@ COPY packages/api-versioning/src ./packages/api-versioning/src
 COPY packages/observability/src ./packages/observability/src
 COPY packages/sentry/src ./packages/sentry/src
 COPY services/users/src ./services/users/src
+
+# Install all dependencies
+RUN pnpm install --frozen-lockfile
 
 # Build workspace packages and service in a single layer
 RUN pnpm --filter @mbe/types build && \
@@ -60,19 +55,15 @@ WORKDIR /app
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 app
 
-# Copy workspace config
-COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+# Copy pruned workspace files from builder stage
+COPY --from=builder /app/out/pnpm-lock.yaml ./
+COPY --from=builder /app/out/pnpm-workspace.yaml ./
+COPY --from=builder /app/out/package.json ./
+COPY --from=builder /app/out/packages ./packages
+COPY --from=builder /app/out/services ./services
 
-# Copy package.json files
-COPY packages/types/package.json ./packages/types/
-COPY packages/auth/package.json ./packages/auth/
-COPY packages/api-versioning/package.json ./packages/api-versioning/
-COPY packages/observability/package.json ./packages/observability/
-COPY packages/sentry/package.json ./packages/sentry/
-COPY services/users/package.json ./services/users/
-
-# Copy Prisma schema first (needed for generate)
-COPY services/users/prisma ./services/users/prisma
+# Copy Prisma schema (needed for generate)
+COPY --from=builder /app/services/users/prisma ./services/users/prisma
 
 # Install all dependencies (NODE_ENV unset to include devDeps for prisma CLI)
 RUN pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- Use `turbo prune --docker` to create pruned workspaces that only include dependencies needed for each service
- Reduces Docker layer size and speeds up builds by generating a pruned lockfile
- Simplifies Dockerfile by removing manual COPY of individual package.json files

## Changes
- `services/agent/Dockerfile`: Use turbo prune for workspace optimization
- `services/users/Dockerfile`: Use turbo prune for workspace optimization  
- `services/reservations/Dockerfile`: Use turbo prune for workspace optimization

## Testing
Verified `pnpm turbo prune --docker @mbe/agent-service` works correctly, generating a pruned workspace with only required packages.

Closes #342