### PR TITLE
fix(rialto-web): replace aria-label with aria-description on category cards

### DIFF
--- a/apps/rialto-web/src/pages/OverviewPage.tsx
+++ b/apps/rialto-web/src/pages/OverviewPage.tsx
@@ -78,7 +78,7 @@ export function OverviewPage() {
                 style={{ cursor: "pointer" }}
                 role="button"
                 tabIndex={0}
-                aria-label={`Browse ${section.label} components`}
+                aria-description={`Browse ${section.label} components`}
                 onKeyDown={(e) => {
                   if ((e.key === "Enter" || e.key === " ") && firstItem) {
                     e.preventDefault();


### PR DESCRIPTION
## Summary

- Replaces `aria-label` with `aria-description` on the 4 category cards in `OverviewPage.tsx`
- Fixes WCAG 2.5.3 (Label in Name) violation caught by Lighthouse `label-content-name-mismatch` audit
- The previous `aria-label` overrode all inner content as the accessible name while sighted users saw `FORMS` / `DATA DISPLAY` etc. via CSS `text-transform: uppercase` — the accessible name never contained the exact visible string
- With `aria-description`, the accessible name derives from visible inner content (`Text variant="label"` + component list items) while the "Browse X components" hint is preserved for screen reader users

## Test plan

- [ ] Open `/rialto` in a screen reader (e.g. VoiceOver/NVDA) — category cards should announce their section name from visible text, with the "Browse X components" hint as a description
- [ ] Lighthouse accessibility audit on `/rialto` — `label-content-name-mismatch` should no longer fire for the 4 category cards
- [ ] Click and keyboard (Enter/Space) navigation of category cards still works

Closes #617

https://claude.ai/code/session_01BxaWswusL4whTb7NWdVSV5

---
_Generated by [Claude Code](https://claude.ai/code/session_01BxaWswusL4whTb7NWdVSV5)_