### PR TITLE
fix(rialto-web): fix active nav link contrast ratio to meet WCAG AA

### DIFF
--- a/apps/rialto-web/src/components/ShowcaseSidebar.module.css
+++ b/apps/rialto-web/src/components/ShowcaseSidebar.module.css
@@ -235,14 +235,14 @@
 /* ── Active state ────────────────────────────── */
 
 .navLinkActive {
-  color: var(--rialto-accent);
+  color: var(--rialto-text-primary);
   font-weight: var(--rialto-weight-medium);
   background: var(--rialto-accent-muted);
   border-inline-start-color: var(--rialto-accent);
 }
 
 .navLinkActive:hover {
-  color: var(--rialto-accent);
+  color: var(--rialto-text-primary);
   background: var(--rialto-accent-muted);
 }
 


### PR DESCRIPTION
## Summary

- Active sidebar nav links used `--rialto-accent` (#b0841e) as text color on an accent-muted background (~#f3eddf), giving a **2.80:1 contrast ratio** — below the WCAG AA minimum of 4.5:1 for normal-sized text (13px)
- Switch active link text to `--rialto-text-primary` (#1a1918) which achieves ~**15:1 contrast** on the same background
- The amber accent is preserved as the left-border indicator, maintaining the visual active-state design

## What changed

`apps/rialto-web/src/components/ShowcaseSidebar.module.css`:
- `.navLinkActive` — `color` changed from `--rialto-accent` → `--rialto-text-primary`
- `.navLinkActive:hover` — same change

## Test plan

- [ ] Active nav item renders with dark text (not amber) but retains amber left border and muted amber background
- [ ] Active state is visually distinguishable from default and hover states
- [ ] No console errors

Closes #560

https://claude.ai/code/session_018gQSrYfnXgwYHnedVDusPx