### PR TITLE
feat: auto-attach runbooks to health alert issues

### DIFF
--- a/.github/workflows/synthetic-monitoring.yml
+++ b/.github/workflows/synthetic-monitoring.yml
@@ -151,6 +151,12 @@ jobs:
 
       - name: Create health alert issue
         if: steps.health.outputs.status != 'healthy' && steps.existing.outputs.count == '0'
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout: docs/runbooks
+
+      - name: Create health alert issue (cont.)
+        if: steps.health.outputs.status != 'healthy' && steps.existing.outputs.count == '0'
         env:
           GH_TOKEN: ${{ github.token }}
           HEALTH_STATUS: ${{ steps.health.outputs.status }}
@@ -166,39 +172,59 @@ jobs:
           DEPLOY_STATUS=$(echo "$HEALTH_RESPONSE" | jq -r '.subsystems.deploys.status')
 
           SUMMARY=""
+          RUNBOOKS=""
+
           if [ -n "$FAILED_SERVICES" ]; then
             SUMMARY="${SUMMARY}Services down: ${FAILED_SERVICES}. "
+            if [ -f docs/runbooks/services-unhealthy.md ]; then
+              RUNBOOKS="${RUNBOOKS}$(cat docs/runbooks/services-unhealthy.md)
+
+"
+            fi
           fi
           if [ -n "$FAILED_SITES" ]; then
             SUMMARY="${SUMMARY}Static sites down: ${FAILED_SITES}. "
+            if [ -f docs/runbooks/static-sites-unhealthy.md ]; then
+              RUNBOOKS="${RUNBOOKS}$(cat docs/runbooks/static-sites-unhealthy.md)
+
+"
+            fi
           fi
           if [ "$CI_STATUS" != "healthy" ]; then
             SUMMARY="${SUMMARY}CI: ${CI_STATUS}. "
+            if [ -f docs/runbooks/ci-unhealthy.md ]; then
+              RUNBOOKS="${RUNBOOKS}$(cat docs/runbooks/ci-unhealthy.md)
+
+"
+            fi
           fi
           if [ "$DEPLOY_STATUS" != "healthy" ]; then
             SUMMARY="${SUMMARY}Deploys: ${DEPLOY_STATUS}. "
+            if [ -f docs/runbooks/deploys-unhealthy.md ]; then
+              RUNBOOKS="${RUNBOOKS}$(cat docs/runbooks/deploys-unhealthy.md)
+
+"
+            fi
           fi
 
           TITLE="System health ${HEALTH_STATUS}: ${SUMMARY}"
-          # Truncate title to 256 chars
           TITLE="${TITLE:0:256}"
+          DETECTED=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-          BODY=$(cat <<'BODY_EOF'
-          ## System Health Alert
+          BODY="## System Health Alert
 
-          **Status:** `PLACEHOLDER_STATUS`
-          **Detected:** PLACEHOLDER_TIME
-          **Source:** Synthetic monitoring (twice daily)
+**Status:** \`${HEALTH_STATUS}\`
+**Detected:** ${DETECTED}
+**Source:** Synthetic monitoring (twice daily)
 
-          ### Resolution
+To check current status: \`curl -s https://mattbutlerengineering.com/health/system | jq .\`
 
-          This issue was auto-created by synthetic monitoring. It will be picked up by the ship-loop or issue-worker.
+---
 
-          To check current status: `curl -s https://mattbutlerengineering.com/health/system | jq .`
-          BODY_EOF
-          )
-          BODY="${BODY//PLACEHOLDER_STATUS/$HEALTH_STATUS}"
-          BODY="${BODY//PLACEHOLDER_TIME/$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+${RUNBOOKS}
+
+---
+*This issue was auto-created by synthetic monitoring. It will be picked up by the ship-loop or issue-worker.*"
 
           gh issue create \
             --repo "$GITHUB_REPOSITORY" \

--- a/docs/runbooks/ci-unhealthy.md
+++ b/docs/runbooks/ci-unhealthy.md
@@ -1,0 +1,45 @@
+# Runbook: CI Unhealthy
+
+## Quick Diagnosis
+
+```bash
+# Check recent CI runs on main
+gh run list --branch main --limit 10 --json name,conclusion,createdAt \
+  -q '.[] | "\(.conclusion)\t\(.name)\t\(.createdAt)"'
+
+# View the failing run's logs
+gh run view <RUN_ID> --log-failed
+```
+
+## Common Causes
+
+### 1. GitHub Actions billing/quota
+- Error: "job was not started because recent account payments have failed"
+- Fix: Update payment method at GitHub Settings > Billing & plans
+- All workflows fail simultaneously when this happens
+
+### 2. Flaky tests
+- Look for `test` job failures that pass on retry
+- Common culprits: timing-dependent tests, port conflicts, mock cleanup
+- Retry: `gh run rerun <RUN_ID> --failed`
+
+### 3. Dependency issue
+- `pnpm install --frozen-lockfile` fails if lockfile is stale
+- Fix: `pnpm install` locally, commit updated lockfile
+- Check for yanked packages in error output
+
+### 4. Type errors from recent merge
+- `typecheck` job fails after merging incompatible changes
+- Check which packages fail: look for `@mbe/<package>#typecheck` in logs
+- May need to update types in `packages/types/`
+
+### 5. Lint failures
+- Pre-existing lint issues get caught when CI cache is invalidated
+- Fix the lint errors or update `.eslintrc` if rules changed
+
+## Recovery Steps
+
+1. **If billing issue**: Update payment — no code fix needed
+2. **If flaky test**: Retry the run, then fix the flaky test
+3. **If real failure**: Check the specific job and step that failed, fix the code
+4. **Quick retry**: `gh run rerun <RUN_ID> --failed`

--- a/docs/runbooks/deploys-unhealthy.md
+++ b/docs/runbooks/deploys-unhealthy.md
@@ -1,0 +1,48 @@
+# Runbook: Deploys Unhealthy
+
+## Quick Diagnosis
+
+```bash
+# Check recent deploy workflows
+gh run list --workflow deploy-services.yml --limit 5 --json conclusion,createdAt \
+  -q '.[] | "\(.conclusion)\t\(.createdAt)"'
+gh run list --workflow deploy-static.yml --limit 5 --json conclusion,createdAt \
+  -q '.[] | "\(.conclusion)\t\(.createdAt)"'
+
+# Check Pulumi deploy
+gh run list --workflow pulumi-up.yml --limit 5 --json conclusion,createdAt \
+  -q '.[] | "\(.conclusion)\t\(.createdAt)"'
+```
+
+## Common Causes
+
+### 1. Deploy workflow failed
+- Check workflow logs: `gh run view <RUN_ID> --log-failed`
+- Common: missing secrets, Docker build failure, network timeout
+
+### 2. Database migration failed
+- Pre-deploy migration job runs before services start
+- Check migration logs in DO dashboard
+- Fix: `pnpm --filter @mbe/<service> db:migrate:deploy` locally to diagnose
+
+### 3. Pulumi state conflict
+- Multiple Pulumi runs can conflict on the state lock
+- Check: `cd infrastructure/pulumi && pulumi stack`
+- Fix: `pulumi cancel` to release a stuck lock (use with caution)
+
+### 4. Cloudflare API error
+- Static site deploys use `wrangler` which calls CF API
+- Check CF API status and token expiration
+- Verify `CLOUDFLARE_API_TOKEN` secret is valid
+
+### 5. DigitalOcean API error
+- Service deploys use `doctl` which calls DO API
+- Check DO API status and token expiration
+- Verify `DIGITALOCEAN_ACCESS_TOKEN` secret is valid
+
+## Recovery Steps
+
+1. **If migration failed**: Fix the migration, push to main, CI will redeploy
+2. **If Docker build failed**: Check Dockerfile changes in the failing commit
+3. **If secret expired**: Rotate the secret in GitHub Settings > Secrets
+4. **Manual redeploy**: Trigger workflow manually via GitHub Actions UI

--- a/docs/runbooks/services-unhealthy.md
+++ b/docs/runbooks/services-unhealthy.md
@@ -1,0 +1,38 @@
+# Runbook: API Services Unhealthy
+
+## Quick Diagnosis
+
+```bash
+# Check each service health endpoint
+curl -sf https://api.mattbutlerengineering.com/api/v1/users/health | jq .
+curl -sf https://api.mattbutlerengineering.com/api/v1/reservations/health | jq .
+curl -sf https://api.mattbutlerengineering.com/v1/sessions | jq .pagination
+```
+
+## Common Causes
+
+### 1. DigitalOcean App Platform issue
+- Check [DO dashboard](https://cloud.digitalocean.com/apps) for app status
+- Look for failed deployments, OOM kills, or scaling issues
+- Check app logs: `doctl apps logs <app-id> --type run`
+
+### 2. Database connectivity
+- Health endpoints include DB latency — if latency > 1000ms or status is "error", DB is the issue
+- Check Prisma connection string in DO environment variables
+- Verify Postgres is running and accepting connections
+
+### 3. Auth0 outage
+- Services depend on Auth0 for JWT verification
+- Check [Auth0 status](https://status.auth0.com/)
+- Non-health endpoints will return 401 if JWKS fetch fails
+
+### 4. Recent deploy broke something
+- Check recent deploys: `gh run list --workflow deploy-services.yml --limit 5`
+- Rollback: trigger previous successful deploy or revert the merge commit
+
+## Recovery Steps
+
+1. **If all services down**: Check DO App Platform status and recent deploys
+2. **If one service down**: Check that service's logs via DO dashboard
+3. **If DB is slow**: Check connection pool utilization, consider restarting the service
+4. **If intermittent**: May be a cold start issue — DO scales to zero on free tier

--- a/docs/runbooks/static-sites-unhealthy.md
+++ b/docs/runbooks/static-sites-unhealthy.md
@@ -1,0 +1,38 @@
+# Runbook: Static Sites Unhealthy
+
+## Quick Diagnosis
+
+```bash
+# Check each static site
+curl -sf -o /dev/null -w "%{http_code}" https://mattbutlerengineering.com/
+curl -sf -o /dev/null -w "%{http_code}" https://mattbutlerengineering.com/hospitality
+curl -sf -o /dev/null -w "%{http_code}" https://mattbutlerengineering.com/rialto
+curl -sf -o /dev/null -w "%{http_code}" https://mattbutlerengineering.com/gen
+```
+
+## Common Causes
+
+### 1. Cloudflare Worker deployment failed
+- Check [CF dashboard](https://dash.cloudflare.com/) for Worker status
+- Each site is a separate Worker bound via Service Binding in the edge router
+- Failed `wrangler deploy` leaves the previous version running
+
+### 2. Edge router misconfiguration
+- The edge router (`infrastructure/worker/edge-router.js`) routes by path prefix
+- Check recent changes to the router for routing bugs
+- Test routing: `curl -v https://mattbutlerengineering.com/hospitality`
+
+### 3. Build output missing
+- Static sites are SPAs — if `dist/` is empty, the Worker serves nothing
+- Check CI build step: `gh run list --workflow deploy-static.yml --limit 5`
+- Verify build locally: `pnpm --filter @mbe/marketing build`
+
+### 4. DNS/CDN issue
+- Static sites bypass CDN (Service Bindings) — CDN cache is not the issue
+- Check if `mattbutlerengineering.com` resolves: `dig mattbutlerengineering.com AAAA`
+
+## Recovery Steps
+
+1. **If all sites down**: Edge router Worker is likely the issue — check CF dashboard
+2. **If one site down**: That site's Worker failed to deploy — check deploy logs
+3. **Rollback**: Deploy previous version via `wrangler rollback` or retrigger last successful deploy


### PR DESCRIPTION
## Summary

- 4 runbook markdown files in `docs/runbooks/` (services, static sites, CI, deploys)
- Synthetic monitoring embeds relevant runbooks in auto-created health alert issues
- Runbooks include specific diagnostic commands, common causes, and recovery steps
- Easy to update runbooks without changing workflow code

Closes #239