### PR TITLE
feat: performance budget — track p95 latency trends and alert on regression

### DIFF
--- a/.github/workflows/synthetic-monitoring.yml
+++ b/.github/workflows/synthetic-monitoring.yml
@@ -40,6 +40,33 @@ jobs:
             echo "All systems healthy."
           fi
 
+      - name: Record latency samples to KV
+        env:
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CF_API_TOKEN: ${{ secrets.MBE_CLOUDFLARE_API_TOKEN }}
+          KV_NS_ID: ${{ secrets.HEALTH_KV_NAMESPACE_ID }}
+          HEALTH_RESPONSE: ${{ steps.health.outputs.response }}
+        run: |
+          HOUR_KEY=$(date -u +%Y-%m-%d-%H)
+
+          # Extract per-service latencies from the health response
+          LATENCIES=$(echo "$HEALTH_RESPONSE" | jq -c '{
+            timestamp: now | todate,
+            services: (
+              [.services // {} | to_entries[] | {key: .key, value: {latency: (.value.latency // .value.checks[0].latency // null), status: .value.status}}]
+              | from_entries
+            )
+          }' 2>/dev/null || echo '{}')
+
+          if [ "$LATENCIES" != "{}" ]; then
+            curl -sf -X PUT \
+              "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/storage/kv/namespaces/${KV_NS_ID}/values/latency%2F${HOUR_KEY}" \
+              -H "Authorization: Bearer ${CF_API_TOKEN}" \
+              -H "Content-Type: application/json" \
+              -d "$LATENCIES"
+            echo "Recorded latency sample for $HOUR_KEY"
+          fi
+
       - name: Notify webhook on status change
         if: vars.HEALTH_WEBHOOK_URL != ''
         env:

--- a/infrastructure/worker/edge-router.js
+++ b/infrastructure/worker/edge-router.js
@@ -644,6 +644,109 @@ async function handleHealthUptime(env) {
  * PUT /api/flags/<name> - create/update a flag
  * DELETE /api/flags/<name> - delete a flag
  */
+/**
+ * Handle GET /health/performance — 7-day latency trends per service.
+ *
+ * Reads latency/ KV keys for the last 7 days (up to 336 hourly samples),
+ * computes per-service average and p95 latency, and flags regressions
+ * where current p95 exceeds 1.5x the 7-day average.
+ */
+async function handleHealthPerformance(env) {
+  const days = 7;
+  const keys = [];
+  const now = new Date();
+
+  // Generate hourly keys for the last 7 days
+  for (let h = 0; h < days * 24; h++) {
+    const d = new Date(now.getTime() - h * 3600_000);
+    keys.push(`latency/${d.toISOString().slice(0, 13).replace("T", "-")}`);
+  }
+
+  // Read all samples (KV list is faster but we know the keys)
+  // Batch in groups of 50 to avoid overwhelming KV
+  const samples = [];
+  for (let i = 0; i < keys.length; i += 50) {
+    const batch = keys.slice(i, i + 50);
+    const results = await Promise.all(
+      batch.map((key) => env.HEALTH_STATE.get(key, "json"))
+    );
+    for (const r of results) {
+      if (r) samples.push(r);
+    }
+  }
+
+  if (samples.length === 0) {
+    return new Response(
+      JSON.stringify({
+        message: "No latency data available yet. Samples are recorded twice daily.",
+        samplesCollected: 0,
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  // Aggregate per-service latencies
+  const serviceLatencies = {};
+  for (const sample of samples) {
+    const services = sample.services ?? {};
+    for (const [name, data] of Object.entries(services)) {
+      if (data.latency == null) continue;
+      if (!serviceLatencies[name]) serviceLatencies[name] = [];
+      serviceLatencies[name].push(data.latency);
+    }
+  }
+
+  // Compute stats per service
+  const serviceStats = {};
+  const alerts = [];
+
+  for (const [name, latencies] of Object.entries(serviceLatencies)) {
+    const sorted = [...latencies].sort((a, b) => a - b);
+    const avg = sorted.reduce((sum, v) => sum + v, 0) / sorted.length;
+    const p95Index = Math.floor(sorted.length * 0.95);
+    const p95 = sorted[p95Index] ?? sorted[sorted.length - 1];
+
+    // Recent p95 = last 10% of samples (most recent)
+    const recentCount = Math.max(1, Math.floor(sorted.length * 0.1));
+    const recentLatencies = latencies.slice(-recentCount);
+    const recentSorted = [...recentLatencies].sort((a, b) => a - b);
+    const recentP95Index = Math.floor(recentSorted.length * 0.95);
+    const recentP95 = recentSorted[recentP95Index] ?? recentSorted[recentSorted.length - 1];
+
+    const trend =
+      recentP95 > avg * 1.5 ? "degrading" :
+      recentP95 < avg * 0.8 ? "improving" : "stable";
+
+    serviceStats[name] = {
+      avgMs: Math.round(avg),
+      p95Ms: Math.round(p95),
+      recentP95Ms: Math.round(recentP95),
+      samples: latencies.length,
+      trend,
+    };
+
+    if (trend === "degrading") {
+      alerts.push(`${name}: p95 ${Math.round(recentP95)}ms exceeds 1.5x average (${Math.round(avg)}ms)`);
+    }
+  }
+
+  return new Response(
+    JSON.stringify({
+      periodDays: days,
+      samplesCollected: samples.length,
+      services: serviceStats,
+      alerts,
+    }),
+    {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "public, max-age=300",
+      },
+    }
+  );
+}
+
 async function handleFeatureFlags(request, env, url) {
   const flagName = url.pathname.replace("/api/flags/", "");
   const authHeader = request.headers.get("Authorization");
@@ -733,6 +836,10 @@ export default {
 
     if (url.pathname === "/health/uptime") {
       return handleHealthUptime(env);
+    }
+
+    if (url.pathname === "/health/performance") {
+      return handleHealthPerformance(env);
     }
 
     // ── Feature flags admin API ─────────────────────────────────────


### PR DESCRIPTION
## Summary

- Synthetic monitoring writes per-service latency samples to KV (`latency/YYYY-MM-DD-HH`)
- New `/health/performance` endpoint computes 7-day trends per service
- Flags services where recent p95 exceeds 1.5x their 7-day average
- Returns avg, p95, recent p95, sample count, and trend (improving/stable/degrading)

## Test plan
- [ ] Synthetic monitoring records latency samples after health check
- [ ] `/health/performance` returns trend data after samples accumulate
- [ ] Returns helpful message when no data exists yet
- [ ] Degrading trend correctly identified when p95 > 1.5x average

Closes #238