### PR TITLE
perf(rialto): enable per-component subpath imports for tree-shaking

### DIFF
--- a/packages/rialto/llms-full.txt
+++ b/packages/rialto/llms-full.txt
@@ -1,5 +1,36 @@
 <codebase path="packages/rialto">
   <section priority="medium" role="scripts">
+  <file path="scripts/lib-entrypoints.ts">
+    export interface LibEntry {
+      /** Subpath segment after the package name, e.g. "Button" or "." for root. */
+      subpath: string;
+      /** Absolute path to the source entry. */
+      source: string;
+      /** Vite/Rollup chunk name (without extension). */
+      chunkName: string;
+    }
+    function listComponentEntries(): LibEntry[] {
+      const dirents = fs.readdirSync(componentsDir, { withFileTypes: true });
+      const entries: LibEntry[] = [];
+      for (const dirent of dirents) {
+        if (!dirent.isDirectory()) continue;
+        if (dirent.name.startsWith("_") || dirent.name.startsWith(".")) continue;
+        const indexPath = path.join(componentsDir, dirent.name, "index.ts");
+        if (!fs.existsSync(indexPath)) continue;
+        entries.push({
+          subpath: dirent.name,
+          source: indexPath,
+          // chunkName drives the emitted JS path. Putting it inside the
+          // component's own folder (alongside the d.ts files emitted by
+          // vite-plugin-dts) prevents TypeScript bundler resolution from
+          // ever finding a sibling `.js` with no adjacent `.d.ts`.
+          chunkName: `components/${dirent.name}/index`,
+        });
+      }
+      entries.sort((a, b) => a.subpath.localeCompare(b.subpath));
+      return entries;
+    }
+  </file>
   <file path="scripts/generate-registry.ts">
     interface PropInfo {
       name: string;
@@ -37,6 +68,14 @@
     interface TokenGroup {
       readonly [key: string]: DtcgToken | TokenGroup;
     }
+  </file>
+  <file path="scripts/generate-exports.ts">
+    interface ExportEntry {
+      types?: string;
+      import?: string;
+      default?: string;
+    }
+    type ExportsMap = Record<string, string | ExportEntry>;
   </file>
   <file path="scripts/character-limits.ts">
     export interface CharacterLimit {

--- a/packages/rialto/llms.txt
+++ b/packages/rialto/llms.txt
@@ -1,5 +1,17 @@
 <codebase path="packages/rialto">
   <section priority="medium" role="scripts">
+  <file path="scripts/lib-entrypoints.ts">
+    <item priority="low">
+      interface LibEntry {
+        subpath: string;
+        source: string;
+        chunkName: string;
+      }
+    </item>
+    <item priority="medium">
+      function listComponentEntries(): LibEntry[] { /* ... */ }
+    </item>
+  </file>
   <file path="scripts/generate-registry.ts">
     <item priority="high">
       interface PropInfo {
@@ -48,6 +60,18 @@
       interface TokenGroup {
         
       }
+    </item>
+  </file>
+  <file path="scripts/generate-exports.ts">
+    <item priority="high">
+      interface ExportEntry {
+        types?: string;
+        import?: string;
+        default?: string;
+      }
+    </item>
+    <item priority="high">
+      type ExportsMap = Record<string, string | ExportEntry>;
     </item>
   </file>
   <file path="scripts/character-limits.ts">

--- a/packages/rialto/package.json
+++ b/packages/rialto/package.json
@@ -14,6 +14,286 @@
       "types": "./dist/lib/tokens/motion.d.ts",
       "import": "./dist/lib/motion.js"
     },
+    "./providers": {
+      "types": "./dist/lib/providers/index.d.ts",
+      "import": "./dist/lib/providers/index.js"
+    },
+    "./hooks": {
+      "types": "./dist/lib/hooks/index.d.ts",
+      "import": "./dist/lib/hooks/index.js"
+    },
+    "./Accordion": {
+      "types": "./dist/lib/components/Accordion/index.d.ts",
+      "import": "./dist/lib/components/Accordion/index.js"
+    },
+    "./Alert": {
+      "types": "./dist/lib/components/Alert/index.d.ts",
+      "import": "./dist/lib/components/Alert/index.js"
+    },
+    "./AppBar": {
+      "types": "./dist/lib/components/AppBar/index.d.ts",
+      "import": "./dist/lib/components/AppBar/index.js"
+    },
+    "./AspectRatio": {
+      "types": "./dist/lib/components/AspectRatio/index.d.ts",
+      "import": "./dist/lib/components/AspectRatio/index.js"
+    },
+    "./Autocomplete": {
+      "types": "./dist/lib/components/Autocomplete/index.d.ts",
+      "import": "./dist/lib/components/Autocomplete/index.js"
+    },
+    "./Avatar": {
+      "types": "./dist/lib/components/Avatar/index.d.ts",
+      "import": "./dist/lib/components/Avatar/index.js"
+    },
+    "./Badge": {
+      "types": "./dist/lib/components/Badge/index.d.ts",
+      "import": "./dist/lib/components/Badge/index.js"
+    },
+    "./Banner": {
+      "types": "./dist/lib/components/Banner/index.d.ts",
+      "import": "./dist/lib/components/Banner/index.js"
+    },
+    "./Breadcrumb": {
+      "types": "./dist/lib/components/Breadcrumb/index.d.ts",
+      "import": "./dist/lib/components/Breadcrumb/index.js"
+    },
+    "./Button": {
+      "types": "./dist/lib/components/Button/index.d.ts",
+      "import": "./dist/lib/components/Button/index.js"
+    },
+    "./Card": {
+      "types": "./dist/lib/components/Card/index.d.ts",
+      "import": "./dist/lib/components/Card/index.js"
+    },
+    "./Chalkboard": {
+      "types": "./dist/lib/components/Chalkboard/index.d.ts",
+      "import": "./dist/lib/components/Chalkboard/index.js"
+    },
+    "./Checkbox": {
+      "types": "./dist/lib/components/Checkbox/index.d.ts",
+      "import": "./dist/lib/components/Checkbox/index.js"
+    },
+    "./Collapsible": {
+      "types": "./dist/lib/components/Collapsible/index.d.ts",
+      "import": "./dist/lib/components/Collapsible/index.js"
+    },
+    "./CommandPalette": {
+      "types": "./dist/lib/components/CommandPalette/index.d.ts",
+      "import": "./dist/lib/components/CommandPalette/index.js"
+    },
+    "./ConfirmDialog": {
+      "types": "./dist/lib/components/ConfirmDialog/index.d.ts",
+      "import": "./dist/lib/components/ConfirmDialog/index.js"
+    },
+    "./ContextMenu": {
+      "types": "./dist/lib/components/ContextMenu/index.d.ts",
+      "import": "./dist/lib/components/ContextMenu/index.js"
+    },
+    "./DataList": {
+      "types": "./dist/lib/components/DataList/index.d.ts",
+      "import": "./dist/lib/components/DataList/index.js"
+    },
+    "./Dialog": {
+      "types": "./dist/lib/components/Dialog/index.d.ts",
+      "import": "./dist/lib/components/Dialog/index.js"
+    },
+    "./DisabledTooltip": {
+      "types": "./dist/lib/components/DisabledTooltip/index.d.ts",
+      "import": "./dist/lib/components/DisabledTooltip/index.js"
+    },
+    "./Divider": {
+      "types": "./dist/lib/components/Divider/index.d.ts",
+      "import": "./dist/lib/components/Divider/index.js"
+    },
+    "./Drawer": {
+      "types": "./dist/lib/components/Drawer/index.d.ts",
+      "import": "./dist/lib/components/Drawer/index.js"
+    },
+    "./DropdownMenu": {
+      "types": "./dist/lib/components/DropdownMenu/index.d.ts",
+      "import": "./dist/lib/components/DropdownMenu/index.js"
+    },
+    "./EmptyState": {
+      "types": "./dist/lib/components/EmptyState/index.d.ts",
+      "import": "./dist/lib/components/EmptyState/index.js"
+    },
+    "./ErrorBoundary": {
+      "types": "./dist/lib/components/ErrorBoundary/index.d.ts",
+      "import": "./dist/lib/components/ErrorBoundary/index.js"
+    },
+    "./Ferrofluid": {
+      "types": "./dist/lib/components/Ferrofluid/index.d.ts",
+      "import": "./dist/lib/components/Ferrofluid/index.js"
+    },
+    "./FlipDot": {
+      "types": "./dist/lib/components/FlipDot/index.d.ts",
+      "import": "./dist/lib/components/FlipDot/index.js"
+    },
+    "./Footer": {
+      "types": "./dist/lib/components/Footer/index.d.ts",
+      "import": "./dist/lib/components/Footer/index.js"
+    },
+    "./GenCopilot": {
+      "types": "./dist/lib/components/GenCopilot/index.d.ts",
+      "import": "./dist/lib/components/GenCopilot/index.js"
+    },
+    "./GlobalNav": {
+      "types": "./dist/lib/components/GlobalNav/index.d.ts",
+      "import": "./dist/lib/components/GlobalNav/index.js"
+    },
+    "./Hero": {
+      "types": "./dist/lib/components/Hero/index.d.ts",
+      "import": "./dist/lib/components/Hero/index.js"
+    },
+    "./HoverCard": {
+      "types": "./dist/lib/components/HoverCard/index.d.ts",
+      "import": "./dist/lib/components/HoverCard/index.js"
+    },
+    "./ImageUpload": {
+      "types": "./dist/lib/components/ImageUpload/index.d.ts",
+      "import": "./dist/lib/components/ImageUpload/index.js"
+    },
+    "./Input": {
+      "types": "./dist/lib/components/Input/index.d.ts",
+      "import": "./dist/lib/components/Input/index.js"
+    },
+    "./InputGroup": {
+      "types": "./dist/lib/components/InputGroup/index.d.ts",
+      "import": "./dist/lib/components/InputGroup/index.js"
+    },
+    "./Kbd": {
+      "types": "./dist/lib/components/Kbd/index.d.ts",
+      "import": "./dist/lib/components/Kbd/index.js"
+    },
+    "./MasterOverride": {
+      "types": "./dist/lib/components/MasterOverride/index.d.ts",
+      "import": "./dist/lib/components/MasterOverride/index.js"
+    },
+    "./Meter": {
+      "types": "./dist/lib/components/Meter/index.d.ts",
+      "import": "./dist/lib/components/Meter/index.js"
+    },
+    "./Navbar": {
+      "types": "./dist/lib/components/Navbar/index.d.ts",
+      "import": "./dist/lib/components/Navbar/index.js"
+    },
+    "./NavigationMenu": {
+      "types": "./dist/lib/components/NavigationMenu/index.d.ts",
+      "import": "./dist/lib/components/NavigationMenu/index.js"
+    },
+    "./NumberInput": {
+      "types": "./dist/lib/components/NumberInput/index.d.ts",
+      "import": "./dist/lib/components/NumberInput/index.js"
+    },
+    "./PageHeader": {
+      "types": "./dist/lib/components/PageHeader/index.d.ts",
+      "import": "./dist/lib/components/PageHeader/index.js"
+    },
+    "./Pagination": {
+      "types": "./dist/lib/components/Pagination/index.d.ts",
+      "import": "./dist/lib/components/Pagination/index.js"
+    },
+    "./PinInput": {
+      "types": "./dist/lib/components/PinInput/index.d.ts",
+      "import": "./dist/lib/components/PinInput/index.js"
+    },
+    "./Popover": {
+      "types": "./dist/lib/components/Popover/index.d.ts",
+      "import": "./dist/lib/components/Popover/index.js"
+    },
+    "./Progress": {
+      "types": "./dist/lib/components/Progress/index.d.ts",
+      "import": "./dist/lib/components/Progress/index.js"
+    },
+    "./ScrollArea": {
+      "types": "./dist/lib/components/ScrollArea/index.d.ts",
+      "import": "./dist/lib/components/ScrollArea/index.js"
+    },
+    "./SegmentedControl": {
+      "types": "./dist/lib/components/SegmentedControl/index.d.ts",
+      "import": "./dist/lib/components/SegmentedControl/index.js"
+    },
+    "./Select": {
+      "types": "./dist/lib/components/Select/index.d.ts",
+      "import": "./dist/lib/components/Select/index.js"
+    },
+    "./Sidebar": {
+      "types": "./dist/lib/components/Sidebar/index.d.ts",
+      "import": "./dist/lib/components/Sidebar/index.js"
+    },
+    "./Skeleton": {
+      "types": "./dist/lib/components/Skeleton/index.d.ts",
+      "import": "./dist/lib/components/Skeleton/index.js"
+    },
+    "./Slider": {
+      "types": "./dist/lib/components/Slider/index.d.ts",
+      "import": "./dist/lib/components/Slider/index.js"
+    },
+    "./SplitFlap": {
+      "types": "./dist/lib/components/SplitFlap/index.d.ts",
+      "import": "./dist/lib/components/SplitFlap/index.js"
+    },
+    "./SplitScreenExit": {
+      "types": "./dist/lib/components/SplitScreenExit/index.d.ts",
+      "import": "./dist/lib/components/SplitScreenExit/index.js"
+    },
+    "./Stack": {
+      "types": "./dist/lib/components/Stack/index.d.ts",
+      "import": "./dist/lib/components/Stack/index.js"
+    },
+    "./Stat": {
+      "types": "./dist/lib/components/Stat/index.d.ts",
+      "import": "./dist/lib/components/Stat/index.js"
+    },
+    "./Steps": {
+      "types": "./dist/lib/components/Steps/index.d.ts",
+      "import": "./dist/lib/components/Steps/index.js"
+    },
+    "./Table": {
+      "types": "./dist/lib/components/Table/index.d.ts",
+      "import": "./dist/lib/components/Table/index.js"
+    },
+    "./Tabs": {
+      "types": "./dist/lib/components/Tabs/index.d.ts",
+      "import": "./dist/lib/components/Tabs/index.js"
+    },
+    "./Tag": {
+      "types": "./dist/lib/components/Tag/index.d.ts",
+      "import": "./dist/lib/components/Tag/index.js"
+    },
+    "./Text": {
+      "types": "./dist/lib/components/Text/index.d.ts",
+      "import": "./dist/lib/components/Text/index.js"
+    },
+    "./TextArea": {
+      "types": "./dist/lib/components/TextArea/index.d.ts",
+      "import": "./dist/lib/components/TextArea/index.js"
+    },
+    "./ThemeToggle": {
+      "types": "./dist/lib/components/ThemeToggle/index.d.ts",
+      "import": "./dist/lib/components/ThemeToggle/index.js"
+    },
+    "./Timeline": {
+      "types": "./dist/lib/components/Timeline/index.d.ts",
+      "import": "./dist/lib/components/Timeline/index.js"
+    },
+    "./Toast": {
+      "types": "./dist/lib/components/Toast/index.d.ts",
+      "import": "./dist/lib/components/Toast/index.js"
+    },
+    "./Toggle": {
+      "types": "./dist/lib/components/Toggle/index.d.ts",
+      "import": "./dist/lib/components/Toggle/index.js"
+    },
+    "./Tooltip": {
+      "types": "./dist/lib/components/Tooltip/index.d.ts",
+      "import": "./dist/lib/components/Tooltip/index.js"
+    },
+    "./Tree": {
+      "types": "./dist/lib/components/Tree/index.d.ts",
+      "import": "./dist/lib/components/Tree/index.js"
+    },
     "./styles": {
       "default": "./dist/lib/styles.css"
     },
@@ -27,15 +307,17 @@
     "dist/manifest.json"
   ],
   "sideEffects": [
-    "*.css"
+    "**/*.css"
   ],
   "scripts": {
-    "build": "vite build --config vite.config.lib.ts && pnpm manifest",
+    "build": "vite build --config vite.config.lib.ts && pnpm manifest && pnpm exports",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "eslint .",
     "manifest": "pnpm exec tsx scripts/generate-manifest.ts",
+    "exports": "pnpm exec tsx scripts/generate-exports.ts",
+    "exports:check": "pnpm exec tsx scripts/generate-exports.ts --check",
     "build:registry": "pnpm exec tsx scripts/generate-registry.ts"
   },
   "peerDependencies": {

--- a/packages/rialto/scripts/generate-exports.ts
+++ b/packages/rialto/scripts/generate-exports.ts
@@ -1,0 +1,103 @@
+#!/usr/bin/env npx tsx
+/**
+ * Rewrites the `exports` field of packages/rialto/package.json to expose
+ * one subpath per library entry — keeping it in sync with whatever
+ * `vite.config.lib.ts` actually built.
+ *
+ * Run after `vite build` so the exports map only references files that
+ * exist in dist/lib.
+ *
+ * Run with --check to fail (non-zero exit) instead of writing — useful in
+ * a precommit/CI-style verification.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { libEntries } from "./lib-entrypoints.js";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "..");
+const pkgJsonPath = path.join(repoRoot, "package.json");
+
+interface ExportEntry {
+  types?: string;
+  import?: string;
+  default?: string;
+}
+
+type ExportsMap = Record<string, string | ExportEntry>;
+
+function buildExportsMap(): ExportsMap {
+  const exportsMap: ExportsMap = {};
+
+  for (const entry of libEntries) {
+    // chunkName already includes any "/index" suffix where applicable.
+    const jsRelative = `./dist/lib/${entry.chunkName}.js`;
+    // d.ts location:
+    //   - root barrel: dist/lib/lib-entry.d.ts
+    //   - motion: dist/lib/tokens/motion.d.ts
+    //   - hooks: dist/lib/hooks/index.d.ts
+    //   - providers: dist/lib/providers/index.d.ts
+    //   - components/<Name>: dist/lib/components/<Name>/index.d.ts
+    let typesRelative: string;
+    if (entry.subpath === ".") {
+      typesRelative = "./dist/lib/lib-entry.d.ts";
+    } else if (entry.subpath === "motion") {
+      typesRelative = "./dist/lib/tokens/motion.d.ts";
+    } else if (entry.subpath === "hooks") {
+      typesRelative = "./dist/lib/hooks/index.d.ts";
+    } else if (entry.subpath === "providers") {
+      typesRelative = "./dist/lib/providers/index.d.ts";
+    } else {
+      typesRelative = `./dist/lib/components/${entry.subpath}/index.d.ts`;
+    }
+    const key = entry.subpath === "." ? "." : `./${entry.subpath}`;
+    exportsMap[key] = {
+      types: typesRelative,
+      import: jsRelative,
+    };
+  }
+
+  // Static, non-component subpaths.
+  exportsMap["./styles"] = { default: "./dist/lib/styles.css" };
+  exportsMap["./manifest"] = "./dist/manifest.json";
+
+  return exportsMap;
+}
+
+function loadPkg(): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(pkgJsonPath, "utf8")) as Record<string, unknown>;
+}
+
+function main(): void {
+  const checkOnly = process.argv.includes("--check");
+  const desired = buildExportsMap();
+  const pkg = loadPkg();
+  const currentExports = pkg.exports;
+  const currentJson = JSON.stringify(currentExports, null, 2);
+  const desiredJson = JSON.stringify(desired, null, 2);
+
+  if (currentJson === desiredJson) {
+    process.stdout.write("[generate-exports] exports map already in sync.\n");
+    return;
+  }
+
+  if (checkOnly) {
+    process.stderr.write(
+      "[generate-exports] package.json exports map is out of sync. " +
+        "Run `pnpm exports` or `pnpm build` to regenerate.\n"
+    );
+    process.exit(1);
+  }
+
+  pkg.exports = desired;
+  // Preserve key order: write back with 2-space indent + trailing newline
+  // to match the rest of the file's style.
+  fs.writeFileSync(pkgJsonPath, JSON.stringify(pkg, null, 2) + "\n");
+  process.stdout.write(
+    `[generate-exports] wrote ${Object.keys(desired).length} export entries to package.json\n`
+  );
+}
+
+main();

--- a/packages/rialto/scripts/lib-entrypoints.ts
+++ b/packages/rialto/scripts/lib-entrypoints.ts
@@ -1,0 +1,91 @@
+/**
+ * Single source of truth for which modules are emitted as separate
+ * library entry points. Used by:
+ *   - vite.config.lib.ts (build-time entry map)
+ *   - scripts/generate-exports.ts (package.json exports map writer)
+ *
+ * Adding a new top-level component: just create
+ * src/components/<Name>/index.ts and `pnpm build` picks it up.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "..");
+
+export interface LibEntry {
+  /** Subpath segment after the package name, e.g. "Button" or "." for root. */
+  subpath: string;
+  /** Absolute path to the source entry. */
+  source: string;
+  /** Vite/Rollup chunk name (without extension). */
+  chunkName: string;
+}
+
+const componentsDir = path.join(repoRoot, "src/components");
+
+function listComponentEntries(): LibEntry[] {
+  const dirents = fs.readdirSync(componentsDir, { withFileTypes: true });
+  const entries: LibEntry[] = [];
+  for (const dirent of dirents) {
+    if (!dirent.isDirectory()) continue;
+    if (dirent.name.startsWith("_") || dirent.name.startsWith(".")) continue;
+    const indexPath = path.join(componentsDir, dirent.name, "index.ts");
+    if (!fs.existsSync(indexPath)) continue;
+    entries.push({
+      subpath: dirent.name,
+      source: indexPath,
+      // chunkName drives the emitted JS path. Putting it inside the
+      // component's own folder (alongside the d.ts files emitted by
+      // vite-plugin-dts) prevents TypeScript bundler resolution from
+      // ever finding a sibling `.js` with no adjacent `.d.ts`.
+      chunkName: `components/${dirent.name}/index`,
+    });
+  }
+  entries.sort((a, b) => a.subpath.localeCompare(b.subpath));
+  return entries;
+}
+
+const componentEntries = listComponentEntries();
+
+/** All entries emitted by the library build, including root and side modules. */
+export const libEntries: LibEntry[] = [
+  // Root barrel — preserved for back-compat with `import { x } from "@.../rialto"`.
+  {
+    subpath: ".",
+    source: path.join(repoRoot, "src/lib-entry.ts"),
+    chunkName: "rialto",
+  },
+  // Pre-existing motion subpath.
+  {
+    subpath: "motion",
+    source: path.join(repoRoot, "src/tokens/motion.ts"),
+    chunkName: "motion",
+  },
+  // Providers subpath — RialtoProvider, useDeviceContext, vibes, etc.
+  // chunkName uses /index so the emitted JS lands inside the same folder
+  // as vite-plugin-dts's d.ts output (dist/lib/providers/) and TypeScript
+  // bundler resolution finds the d.ts via folder fallback.
+  {
+    subpath: "providers",
+    source: path.join(repoRoot, "src/providers/index.ts"),
+    chunkName: "providers/index",
+  },
+  // Hooks subpath. Same /index treatment as providers.
+  {
+    subpath: "hooks",
+    source: path.join(repoRoot, "src/hooks/index.ts"),
+    chunkName: "hooks/index",
+  },
+  ...componentEntries,
+];
+
+/** Vite expects an object map of chunkName -> source path. */
+export function viteEntryMap(): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const entry of libEntries) {
+    out[entry.chunkName] = entry.source;
+  }
+  return out;
+}

--- a/packages/rialto/src/hooks/index.ts
+++ b/packages/rialto/src/hooks/index.ts
@@ -1,0 +1,3 @@
+export { useDirection } from "./useDirection";
+export { useScrollReveal } from "./useScrollReveal";
+export { useTilt } from "./useTilt";

--- a/packages/rialto/vite.config.lib.ts
+++ b/packages/rialto/vite.config.lib.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import dts from "vite-plugin-dts";
-import path from "path";
+import { viteEntryMap } from "./scripts/lib-entrypoints";
 
 export default defineConfig({
   plugins: [react(), dts({ tsconfigPath: "./tsconfig.lib.json" })],
@@ -13,15 +13,23 @@ export default defineConfig({
   build: {
     outDir: "dist/lib",
     lib: {
-      entry: {
-        rialto: path.resolve(__dirname, "src/lib-entry.ts"),
-        motion: path.resolve(__dirname, "src/tokens/motion.ts"),
-      },
+      // Multi-entry library mode: one chunk per top-level component (plus
+      // root barrel, motion tokens, providers, hooks). Lets consumers do
+      // `import { Button } from "@mattbutlerengineering/rialto/Button"`
+      // without pulling the whole library through the barrel.
+      entry: viteEntryMap(),
       formats: ["es"],
       cssFileName: "styles",
     },
     rollupOptions: {
       external: ["react", "react-dom", "react/jsx-runtime", "framer-motion", "lucide-react"],
+      output: {
+        // Stable filenames so the package.json exports map can point at
+        // them without a content hash. Shared code lands in chunks/ so
+        // top-level paths stay clean.
+        entryFileNames: "[name].js",
+        chunkFileNames: "chunks/[name]-[hash].js",
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary

The Rialto library was shipped as a single 343 kB JS barrel. Even with ESM and `sideEffects: ["*.css"]`, bundlers couldn't tree-shake — bundlers can drop dead exports, but not dead bodies inside one module. Importing one component pulled the whole library.

This PR splits the build into per-component entries and adds a subpath export for each, so consumers can write either of:

```ts
import { Button } from "@mattbutlerengineering/rialto";          // tree-shakes now
import { Button } from "@mattbutlerengineering/rialto/Button";   // even smaller
```

## Bundle-size measurement

Single-component consumer bundled with esbuild (ESM, minified, peers external):

| Import | Before | After | Delta |
|---|---:|---:|---:|
| `from "@.../rialto"` (root barrel, just Button) | 245.6 kB / 73.1 kB gzip | **5.7 kB / 2.0 kB gzip** | **-97.7%** |
| `from "@.../rialto/Button"` (subpath) | n/a (no subpath existed) | **1.3 kB / 0.7 kB gzip** | new |

Measurement script: `/tmp/rialto-audit/measure.sh` (esbuild bundling against built dist with the `@mattbutlerengineering/rialto` import aliased to the dist file). Numbers are JS only; CSS still ships as the same `@mattbutlerengineering/rialto/styles` import (~143 kB / ~18 kB gzip uncompressed -- unchanged).

The remaining ~5.7 kB on the root-barrel side is the small re-export shim (`rialto.js` is now 11.8 kB, of which only the chunks reachable from `Button` survive treeshake), plus the `motion.js` chunk (~860 B) Button itself depends on. Subsequent additional imports from the root reuse the same chunks.

## Root cause

**(b) Single-entry barrel.** Vite's library mode was configured with one `rialto` entry that pulled the full barrel into one ES module. Bundlers can drop unused named exports, but not unused code inside a module body. Once the build is multi-entry, each component is a separate ES module and dead-chunk elimination kicks in.

`sideEffects` was already `["*.css"]` (close to right -- tightened to `["**/*.css"]` to match nested CSS files in the dist).

## Changes

- `vite.config.lib.ts`: multi-entry library mode, one chunk per component (plus root, motion, providers, hooks). Stable `[name].js` filenames; shared code in `chunks/`.
- `scripts/lib-entrypoints.ts`: scans `src/components/` -- single source of truth for both vite entries and the exports map. Adding a new component requires no manual config change beyond the existing `src/components/index.ts` barrel.
- `scripts/generate-exports.ts`: rewrites `package.json` `exports` to expose one subpath per top-level component. `pnpm exports:check` for precommit/CI.
- `package.json`: 74 export entries (one per component plus root/motion/hooks/providers/styles/manifest), tightened `sideEffects` glob.
- `src/hooks/index.ts`: added a barrel so the new `./hooks` subpath has a clean entry point.

## Compatibility

**No breaking changes.** The root `.` export still exposes every component the same way it did before. All four pre-existing exports (`.`, `./motion`, `./styles`, `./manifest`) keep their resolved targets. New entries are additive.

A subtle gotcha worth noting (handled in the PR but flagging for reviewers): the per-component JS now lives at `dist/lib/components/<Name>/index.js` -- the same folder as `vite-plugin-dts`'s emitted `<Name>/index.d.ts`. An earlier iteration emitted them as siblings (`Banner.js` next to `Banner/`) which caused TypeScript bundler resolution to prefer the `.js` (no adjacent `.d.ts`) over the folder fallback, breaking ~630 type lookups in `apps/rialto-web`. The chosen layout puts both in the same folder so resolution is unambiguous.

## Test plan

- [x] `pnpm --dir packages/rialto test` -- 309 passing (16 files), unchanged from baseline
- [x] `pnpm --dir packages/rialto typecheck` -- clean
- [x] `pnpm --dir packages/rialto lint` -- 0 errors (123 pre-existing warnings, unchanged)
- [x] `pnpm --dir packages/rialto build` -- emits per-component chunks + regenerates exports map
- [x] `pnpm --dir apps/rialto-web typecheck` -- only the pre-existing `TS2882` on `/styles` remains (was 1 error before, still 1 after; documented in `CLAUDE.md`)
- [x] Manually verified subpath imports type-check: `import { Button } from "@.../rialto/Button"`, `import { useScrollReveal } from "@.../rialto/hooks"`, `import { RialtoProvider } from "@.../rialto/providers"` all resolve with full type info

CI is intentionally unpaid on this account per `CLAUDE.md`; all validation is local.