### PR TITLE
test: add 23 React hook and context tests for hospitality and gen apps

### DIFF
--- a/apps/gen/package.json
+++ b/apps/gen/package.json
@@ -9,6 +9,8 @@
     "preview": "vite preview",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "test:a11y": "playwright test --config playwright.config.ts e2e/a11y.test.ts",
     "size": "size-limit",
     "size:check": "size-limit"
@@ -39,10 +41,14 @@
     "@axe-core/playwright": "^4.11.1",
     "@mbe/config": "workspace:*",
     "@playwright/test": "^1.59.1",
+    "@testing-library/jest-dom": "catalog:",
+    "@testing-library/react": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "catalog:",
+    "jsdom": "catalog:",
     "typescript": "catalog:",
-    "vite": "catalog:"
+    "vite": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/apps/gen/src/hooks/useGenStream.test.ts
+++ b/apps/gen/src/hooks/useGenStream.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useGenStream } from "./useGenStream.js";
+
+/* ── Mocks ──────────────────────────────────────────────────── */
+
+vi.mock("@mbe/auth/react", () => ({
+  useAuth: () => ({ accessToken: "test-token-123" }),
+}));
+
+// Mock flatToTree to return a simple spec from accumulated elements
+vi.mock("@json-render/react", () => ({
+  flatToTree: (elements: unknown[]) => ({ type: "root", children: elements }),
+}));
+
+const mockStreamNDJSON = vi.fn();
+
+vi.mock("@mbe/api-client/streaming", () => ({
+  streamNDJSON: (...args: unknown[]) => mockStreamNDJSON(...args),
+}));
+
+beforeEach(() => {
+  mockStreamNDJSON.mockReset();
+});
+
+/* ── Helpers ────────────────────────────────────────────────── */
+
+async function* asyncGen<T>(items: T[]): AsyncGenerator<T> {
+  for (const item of items) {
+    yield item;
+  }
+}
+
+async function* asyncGenError(msg: string): AsyncGenerator<never> {
+  yield* ([] as never[]); // satisfy require-yield
+  throw new Error(msg);
+}
+
+describe("useGenStream", () => {
+  it("sends POST with prompt and auth header via streamNDJSON", async () => {
+    mockStreamNDJSON.mockReturnValue(asyncGen([]));
+
+    const { result } = renderHook(() =>
+      useGenStream({ api: "/api/gen" })
+    );
+
+    await act(async () => {
+      await result.current.send("Hello world");
+    });
+
+    expect(mockStreamNDJSON).toHaveBeenCalledOnce();
+    const callArgs = mockStreamNDJSON.mock.calls[0][0];
+    expect(callArgs.url).toBe("/api/gen");
+    expect(callArgs.body).toEqual({ prompt: "Hello world", context: undefined });
+    expect(callArgs.headers).toEqual({
+      Authorization: "Bearer test-token-123",
+    });
+  });
+
+  it("parses NDJSON elements and builds spec incrementally", async () => {
+    const elements = [
+      { type: "heading", props: { children: "Title" }, id: "1" },
+      { type: "paragraph", props: { children: "Body" }, id: "2" },
+    ];
+    mockStreamNDJSON.mockReturnValue(asyncGen(elements));
+
+    const { result } = renderHook(() =>
+      useGenStream({ api: "/api/gen" })
+    );
+
+    await act(async () => {
+      await result.current.send("Generate something");
+    });
+
+    expect(result.current.spec).not.toBeNull();
+    expect(result.current.rawLines).toHaveLength(2);
+    expect(result.current.isStreaming).toBe(false);
+  });
+
+  it("calls onComplete with final spec and raw lines", async () => {
+    const elements = [
+      { type: "text", props: { children: "Hello" }, id: "1" },
+    ];
+    mockStreamNDJSON.mockReturnValue(asyncGen(elements));
+
+    const onComplete = vi.fn();
+    const { result } = renderHook(() =>
+      useGenStream({ api: "/api/gen", onComplete })
+    );
+
+    await act(async () => {
+      await result.current.send("Test prompt");
+    });
+
+    expect(onComplete).toHaveBeenCalledOnce();
+    const [spec, rawLines] = onComplete.mock.calls[0];
+    expect(spec).not.toBeNull();
+    expect(rawLines).toHaveLength(1);
+  });
+
+  it("handles abort without setting error", async () => {
+    const abortError = Object.assign(new Error("Aborted"), { name: "AbortError" });
+    mockStreamNDJSON.mockImplementation(() => {
+      async function* gen(): AsyncGenerator<never> {
+        yield* ([] as never[]); // satisfy require-yield
+        throw abortError;
+      }
+      return gen();
+    });
+
+    const onError = vi.fn();
+    const { result } = renderHook(() =>
+      useGenStream({ api: "/api/gen", onError })
+    );
+
+    await act(async () => {
+      await result.current.send("Abort test");
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.isStreaming).toBe(false);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("calls onError when stream fails with non-abort error", async () => {
+    mockStreamNDJSON.mockReturnValue(asyncGenError("Server error"));
+
+    const onError = vi.fn();
+    const { result } = renderHook(() =>
+      useGenStream({ api: "/api/gen", onError })
+    );
+
+    await act(async () => {
+      await result.current.send("Fail test");
+    });
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe("Server error");
+    expect(result.current.isStreaming).toBe(false);
+    expect(onError).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/gen/vitest.config.ts
+++ b/apps/gen/vitest.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import { resolve } from "path";
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@": resolve(__dirname, "./src"),
+    },
+  },
+  css: {
+    modules: {
+      localsConvention: "camelCase",
+    },
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    include: ["src/**/*.test.{ts,tsx}"],
+    css: {
+      modules: {
+        classNameStrategy: "non-scoped",
+      },
+    },
+  },
+});

--- a/apps/hospitality/src/contexts/VenueContext.test.tsx
+++ b/apps/hospitality/src/contexts/VenueContext.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { VenueProvider, useVenue } from "./VenueContext.js";
+import type { Venue } from "@mbe/types";
+
+/* ── Mocks ──────────────────────────────────────────────────── */
+
+const mockVenues: readonly Venue[] = [
+  {
+    id: "venue-1",
+    venueGroupId: null,
+    name: "Downtown Bistro",
+    slug: "downtown-bistro",
+    ianaTimezone: "America/New_York",
+    currencyCode: "USD",
+    operatingHours: null,
+    settings: null,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+  },
+  {
+    id: "venue-2",
+    venueGroupId: null,
+    name: "Uptown Grill",
+    slug: "uptown-grill",
+    ianaTimezone: "America/Chicago",
+    currencyCode: "USD",
+    operatingHours: null,
+    settings: null,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+  },
+];
+
+const mockList = vi.fn();
+
+vi.mock("@mbe/api-client", () => ({
+  createApiClient: () => ({
+    venues: { list: mockList },
+  }),
+}));
+
+vi.mock("@mbe/auth/react", () => ({
+  useAuth: () => ({ accessToken: "test-token" }),
+}));
+
+// localStorage mock
+const storageMap = new Map<string, string>();
+
+beforeEach(() => {
+  storageMap.clear();
+  vi.stubGlobal("localStorage", {
+    getItem: (key: string) => storageMap.get(key) ?? null,
+    setItem: (key: string, value: string) => storageMap.set(key, value),
+    removeItem: (key: string) => storageMap.delete(key),
+    clear: () => storageMap.clear(),
+    length: 0,
+    key: () => null,
+  });
+
+  mockList.mockReset();
+  mockList.mockResolvedValue({ data: mockVenues });
+});
+
+function wrapper({ children }: { readonly children: ReactNode }) {
+  return <VenueProvider>{children}</VenueProvider>;
+}
+
+describe("VenueContext", () => {
+  it("fetches venues on mount and selects the first venue", async () => {
+    const { result } = renderHook(() => useVenue(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockList).toHaveBeenCalledOnce();
+    expect(result.current.venues).toHaveLength(2);
+    expect(result.current.selectedVenueId).toBe("venue-1");
+    expect(result.current.selectedVenue?.name).toBe("Downtown Bistro");
+    expect(result.current.isMultiVenue).toBe(true);
+  });
+
+  it("persists selected venue in localStorage", async () => {
+    const { result } = renderHook(() => useVenue(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    act(() => {
+      result.current.setVenueId("venue-2");
+    });
+
+    expect(result.current.selectedVenueId).toBe("venue-2");
+    expect(storageMap.get("mbe-hospitality-venue-id")).toBe("venue-2");
+  });
+
+  it("restores venue selection from localStorage", async () => {
+    storageMap.set("mbe-hospitality-venue-id", "venue-2");
+
+    const { result } = renderHook(() => useVenue(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.selectedVenueId).toBe("venue-2");
+    expect(result.current.selectedVenue?.name).toBe("Uptown Grill");
+  });
+
+  it("handles fetch error by clearing venues", async () => {
+    mockList.mockRejectedValueOnce(new Error("Network error"));
+
+    const { result } = renderHook(() => useVenue(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.venues).toHaveLength(0);
+    expect(result.current.selectedVenueId).toBeNull();
+    expect(result.current.selectedVenue).toBeNull();
+  });
+
+  it("throws when useVenue is called outside VenueProvider", () => {
+    // Suppress React error boundary console noise
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() => {
+      renderHook(() => useVenue());
+    }).toThrow("useVenue must be used within a VenueProvider");
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/apps/hospitality/src/hooks/useDashboardStats.test.ts
+++ b/apps/hospitality/src/hooks/useDashboardStats.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { computeStats } from "./useDashboardStats.js";
+import type { DashboardStats } from "./useDashboardStats.js";
+import type { Reservation } from "@mbe/types";
+
+/* ── Helpers ────────────────────────────────────────────────── */
+
+function makeReservation(
+  overrides: Partial<Reservation> = {}
+): Reservation {
+  return {
+    id: "res-1",
+    date: "2026-01-15",
+    startTime: "18:00",
+    endTime: "20:00",
+    partySize: 4,
+    status: "CONFIRMED",
+    notes: null,
+    cancellationReason: null,
+    cancellationNote: null,
+    guestName: "Test Guest",
+    guestEmail: null,
+    guestPhone: null,
+    guestId: null,
+    userId: null,
+    tableId: "table-1",
+    venueId: "venue-1",
+    createdAt: "2026-01-15T00:00:00Z",
+    updatedAt: "2026-01-15T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("computeStats", () => {
+  it("returns fallback stats for empty reservations list", () => {
+    const stats: DashboardStats = computeStats([]);
+
+    expect(stats.totalReservations).toBe(0);
+    expect(stats.expectedCovers).toBe(0);
+    expect(stats.upcomingCount).toBe(0);
+    expect(stats.cancellationRate).toBe(0);
+    expect(stats.cancellationTrend).toBe("neutral");
+  });
+
+  it("counts active reservations excluding cancelled and no-shows", () => {
+    const reservations = [
+      makeReservation({ id: "r1", status: "CONFIRMED", partySize: 4 }),
+      makeReservation({ id: "r2", status: "PENDING", partySize: 2 }),
+      makeReservation({ id: "r3", status: "CANCELLED", partySize: 6 }),
+      makeReservation({ id: "r4", status: "NO_SHOW", partySize: 3 }),
+      makeReservation({ id: "r5", status: "COMPLETED", partySize: 5 }),
+    ];
+
+    const stats = computeStats(reservations);
+
+    // Active = CONFIRMED + PENDING + COMPLETED = 3
+    expect(stats.totalReservations).toBe(3);
+  });
+
+  it("sums expected covers from active reservations only", () => {
+    const reservations = [
+      makeReservation({ id: "r1", status: "CONFIRMED", partySize: 4 }),
+      makeReservation({ id: "r2", status: "PENDING", partySize: 2 }),
+      makeReservation({ id: "r3", status: "CANCELLED", partySize: 10 }),
+    ];
+
+    const stats = computeStats(reservations);
+
+    // Only CONFIRMED(4) + PENDING(2) = 6
+    expect(stats.expectedCovers).toBe(6);
+  });
+
+  it("calculates correct cancellation rate", () => {
+    const reservations = [
+      makeReservation({ id: "r1", status: "CONFIRMED" }),
+      makeReservation({ id: "r2", status: "CANCELLED" }),
+      makeReservation({ id: "r3", status: "CONFIRMED" }),
+      makeReservation({ id: "r4", status: "CANCELLED" }),
+    ];
+
+    const stats = computeStats(reservations);
+
+    // 2 cancelled out of 4 = 50%
+    expect(stats.cancellationRate).toBe(50);
+    expect(stats.cancellationTrend).toBe("up"); // >10% -> "up"
+  });
+
+  it("returns 'down' cancellation trend when rate is below 5%", () => {
+    // Need a rate < 5% -> 0 cancelled out of many
+    const reservations = Array.from({ length: 25 }, (_, i) =>
+      makeReservation({ id: `r${i}`, status: "CONFIRMED" })
+    );
+    // Add 1 cancelled to get 1/26 = ~4%
+    reservations.push(
+      makeReservation({ id: "cancelled-1", status: "CANCELLED" })
+    );
+
+    const stats = computeStats(reservations);
+
+    expect(stats.cancellationRate).toBe(4); // Math.round(1/26*100) = 4
+    expect(stats.cancellationTrend).toBe("down");
+  });
+});

--- a/apps/hospitality/src/hooks/useDashboardStats.ts
+++ b/apps/hospitality/src/hooks/useDashboardStats.ts
@@ -44,7 +44,7 @@ function computeUpcoming(reservations: readonly Reservation[]): number {
   }).length;
 }
 
-function computeStats(reservations: readonly Reservation[]): DashboardStats {
+export function computeStats(reservations: readonly Reservation[]): DashboardStats {
   if (reservations.length === 0) return FALLBACK_STATS;
 
   const active = reservations.filter(

--- a/apps/hospitality/src/hooks/useReservationEvents.test.ts
+++ b/apps/hospitality/src/hooks/useReservationEvents.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useReservationEvents } from "./useReservationEvents.js";
+import type { ReservationEvent } from "./useReservationEvents.js";
+
+/* ── Mock EventSource ──────────────────────────────────────────── */
+
+type EventSourceListener = (event: MessageEvent) => void;
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+
+  url: string;
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  private listeners = new Map<string, EventSourceListener[]>();
+  readyState = 0;
+
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: EventSourceListener): void {
+    const existing = this.listeners.get(type) ?? [];
+    this.listeners.set(type, [...existing, listener]);
+  }
+
+  removeEventListener(type: string, listener: EventSourceListener): void {
+    const existing = this.listeners.get(type) ?? [];
+    this.listeners.set(
+      type,
+      existing.filter((l) => l !== listener)
+    );
+  }
+
+  close(): void {
+    this.readyState = 2;
+  }
+
+  // Test helpers
+  simulateOpen(): void {
+    this.readyState = 1;
+    this.onopen?.();
+  }
+
+  simulateError(): void {
+    this.onerror?.();
+  }
+
+  simulateEvent(type: string, data: unknown): void {
+    const listeners = this.listeners.get(type) ?? [];
+    const event = new MessageEvent(type, { data: JSON.stringify(data) });
+    for (const listener of listeners) {
+      listener(event);
+    }
+  }
+}
+
+function latestEventSource(): MockEventSource {
+  return MockEventSource.instances[MockEventSource.instances.length - 1];
+}
+
+beforeEach(() => {
+  MockEventSource.instances = [];
+  vi.stubGlobal("EventSource", MockEventSource);
+  // The hook uses `import.meta.env.VITE_API_URL` which defaults to "" in tests.
+  // `new URL("")` is invalid, so provide a base URL.
+  vi.stubEnv("VITE_API_URL", "http://localhost:3000");
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("useReservationEvents", () => {
+  it("connects with the correct URL containing venueId", () => {
+    renderHook(() =>
+      useReservationEvents({ venueId: "venue-42" })
+    );
+
+    const es = latestEventSource();
+    expect(es.url).toContain("/api/v1/events/stream");
+    expect(es.url).toContain("venueId=venue-42");
+  });
+
+  it("sets isConnected to true on open", () => {
+    const { result } = renderHook(() =>
+      useReservationEvents({ venueId: "v1" })
+    );
+
+    expect(result.current.isConnected).toBe(false);
+
+    act(() => {
+      latestEventSource().simulateOpen();
+    });
+
+    expect(result.current.isConnected).toBe(true);
+  });
+
+  it("calls onReservationCreated when reservation:created event fires", () => {
+    const onCreated = vi.fn();
+    renderHook(() =>
+      useReservationEvents({
+        venueId: "v1",
+        onReservationCreated: onCreated,
+      })
+    );
+
+    const eventPayload: ReservationEvent = {
+      type: "reservation:created",
+      venueId: "v1",
+      timestamp: "2026-01-01T00:00:00Z",
+      data: {
+        id: "res-1",
+        date: "2026-01-01",
+        startTime: "18:00",
+        endTime: "20:00",
+        partySize: 4,
+        status: "CONFIRMED",
+        notes: null,
+        cancellationReason: null,
+        cancellationNote: null,
+        guestName: "Test",
+        guestEmail: null,
+        guestPhone: null,
+        guestId: null,
+        userId: null,
+        tableId: "t1",
+        venueId: "v1",
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+    };
+
+    act(() => {
+      latestEventSource().simulateEvent("reservation:created", eventPayload);
+    });
+
+    expect(onCreated).toHaveBeenCalledOnce();
+    expect(onCreated).toHaveBeenCalledWith(eventPayload.data);
+  });
+
+  it("calls onReservationCancelled when reservation:cancelled event fires", () => {
+    const onCancelled = vi.fn();
+    renderHook(() =>
+      useReservationEvents({
+        venueId: "v1",
+        onReservationCancelled: onCancelled,
+      })
+    );
+
+    const eventPayload: ReservationEvent = {
+      type: "reservation:cancelled",
+      venueId: "v1",
+      timestamp: "2026-01-01T00:00:00Z",
+      data: {
+        id: "res-2",
+        date: "2026-01-01",
+        startTime: "19:00",
+        endTime: "21:00",
+        partySize: 2,
+        status: "CANCELLED",
+        notes: null,
+        cancellationReason: "guest_request",
+        cancellationNote: null,
+        guestName: "Jane",
+        guestEmail: null,
+        guestPhone: null,
+        guestId: null,
+        userId: null,
+        tableId: "t2",
+        venueId: "v1",
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+    };
+
+    act(() => {
+      latestEventSource().simulateEvent(
+        "reservation:cancelled",
+        eventPayload
+      );
+    });
+
+    expect(onCancelled).toHaveBeenCalledOnce();
+  });
+
+  it("calls onTableUpdated when table:updated event fires", () => {
+    const onTable = vi.fn();
+    renderHook(() =>
+      useReservationEvents({ venueId: "v1", onTableUpdated: onTable })
+    );
+
+    const eventPayload: ReservationEvent = {
+      type: "table:updated",
+      venueId: "v1",
+      timestamp: "2026-01-01T00:00:00Z",
+      data: {
+        id: "t1",
+        name: "Table 1",
+        tableNumber: "1",
+        capacity: 4,
+        minCovers: 1,
+        maxCovers: 4,
+        location: null,
+        isActive: true,
+        priority: 1,
+        status: "AVAILABLE",
+        venueId: "v1",
+        floorPlanId: null,
+        shapeMetadata: null,
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+    };
+
+    act(() => {
+      latestEventSource().simulateEvent("table:updated", eventPayload);
+    });
+
+    expect(onTable).toHaveBeenCalledOnce();
+    expect(onTable).toHaveBeenCalledWith(eventPayload.data);
+  });
+
+  it("sets error and calls onError on EventSource error", () => {
+    const onError = vi.fn();
+    const { result } = renderHook(() =>
+      useReservationEvents({ venueId: "v1", onError })
+    );
+
+    act(() => {
+      latestEventSource().simulateOpen();
+    });
+    expect(result.current.isConnected).toBe(true);
+
+    act(() => {
+      latestEventSource().simulateError();
+    });
+
+    expect(result.current.isConnected).toBe(false);
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe("SSE connection error");
+    expect(onError).toHaveBeenCalledOnce();
+  });
+
+  it("attempts reconnection with exponential backoff on error", () => {
+    renderHook(() => useReservationEvents({ venueId: "v1" }));
+
+    const initialCount = MockEventSource.instances.length;
+
+    act(() => {
+      latestEventSource().simulateError();
+    });
+
+    // First reconnect at 1000ms
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(MockEventSource.instances.length).toBe(initialCount + 1);
+
+    // Second error -> reconnect at 2000ms
+    act(() => {
+      latestEventSource().simulateError();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(1999);
+    });
+    expect(MockEventSource.instances.length).toBe(initialCount + 1);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(MockEventSource.instances.length).toBe(initialCount + 2);
+  });
+
+  it("cleans up EventSource on unmount", () => {
+    const { unmount } = renderHook(() =>
+      useReservationEvents({ venueId: "v1" })
+    );
+
+    const es = latestEventSource();
+    expect(es.readyState).not.toBe(2);
+
+    unmount();
+
+    expect(es.readyState).toBe(2);
+  });
+
+  it("does not connect when enabled is false", () => {
+    const initialCount = MockEventSource.instances.length;
+
+    renderHook(() =>
+      useReservationEvents({ venueId: "v1", enabled: false })
+    );
+
+    expect(MockEventSource.instances.length).toBe(initialCount);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,12 @@ importers:
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1
+      '@testing-library/jest-dom':
+        specifier: 'catalog:'
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.14
@@ -168,12 +174,18 @@ importers:
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 6.0.1(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      jsdom:
+        specifier: 'catalog:'
+        version: 29.0.2
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
       vite:
         specifier: 'catalog:'
         version: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(jsdom@29.0.2)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/hospitality:
     dependencies:


### PR DESCRIPTION
## Summary
- `useReservationEvents.test.ts` — 8 tests (SSE connect, events, reconnection, cleanup)
- `VenueContext.test.tsx` — 5 tests (fetch, persist, restore, error, provider guard)
- `useDashboardStats.test.ts` — 5 tests (stats computation, cancellation rate)
- `useGenStream.test.ts` — 5 tests (POST, NDJSON parsing, abort, onError)

Test coverage: 4 → 27 tests (6.75x increase)

## Test plan
- [x] All tests pass locally
- [ ] CI passes

Closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)