### PR TITLE
feat: public status page at /status showing system health

### DIFF
--- a/apps/marketing/src/App.tsx
+++ b/apps/marketing/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { Routes, Route } from "react-router-dom";
 import { Footer, GlobalNav } from "@mbe/rialto";
 import { HomePage } from "./pages/HomePage";
+import { StatusPage } from "./pages/StatusPage";
 import { NotFoundPage } from "./pages/NotFoundPage";
 import styles from "./App.module.css";
 
@@ -35,6 +36,7 @@ export function App({ theme, onThemeToggle }: AppProps) {
       <main id="main-content" tabIndex={-1} className={styles.main}>
         <Routes>
           <Route path="/" element={<HomePage />} />
+          <Route path="/status" element={<StatusPage />} />
           <Route path="*" element={<NotFoundPage />} />
         </Routes>
       </main>

--- a/apps/marketing/src/pages/StatusPage.module.css
+++ b/apps/marketing/src/pages/StatusPage.module.css
@@ -1,0 +1,62 @@
+.container {
+  max-width: 48rem;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+.header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.header h1 {
+  font-size: 1.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.overallStatus {
+  margin: 1rem 0;
+}
+
+.lastChecked {
+  font-size: 0.875rem;
+  opacity: 0.6;
+}
+
+.section {
+  margin-bottom: 2rem;
+}
+
+.section h2 {
+  font-size: 1.125rem;
+  margin-bottom: 0.75rem;
+  opacity: 0.8;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));
+  gap: 0.75rem;
+}
+
+.card {
+  padding: 1rem;
+}
+
+.cardHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.serviceName {
+  font-weight: 600;
+  font-size: 0.9375rem;
+}
+
+.meta {
+  margin-top: 0.5rem;
+  font-size: 0.8125rem;
+  opacity: 0.6;
+}

--- a/apps/marketing/src/pages/StatusPage.tsx
+++ b/apps/marketing/src/pages/StatusPage.tsx
@@ -1,0 +1,215 @@
+import { useState, useEffect, useCallback } from "react";
+import { Card, Badge, Spinner } from "@mbe/rialto";
+import styles from "./StatusPage.module.css";
+
+interface ServiceStatus {
+  readonly name: string;
+  readonly url: string;
+  readonly status: "ok" | "degraded" | "error" | "loading";
+  readonly version?: string;
+  readonly latency?: number;
+  readonly checkedAt?: string;
+}
+
+const SERVICES = [
+  { name: "Users API", url: "/api/v1/users/health" },
+  { name: "Reservations API", url: "/api/v1/reservations/health" },
+  { name: "Agent API", url: "/api/gen/health" },
+] as const;
+
+const STATIC_SITES = [
+  { name: "Marketing", url: "/" },
+  { name: "Hospitality", url: "/hospitality" },
+  { name: "Rialto", url: "/rialto" },
+] as const;
+
+const POLL_INTERVAL_MS = 30_000;
+
+function statusColor(status: string): "green" | "yellow" | "red" | "neutral" {
+  switch (status) {
+    case "ok":
+      return "green";
+    case "degraded":
+      return "yellow";
+    case "error":
+      return "red";
+    default:
+      return "neutral";
+  }
+}
+
+function statusLabel(status: string): string {
+  switch (status) {
+    case "ok":
+      return "Operational";
+    case "degraded":
+      return "Degraded";
+    case "error":
+      return "Down";
+    case "loading":
+      return "Checking...";
+    default:
+      return "Unknown";
+  }
+}
+
+async function checkService(url: string): Promise<Omit<ServiceStatus, "name" | "url">> {
+  const start = Date.now();
+  try {
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(10_000),
+    });
+    const latency = Date.now() - start;
+    if (!response.ok) {
+      return { status: "error", latency, checkedAt: new Date().toISOString() };
+    }
+    const data = await response.json();
+    return {
+      status: data.status === "ok" ? "ok" : "degraded",
+      version: data.version,
+      latency,
+      checkedAt: new Date().toISOString(),
+    };
+  } catch {
+    return {
+      status: "error",
+      latency: Date.now() - start,
+      checkedAt: new Date().toISOString(),
+    };
+  }
+}
+
+async function checkStaticSite(url: string): Promise<Omit<ServiceStatus, "name" | "url">> {
+  const start = Date.now();
+  try {
+    const response = await fetch(url, {
+      method: "HEAD",
+      signal: AbortSignal.timeout(10_000),
+    });
+    const latency = Date.now() - start;
+    return {
+      status: response.ok ? "ok" : "error",
+      latency,
+      checkedAt: new Date().toISOString(),
+    };
+  } catch {
+    return {
+      status: "error",
+      latency: Date.now() - start,
+      checkedAt: new Date().toISOString(),
+    };
+  }
+}
+
+function overallStatus(statuses: ServiceStatus[]): "ok" | "degraded" | "error" | "loading" {
+  if (statuses.some((s) => s.status === "loading")) return "loading";
+  if (statuses.every((s) => s.status === "ok")) return "ok";
+  if (statuses.some((s) => s.status === "error")) return "error";
+  return "degraded";
+}
+
+export function StatusPage() {
+  const [services, setServices] = useState<ServiceStatus[]>(
+    SERVICES.map((s) => ({ ...s, status: "loading" as const }))
+  );
+  const [sites, setSites] = useState<ServiceStatus[]>(
+    STATIC_SITES.map((s) => ({ ...s, status: "loading" as const }))
+  );
+  const [lastRefresh, setLastRefresh] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    const serviceResults = await Promise.all(
+      SERVICES.map(async (s) => ({
+        ...s,
+        ...(await checkService(s.url)),
+      }))
+    );
+    setServices(serviceResults);
+
+    const siteResults = await Promise.all(
+      STATIC_SITES.map(async (s) => ({
+        ...s,
+        ...(await checkStaticSite(s.url)),
+      }))
+    );
+    setSites(siteResults);
+    setLastRefresh(new Date().toISOString());
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    const interval = setInterval(refresh, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [refresh]);
+
+  const allStatuses = [...services, ...sites];
+  const overall = overallStatus(allStatuses);
+
+  return (
+    <div className={styles.container}>
+      <header className={styles.header}>
+        <h1>System Status</h1>
+        <div className={styles.overallStatus}>
+          <Badge color={statusColor(overall)} size="lg">
+            {overall === "loading" ? "Checking..." : statusLabel(overall)}
+          </Badge>
+        </div>
+        {lastRefresh && (
+          <p className={styles.lastChecked}>
+            Last checked: {new Date(lastRefresh).toLocaleTimeString()}
+            {" · "}Refreshes every 30s
+          </p>
+        )}
+      </header>
+
+      <section className={styles.section}>
+        <h2>API Services</h2>
+        <div className={styles.grid}>
+          {services.map((service) => (
+            <Card key={service.name} className={styles.card}>
+              <div className={styles.cardHeader}>
+                <span className={styles.serviceName}>{service.name}</span>
+                {service.status === "loading" ? (
+                  <Spinner size="sm" />
+                ) : (
+                  <Badge color={statusColor(service.status)}>
+                    {statusLabel(service.status)}
+                  </Badge>
+                )}
+              </div>
+              {service.latency !== undefined && (
+                <p className={styles.meta}>
+                  Latency: {service.latency}ms
+                  {service.version && ` · v${service.version}`}
+                </p>
+              )}
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.section}>
+        <h2>Static Sites</h2>
+        <div className={styles.grid}>
+          {sites.map((site) => (
+            <Card key={site.name} className={styles.card}>
+              <div className={styles.cardHeader}>
+                <span className={styles.serviceName}>{site.name}</span>
+                {site.status === "loading" ? (
+                  <Spinner size="sm" />
+                ) : (
+                  <Badge color={statusColor(site.status)}>
+                    {statusLabel(site.status)}
+                  </Badge>
+                )}
+              </div>
+              {site.latency !== undefined && (
+                <p className={styles.meta}>Latency: {site.latency}ms</p>
+              )}
+            </Card>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Public status page at `/status` on the marketing site
- Fetches health from 3 API services + 3 static sites
- Color-coded status: green (operational), yellow (degraded), red (down)
- Auto-refreshes every 30s with last-checked timestamp
- Uses Rialto components (Card, Badge, Spinner)
- Mobile responsive grid

## Test plan
- [ ] `/status` renders on marketing site
- [ ] Shows real-time status of all services
- [ ] Auto-refreshes every 30 seconds
- [ ] Handles service timeouts gracefully (shows "Down")

Closes #234