### PR TITLE
seo: add /rialto/components/flip-dot to sitemap.xml

### DIFF
--- a/apps/marketing/public/sitemap.xml
+++ b/apps/marketing/public/sitemap.xml
@@ -129,6 +129,11 @@
     <lastmod>2026-03-31</lastmod>
     <priority>0.5</priority>
   </url>
+  <url>
+    <loc>https://mattbutlerengineering.com/rialto/components/flip-dot</loc>
+    <lastmod>2026-04-11</lastmod>
+    <priority>0.5</priority>
+  </url>
 
   <!-- Rialto Components: Navigation -->
   <url>


### PR DESCRIPTION
## Summary

- Adds missing `/rialto/components/flip-dot` entry to `apps/marketing/public/sitemap.xml`
- FlipDot was shipped on 2026-04-11 but never added to the sitemap, blocking search engine discovery
- Entry placed alongside other data-display components (after `kbd`) with `lastmod: 2026-04-11` and `priority: 0.5` matching the pattern for all component pages

## Test plan

- [ ] Verify `sitemap.xml` contains the flip-dot URL with correct `lastmod` and `priority`
- [ ] Confirm the URL resolves: https://mattbutlerengineering.com/rialto/components/flip-dot

Closes #576

https://claude.ai/code/session_01Ka4tqcL4NjdLLbiSmw7md2