### PR TITLE
fix(rialto): fix accent text color contrast to meet WCAG AA across 7 components

### DIFF
--- a/packages/rialto/src/components/Breadcrumb/Breadcrumb.module.css
+++ b/packages/rialto/src/components/Breadcrumb/Breadcrumb.module.css
@@ -38,7 +38,7 @@
 }
 
 .link:hover {
-  color: var(--rialto-accent);
+  color: var(--rialto-text-primary);
   background: var(--rialto-accent-muted);
 }
 

--- a/packages/rialto/src/components/GlobalNav/GlobalNav.module.css
+++ b/packages/rialto/src/components/GlobalNav/GlobalNav.module.css
@@ -32,7 +32,7 @@
 }
 
 .brand:hover {
-  color: var(--rialto-accent);
+  color: var(--rialto-text-primary);
 }
 
 /* ── Desktop links ──────────────────────────────── */

--- a/packages/rialto/src/components/Select/Select.module.css
+++ b/packages/rialto/src/components/Select/Select.module.css
@@ -127,7 +127,7 @@
 }
 
 .option[data-selected="true"] {
-  color: var(--rialto-accent);
+  color: var(--rialto-text-primary);
   font-weight: var(--rialto-weight-medium);
 }
 

--- a/packages/rialto/src/components/Sidebar/Sidebar.module.css
+++ b/packages/rialto/src/components/Sidebar/Sidebar.module.css
@@ -76,13 +76,13 @@
 
 .itemActive {
   background: var(--rialto-accent-muted);
-  color: var(--rialto-accent);
+  color: var(--rialto-text-primary);
   box-shadow: inset 3px 0 0 var(--rialto-accent);
 }
 
 .itemActive:hover {
   background: var(--rialto-accent-muted);
-  color: var(--rialto-accent);
+  color: var(--rialto-text-primary);
 }
 
 .itemDisabled {

--- a/packages/rialto/src/components/Steps/Steps.module.css
+++ b/packages/rialto/src/components/Steps/Steps.module.css
@@ -93,7 +93,7 @@
 /* Current: gold ring with glow */
 .current .node {
   border-color: var(--rialto-accent);
-  color: var(--rialto-accent);
+  color: var(--rialto-text-primary);
   box-shadow:
     0 0 0 3px var(--rialto-surface),
     0 0 0 5px rgb(196 146 42 / 0.3),
@@ -140,7 +140,7 @@
 }
 
 .current .stepLabel {
-  color: var(--rialto-accent);
+  color: var(--rialto-text-primary);
 }
 
 .stepDescription {

--- a/packages/rialto/src/components/Table/Table.module.css
+++ b/packages/rialto/src/components/Table/Table.module.css
@@ -47,11 +47,11 @@
 }
 
 .sortActive {
-  color: var(--rialto-accent);
+  color: var(--rialto-text-primary);
 }
 
 .sortActive:hover {
-  color: var(--rialto-accent-hover);
+  color: var(--rialto-text-secondary);
 }
 
 .sortIcon {

--- a/packages/rialto/src/components/Timeline/Timeline.module.css
+++ b/packages/rialto/src/components/Timeline/Timeline.module.css
@@ -47,7 +47,7 @@
 }
 
 .active .timestamp {
-  color: var(--rialto-accent);
+  color: var(--rialto-text-secondary);
 }
 
 /* ── Track (node column) ────────────────────── */
@@ -122,7 +122,7 @@
 }
 
 .active .title {
-  color: var(--rialto-accent);
+  color: var(--rialto-text-primary);
 }
 
 .error .title {


### PR DESCRIPTION
## Summary

`--rialto-accent` (#b0841e) achieves only 3.16:1 on the standard surface (#f8f6f3) — below the WCAG AA 4.5:1 threshold for normal-sized text. This PR removes all uses of the accent token as **foreground text color**, replacing with appropriate text tokens. Decorative uses (borders, backgrounds, box-shadows, icons, focus rings) are unchanged.

## Changes

| Component | Property fixed | Old → New |
|-----------|---------------|-----------|
| `Steps` | `.current .node` text | `--rialto-accent` → `--rialto-text-primary` |
| `Steps` | `.current .stepLabel` | `--rialto-accent` → `--rialto-text-primary` |
| `Sidebar` | `.itemActive` text | `--rialto-accent` → `--rialto-text-primary` |
| `Sidebar` | `.itemActive:hover` text | `--rialto-accent` → `--rialto-text-primary` |
| `Timeline` | `.active .title` | `--rialto-accent` → `--rialto-text-primary` |
| `Timeline` | `.active .timestamp` | `--rialto-accent` → `--rialto-text-secondary` |
| `Table` | `.sortActive` | `--rialto-accent` → `--rialto-text-primary` |
| `Table` | `.sortActive:hover` | `--rialto-accent-hover` → `--rialto-text-secondary` |
| `Select` | `.option[data-selected]` text | `--rialto-accent` → `--rialto-text-primary` |
| `Breadcrumb` | `.link:hover` text | `--rialto-accent` → `--rialto-text-primary` |
| `GlobalNav` | `.brand:hover` text | `--rialto-accent` → `--rialto-text-primary` |

Active/selected state is still visually communicated via gold accent in non-text elements: inset box-shadow (Sidebar), border + glow ring (Steps/Timeline), check icon (Select), underline (GlobalNav active link), accent-muted background (Breadcrumb hover).

## Test plan

- [ ] Steps: current step node and label render in dark text; gold ring/border still shows
- [ ] Sidebar: active item renders in dark text; gold left-bar indicator still shows
- [ ] Timeline: active item title and timestamp render in dark/secondary text; node glow still shows
- [ ] Table: active sort column header renders in dark text; sort icon still visible
- [ ] Select: selected option renders in dark bold text; gold check mark still shows
- [ ] Breadcrumb: hover renders in dark text with amber-muted background highlight
- [ ] GlobalNav: brand hover renders in dark text (not amber)

Closes #561

https://claude.ai/code/session_01PuQrvqxCeSjRVCpCXpZ6ti