### PR TITLE
seo(gen): fix page title — expand "MBE" to "Matt Butler Engineering"

### DIFF
--- a/apps/gen/index.html
+++ b/apps/gen/index.html
@@ -16,7 +16,7 @@
     <meta name="twitter:image" content="https://mattbutlerengineering.com/og-image.svg" />
     <meta name="theme-color" content="#1a1a1a" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.svg" />
-    <title>Gen | MBE</title>
+    <title>Gen | Matt Butler Engineering</title>
   </head>
   <body>
     <noscript>


### PR DESCRIPTION
## Summary

- Changes `<title>Gen | MBE</title>` → `<title>Gen | Matt Butler Engineering</title>` in `apps/gen/index.html`
- Eliminates the mismatch between the browser tab title and `og:title` / `twitter:title`, which already use the full name
- Improves SEO consistency (search engines prefer `<title>` to match OG metadata)

## Test plan

- [ ] Verify `apps/gen/index.html` `<title>` reads `Gen | Matt Butler Engineering`
- [ ] Confirm `<title>`, `og:title`, and `twitter:title` all match

Closes #599