### PR TITLE
feat: track cumulative agent spend per ship-loop iteration

### DIFF
--- a/.claude/skills/progress-tracker/SKILL.md
+++ b/.claude/skills/progress-tracker/SKILL.md
@@ -35,7 +35,20 @@ gh run list --branch main --limit 20 --json conclusion,createdAt
 
 # Meta-improvement suggestions created
 gh issue list --label "meta-improvement" --state all --json number,title,state
+
+# Agent spend (from local cost log)
+# Read .claude/agent-spend.jsonl and aggregate by date
+cat .claude/agent-spend.jsonl 2>/dev/null | tail -100
 ```
+
+#### Cost Log Format
+
+The file `.claude/agent-spend.jsonl` contains one JSON object per line:
+```json
+{"date":"2026-04-06","timestamp":"2026-04-06T12:00:00Z","costUsd":0.45,"issueNumber":199,"model":"claude-sonnet-4-6"}
+```
+
+Log entries are written by `pnpm log:cost -- --cost <usd> --issue <num>` after each agent session.
 
 ### Step 2: Compute Metrics
 
@@ -52,6 +65,9 @@ Calculate these key indicators:
 | **Queue Depth** | Count of issues with `ready` label (target: < 5) |
 | **Stale Issues** | Issues with `ready` label open > 7 days |
 | **Blocked Issues** | Issues with `agent-failed` label not re-queued |
+| **Daily Agent Spend** | Sum of costUsd from .claude/agent-spend.jsonl for today (target: < $10) |
+| **7d Agent Spend** | Sum of costUsd from last 7 days of entries |
+| **Avg Cost/Issue** | 7d spend / issues closed in 7d |
 
 ### Step 3: Analyze Patterns
 
@@ -90,6 +106,9 @@ Append a dated entry to `.claude/improvement-loop/log.md`:
 | CI Pass Rate | N% | >95% | ✅/⚠️/❌ |
 | Queue Depth | N | <5 | ✅/⚠️/❌ |
 | Stale Issues | N | 0 | ✅/⚠️/❌ |
+| Daily Agent Spend | $N.NN | <$10 | ✅/⚠️/❌ |
+| 7d Agent Spend | $N.NN | <$50 | ✅/⚠️/❌ |
+| Avg Cost/Issue | $N.NN | <$2 | ✅/⚠️/❌ |
 
 ### Patterns
 - [Notable patterns observed]
@@ -135,6 +154,9 @@ Only create improvement issues for patterns seen **consistently over 3+ days**. 
 | CI Pass Rate | > 95% | 85-95% | < 85% |
 | Queue Depth | < 5 | 5-10 | > 10 |
 | Avg Time-to-Close | < 24h | 24-72h | > 72h |
+| Daily Agent Spend | < $10 | $10-$20 | > $20 |
+| 7d Agent Spend | < $50 | $50-$100 | > $100 |
+| Avg Cost/Issue | < $2 | $2-$5 | > $5 |
 
 ## Self-Tuning Actions
 
@@ -213,5 +235,5 @@ If reverts > 3 in a week, flag it — the loop may be pushing broken code.
 - **Max 2 meta-improvement issues per run** — avoid flooding the queue
 - **Max 2 auto-retries per run** — don't flood the ready queue
 - **Append-only log** — never delete or modify previous log entries
-- **No cost data** — do not attempt to query API costs (not available via gh CLI)
+- **Cost data** — read from `.claude/agent-spend.jsonl` (logged by `pnpm log:cost` after each agent session)
 - **Circuit breaker threshold** — only pause at 50% failure rate over 3+ days, not single bad days

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ coverage/
 # Claude Code (keep skills, ignore local settings)
 .claude/settings.local.json
 .claude/improvement-loop/
+.claude/agent-spend.jsonl
 
 # Playwright
 e2e/.auth/

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "graph": "node scripts/generate-dep-graph.js",
     "check:schema-compat": "node scripts/check-schema-compat.js",
     "schema:baseline": "tsx scripts/update-schema-baselines.js",
+    "log:cost": "node scripts/log-agent-cost.js",
     "build": "turbo run build",
     "test": "turbo run test",
     "test:contract": "turbo run test:contract",

--- a/scripts/log-agent-cost.js
+++ b/scripts/log-agent-cost.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+/**
+ * Log agent session cost for spend tracking.
+ *
+ * Appends a JSON-lines entry to .claude/agent-spend.jsonl with cost,
+ * issue number, and timestamp. The progress tracker aggregates these
+ * to compute daily spend and flag threshold breaches.
+ *
+ * Usage: node scripts/log-agent-cost.js --cost 0.45 --issue 199 [--model claude-sonnet-4-6]
+ */
+
+import { appendFileSync, readFileSync, existsSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, "..");
+const LOG_PATH = join(root, ".claude", "agent-spend.jsonl");
+const DAILY_THRESHOLD_USD = parseFloat(
+  process.env.AGENT_DAILY_SPEND_LIMIT ?? "10"
+);
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i++) {
+    if (argv[i] === "--cost" && argv[i + 1]) {
+      args.cost = parseFloat(argv[i + 1]);
+      i++;
+    } else if (argv[i] === "--issue" && argv[i + 1]) {
+      args.issue = parseInt(argv[i + 1], 10);
+      i++;
+    } else if (argv[i] === "--model" && argv[i + 1]) {
+      args.model = argv[i + 1];
+      i++;
+    }
+  }
+  return args;
+}
+
+function todayKey() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function getDailySpend() {
+  if (!existsSync(LOG_PATH)) return 0;
+  const today = todayKey();
+  let total = 0;
+  for (const line of readFileSync(LOG_PATH, "utf-8").split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const entry = JSON.parse(line);
+      if (entry.date === today) {
+        total += entry.costUsd ?? 0;
+      }
+    } catch {
+      // skip malformed lines
+    }
+  }
+  return total;
+}
+
+// CLI runner
+const args = parseArgs(process.argv);
+
+if (args.cost === undefined || args.cost === null) {
+  console.log("Usage: node scripts/log-agent-cost.js --cost <usd> --issue <number> [--model <id>]");
+  process.exit(1);
+}
+
+// Ensure .claude directory exists
+const logDir = dirname(LOG_PATH);
+if (!existsSync(logDir)) {
+  mkdirSync(logDir, { recursive: true });
+}
+
+const entry = {
+  date: todayKey(),
+  timestamp: new Date().toISOString(),
+  costUsd: args.cost,
+  issueNumber: args.issue ?? null,
+  model: args.model ?? null,
+};
+
+appendFileSync(LOG_PATH, JSON.stringify(entry) + "\n");
+
+const dailySpend = getDailySpend();
+console.log(`Logged: $${args.cost.toFixed(4)} for issue #${args.issue ?? "unknown"}`);
+console.log(`Daily spend: $${dailySpend.toFixed(4)} / $${DAILY_THRESHOLD_USD.toFixed(2)} limit`);
+
+if (dailySpend >= DAILY_THRESHOLD_USD) {
+  console.log(`\n⚠️  ALERT: Daily spend ($${dailySpend.toFixed(2)}) exceeds threshold ($${DAILY_THRESHOLD_USD.toFixed(2)})`);
+  process.exit(2); // Exit code 2 = threshold exceeded (not a script error)
+}


### PR DESCRIPTION
## Summary

- **`scripts/log-agent-cost.js`** — JSONL logger for per-session agent cost
- **`pnpm log:cost`** — convenience script (`--cost <usd> --issue <num> --model <id>`)
- **Progress tracker** updated to aggregate daily/weekly spend with thresholds
- Cost log at `.claude/agent-spend.jsonl` (gitignored, local state)
- Exit code 2 when daily threshold ($10 default, configurable via `AGENT_DAILY_SPEND_LIMIT`) exceeded

### Thresholds
| Metric | Green | Yellow | Red |
|--------|-------|--------|-----|
| Daily Agent Spend | < $10 | $10-$20 | > $20 |
| 7d Agent Spend | < $50 | $50-$100 | > $100 |
| Avg Cost/Issue | < $2 | $2-$5 | > $5 |

## Test plan
- [x] `pnpm log:cost -- --cost 0.45 --issue 199` logs to JSONL
- [x] Cumulative daily spend computed correctly across multiple entries
- [x] Exit code 2 when threshold exceeded
- [ ] Progress tracker reads and reports cost metrics

Closes #224