### PR TITLE
fix(rialto): make aria-label required on FlipDotProps

### DIFF
--- a/packages/rialto/src/components/FlipDot/FlipDot.tsx
+++ b/packages/rialto/src/components/FlipDot/FlipDot.tsx
@@ -19,9 +19,11 @@ export type StaggerDirection =
   | "center-out"
   | "random";
 
-export interface FlipDotProps extends HTMLAttributes<HTMLDivElement> {
+export interface FlipDotProps extends Omit<HTMLAttributes<HTMLDivElement>, "aria-label"> {
   /** 2D boolean grid — `true` = on (bright), `false` = off (dark). Outer array = rows. */
   matrix: readonly (readonly boolean[])[];
+  /** Accessible name for screen readers — required because the component renders as role="img". */
+  "aria-label": string;
   /** Override column count. Matrix is padded/truncated to fit. */
   cols?: number;
   /** Override row count. Matrix is padded/truncated to fit. */


### PR DESCRIPTION
## Summary

- `FlipDot` renders with `role="img"`, which requires an accessible name per WCAG 2.1 SC 1.1.1 (Non-text Content)
- Previously `aria-label` was inherited as optional from `HTMLAttributes<HTMLDivElement>` — callers could omit it and TypeScript would not complain
- Fix uses `Omit<HTMLAttributes<HTMLDivElement>, "aria-label">` + `"aria-label": string` to enforce the accessible name at compile time
- All 7 existing call sites in `FlipDotPage.tsx` and all test cases already provide `aria-label` — no callers broken

## Test plan

- [ ] `pnpm typecheck` passes with no new errors
- [ ] Attempting to use `<FlipDot matrix={...} />` without `aria-label` now produces a TypeScript error
- [ ] All existing test cases in `FlipDot.test.tsx` continue to pass

Closes #577

https://claude.ai/code/session_015Q3rdFrf7TiAe9Y4aDHGAo