### PR TITLE
feat: Lighthouse score trend tracking

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,61 @@
+name: Lighthouse Score Tracking
+
+on:
+  schedule:
+    - cron: "43 6 * * 1" # Weekly Monday 6:43 AM UTC
+  workflow_dispatch:
+
+jobs:
+  lighthouse:
+    name: Lighthouse Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    strategy:
+      matrix:
+        app:
+          - { name: "marketing", url: "https://mattbutlerengineering.com/" }
+          - { name: "hospitality", url: "https://mattbutlerengineering.com/hospitality" }
+          - { name: "rialto", url: "https://mattbutlerengineering.com/rialto" }
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Run Lighthouse
+        id: lh
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          urls: ${{ matrix.app.url }}
+          temporaryPublicStorage: true
+
+      - name: Extract and store scores
+        env:
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CF_API_TOKEN: ${{ secrets.MBE_CLOUDFLARE_API_TOKEN }}
+          KV_NS_ID: ${{ secrets.HEALTH_KV_NAMESPACE_ID }}
+          APP_NAME: ${{ matrix.app.name }}
+          LH_MANIFEST: ${{ steps.lh.outputs.manifest }}
+        run: |
+          DATE=$(date -u +%Y-%m-%d)
+
+          PERF=$(echo "$LH_MANIFEST" | jq -r '.[0].summary.performance // 0' | awk '{printf "%.0f", $1 * 100}')
+          A11Y=$(echo "$LH_MANIFEST" | jq -r '.[0].summary.accessibility // 0' | awk '{printf "%.0f", $1 * 100}')
+          BP=$(echo "$LH_MANIFEST" | jq -r '.[0].summary."best-practices" // 0' | awk '{printf "%.0f", $1 * 100}')
+          SEO=$(echo "$LH_MANIFEST" | jq -r '.[0].summary.seo // 0' | awk '{printf "%.0f", $1 * 100}')
+
+          PAYLOAD=$(jq -nc \
+            --arg app "$APP_NAME" \
+            --arg date "$DATE" \
+            --argjson perf "${PERF:-0}" \
+            --argjson a11y "${A11Y:-0}" \
+            --argjson bp "${BP:-0}" \
+            --argjson seo "${SEO:-0}" \
+            '{app: $app, date: $date, performance: $perf, accessibility: $a11y, bestPractices: $bp, seo: $seo}')
+
+          curl -sf -X PUT \
+            "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/storage/kv/namespaces/${KV_NS_ID}/values/lighthouse%2F${DATE}-${APP_NAME}" \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD"
+
+          echo "Stored: $APP_NAME perf=$PERF a11y=$A11Y bp=$BP seo=$SEO"

--- a/infrastructure/worker/edge-router.js
+++ b/infrastructure/worker/edge-router.js
@@ -747,6 +747,86 @@ async function handleHealthPerformance(env) {
   );
 }
 
+/**
+ * Handle GET /health/lighthouse — 30-day Lighthouse score trends per app.
+ *
+ * Reads lighthouse/ KV keys, groups by app, computes average scores and
+ * trend direction. Alerts if any category drops >5 points over 2 weeks.
+ */
+async function handleHealthLighthouse(env) {
+  // List all lighthouse/ keys
+  const listResult = await env.HEALTH_STATE.list({ prefix: "lighthouse/" });
+  const keys = listResult.keys.map((k) => k.name);
+
+  if (keys.length === 0) {
+    return new Response(
+      JSON.stringify({
+        message: "No Lighthouse data available yet. Scores are recorded weekly.",
+        appsTracked: 0,
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  // Read all scores
+  const entries = await Promise.all(
+    keys.map(async (key) => {
+      const data = await env.HEALTH_STATE.get(key, "json");
+      return data;
+    })
+  );
+  const scores = entries.filter(Boolean);
+
+  // Group by app
+  const byApp = {};
+  for (const score of scores) {
+    if (!byApp[score.app]) byApp[score.app] = [];
+    byApp[score.app].push(score);
+  }
+
+  // Compute trends per app
+  const apps = {};
+  const alerts = [];
+  const categories = ["performance", "accessibility", "bestPractices", "seo"];
+
+  for (const [app, appScores] of Object.entries(byApp)) {
+    const sorted = appScores.sort((a, b) => a.date.localeCompare(b.date));
+    const latest = sorted[sorted.length - 1];
+    const twoWeeksAgo = sorted.find((s) => {
+      const d = new Date(s.date);
+      const cutoff = new Date(Date.now() - 14 * 86400_000);
+      return d <= cutoff;
+    }) ?? sorted[0];
+
+    const appStats = { latest: {}, trend: {}, dataPoints: sorted.length };
+
+    for (const cat of categories) {
+      appStats.latest[cat] = latest[cat] ?? null;
+      const diff = (latest[cat] ?? 0) - (twoWeeksAgo[cat] ?? 0);
+      appStats.trend[cat] = diff > 5 ? "improving" : diff < -5 ? "degrading" : "stable";
+
+      if (diff < -5) {
+        alerts.push(
+          `${app}: ${cat} dropped ${Math.abs(Math.round(diff))} points (${twoWeeksAgo[cat]} → ${latest[cat]})`
+        );
+      }
+    }
+
+    apps[app] = appStats;
+  }
+
+  return new Response(
+    JSON.stringify({ periodDays: 30, apps, alerts }),
+    {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "public, max-age=3600",
+      },
+    }
+  );
+}
+
 async function handleFeatureFlags(request, env, url) {
   const flagName = url.pathname.replace("/api/flags/", "");
   const authHeader = request.headers.get("Authorization");
@@ -840,6 +920,10 @@ export default {
 
     if (url.pathname === "/health/performance") {
       return handleHealthPerformance(env);
+    }
+
+    if (url.pathname === "/health/lighthouse") {
+      return handleHealthLighthouse(env);
     }
 
     // ── Feature flags admin API ─────────────────────────────────────


### PR DESCRIPTION
## Summary
- Weekly Lighthouse CI workflow for marketing, hospitality, rialto
- Scores stored to KV per-app per-week
- `/health/lighthouse` endpoint: 30-day trends with >5pt degradation alerts
- 1-hour cache on lighthouse response

Closes #245