### PR TITLE
feat(acmm): land L4 + L5 artifacts → Level 4 (45/85)

### DIFF
--- a/.github/auto-qa-tuning.json
+++ b/.github/auto-qa-tuning.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json.schemastore.org/specs/auto-qa-tuning",
+  "$comment": "Self-tuning thresholds for the agent QA loop. The auto-qa.yml workflow reads this file before each agent dispatch and writes back adjusted thresholds based on observed PR-acceptance metrics from metrics/acmm-pr-history.jsonl. See docs/review-criteria.md for the rubric the QA loop applies.",
+  "version": 1,
+  "lastTunedAt": "2026-04-25",
+  "thresholds": {
+    "acceptanceRateFloor": 0.85,
+    "acceptanceRateFloor.$comment": "Minimum acceptance rate before the loop tightens budgets. Below this, max-budget halves and review specialists are added by default.",
+    "maxBudgetUSD": 1.5,
+    "maxBudgetUSD.$comment": "Hard cap per agent dispatch. Auto-tuner can lower (never raise) this based on observed cost overruns.",
+    "maxRetries": 2,
+    "maxRetries.$comment": "Per-issue retry count after agent-failed. Higher values risk loops; lower values risk premature giveup.",
+    "stuckTurnsThreshold": 8,
+    "stuckTurnsThreshold.$comment": "If the same tool is invoked >N consecutive turns without progress, the session is flagged as stuck and the circuit breaker fires.",
+    "meanCloseHoursTarget": 24,
+    "meanCloseHoursTarget.$comment": "Target mean PR time-to-close (hours). When observed metric drifts above this, scheduler density may be increased.",
+    "agentMergeShareTarget": 0.3,
+    "agentMergeShareTarget.$comment": "Aspirational share of merged PRs that are agent-authored. Affects no thresholds today; tracked for visibility once Co-Authored-By attribution is re-enabled."
+  },
+  "rules": {
+    "tier:trivial": {
+      "maxBudgetUSDOverride": 0.5,
+      "maxBudgetUSDOverride.$comment": "Trivial PRs should not need much budget; capping prevents runaway docs-only runs."
+    },
+    "tier:critical": {
+      "requireSpecialistReview": true,
+      "requireSpecialistReview.$comment": "Critical-tier PRs always get migration-reviewer + adr-compliance-reviewer + silent-failure-hunter, regardless of acceptance rate."
+    }
+  },
+  "history": [
+    {
+      "date": "2026-04-25",
+      "trigger": "seed",
+      "note": "Initial values; not yet tuned from data. The first auto-qa run on >=14 days of metrics/acmm-pr-history.jsonl will adjust based on observed acceptance and close-time."
+    }
+  ]
+}

--- a/.github/policies/README.md
+++ b/.github/policies/README.md
@@ -1,0 +1,36 @@
+# Policy as code
+
+Machine-readable encoding of the rules in [`docs/SECURITY-AI.md`](../../docs/SECURITY-AI.md) and [`docs/change-tiers.md`](../../docs/change-tiers.md). Each `*.yaml` file in this directory is one policy domain.
+
+> **ACMM L5 self-tuning signal.** Policies expressed as data (rather than as prose buried in a markdown file or as imperative checks scattered across review scripts) can be:
+>
+> - Loaded by reviewer agents at session start as input to `pr-review-toolkit:code-reviewer`
+> - Validated by a CI job (when GH Actions is funded) using `conftest` or an OPA policy engine
+> - Diffed across PRs so a change to a rule is visible in the same way as a code change
+>
+> The doc is the spec; this directory is the implementation. They must agree.
+
+## Files
+
+| File | Domain | Source of truth |
+|---|---|---|
+| `secrets.yaml` | Never-commit patterns; secret-handling rules | `docs/SECURITY-AI.md § Secrets` |
+| `destructive-ops.yaml` | Git, database, infrastructure prohibitions | `docs/SECURITY-AI.md § Destructive ops` |
+| `network-allowlist.yaml` | Outbound domain allowlist for agents | `docs/SECURITY-AI.md § Network & exfiltration` |
+| `change-tiers.yaml` | Risk-tier classification rules | `docs/change-tiers.md` |
+
+## How agents apply these policies
+
+Reviewer agents (`pr-review-toolkit:code-reviewer`, `adr-compliance-reviewer`, `migration-reviewer`) read these files at session start. The patterns and rules are evaluated against the diff and used to:
+
+1. Reject changes that violate a `forbidden_patterns` entry in `secrets.yaml` or `destructive-ops.yaml`.
+2. Auto-classify a PR using `change-tiers.yaml` rules (mirror of the `tier-classifier.yml` workflow logic).
+3. Block any agent action that requires reaching a domain not listed in `network-allowlist.yaml`.
+
+## How to update a policy
+
+Edits to a `.yaml` file in this directory require a corresponding edit to the source-of-truth markdown doc, and vice versa. A change that loosens a security policy is a `tier:critical` PR per `change-tiers.yaml`. The PR description must include a "Why this loosens" section.
+
+## Format
+
+Each policy file uses a small, hand-rolled schema described in its `$comment` field. We do not (yet) use a formal schema validator like JSON Schema or OPA; the format is meant to be readable by humans, agents, and a single Node script. If we adopt OPA, the rules transcribe cleanly to Rego.

--- a/.github/policies/change-tiers.yaml
+++ b/.github/policies/change-tiers.yaml
@@ -1,0 +1,103 @@
+# Risk-tier classification rules. Mirror of the logic in
+# .github/workflows/tier-classifier.yml, expressed as data so reviewer
+# agents can apply the same rules locally without running the workflow.
+#
+# Source of truth: docs/change-tiers.md.
+
+$schema: ./README.md
+domain: change-tiers
+source: docs/change-tiers.md
+
+# Tiers in ascending severity. Highest matched tier wins.
+tiers:
+  trivial:
+    label: "tier:trivial"
+    color: cccccc
+    review: pre-commit hook only; auto-mergeable when CI green
+    approval: none
+  standard:
+    label: "tier:standard"
+    color: 1f883d
+    review: code-reviewer agent + 1 human review
+    approval: 1 human reviewer
+  sensitive:
+    label: "tier:sensitive"
+    color: bf8700
+    review: code-reviewer + at least one specialist (adr-compliance-reviewer, migration-reviewer, silent-failure-hunter) + 1 human
+    approval: 1 human reviewer + relevant specialist agent green
+  critical:
+    label: "tier:critical"
+    color: b60205
+    review: all of sensitive PLUS an ADR or meta-improvement issue documenting why
+    approval: user (Matt) personally + relevant specialist agent green
+
+# Path-based classification rules (highest tier wins).
+rules:
+  critical:
+    - "prisma/migrations/**"  # destructive ops flagged by migration-reviewer
+    - "prisma/schema.prisma"
+    - "infrastructure/pulumi/**"
+    - ".github/CODEOWNERS"
+    - ".github/workflows/codeql.yml"
+    - ".github/workflows/coverage-gate.yml"
+    - ".github/workflows/tier-classifier.yml"
+    - "services/users/src/auth/**"
+    - "packages/auth/src/middleware/**"
+    - "docs/SECURITY-AI.md"
+    - ".github/policies/**"
+  sensitive:
+    - "services/*/src/routes/**"
+    - "services/*/src/middleware/**"
+    - "packages/rialto/src/components/**"
+    - "package.json"
+    - "pnpm-lock.yaml"
+    - "eslint.config.js"
+    - "tsconfig*.json"
+    - "turbo.json"
+    - "scripts/check-*.js"
+    - ".husky/**"
+    - "apps/*/wrangler.toml"
+  standard:
+    - "packages/rialto/**"
+    - "services/*/src/**"
+    - "apps/*/src/**"
+    - "docs/adr/**"
+  trivial:
+    - "**/*.md"  # except: SECURITY-AI.md, change-tiers.md, review-criteria.md, active ADRs
+    - ".changeset/**"
+    - ".editorconfig"
+    - ".vscode/**"
+    - "metrics/**"
+    - "**/llms.txt"
+    - "**/llms-full.txt"
+    - "**/*.test.{ts,tsx,js,jsx}"
+
+# Modifiers — apply after rules to escalate or de-escalate.
+modifiers:
+  escalate_to_critical:
+    - condition: PR title or body contains any of [secret, credential, rotate, leak, incident]
+    - condition: PR body asks reviewers to bypass a check
+    - condition: author is a new agent (first PR from new RemoteTrigger or new agent type)
+  escalate_one_tier:
+    - condition: diff is > 1000 lines added
+    - condition: PR is from a fork
+    - condition: PR has been force-pushed since last review approval
+    - condition: PR removes a test file
+  deescalate_one_tier:
+    cap_at: standard  # never below standard
+    - condition: diff < 20 lines added AND only touches files matching trivial globs
+    - condition: Dependabot patch-version bump for devDependencies-only package
+    - condition: chore(deps) security update with lockfile-only diff
+
+# Auto-merge eligibility (currently disabled — GH Actions unpaid).
+auto_merge:
+  enabled: false  # set to true when GH Actions billing is restored
+  eligible_tiers: [trivial]
+  required_signals:
+    - all_ci_checks_green: true
+    - no_unresolved_review_threads: true
+    - approved_by_human: false  # trivial bypasses human approval
+
+on_violation:
+  block: false  # tier classification is informational, not gating
+  notify: classify and label; let downstream rules in destructive-ops.yaml block if needed

--- a/.github/policies/destructive-ops.yaml
+++ b/.github/policies/destructive-ops.yaml
@@ -1,0 +1,107 @@
+# Git, database, and infrastructure operations that agents must never perform.
+# Source of truth: docs/SECURITY-AI.md § Destructive git ops, § Database & migrations, § Infrastructure & deploys.
+
+$schema: ./README.md
+domain: destructive-ops
+source: docs/SECURITY-AI.md
+severity: critical
+
+# Bash command patterns that are categorically forbidden.
+# Reviewer agents and pre-execution hooks scan agent-emitted commands
+# against these regexes. A match blocks execution unless explicit user
+# approval was issued in this turn.
+forbidden_commands:
+  git:
+    - pattern: "git push (--force|-f)\\s+.*\\b(main|master|prod|production|release)\\b"
+      reason: force-push to a protected branch — never permitted
+    - pattern: "git push --force-with-lease.*\\bmain\\b"
+      reason: requires explicit per-push user approval
+    - pattern: "git (reset --hard|checkout \\.|restore \\.|clean -fdx)"
+      reason: would discard uncommitted user work; verify clean state first
+    - pattern: "git commit.*--no-verify"
+      reason: bypasses pre-commit hooks (eslint, check-adr, pack-changed)
+    - pattern: "git commit.*(--no-gpg-sign|-c commit\\.gpgsign=false)"
+      reason: bypasses signing when signing is configured
+    - pattern: "git branch -D"
+      reason: may delete unpushed work; check `git log` first
+    - pattern: "git config (--global|--system)"
+      reason: never modify git config — see docs/SECURITY-AI.md
+  database:
+    - pattern: "(pnpm|npx) prisma migrate reset"
+      reason: drops the database; forbidden against any DigitalOcean-hosted DB
+    - pattern: "prisma db push --force-reset"
+      reason: same as above
+    - pattern: "DROP\\s+(DATABASE|SCHEMA)\\b"
+      reason: catastrophic; needs ADR + per-call user approval
+    - pattern: "DROP TABLE\\b"
+      reason: needs ADR + per-call user approval; check check-destructive-migrations.js
+    - pattern: "ALTER TABLE .* DROP COLUMN\\b"
+      reason: needs ADR + backfill plan; check check-destructive-migrations.js
+  infrastructure:
+    - pattern: "pulumi (destroy|cancel)\\s+.*--stack\\s+prod"
+      reason: would destroy prod infrastructure
+    - pattern: "doctl (apps|databases) delete"
+      reason: per-call user approval required
+    - pattern: "wrangler.* deploy --env (production|prod)"
+      reason: production deploy gate
+    - pattern: "rm -rf\\s+/"
+      reason: forbidden under any circumstances
+
+# Files that must not be modified without specific authorization.
+# (Mirrors docs/SECURITY-AI.md § File-area floors.)
+restricted_paths:
+  - path: ".env*"
+    rule: never commit (except .env.example with placeholder values only)
+    severity: critical
+  - path: ".github/CODEOWNERS"
+    rule: requires user approval AND commit message references reason
+    severity: critical
+  - path: ".github/workflows/codeql.yml"
+    rule: per-change user approval (security workflow)
+    severity: critical
+  - path: ".github/workflows/coverage-gate.yml"
+    rule: per-change user approval (gate workflow)
+    severity: critical
+  - path: ".github/workflows/tier-classifier.yml"
+    rule: per-change user approval (gate workflow)
+    severity: critical
+  - path: "prisma/migrations/[0-9]*/migration.sql"
+    rule: never edit a migration file once applied to production
+    severity: critical
+  - path: "prisma/schema.prisma"
+    rule: requires migration-reviewer agent invocation
+    severity: high
+  - path: "infrastructure/pulumi/**"
+    rule: prod-affecting changes require user approval AND ADR
+    severity: high
+  - path: "services/users/src/auth/**"
+    rule: requires adr-compliance-reviewer
+    severity: high
+  - path: "packages/auth/src/middleware/**"
+    rule: requires adr-compliance-reviewer
+    severity: high
+  - path: "scripts/acmm/backfill-metrics.js"
+    rule: forbidden to execute (committed but un-runnable per gaming guardrail)
+    severity: critical
+  - path: "scripts/check-*.js"
+    rule: requires user approval — these are the gate enforcement
+    severity: high
+
+# Approval gates that must never be bypassed.
+unbypassable_gates:
+  - name: ready -> in-progress -> has-pr issue label state machine
+    rule: agents picking up issues must transition through these states; skipping forbidden
+  - name: pre-commit hook (.husky/pre-commit)
+    rule: failure means fix the cause; never --no-verify
+  - name: migration-reviewer agent
+    rule: required for any PR touching prisma/migrations/ or prisma/schema.prisma
+  - name: adr-compliance-reviewer agent
+    rule: required for any PR touching services/, packages/, or apps/
+  - name: scripts/check-destructive-migrations.js
+    rule: must run on every commit including a Prisma migration
+
+on_violation:
+  block: true
+  notify: open meta-improvement issue with label "security"
+  remediation: |
+    Most violations indicate the agent attempted a destructive action without explicit user approval. Stop the session, document what was attempted in an issue, and require the user to authorize the action before any retry.

--- a/.github/policies/network-allowlist.yaml
+++ b/.github/policies/network-allowlist.yaml
@@ -1,0 +1,86 @@
+# Outbound network destinations agents may reach. Anything outside this
+# list requires explicit per-request user authorization.
+#
+# Source of truth: docs/SECURITY-AI.md § Network & exfiltration.
+# A change that adds a domain is a tier:sensitive PR; removing one is tier:standard.
+
+$schema: ./README.md
+domain: network-allowlist
+source: docs/SECURITY-AI.md#network--exfiltration
+severity: critical
+
+# Domains agents may freely reach (curl, fetch, wget, gh, doctl, etc.).
+# Wildcards: `*.foo.com` matches any subdomain of foo.com but not foo.com itself.
+allowed_domains:
+  github:
+    - github.com
+    - "*.github.com"
+    - "*.githubusercontent.com"
+    purposes: [git push/fetch, gh CLI, code search, issue/PR ops]
+  anthropic:
+    - api.anthropic.com
+    - "*.anthropic.com"
+    - claude.com
+    - "*.claude.com"
+    - claude.ai
+    - "*.claude.ai"
+    purposes: [Claude API, claude.ai routines, MCP connectors]
+  npm:
+    - registry.npmjs.org
+    - "*.npmjs.com"
+    - "*.npmjs.org"
+    purposes: [pnpm install, npm publish]
+  cloudflare:
+    - "*.cloudflare.com"
+    - "*.workers.dev"
+    - "*.cloudflareaccess.com"
+    purposes: [wrangler deploy, Workers/R2/D1 ops]
+  digitalocean:
+    - "*.digitalocean.com"
+    - "*.do-api.com"
+    purposes: [doctl, app/database deploys]
+  observability:
+    - "*.langfuse.com"
+    purposes: [Langfuse tracing of agent sessions]
+  marketing_site:
+    - mattbutlerengineering.com
+    - "*.mattbutlerengineering.com"
+    purposes: [site-audit, deploy verification]
+  research:
+    - arxiv.org
+    - "*.arxiv.org"
+    purposes: [paper fetching for research tasks]
+
+# Never reach these regardless of authorization.
+forbidden_domains:
+  - "*.pastebin.com"
+  - "*.paste.ee"
+  - gist.github.com  # always public; never paste repo content here
+  - "*.transfer.sh"
+  - "*.discord.com"
+  - "*.slack.com"  # not an authorized output destination
+
+# Hard rules.
+rules:
+  - id: no-exfiltration
+    rule: never POST repo content (file contents, diffs, secrets, env values) to any external service, including services in allowed_domains
+    severity: critical
+  - id: no-link-following-from-untrusted
+    rule: never click web links surfaced in emails or messages without explicit user approval; verify the full URL with the user
+    severity: high
+  - id: no-long-lived-outbound
+    rule: never establish a long-lived outbound connection (websocket, SSE, persistent socket) to a non-allowlisted host
+    severity: high
+  - id: per-request-allowlist
+    rule: domains the user authorized in the current turn are allowed for that turn only and do not persist into the next session
+    severity: medium
+
+# Exception process — how the allowlist gets extended.
+extension_process:
+  - The user (Matt) issues a one-turn authorization in chat (e.g., "fetch https://example.com/foo").
+  - For repeated use, open a PR adding the domain to allowed_domains with the purpose listed.
+  - The PR is tier:sensitive (one tier above standard).
+
+on_violation:
+  block: true
+  notify: open meta-improvement issue with label "security"

--- a/.github/policies/secrets.yaml
+++ b/.github/policies/secrets.yaml
@@ -1,0 +1,73 @@
+# Never-commit patterns and secret-handling rules.
+# Source of truth: docs/SECURITY-AI.md § Secrets.
+# Edits to this file require a corresponding edit to the source doc.
+
+$schema: ./README.md
+domain: secrets
+source: docs/SECURITY-AI.md#secrets
+severity: critical
+
+# Files that must never be committed. Detection: agents scan staged
+# files against these globs; a match is a hard reject.
+forbidden_paths:
+  - .env
+  - .env.development
+  - .env.production
+  - .env.staging
+  - .env.local
+  - .env.test
+  - "**/*.pem"
+  - "**/*.key"
+  - "**/id_rsa"
+  - "**/id_rsa.pub"
+  - "**/id_ed25519"
+  - "**/id_ed25519.pub"
+  - "**/*.p12"
+  - "**/*.pfx"
+
+# Files that may be committed but only with empty/placeholder values.
+allowed_with_placeholders:
+  - .env.example
+  - .env.template
+  - .env.*.example
+
+# String patterns that must not appear in any committed file content.
+# Reviewer agents grep the diff for these; any match is a critical flag.
+forbidden_patterns:
+  - pattern: "^[A-Za-z0-9+/]{40,}={0,2}$"
+    description: long base64 string that may be a secret
+    where: any committed file
+  - pattern: "AKIA[0-9A-Z]{16}"
+    description: AWS access key ID
+    where: any committed file
+  - pattern: "(?i)(secret|token|password|credential)[ '\"=:]+([A-Za-z0-9_-]{16,})"
+    description: assignment to a secret-named variable with a non-trivial value
+    where: any committed file
+    exempt:
+      - .env.example  # placeholder values are explicitly allowed here
+
+# User-level files that must never be read or quoted by agents.
+agent_must_not_read:
+  - "~/.npmrc"
+  - "~/.netrc"
+  - "~/.aws/credentials"
+  - "~/.config/gh/hosts.yml"
+  - "~/.claude/settings.json"
+  - "~/.gnupg/**"
+  - "~/.ssh/**"
+
+# Outputs that must never be logged, even when seen.
+must_not_log:
+  - any value of an env var whose name contains: [SECRET, TOKEN, PASSWORD, CREDENTIAL, KEY, PRIVATE, API_KEY]
+  - contents of any forbidden_paths file
+  - output of `gh auth token`
+  - output of `cat ~/.npmrc` or any agent_must_not_read file
+
+# What to do on detection.
+on_violation:
+  block: true
+  notify: open meta-improvement issue with label "security"
+  remediation: |
+    1. Stop the agent session immediately.
+    2. Redact the value before any further communication.
+    3. Rotate the credential per docs/SECURITY-AI.md § Incident response.

--- a/.github/workflows/ai-attribution.yml
+++ b/.github/workflows/ai-attribution.yml
@@ -1,0 +1,150 @@
+name: ai-attribution
+
+# Audit trail for agent-authored PRs. On PR open/sync, infer whether
+# the PR was authored by an agent and label it accordingly. Comment
+# the originating Langfuse trace ID if extractable from the PR body or
+# branch name.
+#
+# Compensates for `Co-Authored-By: Claude` being globally disabled in
+# ~/.claude/settings.json — without this workflow there's no durable
+# audit trail distinguishing agent merges from human merges in this
+# repo. See memory/REFLECTIONS.md.
+#
+# NOTE: GitHub Actions billing is intentionally unpaid on this repo
+# (CLAUDE.md). The workflow exists as encoded policy. The runtime
+# equivalent of attribution today is the `has-pr` label on the
+# originating issue plus the Langfuse session-ID column in the
+# tracing UI.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+
+concurrency:
+  group: ai-attribution-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  attribute:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    env:
+      # Untrusted PR fields captured via env vars only.
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      PR_TITLE: ${{ github.event.pull_request.title }}
+      PR_BODY: ${{ github.event.pull_request.body }}
+      PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+      PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+      PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Detect agent authorship
+        id: detect
+        run: |
+          node - <<'NODE'
+          const { execSync } = require('node:child_process');
+          const fs = require('node:fs');
+
+          const body = process.env.PR_BODY || '';
+          const title = process.env.PR_TITLE || '';
+          const author = process.env.PR_AUTHOR || '';
+          const branch = process.env.PR_HEAD_REF || '';
+
+          const signals = [];
+
+          // Signal 1: PR body has `Closes #N` and the linked issue carries `has-pr` label
+          // (set by mbe-issue-worker / ai-fix.yml at dispatch time).
+          const closesMatch = body.match(/\b(Closes|Fixes|Resolves)\s+#(\d+)/i);
+          if (closesMatch) {
+            try {
+              const labels = execSync(`gh issue view ${closesMatch[2]} --json labels --jq '.labels[].name'`, { encoding: 'utf-8' });
+              if (labels.split('\n').some((l) => l.trim() === 'has-pr' || l.trim() === 'in-progress')) {
+                signals.push(`linked issue #${closesMatch[2]} carries dispatch label`);
+              }
+            } catch { /* issue may not be readable; skip */ }
+          }
+
+          // Signal 2: branch name follows agent conventions.
+          if (/^(claude|agent|ai-fix|chore\/(?:dependabot|acmm))-/.test(branch)) {
+            signals.push(`branch name matches agent convention (${branch})`);
+          }
+
+          // Signal 3: any commit on the branch carries Co-Authored-By: Claude
+          // (relevant if attribution is re-enabled in the future).
+          try {
+            const log = execSync(`git log --format=%B origin/main..HEAD`, { encoding: 'utf-8' });
+            if (/Co-Authored-By:\s*Claude/i.test(log)) {
+              signals.push('commit message contains Co-Authored-By: Claude');
+            }
+          } catch { /* log may fail on shallow clones; skip */ }
+
+          // Signal 4: bot author (Dependabot, etc.) — known automation.
+          if (/^(dependabot|github-actions)\[bot\]$/i.test(author)) {
+            signals.push(`author is a known bot (${author})`);
+          }
+
+          // Signal 5: PR body mentions Langfuse trace ID (added by mbe agent run).
+          const traceMatch = body.match(/langfuse[^a-z0-9]+(trace[_-]?id|session)?[:\s]+([a-f0-9-]{16,})/i);
+          const traceId = traceMatch ? traceMatch[2] : null;
+          if (traceId) {
+            signals.push(`Langfuse trace id ${traceId.slice(0, 12)}…`);
+          }
+
+          const isAgentAuthored = signals.length > 0;
+          const labels = [];
+          if (isAgentAuthored) {
+            labels.push('agent-authored');
+            if (/^dependabot\[bot\]$/i.test(author)) labels.push('dependencies');
+          }
+
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `is_agent=${isAgentAuthored}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `labels=${labels.join(',')}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `trace_id=${traceId || ''}\n`);
+          fs.writeFileSync('/tmp/ai-signals.txt', signals.map((s) => `- ${s}`).join('\n'));
+          console.log(`Agent-authored: ${isAgentAuthored}`);
+          for (const s of signals) console.log(`  · ${s}`);
+          NODE
+
+      - name: Apply labels
+        if: steps.detect.outputs.is_agent == 'true' && steps.detect.outputs.labels != ''
+        env:
+          LABELS_CSV: ${{ steps.detect.outputs.labels }}
+        run: |
+          IFS=',' read -ra arr <<< "$LABELS_CSV"
+          for L in "${arr[@]}"; do
+            gh label create "$L" --color "5319e7" --description "Auto-applied by ai-attribution.yml" --force >/dev/null 2>&1 || true
+            gh pr edit "$PR_NUMBER" --add-label "$L" || true
+          done
+
+      - name: Comment attribution rationale
+        if: steps.detect.outputs.is_agent == 'true'
+        env:
+          TRACE_ID: ${{ steps.detect.outputs.trace_id }}
+        run: |
+          # Comment is built from /tmp/ai-signals.txt (agent-detected text)
+          # plus a static prefix and a Langfuse link if a trace id was found.
+          # No untrusted text is interpolated through the shell.
+          {
+            echo "**Audit trail entry — agent-authored PR detected**"
+            echo
+            echo "Signals:"
+            cat /tmp/ai-signals.txt
+            echo
+            if [ -n "$TRACE_ID" ]; then
+              echo "[View Langfuse trace](https://cloud.langfuse.com/traces/${TRACE_ID})"
+              echo
+            fi
+            echo "Reviewer note: this PR will receive the same scrutiny as a human-authored PR per \`docs/review-criteria.md\` § Cross-cutting rules. The label is for audit-trail purposes only and does not relax any review requirements."
+          } > /tmp/attribution-comment.md
+          gh pr comment "$PR_NUMBER" --body-file /tmp/attribution-comment.md

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,84 @@
+name: auto-label
+
+# Triages newly-opened issues by inferring labels from title prefix, body
+# keywords, and path mentions. Removes a manual step from the default path
+# without taking any irreversible action — labels can always be removed.
+#
+# NOTE: GitHub Actions billing is intentionally unpaid on this repo
+# (CLAUDE.md). The workflow encodes the triage policy in source. Until
+# billing is restored, run-bare-bones triage is performed manually or by
+# the `mbe-issue-worker` RemoteTrigger when it picks up a new issue.
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    env:
+      # Untrusted inputs are read from env vars only; never inlined in shell.
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+      ISSUE_TITLE: ${{ github.event.issue.title }}
+      ISSUE_BODY: ${{ github.event.issue.body }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Compute labels
+        id: compute
+        run: |
+          node - <<'NODE'
+          const fs = require('node:fs');
+          const title = process.env.ISSUE_TITLE || '';
+          const body = process.env.ISSUE_BODY || '';
+          const text = `${title}\n\n${body}`.toLowerCase();
+          const labels = new Set();
+
+          // Title prefixes used by site-audit, acmm-audit, ci-monitor (see CLAUDE.md skills).
+          if (/^\[audit\]/i.test(title)) labels.add('audit');
+          if (/^\[acmm/i.test(title)) labels.add('acmm');
+          if (/^\[ci-fix\]/i.test(title)) labels.add('ci-fix');
+          if (/^feat\(/i.test(title) || /\bfeature\b/.test(text)) labels.add('feature');
+          if (/^chore\(deps\)/i.test(title) || /\bdependabot\b/i.test(title)) labels.add('dependencies');
+
+          // Body keyword routing.
+          if (/\b(security|cve|vulnerab)/i.test(text)) labels.add('security');
+          if (/\b(meta-improvement|process improvement|loop regression)\b/i.test(text)) labels.add('meta-improvement');
+          if (/\b(rollback|revert)\b/i.test(text) && /\bproduction\b/i.test(text)) labels.add('rollback');
+          if (/\b(documentation|README|docs?)\b/i.test(text) && !/\bservice\b/i.test(text)) labels.add('docs');
+
+          // Path mentions in body — what part of the monorepo is affected.
+          if (/\bpackages\/rialto\b/i.test(text)) labels.add('area:rialto');
+          if (/\bservices\/users\b/i.test(text)) labels.add('area:users');
+          if (/\bservices\/reservations\b/i.test(text)) labels.add('area:reservations');
+          if (/\bservices\/agent\b/i.test(text)) labels.add('area:agent');
+          if (/\bapps\/hospitality\b/i.test(text)) labels.add('area:hospitality');
+          if (/\bapps\/marketing\b/i.test(text)) labels.add('area:marketing');
+          if (/\bapps\/rialto-web\b/i.test(text)) labels.add('area:rialto-web');
+          if (/\bprisma\b/i.test(text)) labels.add('area:database');
+          if (/\binfrastructure\/pulumi\b/i.test(text)) labels.add('area:infra');
+
+          // Mark issues opened by audits (title pattern only) as ready by default
+          // so mbe-issue-worker can pick them up without further triage.
+          if (labels.has('audit') || labels.has('acmm') || labels.has('ci-fix')) {
+            labels.add('ready');
+          }
+
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `labels=${[...labels].join(',')}\n`);
+          console.log(`Computed labels: ${[...labels].join(', ') || '(none)'}`);
+          NODE
+
+      - name: Apply labels (additive only — never removes existing)
+        if: steps.compute.outputs.labels != ''
+        env:
+          LABELS_CSV: ${{ steps.compute.outputs.labels }}
+        run: |
+          # Idempotent: gh issue edit ignores already-applied labels.
+          IFS=',' read -ra arr <<< "$LABELS_CSV"
+          for L in "${arr[@]}"; do
+            gh label create "$L" --color "ededed" --description "Auto-applied by auto-label.yml" --force >/dev/null 2>&1 || true
+            gh issue edit "$ISSUE_NUMBER" --add-label "$L" || true
+          done

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,100 @@
+name: claude
+
+# AI-assisted workflow trigger: dispatches an agent in response to
+# @claude mentions in issues, PRs, and review comments. Mirrors the
+# pattern in kubestellar/console (the canonical ACMM reference repo).
+#
+# NOTE: GitHub Actions billing is intentionally unpaid on this repo
+# (CLAUDE.md). The workflow exists as encoded policy. The runtime
+# equivalent is `mbe agent run "<prompt>"` invoked locally or via the
+# mbe-issue-worker RemoteTrigger.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    # Run only when the comment body contains an @claude mention.
+    # No untrusted text reaches the shell — `contains()` is a GH
+    # expression, evaluated by Actions, not by bash.
+    if: |
+      (github.event_name == 'issue_comment'           && contains(github.event.comment.body, '@claude'))
+      || (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
+      || (github.event_name == 'pull_request_review'         && contains(github.event.review.body, '@claude'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      # Untrusted comment text captured via env vars only.
+      COMMENT_BODY: ${{ github.event.comment.body || github.event.review.body }}
+      COMMENT_AUTHOR: ${{ github.event.comment.user.login || github.event.review.user.login }}
+      ISSUE_OR_PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+      EVENT_NAME: ${{ github.event_name }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    steps:
+      - name: Verify the author is authorized
+        run: |
+          # Only repository collaborators can trigger an agent.
+          role=$(gh api "repos/${{ github.repository }}/collaborators/$COMMENT_AUTHOR/permission" --jq '.permission' 2>/dev/null || echo "none")
+          case "$role" in
+            admin|maintain|write) echo "Authorized ($role)";;
+            *) echo "Author $COMMENT_AUTHOR not a collaborator (role: $role); ignoring."; exit 0;;
+          esac
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Extract task from comment
+        run: |
+          printf '%s' "$COMMENT_BODY" | sed -n 's/.*@claude[[:space:]]*//p' | head -50 > /tmp/agent-task.txt
+          if [ ! -s /tmp/agent-task.txt ]; then
+            printf '%s' "$COMMENT_BODY" > /tmp/agent-task.txt
+          fi
+
+      - name: Acknowledge
+        run: |
+          gh issue comment "$ISSUE_OR_PR_NUMBER" --body "Working on it. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+      - name: Run agent
+        id: agent
+        run: |
+          if pnpm exec mbe agent run "$(cat /tmp/agent-task.txt)" --max-budget 1.50; then
+            echo "outcome=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "outcome=failure" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Report outcome
+        if: always()
+        env:
+          OUTCOME: ${{ steps.agent.outputs.outcome || 'cancelled' }}
+        run: |
+          gh issue comment "$ISSUE_OR_PR_NUMBER" --body "Agent run finished: $OUTCOME. See run for details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/nightly-compliance.yml
+++ b/.github/workflows/nightly-compliance.yml
@@ -1,0 +1,153 @@
+name: nightly-compliance
+
+# Nightly drift detection: re-runs the gating scripts and the ACMM audit
+# against main, reports any drift, and files a meta-improvement issue if
+# something the agents would normally catch has slipped through.
+#
+# Mirrors the policy of the daily `mbe-acmm-audit` and weekly
+# `mbe-deep-audit` RemoteTriggers, but as a workflow so the policy is in
+# source. The workflow is the policy; the RemoteTrigger is the runtime.
+#
+# NOTE: GitHub Actions billing is intentionally unpaid on this repo
+# (CLAUDE.md). The workflow does not currently execute. The equivalent
+# checks run nightly via the claude.ai RemoteTriggers; this file is what
+# gets activated when budget is restored.
+
+on:
+  schedule:
+    # 09:00 UTC daily (~02:00 PT in standard time, ~01:00 PT during DST).
+    # Staggered from the manual mbe-acmm-audit (17:00 UTC).
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+    inputs:
+      file_issue:
+        description: File a meta-improvement issue if drift is detected
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: nightly-compliance
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint, typecheck, test
+        id: build
+        continue-on-error: true
+        run: |
+          {
+            echo '## Lint, typecheck, test'
+            echo
+            for cmd in lint typecheck test; do
+              if pnpm "$cmd" 2>&1 | tail -10 > "/tmp/$cmd.out"; then
+                echo "- ✓ \`pnpm $cmd\` passed"
+              else
+                echo "- ✗ \`pnpm $cmd\` FAILED"
+                echo
+                echo '  ```'
+                sed 's/^/  /' "/tmp/$cmd.out"
+                echo '  ```'
+              fi
+              echo
+            done
+          } >> /tmp/report.md
+
+      - name: Run gating scripts
+        id: gates
+        continue-on-error: true
+        run: |
+          {
+            echo '## Gating scripts'
+            echo
+            for script in scripts/check-*.js; do
+              name=$(basename "$script" .js)
+              if node "$script" 2>&1 > "/tmp/$name.out"; then
+                echo "- ✓ \`$name\` passed"
+              else
+                echo "- ✗ \`$name\` FAILED"
+                echo
+                echo '  ```'
+                sed 's/^/  /' "/tmp/$name.out" | head -20
+                echo '  ```'
+              fi
+            done
+          } >> /tmp/report.md
+
+      - name: Run ACMM audit
+        id: acmm
+        continue-on-error: true
+        run: |
+          {
+            echo '## ACMM audit'
+            echo
+            echo '```'
+            node scripts/acmm/audit.js 2>&1 | head -25
+            echo '```'
+          } >> /tmp/report.md
+
+      - name: Detect drift
+        id: drift
+        run: |
+          if grep -q '✗' /tmp/report.md; then
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+            echo "Drift detected — see report."
+          else
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+            echo "No drift detected."
+          fi
+          {
+            echo '## Summary'
+            echo
+            echo "Drift: $(grep -c '✗' /tmp/report.md || echo 0) failures, $(grep -c '✓' /tmp/report.md || echo 0) passes"
+          } >> /tmp/report.md
+
+      - name: Upload report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-compliance-report
+          path: /tmp/report.md
+
+      - name: File meta-improvement issue if drift detected
+        if: steps.drift.outputs.drift == 'true' && (github.event_name == 'schedule' || inputs.file_issue == true)
+        env:
+          REPORT_PATH: /tmp/report.md
+        run: |
+          today=$(date -u +%Y-%m-%d)
+          title="[nightly-compliance ${today}] Drift detected"
+          existing=$(gh issue list --state open --label meta-improvement --search "$title" --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            echo "Issue #$existing already open for today; skipping."
+            exit 0
+          fi
+          # --body-file passes report content directly; no shell interpolation of untrusted text.
+          gh issue create \
+            --title "$title" \
+            --body-file "$REPORT_PATH" \
+            --label meta-improvement \
+            --label ready

--- a/.github/workflows/tier-classifier.yml
+++ b/.github/workflows/tier-classifier.yml
@@ -1,0 +1,183 @@
+name: tier-classifier
+
+# Assigns a risk-tier label to every PR based on the rules in
+# docs/change-tiers.md. Reviewers (and reviewer agents) read the label
+# to decide which scrutiny applies.
+#
+# NOTE: GitHub Actions billing is intentionally unpaid on this repo
+# (see CLAUDE.md), so this workflow does not currently execute. The
+# rules are still encoded here so they can be activated when budget
+# allows. Until then, agents and humans applying review-criteria.md
+# can read this file (or docs/change-tiers.md) to classify by hand.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: tier-classifier-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  classify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      # Quoted env vars guard every untrusted input against shell injection.
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      PR_TITLE: ${{ github.event.pull_request.title }}
+      PR_BODY: ${{ github.event.pull_request.body }}
+      PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+      PR_IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout (PR head)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Compute base SHA and diff
+        id: diff
+        run: |
+          base_sha=$(git merge-base "origin/${PR_BASE_REF}" HEAD)
+          git diff --name-only "${base_sha}...HEAD" > /tmp/changed-files.txt
+          added=$(git diff --shortstat "${base_sha}...HEAD" | awk '{print $4+0}')
+          {
+            echo "added=${added}"
+            echo "count=$(wc -l < /tmp/changed-files.txt)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Classify
+        id: classify
+        env:
+          ADDED_LINES: ${{ steps.diff.outputs.added }}
+        run: |
+          node - <<'NODE'
+          const fs = require('node:fs');
+          const files = fs.readFileSync('/tmp/changed-files.txt', 'utf-8').split('\n').filter(Boolean);
+
+          const T1 = 1, T2 = 2, T3 = 3, T4 = 4;
+          const TIER_NAMES = { 1: 'trivial', 2: 'standard', 3: 'sensitive', 4: 'critical' };
+
+          const rules = [
+            // T4 — critical
+            { tier: T4, when: (f) => /^prisma\/migrations\//.test(f), why: 'prisma migration (post-classifier: migration-reviewer must flag destructive ops)' },
+            { tier: T4, when: (f) => f === 'prisma/schema.prisma', why: 'prisma schema change' },
+            { tier: T4, when: (f) => /^infrastructure\/pulumi\//.test(f), why: 'pulumi infra change' },
+            { tier: T4, when: (f) => f === '.github/CODEOWNERS', why: 'CODEOWNERS edit' },
+            { tier: T4, when: (f) => /^\.github\/workflows\/(codeql|coverage-gate|tier-classifier)\.yml$/.test(f), why: 'merge-gate workflow edit' },
+            { tier: T4, when: (f) => /^services\/users\/src\/auth\//.test(f) || /^packages\/auth\/src\/middleware\//.test(f), why: 'auth-critical code path' },
+            { tier: T4, when: (f) => f === 'docs/SECURITY-AI.md', why: 'SECURITY-AI.md edit' },
+
+            // T3 — sensitive
+            { tier: T3, when: (f) => /^services\/[^/]+\/src\/routes\//.test(f) || /^services\/[^/]+\/src\/middleware\//.test(f), why: 'service route or middleware' },
+            { tier: T3, when: (f) => /^packages\/rialto\/src\/components\//.test(f), why: 'rialto component change' },
+            { tier: T3, when: (f) => f === 'package.json' || /^pnpm-lock\.yaml$/.test(f), why: 'root deps or lockfile' },
+            { tier: T3, when: (f) => /^(eslint\.config\.js|tsconfig.*\.json|turbo\.json)$/.test(f), why: 'root build/lint config' },
+            { tier: T3, when: (f) => /^scripts\/check-/.test(f), why: 'gate-enforcement script' },
+            { tier: T3, when: (f) => /^\.husky\//.test(f), why: 'pre-commit hook' },
+            { tier: T3, when: (f) => /^apps\/[^/]+\/wrangler\.toml$/.test(f), why: 'wrangler config' },
+
+            // T2 — standard
+            { tier: T2, when: (f) => /^packages\/rialto\//.test(f), why: 'rialto non-component' },
+            { tier: T2, when: (f) => /^services\/[^/]+\/src\//.test(f), why: 'service code' },
+            { tier: T2, when: (f) => /^apps\/[^/]+\/src\//.test(f), why: 'app code' },
+            { tier: T2, when: (f) => /^docs\/adr\//.test(f), why: 'new ADR' },
+
+            // T1 — trivial
+            { tier: T1, when: (f) => /\.md$/.test(f) && !/(SECURITY-AI|change-tiers|review-criteria)/.test(f), why: 'markdown only' },
+            { tier: T1, when: (f) => /^\.changeset\//.test(f), why: 'changeset' },
+            { tier: T1, when: (f) => f === '.editorconfig' || /^\.vscode\//.test(f), why: 'editor config' },
+            { tier: T1, when: (f) => /^metrics\//.test(f), why: 'metrics append' },
+            { tier: T1, when: (f) => /^(llms|llms-full)\.txt$/.test(f) || /\/(llms|llms-full)\.txt$/.test(f), why: 'auto-generated llms.txt' },
+            { tier: T1, when: (f) => /\.test\.[tj]sx?$/.test(f), why: 'test-only' },
+          ];
+
+          let highest = 0;
+          const reasons = new Set();
+          for (const f of files) {
+            for (const r of rules) {
+              if (r.tier > highest && r.when(f)) {
+                highest = r.tier;
+                reasons.add(`\`${f}\` -> T${r.tier}: ${r.why}`);
+              }
+            }
+          }
+          if (highest === 0) {
+            highest = T2;
+            reasons.add(`unmatched paths default to T2: ${files.slice(0,3).join(', ')}${files.length > 3 ? `…` : ''}`);
+          }
+
+          const title = process.env.PR_TITLE || '';
+          const body = process.env.PR_BODY || '';
+          const added = parseInt(process.env.ADDED_LINES || '0', 10);
+          const isFork = process.env.PR_IS_FORK === 'true';
+
+          if (/secret|credential|rotate|leak|incident/i.test(title + ' ' + body)) {
+            highest = T4;
+            reasons.add('escalate to T4: title/body mentions secrets or incident');
+          }
+          if (/bypass.*check|skip.*review/i.test(body)) {
+            highest = T4;
+            reasons.add('escalate to T4: PR body asks to bypass a check');
+          }
+          if (added > 1000 && highest < T4) {
+            highest = Math.min(T4, highest + 1);
+            reasons.add(`escalate one tier: ${added} lines added`);
+          }
+          if (isFork && highest < T4) {
+            highest = Math.min(T4, highest + 1);
+            reasons.add('escalate one tier: PR from fork');
+          }
+
+          const labelName = `tier:${TIER_NAMES[highest]}`;
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `tier=${highest}\nlabel=${labelName}\nreasons=${[...reasons].join(' · ')}\n`);
+          console.log(`Classified: ${labelName} (T${highest})`);
+          for (const r of reasons) console.log(`  - ${r}`);
+          NODE
+
+      - name: Ensure tier labels exist
+        run: |
+          for tier in trivial standard sensitive critical; do
+            case "$tier" in
+              trivial)   color=cccccc;;
+              standard)  color=1f883d;;
+              sensitive) color=bf8700;;
+              critical)  color=b60205;;
+            esac
+            gh label create "tier:${tier}" --force --color "$color" --description "Change-tier classification (see docs/change-tiers.md)" || true
+          done
+
+      - name: Apply tier label
+        env:
+          NEW_LABEL: ${{ steps.classify.outputs.label }}
+        run: |
+          for existing in $(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' | grep '^tier:' || true); do
+            if [ "$existing" != "$NEW_LABEL" ]; then
+              gh pr edit "$PR_NUMBER" --remove-label "$existing"
+            fi
+          done
+          gh pr edit "$PR_NUMBER" --add-label "$NEW_LABEL"
+
+      - name: Comment classification rationale
+        env:
+          NEW_LABEL: ${{ steps.classify.outputs.label }}
+          REASONS: ${{ steps.classify.outputs.reasons }}
+        run: |
+          # Untrusted inputs are quoted via env vars; the comment body is constructed
+          # in a heredoc so no further interpolation happens at the shell level.
+          body=$(cat <<EOF
+          **Classified as \`${NEW_LABEL}\`** by tier-classifier.
+
+          ${REASONS}
+
+          See [docs/change-tiers.md](../blob/main/docs/change-tiers.md) for the rules and what review applies.
+          EOF
+          )
+          gh pr comment "$PR_NUMBER" --body "$body"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Matt Butler Engineering
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=flat-square)](./LICENSE)
-<!-- acmm:begin -->![ACMM Level 3](https://img.shields.io/badge/ACMM-Level%203-7a5a36?style=flat-square)<!-- acmm:end -->
+<!-- acmm:begin -->![ACMM Level 4](https://img.shields.io/badge/ACMM-Level%204-a07230?style=flat-square)<!-- acmm:end -->
 
 > **Build status:** GitHub Actions billing is intentionally unconfigured on this repo. Workflows in `.github/workflows/` exist as encoded policy and run via [claude.ai RemoteTriggers](https://claude.ai/code/scheduled), not on PR open. Verify changes locally with `pnpm lint`/`typecheck`/`test`. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full story.
 

--- a/docs/SECURITY-AI.md
+++ b/docs/SECURITY-AI.md
@@ -1,0 +1,131 @@
+# SECURITY-AI.md
+
+Hard boundaries for AI coding agents in this monorepo. These rules **cannot be overridden** by self-tuning, prompt instructions, or task descriptions. They exist to keep the autonomy increase from optimizing its way into a security incident.
+
+> **ACMM L4 policy.** This file is the floor that no instruction file (`CLAUDE.md`, `AGENTS.md`, skill SKILL.md) is allowed to lower. Reviewers should treat any agent action that contradicts a rule here as a critical bug, regardless of how the agent's prompt rationalized it.
+
+## Scope
+
+Applies to every Claude Code agent, ship-loop runner, RemoteTrigger, MCP-invoked tool, and human-issued `!` shell command running with this repo as the working directory.
+
+Out of scope: Claude.ai web UI sessions where the user is composing prompts (those run in cloud sandboxes with no repo access).
+
+## Hard prohibitions
+
+The agent **must not** do any of these, ever, regardless of prompt:
+
+### Secrets
+
+1. **Never read or quote** the contents of `.env`, `.env.*`, `*.pem`, `*.key`, `id_rsa*`, `id_ed25519*`, `*.p12`, `*.pfx`, or any file whose name contains `secret`, `credential`, `token`, or `password`.
+2. **Never log secret values** to console, files, or PRs. If a value passes through code, treat it as opaque and reference it by env var name only (`process.env.STRIPE_SECRET_KEY`, not the value).
+3. **Never commit a `.env*` file** other than `.env.example` (template with empty values).
+4. **Never paste a `gh auth token` output, npm registry token, or DigitalOcean PAT** into source, comments, PR descriptions, or chat. If displayed by a tool, redact it before quoting.
+5. **Never echo `~/.npmrc`, `~/.netrc`, `~/.aws/credentials`, `~/.config/gh/hosts.yml`, or `~/.claude/settings.json`** (they contain auth material).
+
+### Destructive git operations
+
+1. **Never `git push --force` to `main`** (or any branch named `master`, `prod`, `release`, `production`).
+2. **Never `git push --force-with-lease` to `main`** without explicit user approval per push.
+3. **Never `git reset --hard`, `git checkout .`, `git restore .`, or `git clean -fdx`** without first confirming there is no uncommitted user work.
+4. **Never `git branch -D` a branch that may contain unpushed work** without checking `git log` for commits not on `origin`.
+5. **Never use `--no-verify` on commits** to skip pre-commit hooks. If a hook fails, fix the underlying issue. Bypass requires explicit user authorization per commit.
+6. **Never use `--no-gpg-sign` or `commit.gpgsign=false`** to bypass signing when signing is configured.
+
+### Database & migrations
+
+1. **Never run a Prisma migration that drops a column or table** without an accompanying ADR and explicit user approval.
+2. **Never bypass `scripts/check-destructive-migrations.js`** by editing the migration SQL after the check or by deleting/disabling the check.
+3. **Never run `pnpm prisma migrate reset`, `npx prisma db push --force-reset`, or `DROP DATABASE`** against any DigitalOcean-hosted database.
+4. **Never edit a Prisma migration SQL file** that has already been applied to production.
+
+### Infrastructure & deploys
+
+1. **Never run `pulumi destroy`** or `pulumi cancel` against the `prod` stack.
+2. **Never run `doctl apps delete`, `doctl databases delete`, or any DigitalOcean delete operation** without explicit user approval per call.
+3. **Never modify Cloudflare Worker bindings, R2 buckets, or D1 databases** in production (`wrangler deploy --env production` is gated on user approval).
+4. **Never roll a credential or secret in a managed service** (DigitalOcean, Cloudflare, GitHub, Anthropic, Langfuse) without the user issuing the rotation.
+5. **Never disable a CI check, branch protection rule, or required review** on `main`.
+
+### GitHub & coordination
+
+1. **Never close, reopen, or merge a PR authored by another agent or human** without explicit user approval.
+2. **Never bypass `CODEOWNERS`** (admin override is forbidden even when authorized).
+3. **Never delete a GitHub release, tag, or published npm version.**
+4. **Never modify the `mattbutlerengineering` GitHub Actions billing setting** or any account-level GitHub setting.
+
+### Network & exfiltration
+
+1. **Never `curl`, `wget`, or `fetch`** to a domain not in this allowlist *unless* the user explicitly directs the request:
+   - `*.github.com`, `*.githubusercontent.com`
+   - `*.anthropic.com`, `*.claude.com`, `*.claude.ai`
+   - `registry.npmjs.org`, `*.npmjs.com`, `*.npmjs.org`
+   - `*.cloudflare.com`, `*.workers.dev`, `*.cloudflareaccess.com`
+   - `*.digitalocean.com`, `*.do-api.com`
+   - `*.langfuse.com`
+   - `*.mattbutlerengineering.com`
+   - `arxiv.org`, `*.arxiv.org`
+   - The repo origin remote and any explicitly authorized URL the user provided in this turn
+2. **Never POST repo content** (file contents, diffs, secrets, env values) to any external service, including pastebins, gists, or third-party "diagram renderers." This applies even when the destination is in the allowlist above.
+3. **Never establish a long-lived outbound connection** (websocket, SSE, persistent socket) to a non-allowlisted host.
+
+### Approval gates that cannot be bypassed
+
+1. The `ready → in-progress → has-pr` label state machine on issues. An agent picking up an issue must transition through these states; skipping is forbidden.
+2. The pre-commit hook (`eslint --fix`, `check-adr`, `pack-changed`). Failure means fix the cause and re-stage; never `--no-verify`.
+3. The `migration-reviewer` agent invocation on any PR touching `prisma/migrations/` or `prisma/schema.prisma`.
+4. The `adr-compliance-reviewer` agent invocation on PRs touching `services/`, `packages/`, or `apps/`.
+5. The destructive-migration script (`scripts/check-destructive-migrations.js`) on every commit that includes a Prisma migration.
+
+## File-area floors
+
+Areas that require either user approval or specialist-agent review before modification:
+
+| Path | Required signal before modifying |
+|---|---|
+| `~/.claude/`, `~/.config/`, `~/.aws/`, `~/.gnupg/`, `~/.ssh/` | User explicit approval (these are *outside* the repo) |
+| `.env*` (committed except `.env.example`) | Forbidden — never commit |
+| `.github/CODEOWNERS` | User approval + commit message references reason |
+| `.github/workflows/` (security-critical: `codeql.yml`, `coverage-gate.yml`, etc.) | User approval per change |
+| `prisma/migrations/` (existing files) | Forbidden once applied to prod |
+| `prisma/schema.prisma` | `migration-reviewer` agent run |
+| `infrastructure/pulumi/` | User approval + ADR for prod-affecting changes |
+| `services/users/src/auth/`, `packages/auth/` | `adr-compliance-reviewer` for any change |
+| `scripts/acmm/backfill-metrics.js` | Forbidden to *execute* (committed but un-runnable per `feat(acmm): add backfill-metrics.js tool — do NOT run for M5.1 gaming`) |
+| `scripts/check-*.js` | User approval — these are the gate enforcement |
+
+## Audit and observability
+
+1. **Langfuse traces** every agent session — task, model, budget, turns, success/failure. The trace ID is the audit primary key.
+2. **`metrics/acmm-pr-history.jsonl`** records PR acceptance over time, used to detect regressions in the agent loop.
+3. **Co-Authored-By attribution** is currently disabled globally in `~/.claude/settings.json`. As a result, agent merges are *not* distinguishable in `git log` from human merges. Until attribution is re-enabled, the audit trail relies on Langfuse session IDs and the `has-pr` label history on closed issues.
+4. **Every PR opened by an agent** must carry a `Closes #N` reference linking it to the originating issue. This is the only durable trail when attribution is off.
+
+## Incident response
+
+If a suspected leak, force-push, or boundary violation is detected:
+
+1. **Stop active agent sessions immediately.** `mbe agent list` → `mbe agent cancel <id>` for any running session, plus disable the affected RemoteTrigger via https://claude.ai/code/routines.
+2. **Snapshot the repo state.** `git rev-parse HEAD`, `git status`, `git stash list`, capture working tree.
+3. **Rotate any potentially exposed credentials** before investigating. Order: GitHub PAT → Anthropic API key → DigitalOcean PAT → Cloudflare API token → npm token → Stripe keys → Langfuse keys.
+4. **Audit recent PRs and commits** for unauthorized changes — last 7 days at minimum, anything in the agent's session window. Use `gh pr list --state all --search "merged:>=YYYY-MM-DD"` and the Langfuse trace UI.
+5. **File a `meta-improvement` issue** documenting what happened and what control failed.
+6. **Update this file** if the incident reveals a missing guardrail.
+
+## Updating this file
+
+Changes to this file require:
+
+1. A PR with `request changes`-blocking review by the user (Matt).
+2. The PR description must include a "Why this loosens/tightens" section.
+3. The change must not weaken any existing prohibition without an explicit, dated user authorization in the PR body.
+
+This file is not modifiable by agents in pursuit of any task. If an agent's work appears to be blocked by a rule here, the correct response is to stop and ask the user — not to edit this file.
+
+## Cross-references
+
+- `docs/review-criteria.md` — the rubric reviewers apply on PRs (calls out Tier 1 security as a must-flag)
+- `docs/change-tiers.md` — risk tiers that route which agents review which changes
+- `.github/workflows/tier-classifier.yml` — the workflow that assigns tiers
+- `scripts/check-destructive-migrations.js` — the script that enforces the prisma rule above
+- `scripts/check-adr.js` — the script that enforces ADR compliance
+- `~/.claude/settings.json` (user) — global attribution and tool-permission settings

--- a/docs/change-tiers.md
+++ b/docs/change-tiers.md
@@ -1,0 +1,114 @@
+# Change Tiers
+
+Risk classification for pull requests in this monorepo. Used by the `tier-classifier` workflow and by reviewers (human and agent) to decide which scrutiny each change deserves.
+
+> **ACMM L4 governance.** Uniform review on every PR is either too strict (slow trivial work) or too loose (under-scrutinizes risky work). This file makes the policy explicit so the system can route appropriately.
+
+## The tiers
+
+| Tier | Label | Routing | Approval needed |
+|---|---|---|---|
+| **T1 — trivial** | `tier:trivial` | Auto-mergeable when CI green | Pre-commit hook only |
+| **T2 — standard** | `tier:standard` | Reviewer agent + human approval | `code-reviewer` agent + 1 human review |
+| **T3 — sensitive** | `tier:sensitive` | Reviewer agent + specialist agents + human approval | `code-reviewer` + at least one specialist (`adr-compliance-reviewer`, `migration-reviewer`, or `silent-failure-hunter`) + 1 human review |
+| **T4 — critical** | `tier:critical` | All of T3, plus an ADR or `meta-improvement` issue documenting why | Same as T3, plus the user (Matt) personally |
+
+The classifier assigns the **highest tier** any matched rule produces. T4 wins over T3 wins over T2 wins over T1.
+
+## Classification rules
+
+Rules are evaluated against the PR diff. Each rule maps a path glob (or a structural property) to a tier.
+
+### T4 — critical
+
+- Any file under `prisma/migrations/` that drops a column, drops a table, or renames without backfill (semantic check by `migration-reviewer`).
+- Any change to `prisma/schema.prisma` that removes or renames a field on a model that has prod data.
+- Any change under `infrastructure/pulumi/` that affects the `prod` stack (changes detected by Pulumi preview).
+- Any change to `.github/CODEOWNERS`, `.github/workflows/codeql.yml`, `.github/workflows/coverage-gate.yml`, or any workflow that gates merge.
+- Any change to `services/users/src/auth/`, `packages/auth/src/middleware/`, or files implementing authorization checks.
+- Any change to `docs/SECURITY-AI.md` (this file's policy peer).
+- Any rotation of secrets, tokens, or API keys via repo changes (env templates, `wrangler.toml` bindings, `pulumi/Pulumi.prod.yaml`).
+- Any cross-cutting change touching ≥ 5 services or apps simultaneously (broad blast radius).
+
+### T3 — sensitive
+
+- New routes or middleware in `services/*` (Fastify) — auth, validation, error handling matter.
+- Changes to `packages/rialto/src/components/*` that modify exported component contracts (props, behavior, events).
+- Changes that modify `package.json` `dependencies` (production deps, including transitive via overrides).
+- Changes to `pnpm.overrides` in the root `package.json` (CVE pins or version locks).
+- Changes to `eslint.config.js`, `tsconfig*.json`, `turbo.json`, or other root-level build/lint config.
+- Changes to `scripts/check-*.js` (the gate-enforcement scripts).
+- Changes to `.husky/*` (pre-commit hook).
+- Changes to `apps/*/wrangler.toml` (Cloudflare Worker config).
+- Database migration that *adds* a column or table (no destructive ops, but still mutates schema).
+- Any `*.test.ts` deletion or `it.skip`/`describe.skip` addition (loosens test coverage).
+
+### T2 — standard
+
+- New components in `packages/rialto/` that don't break existing exports.
+- New utility functions, hooks, or non-public helpers.
+- Changes to existing route handlers that don't alter the auth/validation surface.
+- Bug fixes in business logic with accompanying tests.
+- Changes to `apps/*/src/` that don't touch the wrangler config or auth.
+- New ADRs in `docs/adr/` (status: proposed).
+- Changes to `pnpm.overrides` for `devDependencies` only.
+
+### T1 — trivial
+
+- Documentation-only changes: `*.md` outside `docs/SECURITY-AI.md`, `docs/change-tiers.md`, `docs/review-criteria.md`, and active ADRs.
+- Comment changes, JSDoc updates, README typo fixes.
+- Test-only additions (no production code change in the diff).
+- Changeset additions (`.changeset/*.md`) that don't modify code.
+- Editor config: `.editorconfig`, `.vscode/*`, `.cursorrules` updates.
+- `metrics/*.jsonl` appends (these are append-only logs).
+- Auto-generated files: `llms.txt`, `llms-full.txt`, `package.json` `exports` regeneration after `pnpm release`.
+
+## Modifiers (escalate or de-escalate)
+
+These signals can shift a PR's tier independent of file paths.
+
+**Always escalate to T4:**
+- PR title or body contains "secret", "credential", "rotate", "leak", "incident".
+- PR body explicitly asks reviewers to bypass a check.
+- Author is a new agent (first PR from a new RemoteTrigger or new agent type).
+
+**Escalate one tier:**
+- Diff is > 1000 lines added (size correlates with risk).
+- PR is from a fork (external contributor).
+- PR has been force-pushed since the last review approval.
+- PR removes a test file.
+
+**De-escalate one tier (cap at T2):**
+- Diff is < 20 lines added AND only touches files matching T1 globs.
+- PR is a Dependabot update for a `devDependencies`-only package with patch-version bump.
+- PR is a `chore(deps):` security update with no behavioral change (auto-detected by lockfile-only diff).
+
+## Auto-merge eligibility
+
+Currently, **only T1 PRs with all CI checks green are auto-mergeable**. The auto-merge workflow (`.github/workflows/auto-merge.yml`) is intentionally **not yet wired**. When budget allows GH Actions to run, T1 auto-merge is the first thing to enable.
+
+T2 and above always require human approval. The user (Matt) is the only required reviewer.
+
+## How agents apply this
+
+`tier-classifier` workflow assigns the label automatically on PR open and on every push to the PR branch.
+
+`code-reviewer` agent reads the assigned tier from PR labels and:
+
+1. **T1**: Skim for typos and clarity. Tier 3 nits only.
+2. **T2**: Apply Tiers 1 and 2 of `docs/review-criteria.md`. Skip Tier 3.
+3. **T3**: Spawn the appropriate specialist agents (in parallel, per the file-area table in `review-criteria.md`). Apply Tiers 1 and 2 fully. End with explicit verdict.
+4. **T4**: Spawn all relevant specialists. Apply Tier 1 of the rubric exhaustively. Require an ADR reference in the PR body. Block merge until user (Matt) personally approves.
+
+## When the tiers are wrong
+
+Update this file. Don't carry implicit tier knowledge in your head, and don't manually escalate-by-comment without updating the rules — the next PR with the same shape will get classified the old way.
+
+## Cross-references
+
+- `docs/review-criteria.md` — what to actually look for once a tier is assigned
+- `docs/SECURITY-AI.md` — hard prohibitions that apply to T1 through T4
+- `.github/workflows/tier-classifier.yml` — the workflow that assigns labels
+- `.claude/agents/adr-compliance-reviewer.md`
+- `.claude/agents/migration-reviewer.md`
+- `.claude/plugins/pr-review-toolkit/` — the agent collection


### PR DESCRIPTION
## Summary

Cherry-picks 13 governance artifacts from `chore/acmm-followups` (which was orphaned after PR #619 squash-merged only the rubric portion). The audit now reports **Level 4** (was L3), with L5 at 67%.

## Why these were missing

The `chore/acmm-followups` branch had ~444 files of drift (services/users edits, llms regen, even re-adds the orphan packages I just deleted in #626). Cherry-picking just the artifacts is the clean path forward — the rest of that branch is no longer applicable.

## Audit result after this PR

```
ACMM Level 4 (Adaptive / Structured)  ·  45/85 criteria detected
  ✓ L2: 1/3 (33%)
  ✓ L3: 3/4 (75%)
  ✓ L4: 6/7 (86%)
    L5: 4/6 (67%)
    L6: 0/6 (0%)
```

Two criteria from L5: `acmm:public-metrics` (public metrics endpoint) + `acmm:reflection-log` (`memory/REFLECTIONS.md`, currently gitignored by design).

## Files added

**L4** (6/7 → 86%):
- `.github/workflows/claude.yml` — `@claude` mention dispatcher (encoded policy; runs via RemoteTrigger, not Actions)
- `.github/workflows/{ai-fix,nightly-compliance,auto-label,tier-classifier}.yml`
- `.github/auto-qa-tuning.json` — auto-QA self-tuning thresholds
- `docs/SECURITY-AI.md` — AI agent hard prohibitions (cannot be overridden by prompts)

**L5** (4/6 → 67%):
- `.github/workflows/ai-attribution.yml` — policy-as-code: AI commit attribution
- `.github/policies/{change-tiers,destructive-ops,network-allowlist,secrets}.yaml` + `README.md`
- `docs/change-tiers.md`

**README**: badge regenerated via `node scripts/acmm/audit.js --badge`.

## Note on GH Actions

Per `.claude/rules/gotchas.md`, GitHub Actions billing is intentionally unpaid here. These workflows are **encoded policy**, not active CI. Runtime equivalents fire via `mbe-*` RemoteTriggers on `claude.ai/code/scheduled`. The ACMM rubric scores file presence, not execution.