### PR TITLE
feat: post-deploy smoke tests via Playwright

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -1,0 +1,69 @@
+name: Post-Deploy Smoke Tests
+
+on:
+  workflow_run:
+    workflows: ["Deploy Services", "Deploy Static Sites"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    name: Smoke Tests
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Install Playwright
+        run: npx playwright install --with-deps chromium
+
+      - name: Run smoke tests
+        env:
+          SMOKE_BASE_URL: "https://mattbutlerengineering.com"
+          SMOKE_API_URL: "https://api.mattbutlerengineering.com"
+        run: npx playwright test --config tests/smoke/playwright.config.ts
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-test-results
+          path: |
+            tests/smoke/test-results/
+            tests/smoke/playwright-report/
+          retention-days: 7
+
+      - name: Create issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TRIGGER_NAME: ${{ github.event.workflow_run.name }}
+        run: |
+          gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "Post-deploy smoke tests failed" \
+            --label "ci-fix" \
+            --label "ready" \
+            --body "## Smoke Test Failure
+
+Post-deploy smoke tests failed after a successful deploy.
+
+**Run:** ${RUN_URL}
+**Date:** $(date -u +%Y-%m-%dT%H:%M:%SZ)
+**Trigger:** ${TRIGGER_NAME:-manual}
+
+### Next Steps
+1. Check test artifacts for failure screenshots
+2. Verify deploy didn't break critical user flows
+3. Consider rollback if critical paths are broken
+
+---
+*Auto-created by smoke-tests workflow*"

--- a/tests/smoke/playwright.config.ts
+++ b/tests/smoke/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: ".",
+  timeout: 30_000,
+  globalTimeout: 120_000, // 2 minute total budget
+  retries: 1,
+  use: {
+    baseURL: process.env.SMOKE_BASE_URL ?? "https://mattbutlerengineering.com",
+    screenshot: "only-on-failure",
+    trace: "on-first-retry",
+  },
+  reporter: [["list"], ["html", { open: "never" }]],
+  projects: [
+    {
+      name: "smoke",
+      use: { browserName: "chromium" },
+    },
+  ],
+});

--- a/tests/smoke/smoke.spec.ts
+++ b/tests/smoke/smoke.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "@playwright/test";
+
+const BASE_URL =
+  process.env.SMOKE_BASE_URL ?? "https://mattbutlerengineering.com";
+const API_URL =
+  process.env.SMOKE_API_URL ?? "https://api.mattbutlerengineering.com";
+
+test.describe("Post-deploy smoke tests", () => {
+  test.describe("Marketing site", () => {
+    test("homepage loads", async ({ page }) => {
+      const response = await page.goto(`${BASE_URL}/`);
+      expect(response?.status()).toBe(200);
+      await expect(page.locator("main")).toBeVisible();
+    });
+
+    test("navigation links work", async ({ page }) => {
+      await page.goto(`${BASE_URL}/`);
+      // Check that global nav is present
+      await expect(page.locator("nav")).toBeVisible();
+    });
+
+    test("status page loads", async ({ page }) => {
+      const response = await page.goto(`${BASE_URL}/status`);
+      expect(response?.status()).toBe(200);
+      await expect(page.getByText("System Status")).toBeVisible();
+    });
+  });
+
+  test.describe("API health", () => {
+    test("users service healthy", async ({ request }) => {
+      const response = await request.get(
+        `${API_URL}/api/v1/users/health`
+      );
+      expect(response.ok()).toBe(true);
+      const body = await response.json();
+      expect(body.status).toBe("ok");
+    });
+
+    test("reservations service healthy", async ({ request }) => {
+      const response = await request.get(
+        `${API_URL}/api/v1/reservations/health`
+      );
+      expect(response.ok()).toBe(true);
+      const body = await response.json();
+      expect(body.status).toBe("ok");
+    });
+
+    test("agent service healthy", async ({ request }) => {
+      const response = await request.get(`${API_URL}/v1/sessions`);
+      expect(response.ok()).toBe(true);
+    });
+  });
+
+  test.describe("Hospitality app", () => {
+    test("loads login page", async ({ page }) => {
+      const response = await page.goto(`${BASE_URL}/hospitality`);
+      expect(response?.status()).toBe(200);
+    });
+  });
+
+  test.describe("Rialto app", () => {
+    test("loads component library", async ({ page }) => {
+      const response = await page.goto(`${BASE_URL}/rialto`);
+      expect(response?.status()).toBe(200);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- 7 Playwright smoke tests across all apps and API services
- Triggered automatically after successful Deploy Services/Static Sites workflows
- Screenshots on failure, auto-creates ci-fix issue
- 2-minute global timeout, manual trigger via workflow_dispatch

Closes #252