### PR TITLE
seo: add robots meta tags to gen and hospitality apps

### DIFF
--- a/apps/gen/index.html
+++ b/apps/gen/index.html
@@ -15,6 +15,7 @@
     <meta name="twitter:description" content="Generative UI playground — type a prompt, watch Rialto components render" />
     <meta name="twitter:image" content="https://mattbutlerengineering.com/og-image.svg" />
     <meta name="theme-color" content="#1a1a1a" />
+    <meta name="robots" content="index, follow" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.svg" />
     <title>Gen | MBE</title>
   </head>

--- a/apps/hospitality/index.html
+++ b/apps/hospitality/index.html
@@ -6,6 +6,7 @@
     <link rel="apple-touch-icon" href="/pwa-192x192.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#2563eb" />
+    <meta name="robots" content="noindex, nofollow" />
     <meta name="description" content="Hospitality management dashboard for reservations, guests, and floor plans" />
     <link rel="canonical" href="https://mattbutlerengineering.com/hospitality" />
     <meta property="og:title" content="Matt Butler Engineering — Hospitality" />


### PR DESCRIPTION
## Summary

- Adds `<meta name="robots" content="index, follow">` to `apps/gen/index.html` (public playground, should be indexed)
- Adds `<meta name="robots" content="noindex, nofollow">` to `apps/hospitality/index.html` (auth-gated app, explicit noindex intent rather than leaving to crawler defaults)

Matches the pattern already used by `apps/marketing/index.html`.

## Test plan

- [ ] Verify `<meta name="robots">` present in gen `<head>` with `index, follow`
- [ ] Verify `<meta name="robots">` present in hospitality `<head>` with `noindex, nofollow`

Closes #598

https://claude.ai/code/session_01ALpDBagd94hUzhnHQ5G3PS