### PR TITLE
feat(infra): codify branch protection rules in Pulumi

### DIFF
--- a/infrastructure/pulumi/Pulumi.prod.yaml
+++ b/infrastructure/pulumi/Pulumi.prod.yaml
@@ -6,6 +6,8 @@ config:
   # AUTH0_DOMAIN, AUTH0_CLIENT_ID, AUTH0_CLIENT_SECRET
   # DIGITALOCEAN_TOKEN
   # CLOUDFLARE_API_TOKEN
+  # GITHUB_TOKEN
+  github:owner: mattbutlerengineering
   mbe-infrastructure:cloudflareZoneId: dfed09378e547f95a3bd645c55ef777d
   mbe-infrastructure:databaseUrl:
     secure: v1:0RzZY3eW9IeiS01y:Kd6Wfxp4JgeBYwuwaJAzdzybDdtEB/Oe7malwhpy4bjn3fj0rMrAFgH0PzpI2cEblybnAu7+B1K3VOVZBuwq8MhN1iiLEXEuOXaAeX0ydf56Yia5NJopxo03MOhWbXijn9iaveUsiPro5GgTfW03ABMEfZ/UONRJ9JKwAw==

--- a/infrastructure/pulumi/github.ts
+++ b/infrastructure/pulumi/github.ts
@@ -1,0 +1,54 @@
+import * as github from "@pulumi/github";
+
+// ── Branch Protection ───────────────────────────────────────────────
+// Codifies the branch protection rules for the main branch.
+// GitHub provider authenticates via GITHUB_TOKEN env var.
+
+const REPO = "mattbutlerengineering";
+
+// Status check contexts must match the `name:` field of each CI job
+// defined in .github/workflows/ci.yml.
+const REQUIRED_STATUS_CHECKS = [
+  "Prepare",
+  "Dockerfile Lint",
+  "Container Security Scan",
+  "Lint",
+  "Typecheck",
+  "Build",
+  "Test",
+  "Validate Migrations",
+] as const;
+
+const mainBranchProtection = new github.BranchProtection(
+  "main-branch-protection",
+  {
+    repositoryId: REPO,
+    pattern: "main",
+
+    // Require pull request reviews before merging
+    requiredPullRequestReviews: [
+      {
+        requiredApprovingReviewCount: 1,
+        dismissStaleReviews: true,
+      },
+    ],
+
+    // Require status checks to pass before merging
+    requiredStatusChecks: [
+      {
+        strict: true,
+        contexts: [...REQUIRED_STATUS_CHECKS],
+      },
+    ],
+
+    // Enforce linear history (no merge commits)
+    requiredLinearHistory: true,
+
+    // Prevent force pushes and branch deletion
+    allowsForcePushes: false,
+    allowsDeletions: false,
+  },
+);
+
+// ── Exports ─────────────────────────────────────────────────────────
+export const branchProtectionId = mainBranchProtection.id;

--- a/infrastructure/pulumi/index.ts
+++ b/infrastructure/pulumi/index.ts
@@ -3,6 +3,7 @@ import * as digitalocean from "@pulumi/digitalocean";
 import * as cloudflare from "@pulumi/cloudflare";
 import { readFileSync } from "node:fs";
 import { auth0Outputs } from "./auth0";
+import { branchProtectionId } from "./github";
 
 // ── Configuration ───────────────────────────────────────────────────
 const config = new pulumi.Config();
@@ -347,3 +348,4 @@ export const hospitalityUrl = pulumi.interpolate`https://${domain}/hospitality`;
 export const rialtoUrl = pulumi.interpolate`https://${domain}/rialto`;
 export const genUrl = pulumi.interpolate`https://${domain}/gen`;
 export const healthKvNamespaceId = healthKv.id;
+export { branchProtectionId };

--- a/infrastructure/pulumi/package.json
+++ b/infrastructure/pulumi/package.json
@@ -13,6 +13,7 @@
     "@pulumi/auth0": "^3.39.0",
     "@pulumi/cloudflare": "^6.14.0",
     "@pulumi/digitalocean": "^4.63.0",
+    "@pulumi/github": "^6.7.0",
     "@pulumi/pulumi": "^3.229.0",
     "@pulumi/random": "^4.19.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -369,6 +369,9 @@ importers:
       '@pulumi/digitalocean':
         specifier: ^4.63.0
         version: 4.63.0(typescript@6.0.2)
+      '@pulumi/github':
+        specifier: ^6.7.0
+        version: 6.12.1(typescript@6.0.2)
       '@pulumi/pulumi':
         specifier: ^3.229.0
         version: 3.229.0(typescript@6.0.2)
@@ -3184,6 +3187,9 @@ packages:
 
   '@pulumi/digitalocean@4.63.0':
     resolution: {integrity: sha512-TnXhoeNWq4aGT4lqUgptwU4eTGO8Trw25v+wfAk7bwW763E5RV9XCzRc8YWRXXAD0ZFqiLIN82I02e4rUiqOmA==}
+
+  '@pulumi/github@6.12.1':
+    resolution: {integrity: sha512-OsbQgF8go/tA1PuMhFq7O0XVfYbwRk0/LHaZTH6OFO395SufdFFa1go3IeXvJCSA5oDCbdULerGg4n9sP8vTLg==}
 
   '@pulumi/pulumi@3.229.0':
     resolution: {integrity: sha512-SoGAonHOrGP/NQQivq3gMz0nlebVUYOf6TgpsPHqvFARsHz4JIR+/fpFm/8JW+Ev5o6tvb6g04a+STmpdxoaOg==}
@@ -11010,6 +11016,14 @@ snapshots:
       - typescript
 
   '@pulumi/digitalocean@4.63.0(typescript@6.0.2)':
+    dependencies:
+      '@pulumi/pulumi': 3.229.0(typescript@6.0.2)
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
+      - typescript
+
+  '@pulumi/github@6.12.1(typescript@6.0.2)':
     dependencies:
       '@pulumi/pulumi': 3.229.0(typescript@6.0.2)
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- Adds `@pulumi/github` provider to infrastructure
- Creates `infrastructure/pulumi/github.ts` with `BranchProtection` resource for `main`:
  - 1 required approving review (stale reviews dismissed)
  - 8 required status checks matching CI jobs: Prepare, Dockerfile Lint, Container Security Scan, Lint, Typecheck, Build, Test, Validate Migrations
  - Strict mode (branch must be up-to-date)
  - Linear history, no force pushes, no deletions
- Branch protection is now auditable, version-controlled, and drift-detectable via `pulumi preview`

## Test plan
- [x] TypeScript compilation passes
- [ ] Run `pulumi preview` to verify resource creation
- [ ] Verify `GITHUB_TOKEN` env var is set with admin:repo scope
- [ ] After apply: verify manual changes to protection rules show as drift

Closes #259