### PR TITLE
fix(ci): unblock 3 workflows rejected at parse-time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
   prepare:
     name: Prepare
     runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
     steps:
       - uses: actions/checkout@v5
@@ -66,16 +69,11 @@ jobs:
           pnpm --filter @mbe/agent-service db:generate
 
       - name: Login to Turborepo Remote Cache
-        if: secrets.TURBO_TOKEN != ''
-        env:
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+        if: env.TURBO_TOKEN != ''
         run: pnpm turbo login --token "$TURBO_TOKEN"
 
       - name: Link to Turborepo Remote Cache
-        if: secrets.TURBO_TOKEN != ''
-        env:
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+        if: env.TURBO_TOKEN != ''
         run: pnpm turbo link --team "$TURBO_TEAM" --token "$TURBO_TOKEN"
 
   hadolint:

--- a/.github/workflows/circuit-breaker.yml
+++ b/.github/workflows/circuit-breaker.yml
@@ -84,18 +84,21 @@ jobs:
       - name: Create issue on circuit trip
         if: steps.check.outputs.blocked == 'true'
         run: |
+          {
+            echo "The deploy circuit breaker has tripped after 2+ consecutive failures."
+            echo
+            echo "Deployments are blocked until manually approved."
+            echo
+            echo "To force a deploy, run:"
+            echo
+            echo '```'
+            echo "gh workflow run circuit-breaker.yml -f force=true"
+            echo '```'
+          } > /tmp/circuit-body.md
           gh issue create \
             --title "Circuit breaker tripped - deploys blocked" \
             --label "ci-fix,blocking" \
-            --body "The deploy circuit breaker has tripped after 2+ consecutive failures.
-
-Deployments are blocked until manually approved.
-
-To force a deploy, run:
-```
-gh workflow run circuit-breaker.yml -f force=true
-```
-"
+            --body-file /tmp/circuit-body.md
 
   block-deploy:
     needs: [circuit-breaker]

--- a/.github/workflows/dependency-freshness.yml
+++ b/.github/workflows/dependency-freshness.yml
@@ -33,23 +33,24 @@ jobs:
 
       - name: Create issue
         if: steps.check.outputs.count != '0'
+        env:
+          OUTDATED_JSON: ${{ steps.check.outputs.outdated }}
         run: |
           DATE=$(date "+%B %Y")
-          
-          ISSUE_BODY="## Outdated Dependencies ($DATE)
-          
-The following dependencies have updates available:
-          
-\`\`\`
-${{ steps.check.outputs.outdated }}
-\`\`\`
-          
-Consider updating these dependencies to stay current.
-"
-          
+          {
+            echo "## Outdated Dependencies ($DATE)"
+            echo
+            echo "The following dependencies have updates available:"
+            echo
+            echo '```'
+            echo "$OUTDATED_JSON"
+            echo '```'
+            echo
+            echo "Consider updating these dependencies to stay current."
+          } > /tmp/freshness-body.md
           gh issue create \
             --title "Dependency freshness: $DATE" \
-            --body "$ISSUE_BODY" \
+            --body-file /tmp/freshness-body.md \
             --label "dependencies"
 
       - name: Update existing issue


### PR DESCRIPTION
## Summary

Three workflows on main were failing instantly (0-sec runs, 0 jobs, "failure" conclusion, name rendered as file path) — GitHub's runner was rejecting them at parse time.

`actionlint` pinpointed three distinct issues:

| Workflow | Issue | Fix |
|---|---|---|
| `ci.yml` | `if: secrets.TURBO_TOKEN != ''` on step level — `secrets` context isn't available in step `if` | Hoisted `TURBO_TOKEN` + `TURBO_TEAM` to job-level `env`, changed step `if` to use `env.TURBO_TOKEN` |
| `circuit-breaker.yml` | Bash multi-line string in `run: |` had lines at column 1, breaking the YAML block scalar | Rewrote using `{ echo ...; }` block writing to file → `gh issue create --body-file` |
| `dependency-freshness.yml` | Same YAML block-scalar bug, plus inline `${{ ... }}` interpolation that triggered the security hook | Same `{ echo ...; }` rewrite + moved `${{ steps.check.outputs.outdated }}` to an env var (workflow-injection-prevention pattern) |

## Why this matters

These three workflows have been silently failing on every push. They appear in `gh run list` as failures, which made the CI dashboard look broken even when actual code was fine. The 0-second + path-as-name pattern is the diagnostic.

## Verification

- [x] `actionlint` exit 0 on all three after the fix
- [ ] CI re-runs them on merge — that's the actual proof