### PR TITLE
feat(booking-widget): add configurable hold timer, cancellation path, and date range selection

### DIFF
--- a/apps/hospitality/src/components/booking-widget/BookingWidget.tsx
+++ b/apps/hospitality/src/components/booking-widget/BookingWidget.tsx
@@ -15,6 +15,12 @@ export interface BookingWidgetProps {
   venueId: string;
   apiBaseUrl?: string;
   maxPartySize?: number;
+  holdDurationMinutes?: number;
+  enableDateRange?: boolean;
+  minDate?: string;
+  maxDate?: string;
+  cancellationUrl?: string;
+  onCancellation?: () => void;
   className?: string;
 }
 
@@ -30,6 +36,12 @@ export function BookingWidget({
   venueId,
   apiBaseUrl = import.meta.env.VITE_API_URL ?? "",
   maxPartySize = 8,
+  holdDurationMinutes = 10,
+  enableDateRange = false,
+  minDate,
+  maxDate,
+  cancellationUrl,
+  onCancellation,
   className = "",
 }: BookingWidgetProps) {
   // Step management
@@ -37,6 +49,7 @@ export function BookingWidget({
 
   // Date and party size
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
+  const [selectedEndDate, setSelectedEndDate] = useState<string | null>(null);
   const [partySize, setPartySize] = useState(2);
 
   // Time slots
@@ -101,6 +114,7 @@ export function BookingWidget({
           date: selectedDate,
           time: slot.time,
           partySize,
+          holdDurationMinutes,
         });
         setHold(newHold);
         setSelectedSlot(slot);
@@ -111,7 +125,7 @@ export function BookingWidget({
         setHoldLoading(false);
       }
     },
-    [api, venueId, selectedDate, partySize]
+    [api, venueId, selectedDate, partySize, holdDurationMinutes]
   );
 
   // Confirm the reservation
@@ -182,6 +196,7 @@ export function BookingWidget({
   const handleNewBooking = useCallback(() => {
     setStep("date-party");
     setSelectedDate(null);
+    setSelectedEndDate(null);
     setPartySize(2);
     setSlots([]);
     setSelectedSlot(null);
@@ -237,11 +252,16 @@ export function BookingWidget({
       {step === "date-party" && (
         <DatePartySelector
           selectedDate={selectedDate}
+          selectedEndDate={selectedEndDate}
           partySize={partySize}
           onDateChange={setSelectedDate}
+          onEndDateChange={enableDateRange ? setSelectedEndDate : undefined}
           onPartySizeChange={setPartySize}
           onNext={handleFindTimes}
           maxPartySize={maxPartySize}
+          enableDateRange={enableDateRange}
+          minDate={minDate}
+          maxDate={maxDate}
         />
       )}
 
@@ -272,7 +292,12 @@ export function BookingWidget({
       )}
 
       {step === "confirmation" && reservation && (
-        <ConfirmationView reservation={reservation} onNewBooking={handleNewBooking} />
+        <ConfirmationView
+          reservation={reservation}
+          onNewBooking={handleNewBooking}
+          cancellationUrl={cancellationUrl}
+          onCancellation={onCancellation}
+        />
       )}
     </div>
   );

--- a/apps/hospitality/src/components/booking-widget/ConfirmationView.tsx
+++ b/apps/hospitality/src/components/booking-widget/ConfirmationView.tsx
@@ -5,9 +5,16 @@ import styles from "./ConfirmationView.module.css";
 export interface ConfirmationViewProps {
   reservation: Reservation;
   onNewBooking: () => void;
+  cancellationUrl?: string;
+  onCancellation?: () => void;
 }
 
-export function ConfirmationView({ reservation, onNewBooking }: ConfirmationViewProps) {
+export function ConfirmationView({
+  reservation,
+  onNewBooking,
+  cancellationUrl,
+  onCancellation,
+}: ConfirmationViewProps) {
   // Format date for display
   const formattedDate = new Date(reservation.date + "T00:00:00").toLocaleDateString("en-US", {
     weekday: "long",
@@ -130,6 +137,22 @@ export function ConfirmationView({ reservation, onNewBooking }: ConfirmationView
 
       {/* Actions */}
       <div className={styles.actions}>
+        {(cancellationUrl || onCancellation) && (
+          <Button
+            variant="ghost"
+            onClick={() => {
+              if (onCancellation) {
+                onCancellation();
+              }
+              if (cancellationUrl) {
+                window.location.href = cancellationUrl;
+              }
+            }}
+            className={styles.fullWidth}
+          >
+            Cancel Reservation
+          </Button>
+        )}
         <Button variant="secondary" onClick={onNewBooking} className={styles.fullWidth}>
           Make Another Reservation
         </Button>

--- a/apps/hospitality/src/components/booking-widget/DatePartySelector.tsx
+++ b/apps/hospitality/src/components/booking-widget/DatePartySelector.tsx
@@ -4,32 +4,36 @@ import styles from "./DatePartySelector.module.css";
 
 export interface DatePartySelectorProps {
   selectedDate: string | null;
+  selectedEndDate?: string | null;
   partySize: number;
   onDateChange: (date: string) => void;
+  onEndDateChange?: (date: string) => void;
   onPartySizeChange: (size: number) => void;
   onNext: () => void;
   minDate?: string;
   maxDate?: string;
   maxPartySize?: number;
+  enableDateRange?: boolean;
 }
 
 const PARTY_SIZE_OPTIONS = [1, 2, 3, 4, 5, 6, 7, 8];
 
 export function DatePartySelector({
   selectedDate,
+  selectedEndDate,
   partySize,
   onDateChange,
+  onEndDateChange,
   onPartySizeChange,
   onNext,
   minDate,
   maxDate,
   maxPartySize = 8,
+  enableDateRange = false,
 }: DatePartySelectorProps) {
-  // Default min date to today
   const today = toDateString(new Date());
   const effectiveMinDate = minDate ?? today;
 
-  // Default max date to 30 days from now
   const thirtyDaysFromNow = new Date();
   thirtyDaysFromNow.setDate(thirtyDaysFromNow.getDate() + 30);
   const effectiveMaxDate = maxDate ?? toDateString(thirtyDaysFromNow);
@@ -40,14 +44,37 @@ export function DatePartySelector({
 
   return (
     <div className={styles.container}>
-      <Input
-        label="Date"
-        type="date"
-        value={selectedDate ?? ""}
-        onChange={(e) => onDateChange(e.target.value)}
-        min={effectiveMinDate}
-        max={effectiveMaxDate}
-      />
+      {enableDateRange ? (
+        <>
+          <Input
+            label="Start Date"
+            type="date"
+            value={selectedDate ?? ""}
+            onChange={(e) => onDateChange(e.target.value)}
+            min={effectiveMinDate}
+            max={effectiveMaxDate}
+          />
+          {onEndDateChange && (
+            <Input
+              label="End Date"
+              type="date"
+              value={selectedEndDate ?? ""}
+              onChange={(e) => onEndDateChange(e.target.value)}
+              min={selectedDate ?? effectiveMinDate}
+              max={effectiveMaxDate}
+            />
+          )}
+        </>
+      ) : (
+        <Input
+          label="Date"
+          type="date"
+          value={selectedDate ?? ""}
+          onChange={(e) => onDateChange(e.target.value)}
+          min={effectiveMinDate}
+          max={effectiveMaxDate}
+        />
+      )}
 
       <div className={styles.field}>
         <span className={styles.label}>Party Size</span>

--- a/packages/types/src/availability.ts
+++ b/packages/types/src/availability.ts
@@ -49,6 +49,7 @@ export interface CreateHoldRequest {
   time: string; // ISO 8601 datetime
   partySize: number;
   tableId?: string; // optional, auto-assign if not provided
+  holdDurationMinutes?: number; // optional, venue default if not provided
 }
 
 export interface ConfirmHoldRequest {

--- a/services/reservations/src/routes/holds.ts
+++ b/services/reservations/src/routes/holds.ts
@@ -129,6 +129,12 @@ export const holdRoutes: FastifyPluginAsync = async (fastify) => {
               type: "string",
               description: "Optional specific table to hold. If not provided, best available table is assigned.",
             },
+            holdDurationMinutes: {
+              type: "integer",
+              minimum: 1,
+              maximum: 60,
+              description: "Override hold duration in minutes. Defaults to venue setting or 10 minutes.",
+            },
           },
         },
         response: {

--- a/services/reservations/src/services/hold.ts
+++ b/services/reservations/src/services/hold.ts
@@ -50,7 +50,7 @@ export const holdService = {
     data: CreateHoldRequest,
     sessionId: string
   ): Promise<CreateHoldResult> {
-    const { venueId, date, time, partySize, tableId } = data;
+    const { venueId, date, time, partySize, tableId, holdDurationMinutes } = data;
 
     // Get venue settings for hold duration
     const venue = await prisma.venue.findUnique({
@@ -62,7 +62,8 @@ export const holdService = {
     }
 
     const settings = venue.settings as VenueSettings | null;
-    const holdDuration = settings?.holdDurationMinutes ?? DEFAULT_HOLD_DURATION;
+    // Use request-provided duration, or fall back to venue setting, or default
+    const holdDuration = holdDurationMinutes ?? settings?.holdDurationMinutes ?? DEFAULT_HOLD_DURATION;
 
     // Calculate times
     const startTime = new Date(time);


### PR DESCRIPTION
## Summary
- Add `holdDurationMinutes` prop to allow configurable hold timer (default 10 min)
- Add `cancellationUrl` and `onCancellation` props for cancellation path handling  
- Add `enableDateRange` prop to toggle date range selection with start/end dates
- Add `minDate` and `maxDate` props for date range constraints
- Update `DatePartySelector` to support date range mode with dual date inputs
- Update backend to support `holdDurationMinutes` override in `CreateHoldRequest`

## Changes

### Frontend (apps/hospitality)
- `BookingWidget.tsx`: Add new props for hold duration, date range, and cancellation
- `DatePartySelector.tsx`: Add date range support with start/end date inputs
- `ConfirmationView.tsx`: Add cancellation button with URL/callback options

### Backend (services/reservations)
- `holds.ts` route: Add `holdDurationMinutes` to request schema
- `hold.ts` service: Use request-provided duration or fall back to venue setting

### Types (packages/types)
- `availability.ts`: Add optional `holdDurationMinutes` to `CreateHoldRequest`

## Testing
- TypeScript compiles without errors (pre-existing reservations service errors are unrelated)
- ESLint passes with no new issues

Closes #437