### PR TITLE
Remove deprecated NAV_SECTIONS export from hospitality

### DIFF
--- a/apps/hospitality/src/nav-sections.ts
+++ b/apps/hospitality/src/nav-sections.ts
@@ -111,9 +111,3 @@ export function buildNavSections(readiness: VenueReadiness): readonly NavSection
   }
   return buildOperationalSections();
 }
-
-/**
- * @deprecated Use buildNavSections(readiness) instead.
- * Kept for backwards compatibility during migration.
- */
-export const NAV_SECTIONS: readonly NavSection[] = buildOperationalSections();


### PR DESCRIPTION
## Summary

- Removes the `NAV_SECTIONS` constant from `apps/hospitality/src/nav-sections.ts` — it was marked `@deprecated` and has zero callers outside its own declaration
- Migration to `buildNavSections(readiness)` is complete; the dead export was the only remaining artifact

## Test plan

- [ ] `grep -r NAV_SECTIONS apps/hospitality/src/` returns no results
- [ ] `pnpm --dir apps/hospitality typecheck` passes (pre-existing env errors aside)
- [ ] No runtime regressions — hospitality sidebar nav continues to work via `buildNavSections`

Closes #600

https://claude.ai/code/session_01FCmSD8cMmXPbJ325ny5QfB