### PR TITLE
fix(rialto): remove aria-disabled on readOnly inputs, add aria-invalid to NumberInput

### DIFF
--- a/packages/rialto/src/components/NumberInput/NumberInput.module.css
+++ b/packages/rialto/src/components/NumberInput/NumberInput.module.css
@@ -163,7 +163,7 @@
 }
 
 /* ── Disabled state ──────────────────────────── */
-.wrapper[aria-disabled="true"] .control {
+.wrapper:has(.input:disabled) .control {
   filter: saturate(0.6) brightness(0.95);
   cursor: not-allowed;
 }

--- a/packages/rialto/src/components/NumberInput/NumberInput.test.tsx
+++ b/packages/rialto/src/components/NumberInput/NumberInput.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * Unit tests for NumberInput — focused on accessibility attributes for
+ * readOnly / disabled / error states.
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { NumberInput } from "./NumberInput";
+
+const noop = () => {};
+
+describe("NumberInput — readOnly + aria-disabled anti-pattern", () => {
+  it("does not set aria-disabled when readOnly is true and disabled is false", () => {
+    render(<NumberInput label="Quantity" value={1} onChange={noop} readOnly />);
+    const input = screen.getByLabelText("Quantity");
+    expect(input).not.toHaveAttribute("aria-disabled");
+    expect(input).toHaveAttribute("readonly");
+    expect(input).not.toBeDisabled();
+  });
+
+  it("uses native disabled (not aria-disabled) when disabled is true", () => {
+    render(<NumberInput label="Quantity" value={1} onChange={noop} disabled />);
+    const input = screen.getByLabelText("Quantity");
+    expect(input).toBeDisabled();
+    expect(input).not.toHaveAttribute("aria-disabled");
+  });
+
+  it("does not force readOnly when only disabled is true", () => {
+    render(<NumberInput label="Quantity" value={1} onChange={noop} disabled />);
+    const input = screen.getByLabelText("Quantity");
+    expect(input).not.toHaveAttribute("readonly");
+  });
+});
+
+describe("NumberInput — aria-invalid for error state", () => {
+  it("sets aria-invalid=true when error is true", () => {
+    render(<NumberInput label="Quantity" value={1} onChange={noop} error />);
+    const input = screen.getByLabelText("Quantity");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("does not set aria-invalid when error is false", () => {
+    render(<NumberInput label="Quantity" value={1} onChange={noop} />);
+    const input = screen.getByLabelText("Quantity");
+    expect(input).not.toHaveAttribute("aria-invalid");
+  });
+});

--- a/packages/rialto/src/components/NumberInput/NumberInput.tsx
+++ b/packages/rialto/src/components/NumberInput/NumberInput.tsx
@@ -139,7 +139,7 @@ export const NumberInput = forwardRef<HTMLDivElement, NumberInputProps>(
 
     return (
       <DisabledTooltip disabled={disabled} disabledReason={disabledReason}>
-        <div ref={ref} className={wrapperClasses} aria-disabled={disabled || undefined}>
+        <div ref={ref} className={wrapperClasses}>
           {label && (
             <label htmlFor={id} className={styles.label}>
               {label}
@@ -177,9 +177,10 @@ export const NumberInput = forwardRef<HTMLDivElement, NumberInputProps>(
               min={min}
               max={max}
               step={step}
-              aria-disabled={disabled || undefined}
+              disabled={disabled}
+              aria-invalid={error || undefined}
               aria-describedby={hint ? `${id}-hint` : undefined}
-              readOnly={disabled || rest.readOnly}
+              readOnly={rest.readOnly}
               {...rest}
             />
             <button

--- a/packages/rialto/src/components/TextArea/TextArea.module.css
+++ b/packages/rialto/src/components/TextArea/TextArea.module.css
@@ -44,7 +44,7 @@
   border-color: var(--rialto-accent);
 }
 
-.textarea[aria-disabled="true"] {
+.textarea:disabled {
   filter: saturate(0.6) brightness(0.95);
   cursor: not-allowed;
   resize: none;

--- a/packages/rialto/src/components/TextArea/TextArea.test.tsx
+++ b/packages/rialto/src/components/TextArea/TextArea.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * Unit tests for TextArea — focused on accessibility attributes for
+ * readOnly / disabled / error states.
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { TextArea } from "./TextArea";
+
+describe("TextArea — readOnly + aria-disabled anti-pattern", () => {
+  it("does not set aria-disabled when readOnly is true and disabled is false", () => {
+    render(<TextArea label="Notes" readOnly />);
+    const textarea = screen.getByLabelText("Notes");
+    expect(textarea).not.toHaveAttribute("aria-disabled");
+    expect(textarea).toHaveAttribute("readonly");
+    expect(textarea).not.toBeDisabled();
+  });
+
+  it("uses native disabled (not aria-disabled) when disabled is true", () => {
+    render(<TextArea label="Notes" disabled />);
+    const textarea = screen.getByLabelText("Notes");
+    expect(textarea).toBeDisabled();
+    expect(textarea).not.toHaveAttribute("aria-disabled");
+  });
+
+  it("does not force readOnly when only disabled is true", () => {
+    render(<TextArea label="Notes" disabled />);
+    const textarea = screen.getByLabelText("Notes");
+    expect(textarea).not.toHaveAttribute("readonly");
+  });
+});

--- a/packages/rialto/src/components/TextArea/TextArea.tsx
+++ b/packages/rialto/src/components/TextArea/TextArea.tsx
@@ -112,9 +112,9 @@ export const TextArea = forwardRef<HTMLDivElement, TextAreaProps>(
               rows={rows}
               value={value}
               onChange={handleChange}
-              aria-disabled={disabled || undefined}
+              disabled={disabled}
               aria-describedby={hint ? `${id}-hint` : undefined}
-              readOnly={disabled || readOnly}
+              readOnly={readOnly}
               {...rest}
             />
             {disabled && disabledReason && (


### PR DESCRIPTION
## Summary

Removes the ARIA anti-pattern where `aria-disabled="true"` was set on inputs that were merely `readOnly` — assistive tech communicates `readOnly` correctly on its own, and pairing it with `aria-disabled` tells AT the control is inoperable, which conflicts.

### Components changed

- **TextArea** (`packages/rialto/src/components/TextArea/TextArea.tsx` + `.module.css`)
  - Replaced `aria-disabled={disabled || undefined}` + `readOnly={disabled || readOnly}` with native `disabled={disabled}` and an unentangled `readOnly={readOnly}`. The two states no longer collide.
  - CSS selector updated from `.textarea[aria-disabled="true"]` to `.textarea:disabled` to keep the disabled visual treatment.

- **NumberInput** (`packages/rialto/src/components/NumberInput/NumberInput.tsx` + `.module.css`)
  - Same fix: removed `aria-disabled` from both the wrapper `<div>` and the `<input>`, set native `disabled` on the input, and stopped forcing `readOnly` when `disabled` is true.
  - Added missing `aria-invalid={error || undefined}` on the `<input>`, mirroring the pattern in `Input.tsx`.
  - Wrapper visual styling switched from `.wrapper[aria-disabled="true"] .control` to `.wrapper:has(.input:disabled) .control`.

### Sweep

Grepped `packages/rialto/src/components/` for other input-like components co-locating `readOnly` with `aria-disabled`. The only files with `readOnly` are `Input.tsx` (already correct), `TextArea.tsx` (fixed here), `NumberInput.tsx` (fixed here), and `PinInput.tsx` (its `readOnly` is bound only to `disabled`, not user-controllable as a separate prop, so it's a different design and not the same anti-pattern).

## Test plan

- [x] `pnpm --dir packages/rialto test` — 18 files, 317 tests pass (incl. new TextArea/NumberInput co-located tests + axe-core suite)
- [x] `pnpm --dir packages/rialto typecheck` — clean
- [x] `pnpm --dir packages/rialto lint` — 0 errors (pre-existing warnings unchanged)
- [x] New tests verify: `readOnly` true + `disabled` false → no `aria-disabled`; `disabled` true → native `disabled` (no `aria-disabled`, no forced `readOnly`); NumberInput `error` → `aria-invalid="true"`