### PR TITLE
chore(acmm): daily audit 2026-04-25

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Matt Butler Engineering
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=flat-square)](./LICENSE)
-<!-- acmm:begin -->![ACMM Level 4](https://img.shields.io/badge/ACMM-Level%204-c4952c?style=flat-square)<!-- acmm:end -->
+<!-- acmm:begin -->![ACMM Level 3](https://img.shields.io/badge/ACMM-Level%203-7a5a36?style=flat-square)<!-- acmm:end -->
 
 > **Build status:** GitHub Actions billing is intentionally unconfigured on this repo. Workflows in `.github/workflows/` exist as encoded policy and run via [claude.ai RemoteTriggers](https://claude.ai/code/scheduled), not on PR open. Verify changes locally with `pnpm lint`/`typecheck`/`test`. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full story.
 


### PR DESCRIPTION
## ACMM Audit — 2026-04-25

**Current level: L3 Measured / Enforced** · 33/85 criteria detected

Badge updated L4 → L3 after the rubric expanded from 36 → 85 criteria (ACMM v2 with all 4 source frameworks). The underlying repo state hasn't regressed — the scoring model is now stricter.

### Per-level threshold

| Level | Detected | Required | % | Passed |
|---|---|---|---|---|
| L2 | 1/3 | 70% | 33% | ✅ (L2 only needs 1) |
| L3 | 3/4 | 70% | 75% | ✅ |
| L4 | 0/7 | 70% | 0% | ❌ |

### Next-level gaps (L3 → L4, need ≥5/7)

- `acmm:auto-qa-tuning` — Auto-QA self-tuning config (`.github/auto-qa-tuning.json`)
- `acmm:nightly-compliance` — Nightly compliance scan workflow
- `acmm:copilot-review-apply` — Automated review application workflow
- `acmm:auto-label` — Automated issue labeling (`.github/labeler.yml`)
- `acmm:ai-fix-workflow` — AI-fix-requested workflow (`.github/workflows/claude.yml`)
- `acmm:tier-classifier` — Change classification policy workflow
- `acmm:security-ai-md` — AI security policy (`SECURITY-AI.md`)

### Notes

- All 13 rubric tests pass
- `--apply` (GitHub issue filing) skipped — `gh` CLI unavailable in this environment; issues were not filed
- `.claude/acmm/state.json` and `report.md` are gitignored; only the README badge is committed

https://claude.ai/code/session_01DqJkdqvukb2D6w6q3RPmbM

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqJkdqvukb2D6w6q3RPmbM)_