### PR TITLE
fix(ci): scope Gitleaks to PR diff, remove unlicensed gitleaks-action

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -16,7 +16,32 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: gitleaks/gitleaks-action@v2
+      - name: Install gitleaks
+        run: |
+          curl -sSL https://github.com/gitleaks/gitleaks/releases/download/v8.28.0/gitleaks_8.28.0_linux_x64.tar.gz | tar -xz -C /tmp
+          sudo mv /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      - name: Scan PR diff
+        if: github.event_name == 'pull_request'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          gitleaks detect \
+            --source . \
+            --log-opts="$BASE_SHA..HEAD" \
+            --config .gitleaks.toml \
+            --verbose \
+            --redact \
+            --exit-code 1
+
+      - name: Scan HEAD commit on push to main
+        if: github.event_name == 'push'
+        run: |
+          gitleaks detect \
+            --source . \
+            --log-opts="HEAD~1..HEAD" \
+            --config .gitleaks.toml \
+            --verbose \
+            --redact \
+            --exit-code 1


### PR DESCRIPTION
## Summary

Fixes #548. The keystone CI blocker — every PR against main has a failing `Gitleaks Secret Scan` check because `gitleaks-action@v2` falls back to full-history scanning without a paid `GITLEAKS_LICENSE` secret, re-flagging Prisma WASM base64 blobs in old commits.

## Root cause

Per issue #548: the action documents `fetch-depth: 0` + no license → full history scan via `git log`. No amount of `.gitleaks.toml` allowlisting fixes this because the scanner hits the old commits before applying config, and the WASM blobs match high-entropy patterns.

## Fix

Replace the unlicensed action with direct `gitleaks` CLI invocation, scoped explicitly to what should be scanned:

| Event | Scope |
|-------|-------|
| `pull_request` | `$BASE_SHA..HEAD` — only the PR's own commits |
| `push` (main) | `HEAD~1..HEAD` — only the newly merged commit |

This is free, deterministic, and mirrors what the paid license would do.

### Command-injection safety

`github.event.pull_request.base.sha` is a GitHub-generated SHA (not user-supplied content), but out of caution it's passed through `env:` then referenced as `"$BASE_SHA"` in the shell — matching the safe pattern from the GitHub Actions injection guide.

## Unblocks

This PR's merge unblocks:
- #587 (security overrides — the other iteration-2 output)
- #547, #549 (previous attempts at the same problem using only allowlists)
- #545, #582, #568, #569, #570, #585 (all pending PRs failing the same check)

## Test plan

- [ ] CI's own Gitleaks check passes on this PR (validates the new CLI flow)
- [ ] After merge, re-run Gitleaks on #587 — should pass
- [ ] Intentionally push a test commit with a fake API key and verify the scanner catches it (can be done in follow-up)

## Follow-ups

- #549 can be merged after this to delete the WASM files from the working tree (separate concern — removes the bad pattern from future diffs too)
- Consider moving to `trufflehog` or `detect-secrets` for verified-secret (not entropy) mode in a future pass