### PR TITLE
feat: uptime SLA tracking via daily health snapshots

### DIFF
--- a/.github/workflows/uptime-snapshot.yml
+++ b/.github/workflows/uptime-snapshot.yml
@@ -1,0 +1,65 @@
+name: Uptime Snapshot
+
+on:
+  schedule:
+    - cron: "17 0 * * *" # Daily at 00:17 UTC (off-minute to avoid fleet congestion)
+  workflow_dispatch: # Manual trigger
+
+jobs:
+  snapshot:
+    name: Record Health Snapshot
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Fetch system health
+        id: health
+        run: |
+          RESPONSE=$(curl -sf --max-time 30 \
+            "https://mattbutlerengineering.com/health/system" || echo '{"status":"error"}')
+          echo "response=$RESPONSE" >> "$GITHUB_OUTPUT"
+          echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Write snapshot to KV
+        env:
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CF_API_TOKEN: ${{ secrets.MBE_CLOUDFLARE_API_TOKEN }}
+          KV_NS_ID: ${{ secrets.HEALTH_KV_NAMESPACE_ID }}
+          SNAPSHOT_DATE: ${{ steps.health.outputs.date }}
+          HEALTH_DATA: ${{ steps.health.outputs.response }}
+        run: |
+          PAYLOAD=$(jq -nc --arg data "$HEALTH_DATA" --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            '{snapshot: ($data | fromjson), timestamp: $ts}')
+
+          curl -sf -X PUT \
+            "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/storage/kv/namespaces/${KV_NS_ID}/values/uptime%2F${SNAPSHOT_DATE}" \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD"
+
+          echo "Wrote snapshot for ${SNAPSHOT_DATE}"
+
+      - name: Cleanup old snapshots (>90 days)
+        env:
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CF_API_TOKEN: ${{ secrets.MBE_CLOUDFLARE_API_TOKEN }}
+          KV_NS_ID: ${{ secrets.HEALTH_KV_NAMESPACE_ID }}
+        run: |
+          CUTOFF=$(date -u -d "90 days ago" +%Y-%m-%d 2>/dev/null || date -u -v-90d +%Y-%m-%d)
+
+          KEYS=$(curl -sf \
+            "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/storage/kv/namespaces/${KV_NS_ID}/keys?prefix=uptime%2F&limit=1000" \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" | jq -r '.result[].name')
+
+          DELETED=0
+          for KEY in $KEYS; do
+            DATE_PART="${KEY#uptime/}"
+            if [[ "$DATE_PART" < "$CUTOFF" ]]; then
+              curl -sf -X DELETE \
+                "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/storage/kv/namespaces/${KV_NS_ID}/values/${KEY}" \
+                -H "Authorization: Bearer ${CF_API_TOKEN}"
+              DELETED=$((DELETED + 1))
+            fi
+          done
+
+          echo "Cleaned up $DELETED snapshots older than $CUTOFF"

--- a/infrastructure/worker/edge-router.js
+++ b/infrastructure/worker/edge-router.js
@@ -562,6 +562,83 @@ async function handleHealthSystem(request, env, requestId) {
 }
 
 /**
+ * Handle GET /health/uptime — compute uptime percentages from daily snapshots.
+ *
+ * Reads the last 30 days of uptime/ keys from KV, computes overall and
+ * per-subsystem uptime as (healthy / total) * 100.
+ */
+async function handleHealthUptime(env) {
+  const days = 30;
+  const keys = [];
+  const today = new Date();
+
+  for (let i = 0; i < days; i++) {
+    const d = new Date(today);
+    d.setUTCDate(d.getUTCDate() - i);
+    keys.push(`uptime/${d.toISOString().slice(0, 10)}`);
+  }
+
+  const snapshots = await Promise.all(
+    keys.map(async (key) => {
+      const raw = await env.HEALTH_STATE.get(key, "json");
+      return raw;
+    })
+  );
+
+  const valid = snapshots.filter(Boolean);
+  const totalDays = valid.length;
+
+  if (totalDays === 0) {
+    return new Response(
+      JSON.stringify({
+        uptime: null,
+        message: "No snapshots available yet. Snapshots are recorded daily.",
+        daysTracked: 0,
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  // Count healthy days per subsystem
+  const subsystemCounts = {};
+  let overallHealthy = 0;
+
+  for (const entry of valid) {
+    const snap = entry.snapshot ?? entry;
+    if (snap.status === "healthy") overallHealthy++;
+
+    // Count per-service health
+    if (snap.services) {
+      for (const [name, svc] of Object.entries(snap.services)) {
+        if (!subsystemCounts[name]) subsystemCounts[name] = { healthy: 0, total: 0 };
+        subsystemCounts[name].total++;
+        if (svc.status === "healthy" || svc.status === "ok") subsystemCounts[name].healthy++;
+      }
+    }
+  }
+
+  const subsystems = {};
+  for (const [name, counts] of Object.entries(subsystemCounts)) {
+    subsystems[name] = {
+      uptimePercent: parseFloat(((counts.healthy / counts.total) * 100).toFixed(2)),
+      healthyDays: counts.healthy,
+      totalDays: counts.total,
+    };
+  }
+
+  return new Response(
+    JSON.stringify({
+      uptimePercent: parseFloat(((overallHealthy / totalDays) * 100).toFixed(2)),
+      healthyDays: overallHealthy,
+      totalDays,
+      periodDays: days,
+      subsystems,
+    }),
+    { status: 200, headers: { "Content-Type": "application/json", "Cache-Control": "public, max-age=300" } }
+  );
+}
+
+/**
  * Handle feature flags admin API.
  * GET /api/flags - list all flags
  * PUT /api/flags/<name> - create/update a flag
@@ -652,6 +729,10 @@ export default {
     // ── Health aggregation endpoint ───────────────────────────────────
     if (url.pathname === "/health/system") {
       return handleHealthSystem(request, env, requestId);
+    }
+
+    if (url.pathname === "/health/uptime") {
+      return handleHealthUptime(env);
     }
 
     // ── Feature flags admin API ─────────────────────────────────────


### PR DESCRIPTION
## Summary

- Daily cron workflow snapshots `/health/system` to Cloudflare KV (`uptime/YYYY-MM-DD`)
- 90-day retention with automatic cleanup of old snapshots
- `/health/uptime` endpoint returns 30-day uptime percentages (overall + per-subsystem)
- 5-minute edge cache on uptime response

## Test plan
- [ ] Manual workflow trigger writes snapshot to KV
- [ ] `/health/uptime` returns computed uptime after snapshots exist
- [ ] Returns helpful message when no snapshots exist yet
- [ ] Old snapshots cleaned up after 90 days

Closes #235