### PR TITLE
feat: system health widget in hospitality admin dashboard

### DIFF
--- a/apps/hospitality/src/components/DashboardLayout.module.css
+++ b/apps/hospitality/src/components/DashboardLayout.module.css
@@ -111,6 +111,9 @@
 .breadcrumbBar {
   /* Pull out to the edges of .content's padding so the bar spans full width,
      then re-apply the same inline padding to align text with page content. */
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   margin-inline: calc(-1 * var(--rialto-space-lg));
   margin-block-start: calc(-1 * var(--rialto-space-lg));
   padding-inline: var(--rialto-space-lg);

--- a/apps/hospitality/src/components/DashboardLayout.tsx
+++ b/apps/hospitality/src/components/DashboardLayout.tsx
@@ -13,6 +13,7 @@ import type { NavItem } from "../nav-sections.js";
 import { VenueProvider } from "../contexts/VenueContext.js";
 import { ReservationDataProvider } from "../contexts/ReservationDataContext.js";
 import { DashboardSidebar } from "./DashboardSidebar.js";
+import { SystemHealthBadge } from "./SystemHealthBadge.js";
 import { VenueSwitcher } from "./VenueSwitcher.js";
 import styles from "./DashboardLayout.module.css";
 
@@ -260,6 +261,7 @@ function DashboardLayoutInner() {
         <main id="main-content" tabIndex={-1} className={styles.content} style={{ outline: "none" }}>
           <div className={styles.breadcrumbBar}>
             <Breadcrumb items={breadcrumbs} />
+            <SystemHealthBadge />
           </div>
           <ErrorBoundary
             fallback={

--- a/apps/hospitality/src/components/SystemHealthBadge.module.css
+++ b/apps/hospitality/src/components/SystemHealthBadge.module.css
@@ -1,0 +1,73 @@
+.trigger {
+  display: flex;
+  align-items: center;
+  padding: 0.25rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  border-radius: var(--rialto-radius-default);
+}
+
+.trigger:hover {
+  background: var(--rialto-surface-hover);
+}
+
+.dot {
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+}
+
+.panel {
+  padding: 0.75rem;
+  min-width: 14rem;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.title {
+  font-weight: 600;
+  font-size: 0.8125rem;
+}
+
+.section {
+  margin-bottom: 0.5rem;
+}
+
+.sectionLabel {
+  display: block;
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--rialto-text-tertiary);
+  margin-bottom: 0.25rem;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.125rem 0;
+  font-size: 0.8125rem;
+}
+
+.name {
+  flex: 1;
+}
+
+.meta {
+  font-size: 0.75rem;
+  color: var(--rialto-text-tertiary);
+}
+
+.footer {
+  margin-top: 0.5rem;
+  padding-top: 0.375rem;
+  border-top: 1px solid var(--rialto-border);
+}

--- a/apps/hospitality/src/components/SystemHealthBadge.tsx
+++ b/apps/hospitality/src/components/SystemHealthBadge.tsx
@@ -1,0 +1,150 @@
+import { useState, useEffect, useCallback } from "react";
+import { Badge, Popover } from "@mbe/rialto";
+import { useAuth } from "@mbe/auth/react";
+import styles from "./SystemHealthBadge.module.css";
+
+interface ServiceHealth {
+  readonly status: string;
+  readonly version?: string;
+  readonly latency?: number;
+}
+
+interface SystemHealth {
+  readonly status: string;
+  readonly timestamp: string;
+  readonly services?: Record<string, ServiceHealth>;
+  readonly staticSites?: Record<string, { status: string }>;
+  readonly ci?: { status: string };
+  readonly deploy?: { status: string };
+}
+
+const POLL_INTERVAL_MS = 60_000;
+
+function statusColor(status: string): "green" | "yellow" | "red" | "neutral" {
+  switch (status) {
+    case "healthy":
+    case "ok":
+      return "green";
+    case "degraded":
+      return "yellow";
+    case "unhealthy":
+    case "error":
+      return "red";
+    default:
+      return "neutral";
+  }
+}
+
+function StatusDot({ status }: { readonly status: string }) {
+  const colorMap: Record<string, string> = {
+    healthy: "var(--rialto-color-green-500, #22c55e)",
+    ok: "var(--rialto-color-green-500, #22c55e)",
+    degraded: "var(--rialto-color-yellow-500, #eab308)",
+    unhealthy: "var(--rialto-color-red-500, #ef4444)",
+    error: "var(--rialto-color-red-500, #ef4444)",
+  };
+  const color = colorMap[status] ?? "var(--rialto-text-tertiary)";
+
+  return (
+    <span
+      className={styles.dot}
+      style={{ backgroundColor: color }}
+      aria-label={`System ${status}`}
+    />
+  );
+}
+
+export function SystemHealthBadge() {
+  const { user } = useAuth();
+  const [health, setHealth] = useState<SystemHealth | null>(null);
+  const [open, setOpen] = useState(false);
+
+  // Only show to admin users
+  const isAdmin = user?.permissions?.includes("admin") ?? false;
+
+  const fetchHealth = useCallback(async () => {
+    try {
+      const response = await fetch("/api/health/system", {
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (response.ok) {
+        setHealth(await response.json());
+      }
+    } catch {
+      // Silent failure — badge just shows stale data
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isAdmin) return;
+    fetchHealth();
+    const interval = setInterval(fetchHealth, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [isAdmin, fetchHealth]);
+
+  if (!isAdmin || !health) return null;
+
+  const trigger = (
+    <button
+      type="button"
+      className={styles.trigger}
+      onClick={() => setOpen((prev) => !prev)}
+      aria-label={`System health: ${health.status}`}
+    >
+      <StatusDot status={health.status} />
+    </button>
+  );
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={setOpen}
+      trigger={trigger}
+      align="end"
+    >
+      <div className={styles.panel}>
+        <div className={styles.header}>
+          <span className={styles.title}>System Health</span>
+          <Badge color={statusColor(health.status)} size="sm">
+            {health.status}
+          </Badge>
+        </div>
+
+        {health.services && (
+          <div className={styles.section}>
+            <span className={styles.sectionLabel}>Services</span>
+            {Object.entries(health.services).map(([name, svc]) => (
+              <div key={name} className={styles.row}>
+                <StatusDot status={svc.status} />
+                <span className={styles.name}>{name}</span>
+                {svc.latency != null && (
+                  <span className={styles.meta}>{svc.latency}ms</span>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {health.ci && (
+          <div className={styles.row}>
+            <StatusDot status={health.ci.status} />
+            <span className={styles.name}>CI</span>
+          </div>
+        )}
+
+        {health.deploy && (
+          <div className={styles.row}>
+            <StatusDot status={health.deploy.status} />
+            <span className={styles.name}>Deploys</span>
+          </div>
+        )}
+
+        <div className={styles.footer}>
+          <span className={styles.meta}>
+            Updated {new Date(health.timestamp).toLocaleTimeString()}
+          </span>
+        </div>
+      </div>
+    </Popover>
+  );
+}


### PR DESCRIPTION
## Summary
- SystemHealthBadge in dashboard breadcrumb bar (admin-only)
- Color-coded dot: green/yellow/red with expandable popover
- Shows per-service status, latency, CI/deploy health
- Polls every 60s, uses Rialto Badge + Popover

Closes #277