### PR TITLE
feat: error rate tracking per API endpoint

### DIFF
--- a/packages/observability/src/error-rates.ts
+++ b/packages/observability/src/error-rates.ts
@@ -1,0 +1,122 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import fp from "fastify-plugin";
+
+declare module "fastify" {
+  interface FastifyInstance {
+    getErrorRates(): ErrorRateSnapshot;
+  }
+}
+
+/**
+ * Per-endpoint error rate tracking with a rolling 5-minute window.
+ *
+ * Registers a Fastify onResponse hook that tracks status codes per
+ * route. Exposes error rates via `app.getErrorRates()` for inclusion
+ * in health check responses.
+ */
+
+interface RequestRecord {
+  readonly timestamp: number;
+  readonly isError: boolean;
+}
+
+export interface EndpointErrorRate {
+  readonly endpoint: string;
+  readonly total: number;
+  readonly errors: number;
+  readonly rate: number;
+}
+
+export interface ErrorRateSnapshot {
+  readonly endpoints: readonly EndpointErrorRate[];
+  readonly degraded: boolean;
+}
+
+const WINDOW_MS = 5 * 60 * 1000; // 5 minutes
+const DEGRADATION_THRESHOLD = 0.10; // 10% error rate
+const IGNORED_PATHS = new Set(["/health", "/docs", "/reference"]);
+
+function createErrorRateTracker() {
+  const records = new Map<string, RequestRecord[]>();
+
+  function record(endpoint: string, statusCode: number): void {
+    const entry: RequestRecord = {
+      timestamp: Date.now(),
+      isError: statusCode >= 400,
+    };
+
+    const existing = records.get(endpoint) ?? [];
+    records.set(endpoint, [...existing, entry]);
+  }
+
+  function prune(): void {
+    const cutoff = Date.now() - WINDOW_MS;
+    for (const [endpoint, entries] of records) {
+      const pruned = entries.filter((r) => r.timestamp >= cutoff);
+      if (pruned.length === 0) {
+        records.delete(endpoint);
+      } else {
+        records.set(endpoint, pruned);
+      }
+    }
+  }
+
+  function snapshot(): ErrorRateSnapshot {
+    prune();
+
+    const endpoints: EndpointErrorRate[] = [];
+    let degraded = false;
+
+    for (const [endpoint, entries] of records) {
+      const total = entries.length;
+      const errors = entries.filter((r) => r.isError).length;
+      const rate = total > 0 ? errors / total : 0;
+
+      endpoints.push({ endpoint, total, errors, rate: Math.round(rate * 1000) / 1000 });
+
+      if (rate > DEGRADATION_THRESHOLD && total >= 5) {
+        degraded = true;
+      }
+    }
+
+    return {
+      endpoints: endpoints.sort((a, b) => b.rate - a.rate),
+      degraded,
+    };
+  }
+
+  return { record, snapshot };
+}
+
+function normalizeRoute(request: FastifyRequest): string {
+  // Use the route pattern (e.g., "/api/v1/users/:id") not the actual URL
+  const routeUrl =
+    (request.routeOptions as { url?: string })?.url ??
+    request.url.split("?")[0];
+  return routeUrl;
+}
+
+async function errorRatePlugin(fastify: FastifyInstance): Promise<void> {
+  const tracker = createErrorRateTracker();
+
+  fastify.addHook(
+    "onResponse",
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      const route = normalizeRoute(request);
+
+      // Skip health/docs endpoints
+      if (IGNORED_PATHS.has(route) || route.startsWith("/docs")) return;
+
+      tracker.record(route, reply.statusCode);
+    }
+  );
+
+  fastify.decorate("getErrorRates", () => tracker.snapshot());
+}
+
+export const errorRatePlugin_ = fp(errorRatePlugin, {
+  name: "error-rate-tracker",
+  fastify: "5.x",
+});
+
+export { createErrorRateTracker };

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -15,6 +15,12 @@ export {
 export type { AgentBaggage } from "./baggage.js";
 
 export { createReadinessTracker } from "./readiness.js";
+
+export { errorRatePlugin_, createErrorRateTracker } from "./error-rates.js";
+export type {
+  EndpointErrorRate,
+  ErrorRateSnapshot,
+} from "./error-rates.js";
 export type {
   ReadinessTracker,
   ReadinessSnapshot,

--- a/services/agent/src/app.ts
+++ b/services/agent/src/app.ts
@@ -5,7 +5,7 @@ import swagger from "@fastify/swagger";
 import swaggerUi from "@fastify/swagger-ui";
 import ScalarApiReference from "@scalar/fastify-api-reference";
 import { authPlugin, getAuthPluginOptionsFromEnv } from "@mbe/auth/fastify";
-import { createRequestIdMiddleware } from "@mbe/observability";
+import { createRequestIdMiddleware, errorRatePlugin_ } from "@mbe/observability";
 import { sentryFastifyPlugin } from "@mbe/sentry/node";
 import { apiVersioningPlugin } from "@mbe/api-versioning/fastify";
 import { registerSchemas } from "./schemas/index.js";
@@ -65,6 +65,9 @@ export async function buildApp(options: AppOptions = {}): Promise<FastifyInstanc
 
   // Propagate X-Request-ID from edge router for distributed tracing
   await fastify.register(createRequestIdMiddleware());
+
+  // Track per-endpoint error rates (exposed via health check)
+  await fastify.register(errorRatePlugin_);
 
   await fastify.register(rateLimit, {
     max: 100,

--- a/services/reservations/src/app.ts
+++ b/services/reservations/src/app.ts
@@ -5,7 +5,7 @@ import swagger from "@fastify/swagger";
 import swaggerUi from "@fastify/swagger-ui";
 import ScalarApiReference from "@scalar/fastify-api-reference";
 import { authPlugin, getAuthPluginOptionsFromEnv } from "@mbe/auth/fastify";
-import { createRequestIdMiddleware } from "@mbe/observability";
+import { createRequestIdMiddleware, errorRatePlugin_ } from "@mbe/observability";
 import { sentryFastifyPlugin } from "@mbe/sentry/node";
 import { apiVersioningPlugin } from "@mbe/api-versioning/fastify";
 import { registerSchemas } from "./schemas/index.js";
@@ -63,6 +63,9 @@ export async function buildApp(options: AppOptions = {}): Promise<FastifyInstanc
 
   // Propagate X-Request-ID from edge router for distributed tracing
   await fastify.register(createRequestIdMiddleware());
+
+  // Track per-endpoint error rates (exposed via health check)
+  await fastify.register(errorRatePlugin_);
 
   await fastify.register(rateLimit, {
     max: 100,

--- a/services/users/src/app.ts
+++ b/services/users/src/app.ts
@@ -5,7 +5,7 @@ import swagger from "@fastify/swagger";
 import swaggerUi from "@fastify/swagger-ui";
 import ScalarApiReference from "@scalar/fastify-api-reference";
 import { authPlugin, getAuthPluginOptionsFromEnv } from "@mbe/auth/fastify";
-import { createRequestIdMiddleware } from "@mbe/observability";
+import { createRequestIdMiddleware, errorRatePlugin_ } from "@mbe/observability";
 import { sentryFastifyPlugin } from "@mbe/sentry/node";
 import { apiVersioningPlugin } from "@mbe/api-versioning/fastify";
 import { registerSchemas } from "./schemas/index.js";
@@ -58,6 +58,9 @@ export async function buildApp(options: AppOptions = {}): Promise<FastifyInstanc
 
   // Propagate X-Request-ID from edge router for distributed tracing
   await fastify.register(createRequestIdMiddleware());
+
+  // Track per-endpoint error rates (exposed via health check)
+  await fastify.register(errorRatePlugin_);
 
   await fastify.register(rateLimit, {
     max: 100,


### PR DESCRIPTION
## Summary
- Fastify plugin tracks 4xx/5xx rates per endpoint (rolling 5-min window)
- Services degrade at >10% error rate on any endpoint (min 5 requests)
- `app.getErrorRates()` for health check integration
- Registered in all 3 services

Closes #249