### PR TITLE
fix(rialto-catalog): add node types + remove unused var to unblock typecheck

### DIFF
--- a/packages/rialto-catalog/src/__tests__/drift-check.test.ts
+++ b/packages/rialto-catalog/src/__tests__/drift-check.test.ts
@@ -9,7 +9,6 @@ const __dirname = path.dirname(__filename);
 
 const packageRoot = path.resolve(__dirname, "../..");
 const generatedFile = path.join(packageRoot, "src/generated-schemas.ts");
-const scriptPath = path.join(packageRoot, "scripts/generate-catalog.ts");
 
 /**
  * Run the generator script via tsx (not a shell command — uses execFileSync).

--- a/packages/rialto-catalog/tsconfig.json
+++ b/packages/rialto-catalog/tsconfig.json
@@ -4,7 +4,8 @@
   "compilerOptions": {
     "noEmit": true,
     "jsx": "react-jsx",
-    "lib": ["ES2022", "DOM"]
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary

Unblocks `pnpm typecheck` workspace-wide. The `packages/rialto-catalog` tsconfig didn't include `@types/node`, so test files using `process`, `node:fs`, `node:path`, `node:url` failed TS2591 (`Cannot find name`).

## Changes

- `packages/rialto-catalog/tsconfig.json`: add `"types": ["node"]` to compilerOptions
- `packages/rialto-catalog/src/__tests__/drift-check.test.ts`: remove unused `scriptPath` const (TS6133 once node types were enabled)

## Verification

- [x] `pnpm --filter @mbe/rialto-catalog typecheck` — clean
- [x] `pnpm typecheck` (workspace) — 26/26 tasks pass
- [x] `pnpm --filter @mbe/rialto-catalog test` — 20/20 pass
- [x] `pnpm lint` (workspace) — clean

## Why this surfaced now

Test runtime uses vitest's auto-provided node globals so the tests never failed at runtime. The TS2591 only fires under `tsc --noEmit`, which only runs when CI is exercised. The fix is two characters away (`"types": ["node"]`) — pure typecheck-side correctness.