### PR TITLE
seo(gen): add canonical link tag to index.html

### DIFF
--- a/apps/gen/index.html
+++ b/apps/gen/index.html
@@ -16,6 +16,7 @@
     <meta name="twitter:image" content="https://mattbutlerengineering.com/og-image.svg" />
     <meta name="theme-color" content="#1a1a1a" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.svg" />
+    <link rel="canonical" href="https://mattbutlerengineering.com/gen/" />
     <title>Gen | MBE</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary

- Adds `<link rel="canonical" href="https://mattbutlerengineering.com/gen/" />` to `apps/gen/index.html`
- Prevents search engines from splitting link equity across URL variations of the `/gen` app
- Consistent with canonical patterns in `apps/marketing/index.html` and `apps/hospitality/index.html`

## Test plan

- [ ] Verify `apps/gen/index.html` contains the canonical tag in the `<head>`
- [ ] No functional regressions — the change is metadata-only

Closes #597

https://claude.ai/code/session_01N13TfXiGbVYzJe9WugwWav