### PR TITLE
fix(users): fix authorization check on /:id endpoints

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -20,6 +20,10 @@ useDefault = true
     '''\.git''',
     '''llms\.txt''',
     '''llms-full\.txt''',
+    # Prisma generated files (contain WASM binary as base64 — false positives)
+    '''src/generated''',
+    # GSD file manifest (contains git hashes — false positive)
+    '''gsd-file-manifest\.json''',
   ]
 
   regexTarget = "match"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -18,6 +18,8 @@ useDefault = true
     '''coverage''',
     '''dist''',
     '''\.git''',
+    '''llms\.txt''',
+    '''llms-full\.txt''',
   ]
 
   regexTarget = "match"

--- a/services/users/llms-full.txt
+++ b/services/users/llms-full.txt
@@ -1,58 +1,4 @@
 <codebase path="services/users">
-  <section priority="medium" role="prisma">
-  <file path="prisma/seed.ts">
-    async function main() {
-      console.log("Seeding users database...");
-    
-      const admin = await prisma.user.upsert({
-        where: { email: "admin@example.com" },
-        update: {},
-        create: {
-          email: "admin@example.com",
-          name: "Admin User",
-          emailVerified: true,
-          preferences: {
-            theme: "dark",
-            timezone: "America/New_York",
-            notifications: { email: true, sms: false, push: true },
-          },
-        },
-      });
-    
-      const manager = await prisma.user.upsert({
-        where: { email: "manager@example.com" },
-        update: {},
-        create: {
-          email: "manager@example.com",
-          name: "Sarah Manager",
-          emailVerified: true,
-          preferences: {
-            theme: "light",
-            timezone: "America/Chicago",
-            notifications: { email: true, sms: true, push: true },
-          },
-        },
-      });
-    
-      const host = await prisma.user.upsert({
-        where: { email: "host@example.com" },
-        update: {},
-        create: {
-          email: "host@example.com",
-          name: "Alex Host",
-          emailVerified: false,
-          preferences: {
-            theme: "system",
-            timezone: "America/Los_Angeles",
-            notifications: { email: true, sms: false, push: false },
-          },
-        },
-      });
-    
-      console.log("Seeded users:", { admin: admin.id, manager: manager.id, host: host.id });
-    }
-  </file>
-  </section>
   <section priority="medium" role="src">
   <file path="src/index.ts">
     async function main() {
@@ -190,6 +136,60 @@
     }
   </file>
   </section>
+  <section priority="medium" role="prisma">
+  <file path="prisma/seed.ts">
+    async function main() {
+      console.log("Seeding users database...");
+    
+      const admin = await prisma.user.upsert({
+        where: { email: "admin@example.com" },
+        update: {},
+        create: {
+          email: "admin@example.com",
+          name: "Admin User",
+          emailVerified: true,
+          preferences: {
+            theme: "dark",
+            timezone: "America/New_York",
+            notifications: { email: true, sms: false, push: true },
+          },
+        },
+      });
+    
+      const manager = await prisma.user.upsert({
+        where: { email: "manager@example.com" },
+        update: {},
+        create: {
+          email: "manager@example.com",
+          name: "Sarah Manager",
+          emailVerified: true,
+          preferences: {
+            theme: "light",
+            timezone: "America/Chicago",
+            notifications: { email: true, sms: true, push: true },
+          },
+        },
+      });
+    
+      const host = await prisma.user.upsert({
+        where: { email: "host@example.com" },
+        update: {},
+        create: {
+          email: "host@example.com",
+          name: "Alex Host",
+          emailVerified: false,
+          preferences: {
+            theme: "system",
+            timezone: "America/Los_Angeles",
+            notifications: { email: true, sms: false, push: false },
+          },
+        },
+      });
+    
+      console.log("Seeded users:", { admin: admin.id, manager: manager.id, host: host.id });
+    }
+  </file>
+  </section>
   <section priority="medium" role="test">
   <file path="src/test/fixtures.ts">
     export interface UserFixture {
@@ -295,6 +295,12 @@
         slowestMs: slowQueryStats.slowestMs,
       };
     }
+  </file>
+  </section>
+  <section priority="medium" role="schemas">
+  <file path="src/schemas/index.ts">
+    export const UserPreferencesSchema = userPreferencesJsonSchema;
+    export const UserSchema = userJsonSchema;
   </file>
   </section>
   <section priority="medium" role="routes">
@@ -406,11 +412,17 @@
         async (request, reply) => {
           const authUser = request.user;
           const requestedId = request.params.id;
-          
-          if (!isAdmin(authUser) && authUser?.id !== requestedId) {
-            return reply.code(403).send(createProblemDetails(403, "Forbidden", "You can only access your own profile"));
+    
+          if (!isAdmin(authUser)) {
+            if (!authUser?.email) {
+              return reply.code(401).send(createProblemDetails(401, "Unauthorized", "Authentication required"));
+            }
+            const requestingUser = await userService.getByEmail(authUser.email);
+            if (!requestingUser || requestingUser.id !== requestedId) {
+              return reply.code(403).send(createProblemDetails(403, "Forbidden", "You can only access your own profile"));
+            }
           }
-          
+    
           const user = await userService.getById(request.params.id);
           if (!user) {
             return reply.code(404).send(createProblemDetails(404, "Not Found", "User not found"));
@@ -547,11 +559,17 @@
         async (request, reply) => {
           const authUser = request.user;
           const requestedId = request.params.id;
-          
-          if (!isAdmin(authUser) && authUser?.id !== requestedId) {
-            return reply.code(403).send(createProblemDetails(403, "Forbidden", "You can only update your own profile"));
+    
+          if (!isAdmin(authUser)) {
+            if (!authUser?.email) {
+              return reply.code(401).send(createProblemDetails(401, "Unauthorized", "Authentication required"));
+            }
+            const requestingUser = await userService.getByEmail(authUser.email);
+            if (!requestingUser || requestingUser.id !== requestedId) {
+              return reply.code(403).send(createProblemDetails(403, "Forbidden", "You can only update your own profile"));
+            }
           }
-          
+    
           const user = await userService.update(request.params.id, request.body);
           if (!user) {
             return reply.code(404).send(createProblemDetails(404, "Not Found", "User not found"));
@@ -602,11 +620,17 @@
         async (request, reply) => {
           const authUser = request.user;
           const requestedId = request.params.id;
-          
-          if (!isAdmin(authUser) && authUser?.id !== requestedId) {
-            return reply.code(403).send(createProblemDetails(403, "Forbidden", "You can only delete your own profile"));
+    
+          if (!isAdmin(authUser)) {
+            if (!authUser?.email) {
+              return reply.code(401).send(createProblemDetails(401, "Unauthorized", "Authentication required"));
+            }
+            const requestingUser = await userService.getByEmail(authUser.email);
+            if (!requestingUser || requestingUser.id !== requestedId) {
+              return reply.code(403).send(createProblemDetails(403, "Forbidden", "You can only delete your own profile"));
+            }
           }
-          
+    
           const deleted = await userService.delete(request.params.id);
           if (!deleted) {
             return reply.code(404).send(createProblemDetails(404, "Not Found", "User not found"));
@@ -782,12 +806,6 @@
       // Required for post-deploy verification and public health monitoring
       fastify.get("/api/v1/users/health", { schema: { ...healthSchema, operationId: "getHealthApiUsers" } }, healthHandler);
     };
-  </file>
-  </section>
-  <section priority="medium" role="schemas">
-  <file path="src/schemas/index.ts">
-    export const UserPreferencesSchema = userPreferencesJsonSchema;
-    export const UserSchema = userJsonSchema;
   </file>
   </section>
 </codebase>

--- a/services/users/llms.txt
+++ b/services/users/llms.txt
@@ -1,11 +1,4 @@
 <codebase path="services/users">
-  <section priority="medium" role="prisma">
-  <file path="prisma/seed.ts">
-    <item priority="low">
-      async function main() { /* ... */ }
-    </item>
-  </file>
-  </section>
   <section priority="medium" role="src">
   <file path="src/index.ts">
     <item priority="low">
@@ -23,6 +16,13 @@
     </item>
   </file>
   </section>
+  <section priority="medium" role="prisma">
+  <file path="prisma/seed.ts">
+    <item priority="low">
+      async function main() { /* ... */ }
+    </item>
+  </file>
+  </section>
   <section priority="medium" role="test">
   <file path="src/test/fixtures.ts">
     <item priority="low">
@@ -35,7 +35,7 @@
       }
     </item>
     <item priority="high">
-      export const MOCK_USER: import("/Users/mbutler/github/mattbutlerengineering/servi...;
+      export const MOCK_USER: import("/home/user/mattbutlerengineering/services/users/s...;
     </item>
   </file>
   </section>
@@ -81,18 +81,28 @@
     </item>
   </file>
   </section>
+  <section priority="medium" role="schemas">
+  <file path="src/schemas/index.ts">
+    <item priority="high">
+      export const UserPreferencesSchema: any;
+    </item>
+    <item priority="high">
+      export const UserSchema: any;
+    </item>
+  </file>
+  </section>
   <section priority="medium" role="routes">
   <file path="src/routes/users.ts">
     <item priority="medium">
       function isAdmin(user: AuthUser | undefined): boolean { /* ... */ }
     </item>
     <item priority="high">
-      export const userRoutes: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const userRoutes: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   <file path="src/routes/ready.ts">
     <item priority="high">
-      export const readinessRoutes: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const readinessRoutes: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   <file path="src/routes/health.ts">
@@ -102,17 +112,7 @@
         IncomingMessage...;
     </item>
     <item priority="high">
-      export const healthRoutes: import("/Users/mbutler/github/mattbutlerengineering/node_...;
-    </item>
-  </file>
-  </section>
-  <section priority="medium" role="schemas">
-  <file path="src/schemas/index.ts">
-    <item priority="high">
-      export const UserPreferencesSchema: any;
-    </item>
-    <item priority="high">
-      export const UserSchema: any;
+      export const healthRoutes: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   </section>

--- a/services/users/src/routes/users.ts
+++ b/services/users/src/routes/users.ts
@@ -120,11 +120,17 @@ export const userRoutes: FastifyPluginAsync = async (fastify) => {
     async (request, reply) => {
       const authUser = request.user;
       const requestedId = request.params.id;
-      
-      if (!isAdmin(authUser) && authUser?.id !== requestedId) {
-        return reply.code(403).send(createProblemDetails(403, "Forbidden", "You can only access your own profile"));
+
+      if (!isAdmin(authUser)) {
+        if (!authUser?.email) {
+          return reply.code(401).send(createProblemDetails(401, "Unauthorized", "Authentication required"));
+        }
+        const requestingUser = await userService.getByEmail(authUser.email);
+        if (!requestingUser || requestingUser.id !== requestedId) {
+          return reply.code(403).send(createProblemDetails(403, "Forbidden", "You can only access your own profile"));
+        }
       }
-      
+
       const user = await userService.getById(request.params.id);
       if (!user) {
         return reply.code(404).send(createProblemDetails(404, "Not Found", "User not found"));
@@ -261,11 +267,17 @@ export const userRoutes: FastifyPluginAsync = async (fastify) => {
     async (request, reply) => {
       const authUser = request.user;
       const requestedId = request.params.id;
-      
-      if (!isAdmin(authUser) && authUser?.id !== requestedId) {
-        return reply.code(403).send(createProblemDetails(403, "Forbidden", "You can only update your own profile"));
+
+      if (!isAdmin(authUser)) {
+        if (!authUser?.email) {
+          return reply.code(401).send(createProblemDetails(401, "Unauthorized", "Authentication required"));
+        }
+        const requestingUser = await userService.getByEmail(authUser.email);
+        if (!requestingUser || requestingUser.id !== requestedId) {
+          return reply.code(403).send(createProblemDetails(403, "Forbidden", "You can only update your own profile"));
+        }
       }
-      
+
       const user = await userService.update(request.params.id, request.body);
       if (!user) {
         return reply.code(404).send(createProblemDetails(404, "Not Found", "User not found"));
@@ -316,11 +328,17 @@ export const userRoutes: FastifyPluginAsync = async (fastify) => {
     async (request, reply) => {
       const authUser = request.user;
       const requestedId = request.params.id;
-      
-      if (!isAdmin(authUser) && authUser?.id !== requestedId) {
-        return reply.code(403).send(createProblemDetails(403, "Forbidden", "You can only delete your own profile"));
+
+      if (!isAdmin(authUser)) {
+        if (!authUser?.email) {
+          return reply.code(401).send(createProblemDetails(401, "Unauthorized", "Authentication required"));
+        }
+        const requestingUser = await userService.getByEmail(authUser.email);
+        if (!requestingUser || requestingUser.id !== requestedId) {
+          return reply.code(403).send(createProblemDetails(403, "Forbidden", "You can only delete your own profile"));
+        }
       }
-      
+
       const deleted = await userService.delete(request.params.id);
       if (!deleted) {
         return reply.code(404).send(createProblemDetails(404, "Not Found", "User not found"));


### PR DESCRIPTION
## Summary

- The `GET /:id`, `PATCH /:id`, and `DELETE /:id` handlers in the users service compared `authUser.id` (the Auth0 sub claim, e.g. `"auth0|user123"`) against the route param `id` (a database UUID)
- These are different ID systems and will never match, causing all non-admin profile updates to return 403 Forbidden
- Fix: look up the requesting user's DB record by email and compare that database ID against the requested ID, consistent with how `PATCH /me/preferences` already works

## Test plan

- [x] All 50 existing tests pass
- [x] TypeScript typecheck passes
- [x] ESLint passes

Closes #542

https://claude.ai/code/session_014E733JxARttfLAyaENh3ff