### PR TITLE
fix(rialto-web): fix broken Privacy Policy link in cookie consent banner

### DIFF
--- a/apps/rialto-web/src/components/CookieConsent/CookieConsent.tsx
+++ b/apps/rialto-web/src/components/CookieConsent/CookieConsent.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Link } from "react-router-dom";
 import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import { Banner, Button, Dialog, Toggle, Stack, Divider } from "@mattbutlerengineering/rialto";
 import { precision } from "@mattbutlerengineering/rialto/motion";
@@ -50,9 +51,9 @@ export function CookieBanner({
           >
             We use cookies to enhance your browsing experience, analyze site traffic, and
             personalize content.{" "}
-            <a href="#privacy" className={styles.privacyLink}>
+            <Link to="/privacy" className={styles.privacyLink}>
               Privacy Policy
-            </a>
+            </Link>
           </Banner>
         </motion.div>
       )}

--- a/apps/rialto-web/src/pages/PrivacyPage.tsx
+++ b/apps/rialto-web/src/pages/PrivacyPage.tsx
@@ -1,0 +1,107 @@
+export function PrivacyPage() {
+  return (
+    <div
+      style={{
+        maxWidth: "680px",
+        margin: "0 auto",
+        padding: "var(--rialto-space-2xl) var(--rialto-space-xl)",
+        color: "var(--rialto-text-primary)",
+        fontFamily: "var(--rialto-font-sans)",
+      }}
+    >
+      <h1
+        style={{
+          fontSize: "var(--rialto-text-2xl)",
+          fontWeight: "var(--rialto-weight-semibold)",
+          marginBottom: "var(--rialto-space-sm)",
+        }}
+      >
+        Privacy Policy
+      </h1>
+      <p
+        style={{
+          fontSize: "var(--rialto-text-sm)",
+          color: "var(--rialto-text-tertiary)",
+          marginBottom: "var(--rialto-space-xl)",
+        }}
+      >
+        Last updated: April 2026
+      </p>
+
+      <section style={{ marginBottom: "var(--rialto-space-xl)" }}>
+        <h2
+          style={{
+            fontSize: "var(--rialto-text-lg)",
+            fontWeight: "var(--rialto-weight-medium)",
+            marginBottom: "var(--rialto-space-sm)",
+          }}
+        >
+          What we collect
+        </h2>
+        <p style={{ fontSize: "var(--rialto-text-md)", lineHeight: 1.6, color: "var(--rialto-text-secondary)" }}>
+          When you visit this site, we may collect anonymous usage data via analytics cookies
+          (e.g. page views, referrer, session duration). We do not collect personally
+          identifiable information unless you voluntarily provide it.
+        </p>
+      </section>
+
+      <section style={{ marginBottom: "var(--rialto-space-xl)" }}>
+        <h2
+          style={{
+            fontSize: "var(--rialto-text-lg)",
+            fontWeight: "var(--rialto-weight-medium)",
+            marginBottom: "var(--rialto-space-sm)",
+          }}
+        >
+          Cookies
+        </h2>
+        <p style={{ fontSize: "var(--rialto-text-md)", lineHeight: 1.6, color: "var(--rialto-text-secondary)" }}>
+          We use cookies to remember your preferences and understand how visitors use the site.
+          Essential cookies are required for the site to function. Analytics and functional
+          cookies are optional and only set with your consent. You can change your preferences
+          at any time using the cookie banner.
+        </p>
+      </section>
+
+      <section style={{ marginBottom: "var(--rialto-space-xl)" }}>
+        <h2
+          style={{
+            fontSize: "var(--rialto-text-lg)",
+            fontWeight: "var(--rialto-weight-medium)",
+            marginBottom: "var(--rialto-space-sm)",
+          }}
+        >
+          Third-party services
+        </h2>
+        <p style={{ fontSize: "var(--rialto-text-md)", lineHeight: 1.6, color: "var(--rialto-text-secondary)" }}>
+          This site may use third-party analytics providers. These providers may set their own
+          cookies and are governed by their respective privacy policies.
+        </p>
+      </section>
+
+      <section>
+        <h2
+          style={{
+            fontSize: "var(--rialto-text-lg)",
+            fontWeight: "var(--rialto-weight-medium)",
+            marginBottom: "var(--rialto-space-sm)",
+          }}
+        >
+          Contact
+        </h2>
+        <p style={{ fontSize: "var(--rialto-text-md)", lineHeight: 1.6, color: "var(--rialto-text-secondary)" }}>
+          Questions about this policy? Reach out at{" "}
+          <a
+            href="mailto:hello@mattbutlerengineering.com"
+            style={{ color: "var(--rialto-color-brand)" }}
+          >
+            hello@mattbutlerengineering.com
+          </a>
+          .
+        </p>
+      </section>
+    </div>
+  );
+}
+
+PrivacyPage.displayName = "PrivacyPage";

--- a/apps/rialto-web/src/routes.tsx
+++ b/apps/rialto-web/src/routes.tsx
@@ -4,6 +4,7 @@ import type { RouteObject } from "react-router-dom";
 import { Spinner } from "@mattbutlerengineering/rialto";
 import { ShowcaseLayout } from "./layouts/ShowcaseLayout";
 import { OverviewPage } from "./pages/OverviewPage";
+import { PrivacyPage } from "./pages/PrivacyPage";
 
 /* ── Lazy-loaded demo pages ──────────────────── */
 const SignIn = lazy(() => import("./pages/auth/SignIn").then((m) => ({ default: m.SignIn })));
@@ -413,6 +414,8 @@ export const routeTree: RouteObject[] = [
   },
   // Standalone visual-test
   { path: "visual-test", element: suspended(VisualTest) },
+  // Privacy policy
+  { path: "privacy", element: <PrivacyPage /> },
   // Catch-all
   { path: "*", element: <Navigate to="/" replace /> },
 ];


### PR DESCRIPTION
## Summary

- Replaces the dead `#privacy` anchor in the cookie consent banner with a React Router `<Link to="/privacy">` 
- Adds a new `/rialto/privacy` route wired into the React Router route tree
- Adds `PrivacyPage.tsx` with a minimal privacy policy (cookies, data collection, contact)

## Test plan

- [ ] Visit `/rialto` — cookie consent banner appears
- [ ] Click "Privacy Policy" link — navigates to `/rialto/privacy` without a full page reload
- [ ] Privacy page renders with correct content and design system tokens
- [ ] Direct navigation to `/rialto/privacy` works

Closes #606

https://claude.ai/code/session_01MFHBjjGeiQxsZjTasf84b1