### PR TITLE
feat(rialto): wire up Changesets for automated releases

### DIFF
--- a/.changeset/0-1-5-components.md
+++ b/.changeset/0-1-5-components.md
@@ -1,0 +1,18 @@
+---
+"@mattbutlerengineering/rialto": patch
+---
+
+Retroactive changeset documenting the v0.1.5 release (previously published manually).
+
+New components:
+
+- `MasterOverride` — staged confirmation control for destructive actions
+- `SplitFlap` — Solari-board style split-flap display
+- `Chalkboard` — handwritten menu / chalkboard surface
+- `SplitScreenExit` — split-screen page transition component
+- `Ferrofluid` — decorative magnetic-fluid animation
+
+Other changes:
+
+- Accessibility fixes for overlay components (Dialog / Popover / Sheet focus + ARIA)
+- Post-`/simplify` refactor across the new components (token usage, prop API cleanup, reduced bespoke CSS)

--- a/packages/rialto/CHANGELOG.md
+++ b/packages/rialto/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @mattbutlerengineering/rialto
+
+## 0.1.5
+
+### Patch Changes
+
+- New components: `MasterOverride`, `SplitFlap`, `Chalkboard`, `SplitScreenExit`, `Ferrofluid`.
+- Accessibility fixes for overlay components (focus management and ARIA on Dialog / Popover / Sheet).
+- Post-`/simplify` refactor across the new components (token usage, prop API cleanup, reduced bespoke CSS).
+
+> Releases prior to 0.1.5 were published manually and are not catalogued here.
+> Future entries will be generated automatically by [Changesets](https://github.com/changesets/changesets).


### PR DESCRIPTION
## What was missing

The repo already had `@changesets/cli` + `@changesets/changelog-github` installed and the root `package.json` scripts wired up (`changeset`, `version-packages`, `release`), but two artefacts were absent that prevented the machinery from actually being used:

1. **No pending changeset** for what shipped in v0.1.5 (which was published manually).
2. **No `packages/rialto/CHANGELOG.md`** — Changesets appends to this file on `version`, and starting from a missing file means the first auto-generated changelog has no header / prior context.

`/Users/mbutler/github/mattbutlerengineering/.changeset/config.json` was already correct and is unchanged in this PR.

## What this PR adds

- `.changeset/0-1-5-components.md` — retroactive `patch` changeset documenting the v0.1.5 release: new components (`MasterOverride`, `SplitFlap`, `Chalkboard`, `SplitScreenExit`, `Ferrofluid`), overlay a11y fixes, post-`/simplify` refactor.
- `packages/rialto/CHANGELOG.md` — seed changelog with a 0.1.5 entry; future entries appended automatically by `changeset version`.

## Config audit (no changes needed)

`.changeset/config.json` already has:

- `changelog: ["@changesets/changelog-github", { "repo": "mattbutlerengineering/mattbutlerengineering" }]`
- `access: "public"`
- `baseBranch: "main"`
- `ignore: []`
- `updateInternalDependencies: "patch"`
- `commit: false`

Only `@mattbutlerengineering/rialto` has `private: false`; every other workspace package (`@mbe/*`, apps, services, tools) is `private: true` and is therefore auto-excluded from `changeset publish`. No `ignore` entries needed. The GitHub Packages registry is configured on the package itself via `publishConfig.registry`, not in changesets config — correct.

## Validation

`changeset status` (run from the worktree against the root binary):

```
🦋  info Packages to be bumped at patch
🦋  - @mattbutlerengineering/rialto 0.1.6
🦋    - .changeset/0-1-5-components.md
🦋  - @mbe/gen 0.0.1            (transitive, private — won't publish)
🦋  - @mbe/hospitality 0.0.1    (transitive, private — won't publish)
🦋  - @mbe/marketing 0.0.1      (transitive, private — won't publish)
🦋  - @mbe/rialto-web 0.0.1     (transitive, private — won't publish)
🦋  - @mbe/rialto-catalog 0.1.1 (transitive, private — won't publish)
🦋  - @mbe/rialto-plugin 0.1.1  (transitive, private — won't publish)
```

Only the public package would actually publish. The transitive bumps come from `updateInternalDependencies: "patch"` — expected, harmless, and only touches `package.json` of internal consumers when `version` runs.

> Note: GitHub Actions is intentionally unpaid on this account, so CI does not run on this PR — validation was done locally only.

## How to use going forward

When making a change to `@mattbutlerengineering/rialto`:

```bash
pnpm changeset            # interactive: select rialto, pick patch, write summary
git add .changeset/*.md
git commit -m "feat(rialto): ..."
```

When ready to release (manually for now, automated later):

```bash
pnpm version-packages     # consumes pending changesets, bumps version, updates CHANGELOG.md
git commit -am "chore(rialto): release"
pnpm release              # builds rialto, publishes to GitHub Packages
```

A future PR can add a Changesets GitHub Action (or a local script) to drive `version` + `release` automatically once GitHub Actions is back on.

## Test plan

- [x] `changeset status` succeeds and reports the pending 0.1.5 entry
- [x] No version bumps or publishes performed in this PR
- [x] All non-rialto packages remain `private: true` and are excluded from publish
- [ ] On merge: dev runs `pnpm changeset` for next rialto change, confirms the workflow end-to-end