### PR TITLE
perf: add long-lived cache headers for hashed assets in wrangler.toml

### DIFF
--- a/apps/marketing/wrangler.toml
+++ b/apps/marketing/wrangler.toml
@@ -5,3 +5,8 @@ compatibility_date = "2026-03-25"
 [assets]
 directory = "./dist"
 not_found_handling = "single-page-application"
+
+[[headers]]
+pattern = "/assets/*"
+[headers.headers]
+Cache-Control = "public, max-age=31536000, immutable"

--- a/apps/rialto-web/wrangler.toml
+++ b/apps/rialto-web/wrangler.toml
@@ -5,3 +5,8 @@ compatibility_date = "2026-03-25"
 [assets]
 directory = "./dist"
 not_found_handling = "single-page-application"
+
+[[headers]]
+pattern = "/assets/*"
+[headers.headers]
+Cache-Control = "public, max-age=31536000, immutable"


### PR DESCRIPTION
## Summary

- Add `Cache-Control: public, max-age=31536000, immutable` header rule for `/assets/*` in `apps/marketing/wrangler.toml`
- Add the same rule to `apps/rialto-web/wrangler.toml`
- Content-hashed filenames make year-long caching safe — the hash changes on every deploy, so stale assets are never served

Lighthouse estimated savings: ~642 KB bandwidth per visit for repeat visitors.

## Test plan

- [ ] Deploy to staging and verify `/assets/*.js` and `/assets/*.css` responses include `Cache-Control: public, max-age=31536000, immutable`
- [ ] Confirm HTML entry point (`/`) still has `Cache-Control: no-cache` (default, untouched)
- [ ] Run Lighthouse audit and confirm `cache-insight` score improves

Closes #563

https://claude.ai/code/session_01N8Q1aqX7ALix4nhvY8SEPV