### PR TITLE
feat(infra): add auto-generated service dependency graph

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,12 @@ jobs:
         run: |
           pnpm audit --audit-level=high || { echo "::error::High or Critical vulnerability found"; exit 1; }
 
+      - name: Regenerate dependency graph
+        run: |
+          node scripts/generate-dep-graph.mjs
+          git diff --exit-code infrastructure/worker/dep-graph.json || \
+            (echo "ERROR: dep-graph.json is stale. Run 'pnpm generate:dep-graph' locally and commit the result." && exit 1)
+
       - name: Check Dockerfile dependencies
         run: node scripts/check-dockerfile-deps.js
 

--- a/infrastructure/worker/dep-graph.json
+++ b/infrastructure/worker/dep-graph.json
@@ -1,0 +1,442 @@
+{
+  "nodes": [
+    {
+      "name": "@mbe/gen",
+      "type": "app",
+      "path": "apps/gen"
+    },
+    {
+      "name": "@mbe/hospitality",
+      "type": "app",
+      "path": "apps/hospitality"
+    },
+    {
+      "name": "@mbe/marketing",
+      "type": "app",
+      "path": "apps/marketing"
+    },
+    {
+      "name": "@mbe/rialto-web",
+      "type": "app",
+      "path": "apps/rialto-web"
+    },
+    {
+      "name": "@mbe/agent-service",
+      "type": "service",
+      "path": "services/agent"
+    },
+    {
+      "name": "@mbe/reservations-service",
+      "type": "service",
+      "path": "services/reservations"
+    },
+    {
+      "name": "@mbe/users-service",
+      "type": "service",
+      "path": "services/users"
+    },
+    {
+      "name": "@mbe/agent-core",
+      "type": "package",
+      "path": "packages/agent-core"
+    },
+    {
+      "name": "@mbe/agent-test-utils",
+      "type": "package",
+      "path": "packages/agent-test-utils"
+    },
+    {
+      "name": "@mbe/api-client",
+      "type": "package",
+      "path": "packages/api-client"
+    },
+    {
+      "name": "@mbe/api-versioning",
+      "type": "package",
+      "path": "packages/api-versioning"
+    },
+    {
+      "name": "@mbe/auth",
+      "type": "package",
+      "path": "packages/auth"
+    },
+    {
+      "name": "@mbe/config",
+      "type": "package",
+      "path": "packages/config"
+    },
+    {
+      "name": "@mbe/feature-flags",
+      "type": "package",
+      "path": "packages/feature-flags"
+    },
+    {
+      "name": "@mbe/mcp-server",
+      "type": "package",
+      "path": "packages/mcp-server"
+    },
+    {
+      "name": "@mbe/observability",
+      "type": "package",
+      "path": "packages/observability"
+    },
+    {
+      "name": "@mbe/rialto",
+      "type": "package",
+      "path": "packages/rialto"
+    },
+    {
+      "name": "@mbe/rialto-catalog",
+      "type": "package",
+      "path": "packages/rialto-catalog"
+    },
+    {
+      "name": "@mbe/rialto-plugin",
+      "type": "package",
+      "path": "packages/rialto-plugin"
+    },
+    {
+      "name": "@mbe/sentry",
+      "type": "package",
+      "path": "packages/sentry"
+    },
+    {
+      "name": "@mbe/types",
+      "type": "package",
+      "path": "packages/types"
+    },
+    {
+      "name": "@mbe/cli",
+      "type": "tool",
+      "path": "tools/cli"
+    },
+    {
+      "name": "@mbe/infrastructure",
+      "type": "tool",
+      "path": "infrastructure/pulumi"
+    }
+  ],
+  "edges": [
+    {
+      "from": "@mbe/gen",
+      "to": "@mbe/api-client",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/gen",
+      "to": "@mbe/auth",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/gen",
+      "to": "@mbe/rialto",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/gen",
+      "to": "@mbe/rialto-catalog",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/gen",
+      "to": "@mbe/config",
+      "type": "devDependency"
+    },
+    {
+      "from": "@mbe/hospitality",
+      "to": "@mbe/api-client",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/hospitality",
+      "to": "@mbe/auth",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/hospitality",
+      "to": "@mbe/rialto",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/hospitality",
+      "to": "@mbe/rialto-catalog",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/hospitality",
+      "to": "@mbe/sentry",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/hospitality",
+      "to": "@mbe/types",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/hospitality",
+      "to": "@mbe/config",
+      "type": "devDependency"
+    },
+    {
+      "from": "@mbe/marketing",
+      "to": "@mbe/rialto",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/marketing",
+      "to": "@mbe/sentry",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/marketing",
+      "to": "@mbe/config",
+      "type": "devDependency"
+    },
+    {
+      "from": "@mbe/rialto-web",
+      "to": "@mbe/rialto",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/rialto-web",
+      "to": "@mbe/sentry",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/rialto-web",
+      "to": "@mbe/config",
+      "type": "devDependency"
+    },
+    {
+      "from": "@mbe/agent-service",
+      "to": "@mbe/agent-core",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/agent-service",
+      "to": "@mbe/api-versioning",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/agent-service",
+      "to": "@mbe/auth",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/agent-service",
+      "to": "@mbe/observability",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/agent-service",
+      "to": "@mbe/rialto-catalog",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/agent-service",
+      "to": "@mbe/sentry",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/agent-service",
+      "to": "@mbe/types",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/agent-service",
+      "to": "@mbe/config",
+      "type": "devDependency"
+    },
+    {
+      "from": "@mbe/reservations-service",
+      "to": "@mbe/api-versioning",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/reservations-service",
+      "to": "@mbe/auth",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/reservations-service",
+      "to": "@mbe/observability",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/reservations-service",
+      "to": "@mbe/sentry",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/reservations-service",
+      "to": "@mbe/types",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/reservations-service",
+      "to": "@mbe/config",
+      "type": "devDependency"
+    },
+    {
+      "from": "@mbe/users-service",
+      "to": "@mbe/api-versioning",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/users-service",
+      "to": "@mbe/auth",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/users-service",
+      "to": "@mbe/observability",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/users-service",
+      "to": "@mbe/sentry",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/users-service",
+      "to": "@mbe/types",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/users-service",
+      "to": "@mbe/config",
+      "type": "devDependency"
+    },
+    {
+      "from": "@mbe/agent-core",
+      "to": "@mbe/types",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/agent-core",
+      "to": "@mbe/config",
+      "type": "devDependency"
+    },
+    {
+      "from": "@mbe/agent-test-utils",
+      "to": "@mbe/agent-core",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/agent-test-utils",
+      "to": "@mbe/types",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/agent-test-utils",
+      "to": "@mbe/config",
+      "type": "devDependency"
+    },
+    {
+      "from": "@mbe/api-client",
+      "to": "@mbe/types",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/api-client",
+      "to": "@mbe/config",
+      "type": "devDependency"
+    },
+    {
+      "from": "@mbe/api-versioning",
+      "to": "@mbe/config",
+      "type": "devDependency"
+    },
+    {
+      "from": "@mbe/auth",
+      "to": "@mbe/types",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/auth",
+      "to": "@mbe/config",
+      "type": "devDependency"
+    },
+    {
+      "from": "@mbe/feature-flags",
+      "to": "@mbe/config",
+      "type": "devDependency"
+    },
+    {
+      "from": "@mbe/mcp-server",
+      "to": "@mbe/config",
+      "type": "devDependency"
+    },
+    {
+      "from": "@mbe/observability",
+      "to": "@mbe/types",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/observability",
+      "to": "@mbe/config",
+      "type": "devDependency"
+    },
+    {
+      "from": "@mbe/rialto",
+      "to": "@mbe/api-client",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/rialto",
+      "to": "@mbe/config",
+      "type": "devDependency"
+    },
+    {
+      "from": "@mbe/rialto-catalog",
+      "to": "@mbe/rialto",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/rialto-catalog",
+      "to": "@mbe/config",
+      "type": "devDependency"
+    },
+    {
+      "from": "@mbe/rialto-plugin",
+      "to": "@mbe/rialto",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/rialto-plugin",
+      "to": "@mbe/config",
+      "type": "devDependency"
+    },
+    {
+      "from": "@mbe/sentry",
+      "to": "@mbe/types",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/sentry",
+      "to": "@mbe/config",
+      "type": "devDependency"
+    },
+    {
+      "from": "@mbe/types",
+      "to": "@mbe/config",
+      "type": "devDependency"
+    },
+    {
+      "from": "@mbe/cli",
+      "to": "@mbe/agent-core",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/cli",
+      "to": "@mbe/types",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/cli",
+      "to": "@mbe/config",
+      "type": "devDependency"
+    }
+  ],
+  "generatedAt": "2026-04-07T22:55:04.802Z"
+}

--- a/infrastructure/worker/edge-router.js
+++ b/infrastructure/worker/edge-router.js
@@ -26,6 +26,7 @@ import {
   recordFailure,
 } from "./circuit-breaker.js";
 import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";
+import depGraph from "./dep-graph.json";
 /**
  * Build security headers with a per-request nonce for CSP script-src.
  * The nonce replaces 'unsafe-inline', preventing injected scripts from
@@ -834,6 +835,23 @@ async function handleHealthLighthouse(env) {
   );
 }
 
+/**
+ * Handle GET /health/deps — return the auto-generated service dependency graph.
+ *
+ * The graph is built at CI time by `scripts/generate-dep-graph.mjs` and
+ * imported as a static JSON module.  Cached for 5 minutes at the edge.
+ */
+function handleHealthDeps() {
+  return new Response(JSON.stringify(depGraph), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "public, max-age=300",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+}
+
 async function handleFeatureFlags(request, env, url) {
   const flagName = url.pathname.replace("/api/flags/", "");
   const authHeader = request.headers.get("Authorization");
@@ -931,6 +949,10 @@ export default {
 
     if (url.pathname === "/health/lighthouse") {
       return handleHealthLighthouse(env);
+    }
+
+    if (url.pathname === "/health/deps") {
+      return handleHealthDeps();
     }
 
     // ── Feature flags admin API ─────────────────────────────────────

--- a/infrastructure/worker/edge-router.test.js
+++ b/infrastructure/worker/edge-router.test.js
@@ -445,6 +445,46 @@ describe("Edge Router", () => {
     });
   });
 
+  describe("Dependency graph endpoint", () => {
+    it("returns JSON at /health/deps", async () => {
+      const response = await edgeRouter.fetch(makeRequest("/health/deps"), env);
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Content-Type")).toBe("application/json");
+      expect(response.headers.get("Cache-Control")).toBe("public, max-age=300");
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+      const body = await response.json();
+      expect(body).toHaveProperty("nodes");
+      expect(body).toHaveProperty("edges");
+      expect(body).toHaveProperty("generatedAt");
+      expect(Array.isArray(body.nodes)).toBe(true);
+      expect(Array.isArray(body.edges)).toBe(true);
+    });
+
+    it("includes node properties (name, type, path)", async () => {
+      const response = await edgeRouter.fetch(makeRequest("/health/deps"), env);
+      const body = await response.json();
+      if (body.nodes.length > 0) {
+        const node = body.nodes[0];
+        expect(node).toHaveProperty("name");
+        expect(node).toHaveProperty("type");
+        expect(node).toHaveProperty("path");
+        expect(["app", "service", "package", "tool"]).toContain(node.type);
+      }
+    });
+
+    it("includes edge properties (from, to, type)", async () => {
+      const response = await edgeRouter.fetch(makeRequest("/health/deps"), env);
+      const body = await response.json();
+      if (body.edges.length > 0) {
+        const edge = body.edges[0];
+        expect(edge).toHaveProperty("from");
+        expect(edge).toHaveProperty("to");
+        expect(edge).toHaveProperty("type");
+        expect(["dependency", "devDependency"]).toContain(edge.type);
+      }
+    });
+  });
+
   describe("Service binding names match wrangler.toml", () => {
     it("uses the expected set of static site bindings", () => {
       // This test serves as a canary — if STATIC_SITE_BINDINGS changes

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "check:dockerfiles": "node scripts/check-dockerfile-deps.js",
     "check:env-sync": "node scripts/check-env-sync.js",
     "graph": "node scripts/generate-dep-graph.js",
+    "generate:dep-graph": "node scripts/generate-dep-graph.mjs",
     "check:schema-compat": "node scripts/check-schema-compat.js",
     "schema:baseline": "tsx scripts/update-schema-baselines.js",
     "log:cost": "node scripts/log-agent-cost.js",

--- a/scripts/generate-dep-graph.mjs
+++ b/scripts/generate-dep-graph.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+
+/**
+ * Generates a JSON dependency graph of workspace packages.
+ *
+ * Parses pnpm-workspace.yaml and all package.json files, builds a graph
+ * of nodes (packages/services/apps) and edges (internal @mbe/* deps),
+ * and writes JSON to infrastructure/worker/dep-graph.json.
+ *
+ * Usage: node scripts/generate-dep-graph.mjs
+ */
+
+import { readFileSync, readdirSync, writeFileSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, "..");
+
+/**
+ * Parse pnpm-workspace.yaml to discover workspace globs.
+ * Only handles the simple `packages:` list format used by this repo.
+ * Returns an array of directory paths (resolved globs).
+ */
+function discoverWorkspaceGlobs() {
+  const wsPath = join(root, "pnpm-workspace.yaml");
+  if (!existsSync(wsPath)) {
+    throw new Error("pnpm-workspace.yaml not found at project root");
+  }
+
+  const content = readFileSync(wsPath, "utf-8");
+  const lines = content.split("\n");
+  const globs = [];
+  let inPackages = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed === "packages:") {
+      inPackages = true;
+      continue;
+    }
+    // Stop when we hit a non-list-item line after entering packages
+    if (inPackages) {
+      if (trimmed.startsWith("- ")) {
+        const glob = trimmed.slice(2).replace(/"/g, "").trim();
+        globs.push(glob);
+      } else if (trimmed !== "" && !trimmed.startsWith("#")) {
+        break;
+      }
+    }
+  }
+
+  return globs;
+}
+
+/**
+ * Classify a workspace path into a node type.
+ */
+function classifyType(wsDir) {
+  if (wsDir.startsWith("apps/")) return "app";
+  if (wsDir.startsWith("services/")) return "service";
+  if (wsDir.startsWith("packages/")) return "package";
+  if (wsDir.startsWith("tools/")) return "tool";
+  if (wsDir.startsWith("infrastructure/")) return "tool";
+  return "package";
+}
+
+/**
+ * Resolve a workspace glob to actual package directories.
+ * Handles both wildcard globs (e.g. "apps/*") and explicit paths
+ * (e.g. "infrastructure/pulumi").
+ */
+function resolveGlob(glob) {
+  const results = [];
+
+  if (glob.endsWith("/*")) {
+    // Wildcard — enumerate subdirectories
+    const parentDir = join(root, glob.slice(0, -2));
+    if (!existsSync(parentDir)) return results;
+
+    for (const entry of readdirSync(parentDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const pkgJsonPath = join(parentDir, entry.name, "package.json");
+      if (existsSync(pkgJsonPath)) {
+        results.push({
+          pkgJsonPath,
+          wsDir: `${glob.slice(0, -2)}/${entry.name}`,
+        });
+      }
+    }
+  } else {
+    // Explicit path
+    const pkgJsonPath = join(root, glob, "package.json");
+    if (existsSync(pkgJsonPath)) {
+      results.push({ pkgJsonPath, wsDir: glob });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Collect internal @mbe/* dependencies from a deps object.
+ * Returns array of { name, type } objects.
+ */
+function collectMbeDeps(depsObj, depType) {
+  if (!depsObj) return [];
+  return Object.keys(depsObj)
+    .filter((name) => name.startsWith("@mbe/"))
+    .map((name) => ({ name, type: depType }));
+}
+
+/**
+ * Build the full dependency graph.
+ * Returns { nodes: [...], edges: [...], generatedAt: ISO string }.
+ */
+function buildGraph() {
+  const globs = discoverWorkspaceGlobs();
+  const workspaces = globs.flatMap(resolveGlob);
+
+  const nodes = [];
+  const edges = [];
+  const nameSet = new Set();
+
+  // First pass: collect all nodes
+  for (const { pkgJsonPath, wsDir } of workspaces) {
+    const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf-8"));
+    if (!pkg.name) continue;
+
+    nodes.push({
+      name: pkg.name,
+      type: classifyType(wsDir),
+      path: wsDir,
+    });
+    nameSet.add(pkg.name);
+  }
+
+  // Second pass: collect edges (only to known internal packages)
+  for (const { pkgJsonPath } of workspaces) {
+    const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf-8"));
+    if (!pkg.name) continue;
+
+    const deps = [
+      ...collectMbeDeps(pkg.dependencies, "dependency"),
+      ...collectMbeDeps(pkg.devDependencies, "devDependency"),
+    ];
+
+    for (const dep of deps) {
+      if (nameSet.has(dep.name)) {
+        edges.push({
+          from: pkg.name,
+          to: dep.name,
+          type: dep.type,
+        });
+      }
+    }
+  }
+
+  return {
+    nodes,
+    edges,
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+// ── Main ──────────────────────────────────────────────────────────────
+
+const graph = buildGraph();
+const outputPath = join(root, "infrastructure", "worker", "dep-graph.json");
+
+writeFileSync(outputPath, JSON.stringify(graph, null, 2) + "\n");
+
+console.log(
+  `Generated dependency graph: ${graph.nodes.length} nodes, ${graph.edges.length} edges → ${outputPath}`
+);


### PR DESCRIPTION
## Summary
- Creates `scripts/generate-dep-graph.mjs` that parses all workspace `package.json` files and builds a dependency graph
- Outputs JSON with nodes (apps, services, packages, tools) and edges (internal @mbe/* dependencies)
- Adds `pnpm generate:dep-graph` convenience script
- Graph endpoint at `/health/deps` on edge router (or generated file for CI)

## Test plan
- [ ] Run `pnpm generate:dep-graph` and verify output
- [ ] Verify all @mbe/* internal dependencies are captured

Closes #257