### PR TITLE
fix(rialto-web): add missing SEO meta tags for marketing parity

### DIFF
--- a/apps/rialto-web/index.html
+++ b/apps/rialto-web/index.html
@@ -17,12 +17,15 @@
         href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;1,9..40,300;1,9..40,400&family=DM+Mono:wght@300;400&family=Bricolage+Grotesque:opsz,wght@12..96,300;12..96,400;12..96,500&display=swap"
       />
     </noscript>
-    <meta name="theme-color" content="#f8f6f3" />
+    <meta name="theme-color" content="#f8f6f3" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#1a1918" media="(prefers-color-scheme: dark)" />
+    <meta name="robots" content="index, follow" />
     <meta
       name="description"
       content="Rialto Design System — a precision-crafted React component library with warm material surfaces, gold accents, and full WCAG AA accessibility."
     />
     <link rel="icon" href="/rialto/favicon.svg" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="/rialto/apple-touch-icon.svg" />
     <link rel="canonical" href="https://mattbutlerengineering.com/rialto/" />
     <meta property="og:title" content="Rialto Design System" />
     <meta property="og:description" content="Component library and design system showcase" />
@@ -34,6 +37,14 @@
     <meta name="twitter:description" content="Component library and design system showcase" />
     <meta name="twitter:image" content="https://mattbutlerengineering.com/og-image.svg" />
     <title>Rialto — Design System</title>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": "Rialto Design System",
+        "url": "https://mattbutlerengineering.com/rialto/"
+      }
+    </script>
   </head>
   <body>
     <script>

--- a/apps/rialto-web/public/apple-touch-icon.svg
+++ b/apps/rialto-web/public/apple-touch-icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 180" fill="none">
+  <rect width="180" height="180" rx="36" fill="#1a1918"/>
+  <text x="90" y="110" font-family="system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="72" font-weight="600" fill="#d4a853" text-anchor="middle">MBE</text>
+</svg>


### PR DESCRIPTION
## Summary

- Add `robots` meta tag (`index, follow`) to `/rialto` index.html
- Add `apple-touch-icon` link + create `public/apple-touch-icon.svg`
- Split single `theme-color` into light (`#f8f6f3`) + dark (`#1a1918`) media-query variants
- Add `WebSite` JSON-LD structured data block

## Test plan

- [ ] Verify `/rialto` page source contains `<meta name="robots" content="index, follow">`
- [ ] Verify `<link rel="apple-touch-icon" href="/rialto/apple-touch-icon.svg">` present and icon loads
- [ ] Verify two `theme-color` meta tags with `media` attributes present
- [ ] Verify JSON-LD structured data block in page source

Closes #593

https://claude.ai/code/session_01YFvtXVSBbUJY7V2BU7hsNA