### PR TITLE
perf(rialto): lazy-load framer-motion in ToastProvider to fix FCP/LCP on /rialto

### DIFF
--- a/packages/rialto/src/components/Toast/Toast.tsx
+++ b/packages/rialto/src/components/Toast/Toast.tsx
@@ -1,107 +1,16 @@
-import { useCallback, useRef, useState, useEffect, type ReactNode } from "react";
-import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
-import { spring } from "../../tokens/motion";
-import { ToastContext, type ToastData, type ToastVariant, type ToastInput } from "./ToastContext";
+import { useCallback, useRef, useState, useEffect, lazy, Suspense, type ReactNode } from "react";
+import { ToastContext, type ToastData, type ToastInput } from "./ToastContext";
 import styles from "./Toast.module.css";
 
-/* ── Single toast ────────────────────────────── */
-function ToastIcon({ variant }: { variant: ToastVariant }) {
-  if (variant === "success") {
-    return (
-      <svg
-        className={styles.icon}
-        viewBox="0 0 18 18"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      >
-        <circle cx="9" cy="9" r="7" />
-        <path d="M6 9l2 2 4-4" />
-      </svg>
-    );
-  }
-  if (variant === "error") {
-    return (
-      <svg
-        className={styles.icon}
-        viewBox="0 0 18 18"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-      >
-        <circle cx="9" cy="9" r="7" />
-        <path d="M6 6l6 6M12 6l-6 6" />
-      </svg>
-    );
-  }
-  if (variant === "accent") {
-    return (
-      <svg
-        className={styles.icon}
-        viewBox="0 0 18 18"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      >
-        <circle cx="9" cy="9" r="7" />
-        <path d="M9 5v3M9 11v1" />
-      </svg>
-    );
-  }
-  return null;
-}
-
-function ToastItem({ toast: t, onDismiss }: { toast: ToastData; onDismiss: (id: string) => void }) {
-  const shouldReduceMotion = useReducedMotion();
-  const duration = t.duration ?? 4000;
-
-  return (
-    <motion.div
-      layout
-      className={`${styles.toast} ${styles[t.variant ?? "default"]}`}
-      initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, x: 80, scale: 0.95 }}
-      animate={{ opacity: 1, x: 0, scale: 1 }}
-      exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, x: 40, scale: 0.95 }}
-      transition={shouldReduceMotion ? { duration: 0.1 } : spring}
-    >
-      <ToastIcon variant={t.variant ?? "default"} />
-      {t.title && <p className={styles.title}>{t.title}</p>}
-      {t.description && <p className={styles.description}>{t.description}</p>}
-
-      <button className={styles.close} onClick={() => onDismiss(t.id)} aria-label="Dismiss">
-        <svg
-          width="10"
-          height="10"
-          viewBox="0 0 10 10"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-        >
-          <path d="M1 1l8 8M9 1l-8 8" />
-        </svg>
-      </button>
-
-      {duration > 0 && (
-        <motion.div
-          className={styles.countdown}
-          initial={{ scaleX: 1 }}
-          animate={{ scaleX: 0 }}
-          transition={{ duration: duration / 1000, ease: "linear" }}
-        />
-      )}
-    </motion.div>
-  );
-}
+const ToastAnimated = lazy(() =>
+  import("./ToastAnimated").then((m) => ({ default: m.ToastAnimated }))
+);
 
 /* ── Provider ────────────────────────────────── */
 export function ToastProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<ToastData[]>([]);
+  // Once true, keeps ToastAnimated mounted so exit animations play correctly.
+  const [everHadToasts, setEverHadToasts] = useState(false);
   const timers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
   const counter = useRef(0);
 
@@ -120,6 +29,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
       const duration = data.duration ?? 4000;
       const newToast: ToastData = { ...data, id, duration };
 
+      setEverHadToasts(true);
       setToasts((prev) => [...prev, newToast]);
 
       if (duration > 0) {
@@ -150,19 +60,19 @@ export function ToastProvider({ children }: { children: ReactNode }) {
       <div className={styles.container} role="region" aria-label="Notifications">
         {/* Polite region — info, success, accent, default (non-critical) */}
         <div aria-live="polite" aria-atomic="false">
-          <AnimatePresence mode="popLayout">
-            {politeToasts.map((t) => (
-              <ToastItem key={t.id} toast={t} onDismiss={dismiss} />
-            ))}
-          </AnimatePresence>
+          {everHadToasts && (
+            <Suspense fallback={null}>
+              <ToastAnimated toasts={politeToasts} onDismiss={dismiss} />
+            </Suspense>
+          )}
         </div>
         {/* Assertive region — error (interrupts user immediately) */}
         <div aria-live="assertive" aria-atomic="false">
-          <AnimatePresence mode="popLayout">
-            {assertiveToasts.map((t) => (
-              <ToastItem key={t.id} toast={t} onDismiss={dismiss} />
-            ))}
-          </AnimatePresence>
+          {everHadToasts && (
+            <Suspense fallback={null}>
+              <ToastAnimated toasts={assertiveToasts} onDismiss={dismiss} />
+            </Suspense>
+          )}
         </div>
       </div>
     </ToastContext.Provider>

--- a/packages/rialto/src/components/Toast/ToastAnimated.tsx
+++ b/packages/rialto/src/components/Toast/ToastAnimated.tsx
@@ -1,0 +1,113 @@
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { spring } from "../../tokens/motion";
+import type { ToastData, ToastVariant } from "./ToastContext";
+import styles from "./Toast.module.css";
+
+function ToastIcon({ variant }: { variant: ToastVariant }) {
+  if (variant === "success") {
+    return (
+      <svg
+        className={styles.icon}
+        viewBox="0 0 18 18"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <circle cx="9" cy="9" r="7" />
+        <path d="M6 9l2 2 4-4" />
+      </svg>
+    );
+  }
+  if (variant === "error") {
+    return (
+      <svg
+        className={styles.icon}
+        viewBox="0 0 18 18"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      >
+        <circle cx="9" cy="9" r="7" />
+        <path d="M6 6l6 6M12 6l-6 6" />
+      </svg>
+    );
+  }
+  if (variant === "accent") {
+    return (
+      <svg
+        className={styles.icon}
+        viewBox="0 0 18 18"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <circle cx="9" cy="9" r="7" />
+        <path d="M9 5v3M9 11v1" />
+      </svg>
+    );
+  }
+  return null;
+}
+
+function ToastItem({ toast: t, onDismiss }: { toast: ToastData; onDismiss: (id: string) => void }) {
+  const shouldReduceMotion = useReducedMotion();
+  const duration = t.duration ?? 4000;
+
+  return (
+    <motion.div
+      layout
+      className={`${styles.toast} ${styles[t.variant ?? "default"]}`}
+      initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, x: 80, scale: 0.95 }}
+      animate={{ opacity: 1, x: 0, scale: 1 }}
+      exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, x: 40, scale: 0.95 }}
+      transition={shouldReduceMotion ? { duration: 0.1 } : spring}
+    >
+      <ToastIcon variant={t.variant ?? "default"} />
+      {t.title && <p className={styles.title}>{t.title}</p>}
+      {t.description && <p className={styles.description}>{t.description}</p>}
+
+      <button className={styles.close} onClick={() => onDismiss(t.id)} aria-label="Dismiss">
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 10 10"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+        >
+          <path d="M1 1l8 8M9 1l-8 8" />
+        </svg>
+      </button>
+
+      {duration > 0 && (
+        <motion.div
+          className={styles.countdown}
+          initial={{ scaleX: 1 }}
+          animate={{ scaleX: 0 }}
+          transition={{ duration: duration / 1000, ease: "linear" }}
+        />
+      )}
+    </motion.div>
+  );
+}
+
+export interface ToastAnimatedProps {
+  toasts: ToastData[];
+  onDismiss: (id: string) => void;
+}
+
+export function ToastAnimated({ toasts, onDismiss }: ToastAnimatedProps) {
+  return (
+    <AnimatePresence mode="popLayout">
+      {toasts.map((t) => (
+        <ToastItem key={t.id} toast={t} onDismiss={onDismiss} />
+      ))}
+    </AnimatePresence>
+  );
+}


### PR DESCRIPTION
## Summary

- `ToastProvider` no longer eagerly imports `framer-motion` at module load time
- Animated rendering is extracted into `ToastAnimated.tsx`, loaded as a dynamic chunk only when the first toast fires
- The `aria-live` regions remain always-mounted (required for screen readers to register them at page load)
- Once `ToastAnimated` loads, it stays mounted so exit animations work correctly when toasts dismiss
- Expected impact: eliminates ~38 kB of unused framer-motion JS from the initial `/rialto` bundle

## Root cause

`ToastProvider` in `@mbe/rialto` imported `motion`, `AnimatePresence`, and `useReducedMotion` from `framer-motion` at the top of `Toast.tsx`. Because `main.tsx` wraps the entire app with `<ToastProvider>`, framer-motion was bundled into the critical-path chunk and loaded on every page visit — even though toasts are rarely shown. Lighthouse flagged 76% of the `motion.js` chunk (38 kB) as unused on initial load.

## What changed

- `packages/rialto/src/components/Toast/Toast.tsx` — removed framer-motion imports; added `React.lazy()` wrapper for `ToastAnimated`; added `everHadToasts` flag to gate the lazy boundary
- `packages/rialto/src/components/Toast/ToastAnimated.tsx` — new file containing `ToastIcon`, `ToastItem`, and `ToastAnimated` (the framer-motion rendering layer)

## Test plan

- [ ] `/rialto` loads without console errors
- [ ] Toast fires correctly when triggered (e.g., from ToastPage)
- [ ] Toast exit animations play on dismiss
- [ ] `pnpm test` passes (existing ToastProvider tests don't fire toasts, so lazy boundary isn't exercised)
- [ ] Check Vite build output: `framer-motion` chunk no longer in initial JS

Closes #551

https://claude.ai/code/session_01R44zcgAwVebKnRTFdejeSL