### PR TITLE
fix(rialto-web): add aria-controls to ShowcaseSidebar disclosure buttons

### DIFF
--- a/apps/rialto-web/src/components/ShowcaseSidebar.tsx
+++ b/apps/rialto-web/src/components/ShowcaseSidebar.tsx
@@ -240,6 +240,7 @@ export function ShowcaseSidebar({
 
         {visibleSections.map((section) => {
           const isExpanded = isFiltering || !collapsed.has(section.label);
+          const sectionId = `sidebar-section-${section.label.toLowerCase().replace(/\s+/g, "-")}`;
 
           return (
             <div key={section.label} className={styles.section}>
@@ -247,6 +248,7 @@ export function ShowcaseSidebar({
                 className={styles.sectionHeader}
                 onClick={() => toggleSection(section.label)}
                 aria-expanded={isExpanded}
+                aria-controls={sectionId}
                 type="button"
               >
                 <span
@@ -259,7 +261,7 @@ export function ShowcaseSidebar({
               </button>
 
               {isExpanded && (
-                <ul className={styles.sectionItems}>
+                <ul id={sectionId} className={styles.sectionItems}>
                   {section.items.map((item) => {
                     const isComingSoon = item.comingSoon === true;
 


### PR DESCRIPTION
## Summary

- Adds a stable `sectionId` (e.g. `sidebar-section-components`) derived from each section label
- Wires `aria-controls={sectionId}` on every disclosure `<button>` so screen readers can identify the controlled region
- Adds matching `id={sectionId}` to each `<ul>` so `aria-controls` resolves to an existing element when expanded

Closes #609

https://claude.ai/code/session_014o1LSU523s5PBg4yRYDpJD

---
_Generated by [Claude Code](https://claude.ai/code/session_014o1LSU523s5PBg4yRYDpJD)_