### PR TITLE
seo: fix OG/Twitter images — switch SVG→PNG and add dimension tags

### DIFF
--- a/apps/gen/index.html
+++ b/apps/gen/index.html
@@ -7,13 +7,16 @@
     <meta name="description" content="Generative UI playground — type a prompt, watch Rialto components render" />
     <meta property="og:title" content="Gen | Matt Butler Engineering" />
     <meta property="og:description" content="Generative UI playground — type a prompt, watch Rialto components render" />
-    <meta property="og:image" content="https://mattbutlerengineering.com/og-image.svg" />
+    <meta property="og:image" content="https://mattbutlerengineering.com/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:url" content="https://mattbutlerengineering.com/gen" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Gen | Matt Butler Engineering" />
     <meta name="twitter:description" content="Generative UI playground — type a prompt, watch Rialto components render" />
-    <meta name="twitter:image" content="https://mattbutlerengineering.com/og-image.svg" />
+    <meta name="twitter:image" content="https://mattbutlerengineering.com/og-image.png" />
     <meta name="theme-color" content="#1a1a1a" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.svg" />
     <title>Gen | MBE</title>

--- a/apps/hospitality/index.html
+++ b/apps/hospitality/index.html
@@ -12,11 +12,14 @@
     <meta property="og:description" content="Hospitality management platform" />
     <meta property="og:url" content="https://mattbutlerengineering.com/hospitality" />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="https://mattbutlerengineering.com/og-image.svg" />
+    <meta property="og:image" content="https://mattbutlerengineering.com/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:type" content="image/png" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Matt Butler Engineering — Hospitality" />
     <meta name="twitter:description" content="Hospitality management platform" />
-    <meta name="twitter:image" content="https://mattbutlerengineering.com/og-image.svg" />
+    <meta name="twitter:image" content="https://mattbutlerengineering.com/og-image.png" />
     <title>Dashboard - Matt Butler Engineering</title>
   </head>
   <body>

--- a/apps/rialto-web/index.html
+++ b/apps/rialto-web/index.html
@@ -28,11 +28,14 @@
     <meta property="og:description" content="Component library and design system showcase" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://mattbutlerengineering.com/rialto/" />
-    <meta property="og:image" content="https://mattbutlerengineering.com/og-image.svg" />
+    <meta property="og:image" content="https://mattbutlerengineering.com/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:type" content="image/png" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Rialto Design System" />
     <meta name="twitter:description" content="Component library and design system showcase" />
-    <meta name="twitter:image" content="https://mattbutlerengineering.com/og-image.svg" />
+    <meta name="twitter:image" content="https://mattbutlerengineering.com/og-image.png" />
     <title>Rialto — Design System</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary

- Switch `og:image` and `twitter:image` from `/og-image.svg` → `/og-image.png` in `rialto-web`, `hospitality`, and `gen` apps — social platforms don't render SVG preview cards
- Add missing `og:image:width` (1200), `og:image:height` (630), and `og:image:type` (image/png) meta tags to match the marketing app and enable crawler pre-fetching

## Test plan

- [ ] Verify `apps/rialto-web/index.html`, `apps/hospitality/index.html`, `apps/gen/index.html` all reference `og-image.png`
- [ ] Confirm `og:image:width`, `og:image:height`, `og:image:type` are present in all three files
- [ ] Paste a URL for each app into https://cards-dev.twitter.com/validator (or opengraph.xyz) and confirm the image preview loads

Closes #581

https://claude.ai/code/session_016PYgvzgedApAmZ42qiFa88