### PR TITLE
fix(ci): pre-land gitleaks allowlist for llms.txt, src/generated, gsd-file-manifest

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -18,6 +18,10 @@ useDefault = true
     '''coverage''',
     '''dist''',
     '''\.git''',
+    '''llms\.txt''',
+    '''llms-full\.txt''',
+    '''src/generated''',
+    '''gsd-file-manifest\.json''',
   ]
 
   regexTarget = "match"


### PR DESCRIPTION
## Summary

- Adds `llms.txt`, `llms-full.txt`, `src/generated`, and `gsd-file-manifest.json` to the Gitleaks path allowlist on `main`
- These files contain content patterns that trigger false positives (email-like strings, Prisma WASM base64, git SHAs)
- Pre-landing this config unblocks PR #545 — Gitleaks was flagging that PR's `llms.txt` changes, but the exclusion config was being added in the same PR, creating a bootstrap problem

## Test plan

- [ ] Gitleaks Secret Scan passes on this PR (no flagged patterns in `.gitleaks.toml` changes)
- [ ] After merge, re-run CI on PR #545 to confirm it now passes Gitleaks

Closes #546

https://claude.ai/code/session_01UwprxvmxzU68thAXRADH5N