### PR TITLE
docs: add architecture decision records (ADR-002 through ADR-006)

### DIFF
--- a/docs/adr/ADR-002-api-versioning-strategy.md
+++ b/docs/adr/ADR-002-api-versioning-strategy.md
@@ -1,0 +1,73 @@
+---
+id: ADR-002
+title: API Versioning Strategy
+status: active
+date: 2026-04-06
+---
+
+# ADR-002: API Versioning Strategy
+
+## Context
+
+As the platform grows, API contracts will inevitably change. We needed a versioning strategy that lets us evolve endpoints without breaking existing clients, while giving those clients clear, programmatic signals about upcoming changes.
+
+## Decision
+
+We use **path-based versioning** (`/api/v1/...`) combined with **HTTP deprecation headers** (RFC 8594 `Deprecation`, RFC 7231 `Sunset`, and `Link` with `rel="successor-version"`).
+
+### Path Prefixes
+
+Each service owns a versioned path prefix on the shared API origin:
+
+- Users Service: `/api/v1/users/*`
+- Reservations Service: `/api/v1/*` (catch-all after more specific prefixes)
+- Agent Service: `/v1/*`
+
+### Deprecation Signaling
+
+When a version is superseded, all responses include:
+
+| Header | Purpose |
+|--------|---------|
+| `Deprecation: true` | Machine-readable flag |
+| `Sunset: <RFC 7231 date>` | Date the version becomes unavailable |
+| `Link: </api/v2/...>; rel="successor-version"` | URL of the replacement |
+
+### Sunset Policy
+
+- **6-month window** between deprecation announcement and removal.
+- No new features on deprecated versions; critical security patches only.
+- Health check responses include `apiVersion`, `successorVersion`, and `sunsetDate` so monitoring tools can alert proactively.
+
+### Version Lifecycle
+
+1. **Current** -- actively maintained, receives features and fixes.
+2. **Deprecated** -- still available but marked with headers; clients should migrate.
+3. **Sunset** -- removed; requests return 410 Gone.
+
+## Consequences
+
+**Benefits:**
+
+- Path prefixes make routing and log filtering straightforward (DigitalOcean ingress rules, Cloudflare edge router, and observability all key on path).
+- Deprecation headers are opt-in to consume -- clients that ignore them keep working until sunset.
+- Health endpoints expose version metadata, enabling automated migration reminders.
+
+**Trade-offs:**
+
+- Path-based versioning duplicates route registrations when two versions coexist.
+- The 6-month window is generous; shorter windows would reduce maintenance burden but increase client churn risk.
+
+## Alternatives Considered
+
+### Query-parameter versioning (`?version=1`)
+
+Rejected because query params are stripped by some CDN configurations and are invisible in access logs without custom parsing.
+
+### Header-only versioning (`Accept: application/vnd.mbe.v1+json`)
+
+Rejected because it complicates debugging (you cannot tell the version from a URL alone), is harder to route at the infrastructure level, and is less discoverable for new API consumers.
+
+### No versioning (single evolving contract)
+
+Rejected because even with additive-only changes, removing or renaming a field is a breaking change, and we cannot coordinate all clients for simultaneous updates.

--- a/docs/adr/ADR-003-error-handling-standard.md
+++ b/docs/adr/ADR-003-error-handling-standard.md
@@ -1,0 +1,92 @@
+---
+id: ADR-003
+title: Error Handling Standard
+status: active
+date: 2026-04-06
+---
+
+# ADR-003: Error Handling Standard
+
+## Context
+
+Early services used ad-hoc error shapes (`{ error, message, statusCode }`). Different services returned slightly different structures, making it difficult for frontend code and external consumers to handle errors uniformly. We needed a single, standards-based error format.
+
+## Decision
+
+All API errors **must** conform to **RFC 7807 Problem Details for HTTP APIs** (`application/problem+json`). During the migration period, responses include both legacy fields and RFC 7807 fields for backward compatibility.
+
+### Canonical Shape
+
+```typescript
+interface ProblemDetails {
+  type: string;     // URI identifying the error type (default: "about:blank")
+  title: string;    // Short human-readable summary
+  status: number;   // HTTP status code
+  detail: string;   // Human-readable explanation specific to this occurrence
+  instance?: string; // URI identifying this specific occurrence
+}
+```
+
+### Backward-Compatible Envelope
+
+The shared `createProblemDetails()` function in `@mbe/types` returns a combined object that satisfies both the legacy `ApiError` interface and RFC 7807:
+
+```typescript
+{
+  // RFC 7807
+  type: "about:blank",
+  title: "Not Found",
+  status: 404,
+  detail: "User with id '123' not found",
+  // Legacy (will be removed after migration)
+  error: "Not Found",
+  message: "User with id '123' not found",
+  statusCode: 404,
+}
+```
+
+### Extension Members
+
+Domain-specific context is passed via extension members (RFC 7807 Section 3.2), not a generic `details` bag:
+
+```json
+{
+  "type": "/errors/table-not-available",
+  "title": "Table Not Available",
+  "status": 409,
+  "detail": "Table 5 is already booked for 19:00",
+  "tableId": "table-5",
+  "conflictingReservationId": "res-123"
+}
+```
+
+### Auth Errors
+
+The `@mbe/auth` Fastify plugin uses `createProblemDetails()` for all 401 responses, ensuring even authentication failures follow the standard format.
+
+## Consequences
+
+**Benefits:**
+
+- Single error shape across all services -- frontend error handling is a single code path.
+- RFC 7807 is a widely adopted standard; third-party consumers and tooling understand it out of the box.
+- The `type` URI enables machine-readable error classification without parsing human-readable strings.
+
+**Trade-offs:**
+
+- Dual-format responses during migration add ~100 bytes per error payload.
+- Services must import and use `createProblemDetails()` from `@mbe/types` rather than throwing raw objects -- enforced by ESLint custom rules.
+
+## Alternatives Considered
+
+### Custom envelope (`{ success: false, error: { code, message } }`)
+
+Rejected because it is non-standard, requiring every consumer to learn our bespoke format. RFC 7807 is already supported by HTTP client libraries and API gateways.
+
+### GraphQL-style errors (`{ errors: [{ message, extensions }] }`)
+
+Rejected because our services use REST, and importing a GraphQL error convention into REST responses would confuse consumers familiar with either standard.
+
+### No standard (let each service decide)
+
+Rejected because inconsistent error shapes were the problem we set out to solve.

--- a/docs/adr/ADR-004-health-check-patterns.md
+++ b/docs/adr/ADR-004-health-check-patterns.md
@@ -1,0 +1,92 @@
+---
+id: ADR-004
+title: Health Check Patterns
+status: active
+date: 2026-04-06
+---
+
+# ADR-004: Health Check Patterns
+
+## Context
+
+Services need health endpoints for three distinct consumers: the hosting platform (DigitalOcean App Platform container probes), external monitoring and post-deploy verification, and operators investigating incidents. A single flat endpoint cannot serve all three without leaking infrastructure details to unauthenticated callers.
+
+## Decision
+
+We use a **two-tier health check architecture**: per-service simple checks and a system-wide aggregation endpoint at the edge.
+
+### Tier 1: Per-Service Health (`/health`)
+
+Every Fastify service exposes identical health routes:
+
+| Path | Purpose |
+|------|---------|
+| `/health` | Internal probe (DO App Platform container health) |
+| `/api/v1/<service>/health` | Public path through DO ingress (post-deploy verification) |
+
+Both return the same `HealthResponse`:
+
+```json
+{
+  "status": "ok | degraded | error",
+  "version": "1.0.0",
+  "apiVersion": "v1",
+  "timestamp": "...",
+  "checks": {
+    "database": { "status": "ok", "latency": 5 },
+    "slow_queries": { "status": "ok", "message": "0 slow queries in last 5min" },
+    "auth0": { "status": "ok", "latency": 42 }
+  }
+}
+```
+
+**Key behaviors:**
+
+- **Slow query tracking**: A rolling window counts queries exceeding a threshold. The `slow_queries` check reports count and worst-case latency over the last 5 minutes.
+- **Latency anomaly detection**: Database ping latency is compared against a rolling average. Spikes trigger `"status": "error"` with diagnostic context.
+- **Tri-state status**: `ok` (all checks pass), `degraded` (non-critical check failing), `error` (critical failure -- returns HTTP 503).
+
+### Tier 2: System Aggregation (`/health/system`)
+
+The Cloudflare edge router exposes `/health/system`, which fans out to all subsystems in parallel:
+
+1. **Services** -- HTTP fetch to each service's `/health` endpoint (5s timeout).
+2. **Static sites** -- HEAD request via Service Bindings (in-process, no network hop).
+3. **CI and deploys** -- Read from Cloudflare KV (written by GitHub Actions post-run).
+
+**Access control:** Unauthenticated requests receive only `{ status, timestamp }`. Detailed subsystem data (service names, latencies, commit SHAs) requires a `Bearer` token matching the `HEALTH_TOKEN` secret. If `HEALTH_TOKEN` is not configured, all requests get the coarse response (safe by default).
+
+**Status computation policy:**
+
+- Any service unhealthy -> system `unhealthy`.
+- 2+ static sites down -> system `unhealthy`.
+- Single static site, CI, or one deploy pipeline failing -> system `degraded`.
+- All passing -> system `healthy`.
+
+## Consequences
+
+**Benefits:**
+
+- Platform health probes hit a lightweight path (`/health`) that avoids external dependencies when possible.
+- The aggregation endpoint gives operators a single URL for full-stack status during incidents.
+- Token-gated detail prevents leaking infrastructure topology to unauthenticated callers.
+- Parallel fan-out keeps aggregation latency bounded by the slowest subsystem (capped at 5s).
+
+**Trade-offs:**
+
+- Two health routes per service (`/health` and `/api/v1/<service>/health`) add minor route registration overhead.
+- KV-based CI/deploy status can become stale if GitHub Actions fails to write; the system handles this by reporting `"stale"` status rather than false-healthy.
+
+## Alternatives Considered
+
+### Single `/health` endpoint with query params for detail level
+
+Rejected because the platform probe and the aggregation endpoint have fundamentally different concerns (container liveness vs. full-stack status). Mixing them increases the blast radius of bugs.
+
+### Third-party status page service (e.g., Betteruptime, Statuspage)
+
+Rejected as the primary mechanism because it adds an external dependency for operational data. The `/health/system` endpoint can feed a status page if needed, keeping the source of truth internal.
+
+### Pull-based monitoring only (external pinger, no aggregation)
+
+Rejected because it cannot provide a single-request full-stack view during incidents and requires configuring each subsystem individually in the monitoring tool.

--- a/docs/adr/ADR-005-service-authentication.md
+++ b/docs/adr/ADR-005-service-authentication.md
@@ -1,0 +1,82 @@
+---
+id: ADR-005
+title: Service Authentication
+status: active
+date: 2026-04-06
+---
+
+# ADR-005: Service Authentication
+
+## Context
+
+The platform serves authenticated users (restaurant operators) across multiple frontend apps and backend services. We needed an authentication strategy that is secure, standards-based, and avoids vendor lock-in to a single identity provider.
+
+## Decision
+
+We use **Auth0 as the OIDC identity provider**, but all client and server code interacts through **standard OIDC/JWKS protocols** rather than Auth0-specific SDKs. This is implemented in the shared `@mbe/auth` package.
+
+### Frontend: OIDC Authorization Code Flow (PKCE)
+
+React apps wrap their component tree with `AuthProvider`, which delegates to `react-oidc-context` (a generic OIDC library):
+
+- Authority, client ID, audience, and redirect URI are passed as props (sourced from build-time env vars).
+- PKCE is used for the authorization code exchange (no client secret in the browser).
+- After sign-in, callback params are stripped from the URL via `history.replaceState`.
+- `useAuth()` exposes `isAuthenticated`, `user`, `accessToken`, `signIn`, `signOut`, and `signInSilent`.
+- `useAccessToken()` provides just the token for API calls.
+- `useRequireAuth()` auto-redirects unauthenticated users to the login page.
+
+### Backend: JWT Verification via JWKS
+
+The `authPlugin` Fastify plugin verifies JWTs on every request:
+
+1. Fetches the signing keys from `{authority}/.well-known/jwks.json` using the `jose` library (not an Auth0 SDK).
+2. Verifies `iss` (must match the configured authority) and `aud` (must match the configured audience).
+3. Populates `request.user: AuthUser` with `id`, `email`, `name`, `picture`, and raw claims.
+4. Returns RFC 7807 Problem Details on failure (see ADR-003).
+
+**Permissive by default:** The global `onRequest` hook rejects invalid tokens but passes through requests with no token. Route-level preHandlers control access:
+
+- `requireAuth` -- returns 401 if `request.user` is not set.
+- `optionalAuth` -- documents that auth is optional; request.user may be undefined.
+
+Health and docs paths are excluded from token verification entirely.
+
+### Environment Configuration
+
+| Variable | Context | Purpose |
+|----------|---------|---------|
+| `AUTH_AUTHORITY` | Backend | OIDC issuer URL |
+| `AUTH_AUDIENCE` | Backend | Expected JWT audience |
+| `VITE_AUTH_AUTHORITY` | Frontend | Same, via build-time env |
+| `VITE_AUTH_CLIENT_ID` | Frontend | Auth0 application client ID |
+
+Auth0 resources (applications, API) are managed via Pulumi using `@pulumi/auth0`, keeping infrastructure as code.
+
+## Consequences
+
+**Benefits:**
+
+- **Provider portability**: Because all code uses standard OIDC/JWKS (not `@auth0/auth0-spa-js` or `@auth0/nextjs-auth0`), switching to another OIDC provider (Clerk, Keycloak, AWS Cognito) requires only changing environment variables and Pulumi configuration.
+- **Shared package**: A single `@mbe/auth` package serves both React and Fastify, eliminating duplicated auth logic across services.
+- **Secure defaults**: Health and docs are excluded; everything else requires a valid token structure, with route-level control for enforcement.
+
+**Trade-offs:**
+
+- Auth0-specific features (Actions, Organizations, MFA enrollment API) require direct Auth0 API calls outside the standard OIDC flow.
+- The permissive hook pattern means forgetting to add `requireAuth` to a sensitive route leaves it open to anonymous access -- mitigated by code review and the `security-reviewer` agent.
+- Token refresh relies on `signInSilent()` (silent renew via hidden iframe or refresh token), which can fail if third-party cookies are blocked -- acceptable because our apps and Auth0 are on different domains and we use refresh tokens as fallback.
+
+## Alternatives Considered
+
+### Auth0-specific SDKs (`@auth0/auth0-react`, `@auth0/nextjs-auth0`)
+
+Rejected because they create hard vendor lock-in. The Auth0 React SDK wraps the same OIDC flows but exposes Auth0-specific APIs that would need to be replaced if we switch providers.
+
+### Self-hosted identity (Keycloak, Ory)
+
+Rejected for now because the operational burden of running and securing an identity service outweighs the cost savings at our current scale. The standard-OIDC approach makes future migration straightforward.
+
+### API gateway token validation (no per-service verification)
+
+Rejected because our edge router (Cloudflare Worker) proxies to DigitalOcean via HTTP, meaning the API origin is technically reachable without the edge. Per-service verification provides defense in depth.

--- a/docs/adr/ADR-006-edge-routing-architecture.md
+++ b/docs/adr/ADR-006-edge-routing-architecture.md
@@ -1,0 +1,101 @@
+---
+id: ADR-006
+title: Edge Routing Architecture
+status: active
+date: 2026-04-06
+---
+
+# ADR-006: Edge Routing Architecture
+
+## Context
+
+The platform serves multiple frontend apps (marketing, hospitality, rialto, gen) and a multi-service API backend from a single domain (`mattbutlerengineering.com`). We needed a routing layer that unifies these under one origin, handles security headers, and avoids stale content after deploys.
+
+## Decision
+
+A single **Cloudflare Worker** (`edge-router`) acts as the front door for all traffic. It routes requests by path prefix, using **Service Bindings** for static sites and **HTTP subrequests** for the API.
+
+### Routing Table
+
+| Pattern | Target | Mechanism |
+|---------|--------|-----------|
+| `/api/*` | DigitalOcean App Platform | HTTP proxy to `API_ORIGIN` |
+| `/hospitality/*` | Hospitality Worker | Service Binding (`env.HOSPITALITY`) |
+| `/rialto/*` | Rialto Worker | Service Binding (`env.RIALTO`) |
+| `/gen/*` | Gen Worker | Service Binding (`env.GEN`) |
+| `/*` | Marketing Worker | Service Binding (`env.MARKETING`) |
+| `/health/system` | Edge router itself | Aggregated health (see ADR-004) |
+
+### Service Bindings for Static Sites
+
+Static site Workers are called via `env.BINDING.fetch()`, which is an in-process function call that **bypasses the Cloudflare CDN entirely**. This eliminates stale HTML after deploys -- the critical problem that motivated this architecture.
+
+The edge router strips path prefixes before forwarding (e.g., `/hospitality/foo` becomes `/foo` on the app Worker), because each app is built with a Vite `base` path but the Worker serves from root.
+
+### HTTP Proxy for API
+
+API requests are forwarded via standard `fetch()` to the DigitalOcean App Platform origin. The edge router:
+
+- Preserves the original path (including `/api/` prefix).
+- Sets `X-Forwarded-Host`, `X-Forwarded-For`, and `X-Request-ID` headers.
+- Injects feature flags from KV as an `X-Feature-Flags` header.
+- Wraps the proxy in a **circuit breaker** (KV-backed state) that opens after repeated 5xx responses and returns a branded error page.
+
+### Security Headers
+
+Every static site response receives security headers injected by the edge router:
+
+- `Strict-Transport-Security` (HSTS with `includeSubDomains`)
+- `X-Frame-Options: DENY`
+- `X-Content-Type-Options: nosniff`
+- `Content-Security-Policy` with a **per-request nonce** for `script-src` (replaces `unsafe-inline`)
+- `Referrer-Policy`, `Permissions-Policy`
+
+HTML responses are processed by `HTMLRewriter` to inject the nonce into all `<script>` tags, allowing Vite-generated inline scripts to execute under the nonce-based CSP.
+
+### Cache Policy
+
+- Hashed assets (`/assets/*` with content hashes): `public, max-age=31536000, immutable`.
+- HTML documents: `public, max-age=0, must-revalidate`.
+- API responses: passed through unmodified.
+
+### Additional Edge Behaviors
+
+- **Rate limiting**: Per-IP, per-path rate limits backed by KV.
+- **www redirect**: `www.mattbutlerengineering.com` -> 301 to bare domain.
+- **Legacy redirects**: `/dashboard/*` -> `/hospitality/*`.
+- **Source map blocking**: `.map` files return 404 (defense in depth; maps are uploaded to Sentry and deleted from dist).
+- **Trailing-slash normalization**: SPA prefixes (`/rialto`, `/hospitality`, `/gen`) redirect to trailing-slash versions to prevent React Router confusion.
+
+## Consequences
+
+**Benefits:**
+
+- **No stale deploys**: Service Bindings skip the CDN cache, so HTML is always fresh. This was the primary driver for this architecture.
+- **Single domain**: All apps and APIs share one origin, avoiding CORS complexity and cookie domain issues.
+- **Centralized security**: Security headers are applied once at the edge, not duplicated across each app's build configuration.
+- **Circuit breaker**: API outages produce a branded error page instead of raw connection errors.
+
+**Trade-offs:**
+
+- The edge router is a single point of failure for all traffic. Mitigated by Cloudflare Workers' global distribution and automatic failover.
+- Adding a new static site requires three changes: create the Worker, add a Service Binding in `wrangler.toml`, and add routing logic in `edge-router.js`.
+- The HTTP proxy to DigitalOcean means API latency includes the extra hop from Cloudflare's nearest PoP to the DO region. Acceptable because the DO API region is chosen for database proximity, not client proximity.
+
+## Alternatives Considered
+
+### Cloudflare Pages with `_redirects` / `_headers`
+
+Rejected because Pages does not support Service Bindings between multiple apps on the same domain, and its CDN cache requires purge-on-deploy to avoid stale HTML.
+
+### Nginx reverse proxy on the API server
+
+Rejected because it does not solve the static site routing problem and loses Cloudflare's global edge network for static content.
+
+### Separate subdomains per app (`hospitality.mattbutlerengineering.com`)
+
+Rejected because it introduces CORS configuration for API calls, complicates cookie sharing, and requires separate TLS certificates or a wildcard cert. A single domain with path-based routing is operationally simpler.
+
+### Cloudflare CDN cache with purge-on-deploy
+
+Rejected as the primary strategy because cache purge is eventually consistent -- users can still see stale HTML for seconds to minutes after a deploy. Service Bindings provide instant consistency.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,38 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) documenting significant technical decisions made in the mattbutlerengineering monorepo.
+
+## Index
+
+| ADR | Title | Status | Date |
+|-----|-------|--------|------|
+| [ADR-001](ADR-001-rialto-over-tailwind.md) | Design System Unification (Rialto over Tailwind) | active | 2026-03-28 |
+| [ADR-002](ADR-002-api-versioning-strategy.md) | API Versioning Strategy | active | 2026-04-06 |
+| [ADR-003](ADR-003-error-handling-standard.md) | Error Handling Standard | active | 2026-04-06 |
+| [ADR-004](ADR-004-health-check-patterns.md) | Health Check Patterns | active | 2026-04-06 |
+| [ADR-005](ADR-005-service-authentication.md) | Service Authentication | active | 2026-04-06 |
+| [ADR-006](ADR-006-edge-routing-architecture.md) | Edge Routing Architecture | active | 2026-04-06 |
+
+## Format
+
+Each ADR follows this structure:
+
+- **Context** -- What problem are we solving?
+- **Decision** -- What did we decide?
+- **Consequences** -- What are the trade-offs?
+- **Alternatives Considered** -- What else did we evaluate?
+
+## Statuses
+
+| Status | Meaning |
+|--------|---------|
+| `active` | Currently in effect |
+| `superseded` | Replaced by a newer ADR |
+| `deprecated` | No longer relevant |
+
+## Adding a New ADR
+
+1. Copy an existing ADR as a template.
+2. Use the next sequential number: `ADR-NNN-short-title.md`.
+3. Fill in all four sections (Context, Decision, Consequences, Alternatives).
+4. Add an entry to the index table above.


### PR DESCRIPTION
## Summary
- Adds 5 new ADRs documenting core architectural decisions:
  - **ADR-002**: API versioning strategy (sunset headers, /api/v1/ prefix)
  - **ADR-003**: Error handling standard (RFC 7807 Problem Details)
  - **ADR-004**: Health check patterns (dual endpoints, edge aggregation)
  - **ADR-005**: Service authentication (Auth0 OIDC, JWT/JWKS verification)
  - **ADR-006**: Edge routing architecture (Cloudflare Workers + Service Bindings)
- Adds `docs/adr/README.md` as the ADR index

## Test plan
- [x] ADRs follow established format (matching ADR-001 style)
- [ ] `mbe check-adr` validates new ADR format
- [ ] Review for accuracy against actual implementation

Closes #410