### PR TITLE
fix(infra): add node types to Pulumi tsconfig — unblock CI Pulumi Up

### DIFF
--- a/infrastructure/pulumi/tsconfig.json
+++ b/infrastructure/pulumi/tsconfig.json
@@ -7,7 +7,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "types": ["node"]
   },
   "include": ["*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary

Fixes [Pulumi Deploy run 24942330215](https://github.com/mattbutlerengineering/mattbutlerengineering/actions/runs/24942330215/job/73038005067), which crashed at `pulumi up` with TS2591 on `infrastructure/pulumi/index.ts:4`:

```
error TS2591: Cannot find name 'node:fs'.
```

The Pulumi entry point imports `readFileSync` from `"node:fs"`, but the tsconfig didn't enable `@types/node` explicitly. ts-node fails to resolve the import at runtime.

## Why it was invisible

`pnpm typecheck` passes workspace-wide because `infrastructure/pulumi/package.json` has no `typecheck` script — turbo's task graph skips it. The error only surfaces when Pulumi invokes ts-node in CI.

## Changes

- `infrastructure/pulumi/tsconfig.json`: add `"types": ["node"]`

## Verification

- [x] `cd infrastructure/pulumi && npx tsc --noEmit` — clean
- [ ] CI re-runs Pulumi Deploy on merge

## Followups (separate PRs)

- Add a `typecheck` script to `infrastructure/pulumi/package.json` so future drift gets caught locally.
- Audit other workspace packages for missing `typecheck` scripts.