### PR TITLE
feat: Slack/Discord webhook notification on health status change

### DIFF
--- a/.github/workflows/synthetic-monitoring.yml
+++ b/.github/workflows/synthetic-monitoring.yml
@@ -40,6 +40,73 @@ jobs:
             echo "All systems healthy."
           fi
 
+      - name: Notify webhook on status change
+        if: vars.HEALTH_WEBHOOK_URL != ''
+        env:
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CF_API_TOKEN: ${{ secrets.MBE_CLOUDFLARE_API_TOKEN }}
+          KV_NS_ID: ${{ secrets.HEALTH_KV_NAMESPACE_ID }}
+          WEBHOOK_URL: ${{ vars.HEALTH_WEBHOOK_URL }}
+          CURRENT_STATUS: ${{ steps.health.outputs.status }}
+          HEALTH_RESPONSE: ${{ steps.health.outputs.response }}
+        run: |
+          # Read previous status from KV
+          PREV=$(curl -sf \
+            "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/storage/kv/namespaces/${KV_NS_ID}/values/health%2Fprevious-status" \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" 2>/dev/null || echo "unknown")
+
+          echo "Previous: $PREV → Current: $CURRENT_STATUS"
+
+          # Store current status for next comparison
+          curl -sf -X PUT \
+            "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/storage/kv/namespaces/${KV_NS_ID}/values/health%2Fprevious-status" \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" \
+            -H "Content-Type: text/plain" \
+            -d "$CURRENT_STATUS"
+
+          # Only fire webhook on status transitions
+          if [ "$PREV" = "$CURRENT_STATUS" ]; then
+            echo "No status change — skipping webhook."
+            exit 0
+          fi
+
+          case "$CURRENT_STATUS" in
+            healthy)  EMOJI="✅"; COLOR=65280 ;;
+            degraded) EMOJI="⚠️"; COLOR=16776960 ;;
+            *)        EMOJI="🔴"; COLOR=16711680 ;;
+          esac
+
+          TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          FAILING=$(echo "$HEALTH_RESPONSE" | jq -r '
+            [(.services // {} | to_entries[] | select(.value.status != "healthy" and .value.status != "ok") | .key)] | join(", ")' 2>/dev/null || echo "")
+
+          PAYLOAD=$(jq -nc \
+            --arg emoji "$EMOJI" \
+            --arg prev "$PREV" \
+            --arg curr "$CURRENT_STATUS" \
+            --arg ts "$TIMESTAMP" \
+            --arg failing "$FAILING" \
+            --argjson color "$COLOR" \
+            '{
+              content: "\($emoji) **Health status changed: \($prev) → \($curr)**\nTime: \($ts)\nFailing: \(if $failing == "" then "none" else $failing end)\nDashboard: https://mattbutlerengineering.com/status",
+              embeds: [{
+                title: "\($emoji) Health: \($prev) → \($curr)",
+                color: $color,
+                fields: [
+                  {name: "Previous", value: $prev, inline: true},
+                  {name: "Current", value: $curr, inline: true},
+                  {name: "Failing", value: (if $failing == "" then "none" else $failing end), inline: false}
+                ],
+                timestamp: $ts
+              }]
+            }')
+
+          curl -sf -X POST "$WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD"
+
+          echo "Webhook fired: $PREV → $CURRENT_STATUS"
+
       - name: Check for existing health issue
         if: steps.health.outputs.status != 'healthy'
         id: existing


### PR DESCRIPTION
## Summary

- Transition-based webhook in synthetic monitoring workflow
- Compares current health status to previous (stored in KV `health/previous-status`)
- Only fires on status changes (healthy→degraded, degraded→unhealthy, recovery)
- Compatible with both Slack incoming webhooks and Discord webhooks
- Payload includes old/new status, failing subsystems, timestamp, link to /status
- No-op when `HEALTH_WEBHOOK_URL` variable not configured

## Setup
Set `HEALTH_WEBHOOK_URL` as a GitHub repository variable (Settings → Variables → Actions).

## Test plan
- [ ] First run stores status in KV and skips webhook (no previous status)
- [ ] Subsequent run with same status skips webhook ("No status change")
- [ ] Status transition fires webhook with correct payload
- [ ] Works with Slack/Discord webhook URLs

Closes #236