### PR TITLE
fix: resolve mcp-server TypeScript build failures

### DIFF
--- a/packages/mcp-server/src/tools/ci.ts
+++ b/packages/mcp-server/src/tools/ci.ts
@@ -1,7 +1,5 @@
 import { execSync } from "node:child_process";
 
-const WORKFLOWS = ["CI", "Deploy Services", "Deploy Static", "Secret Scan"];
-
 export async function ciRunStatus(): Promise<string> {
   try {
     const output = execSync(`gh run list --limit 10 --json name,status,conclusion,workflowName`, {

--- a/packages/mcp-server/src/tools/database.ts
+++ b/packages/mcp-server/src/tools/database.ts
@@ -1,6 +1,4 @@
 import { execSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { join } from "node:path";
 
 export async function dbListTables(): Promise<string> {
   try {

--- a/packages/mcp-server/src/tools/deploy_status.ts
+++ b/packages/mcp-server/src/tools/deploy_status.ts
@@ -1,0 +1,25 @@
+import { execSync } from "node:child_process";
+
+export async function deployStatus(): Promise<string> {
+  try {
+    const output = execSync(`doctl apps list --format ID,Spec.Name,ActiveDeployment.Phase,InProgressDeployment.Phase --no-header`, {
+      encoding: "utf-8",
+    });
+    const lines = output.trim().split("\n").filter(Boolean);
+    const apps = lines.map((line) => {
+      const parts = line.trim().split(/\s{2,}/);
+      return {
+        id: parts[0],
+        name: parts[1],
+        activePhase: parts[2] || "unknown",
+        inProgressPhase: parts[3] || "none",
+      };
+    });
+    return JSON.stringify({ apps }, null, 2);
+  } catch (error) {
+    return JSON.stringify({
+      error: "Failed to get deploy status",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/packages/mcp-server/src/tools/git.ts
+++ b/packages/mcp-server/src/tools/git.ts
@@ -11,7 +11,9 @@ export async function gitWorkflowStatus(): Promise<string> {
       const run = execSync("gh run list --branch main --limit 1 --json conclusion", { encoding: "utf-8" });
       const result = JSON.parse(run);
       ciStatus = result[0]?.conclusion || "unknown";
-    } catch {}
+    } catch {
+      // gh CLI not available or failed - ciStatus remains "unknown"
+    }
 
     return JSON.stringify({
       currentBranch: branch,


### PR DESCRIPTION
## Summary

- Create missing `deploy_status.ts` tool that queries DigitalOcean App Platform status via `doctl`
- Remove unused `WORKFLOWS` constant from `ci.ts` 
- Remove unused `existsSync` and `join` imports from `database.ts`
- Fix empty catch block in `git.ts` (pre-existing lint error)

All four TypeScript build errors from issue #504 are resolved. Lint and typecheck pass locally.

Closes #504

## Test plan

- [ ] `pnpm --filter @mbe/mcp-server typecheck` passes
- [ ] `pnpm --filter @mbe/mcp-server lint` passes
- [ ] CI `lint-typecheck` job passes on this PR
