### PR TITLE
fix(rialto): remove broken prefers-reduced-motion CSS in FlipDot

### DIFF
--- a/packages/rialto/src/components/FlipDot/FlipDot.module.css
+++ b/packages/rialto/src/components/FlipDot/FlipDot.module.css
@@ -61,10 +61,5 @@
   transform: rotateX(180deg);
 }
 
-/* ── Reduced motion: instant swap via opacity ─ */
-
-@media (prefers-reduced-motion: reduce) {
-  .dotInner {
-    transform-style: flat;
-  }
-}
+/* Reduced motion is handled in JS via useReducedMotion() (duration: 0).
+   transform-style: preserve-3d must stay intact for backface-visibility to work. */


### PR DESCRIPTION
## Summary

- Removes the `@media (prefers-reduced-motion: reduce)` block in `FlipDot.module.css` that set `transform-style: flat` on `.dotInner`
- `transform-style: flat` broke `backface-visibility: hidden` on child faces — both `.dotOff` and `.dotOn` became simultaneously visible, causing every dot to render as "on" regardless of actual state
- Reduced motion is already correctly handled in JS via `useReducedMotion()` (framer-motion), which sets `duration: 0` for an instant state snap — no CSS block needed

## Test plan

- [ ] Enable `prefers-reduced-motion: reduce` in OS/browser settings
- [ ] Navigate to the FlipDot showcase page
- [ ] Verify dots render correctly (dark = off, amber = on) — not uniformly lit
- [ ] Verify transitions are instant (no animation) in reduced-motion mode
- [ ] Verify normal operation (animations play) when reduced-motion is off

Closes #574

https://claude.ai/code/session_01ADJL2PgAbFh88XUDvuAU5T