### PR TITLE
fix(ci): unblock 3 more workflows with same multi-line bash bug

### DIFF
--- a/.github/workflows/backup-verify.yml
+++ b/.github/workflows/backup-verify.yml
@@ -86,22 +86,25 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          {
+            echo "## Backup Verification Failed"
+            echo
+            echo "The weekly database schema validation test failed."
+            echo
+            echo "**Run:** ${RUN_URL}"
+            echo "**Date:** $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo
+            echo "### Next Steps"
+            echo "1. Check workflow logs for the specific failure"
+            echo "2. Verify Prisma schema files are valid"
+            echo "3. Run \`prisma db push\` locally to reproduce"
+            echo
+            echo "---"
+            echo "*Auto-created by backup-verify workflow*"
+          } > /tmp/backup-body.md
           gh issue create \
             --repo "$GITHUB_REPOSITORY" \
             --title "Database backup verification failed" \
             --label "ci-fix" \
             --label "ready" \
-            --body "## Backup Verification Failed
-
-The weekly database schema validation test failed.
-
-**Run:** ${RUN_URL}
-**Date:** $(date -u +%Y-%m-%dT%H:%M:%SZ)
-
-### Next Steps
-1. Check workflow logs for the specific failure
-2. Verify Prisma schema files are valid
-3. Run \`prisma db push\` locally to reproduce
-
----
-*Auto-created by backup-verify workflow*"
+            --body-file /tmp/backup-body.md

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -47,23 +47,26 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           TRIGGER_NAME: ${{ github.event.workflow_run.name }}
         run: |
+          {
+            echo "## Smoke Test Failure"
+            echo
+            echo "Post-deploy smoke tests failed after a successful deploy."
+            echo
+            echo "**Run:** ${RUN_URL}"
+            echo "**Date:** $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "**Trigger:** ${TRIGGER_NAME:-manual}"
+            echo
+            echo "### Next Steps"
+            echo "1. Check test artifacts for failure screenshots"
+            echo "2. Verify deploy didn't break critical user flows"
+            echo "3. Consider rollback if critical paths are broken"
+            echo
+            echo "---"
+            echo "*Auto-created by smoke-tests workflow*"
+          } > /tmp/smoke-body.md
           gh issue create \
             --repo "$GITHUB_REPOSITORY" \
             --title "Post-deploy smoke tests failed" \
             --label "ci-fix" \
             --label "ready" \
-            --body "## Smoke Test Failure
-
-Post-deploy smoke tests failed after a successful deploy.
-
-**Run:** ${RUN_URL}
-**Date:** $(date -u +%Y-%m-%dT%H:%M:%SZ)
-**Trigger:** ${TRIGGER_NAME:-manual}
-
-### Next Steps
-1. Check test artifacts for failure screenshots
-2. Verify deploy didn't break critical user flows
-3. Consider rollback if critical paths are broken
-
----
-*Auto-created by smoke-tests workflow*"
+            --body-file /tmp/smoke-body.md

--- a/.github/workflows/synthetic-monitoring.yml
+++ b/.github/workflows/synthetic-monitoring.yml
@@ -231,74 +231,56 @@ jobs:
           DEPLOY_STATUS=$(echo "$HEALTH_RESPONSE" | jq -r '.subsystems.deploys.status')
 
           SUMMARY=""
-          RUNBOOKS=""
-
-          if [ -n "$FAILED_SERVICES" ]; then
-            SUMMARY="${SUMMARY}Services down: ${FAILED_SERVICES}. "
-            if [ -f docs/runbooks/services-unhealthy.md ]; then
-              RUNBOOKS="${RUNBOOKS}$(cat docs/runbooks/services-unhealthy.md)
-
-"
-            fi
-          fi
-          if [ -n "$FAILED_SITES" ]; then
-            SUMMARY="${SUMMARY}Static sites down: ${FAILED_SITES}. "
-            if [ -f docs/runbooks/static-sites-unhealthy.md ]; then
-              RUNBOOKS="${RUNBOOKS}$(cat docs/runbooks/static-sites-unhealthy.md)
-
-"
-            fi
-          fi
-          if [ "$CI_STATUS" != "healthy" ]; then
-            SUMMARY="${SUMMARY}CI: ${CI_STATUS}. "
-            if [ -f docs/runbooks/ci-unhealthy.md ]; then
-              RUNBOOKS="${RUNBOOKS}$(cat docs/runbooks/ci-unhealthy.md)
-
-"
-            fi
-          fi
-          if [ "$DEPLOY_STATUS" != "healthy" ]; then
-            SUMMARY="${SUMMARY}Deploys: ${DEPLOY_STATUS}. "
-            if [ -f docs/runbooks/deploys-unhealthy.md ]; then
-              RUNBOOKS="${RUNBOOKS}$(cat docs/runbooks/deploys-unhealthy.md)
-
-"
-            fi
-          fi
+          [ -n "$FAILED_SERVICES" ] && SUMMARY="${SUMMARY}Services down: ${FAILED_SERVICES}. "
+          [ -n "$FAILED_SITES" ] && SUMMARY="${SUMMARY}Static sites down: ${FAILED_SITES}. "
+          [ "$CI_STATUS" != "healthy" ] && SUMMARY="${SUMMARY}CI: ${CI_STATUS}. "
+          [ "$DEPLOY_STATUS" != "healthy" ] && SUMMARY="${SUMMARY}Deploys: ${DEPLOY_STATUS}. "
 
           TITLE="System health ${HEALTH_STATUS}: ${SUMMARY}"
           TITLE="${TITLE:0:256}"
           DETECTED=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-          # Build timeline section
-          TIMELINE_SECTION=""
-          if [ -n "$TIMELINE" ]; then
-            TIMELINE_SECTION="### Recent Status Transitions
-
-${TIMELINE}
-
-"
-          fi
-
-          BODY="## System Health Alert
-
-**Status:** \`${HEALTH_STATUS}\`
-**Detected:** ${DETECTED}
-**Source:** Synthetic monitoring (twice daily)
-
-To check current status: \`curl -s https://mattbutlerengineering.com/health/system | jq .\`
-
-${TIMELINE_SECTION}---
-
-${RUNBOOKS}
-
----
-*This issue was auto-created by synthetic monitoring. It will be picked up by the ship-loop or issue-worker.*"
+          {
+            echo "## System Health Alert"
+            echo
+            echo "**Status:** \`${HEALTH_STATUS}\`"
+            echo "**Detected:** ${DETECTED}"
+            echo "**Source:** Synthetic monitoring (twice daily)"
+            echo
+            echo "To check current status: \`curl -s https://mattbutlerengineering.com/health/system | jq .\`"
+            echo
+            if [ -n "$TIMELINE" ]; then
+              echo "### Recent Status Transitions"
+              echo
+              echo "${TIMELINE}"
+              echo
+            fi
+            echo "---"
+            echo
+            if [ -n "$FAILED_SERVICES" ] && [ -f docs/runbooks/services-unhealthy.md ]; then
+              cat docs/runbooks/services-unhealthy.md
+              echo
+            fi
+            if [ -n "$FAILED_SITES" ] && [ -f docs/runbooks/static-sites-unhealthy.md ]; then
+              cat docs/runbooks/static-sites-unhealthy.md
+              echo
+            fi
+            if [ "$CI_STATUS" != "healthy" ] && [ -f docs/runbooks/ci-unhealthy.md ]; then
+              cat docs/runbooks/ci-unhealthy.md
+              echo
+            fi
+            if [ "$DEPLOY_STATUS" != "healthy" ] && [ -f docs/runbooks/deploys-unhealthy.md ]; then
+              cat docs/runbooks/deploys-unhealthy.md
+              echo
+            fi
+            echo "---"
+            echo "*This issue was auto-created by synthetic monitoring. It will be picked up by the ship-loop or issue-worker.*"
+          } > /tmp/health-body.md
 
           gh issue create \
             --repo "$GITHUB_REPOSITORY" \
             --title "$TITLE" \
-            --body "$BODY" \
+            --body-file /tmp/health-body.md \
             --label "$ISSUE_LABEL" \
             --label "auto-health" \
             --label "ready"


### PR DESCRIPTION
## Summary

Same root cause as #639 — these 3 workflows were silently failing at parse-time with the diagnostic 0-second-run + path-as-name + 0-jobs pattern. Multi-line bash strings inside `run: |` blocks where lines past the first were at column 1 broke the YAML block scalar.

| Workflow | Files | Fix |
|---|---|---|
| `smoke-tests.yml` | 1 multi-line `--body "..."` | `{ echo ...; } > file` + `--body-file` |
| `backup-verify.yml` | 1 multi-line `--body "..."` | same |
| `synthetic-monitoring.yml` | 4 RUNBOOKS multi-lines + 1 TIMELINE_SECTION + 1 BODY | Same pattern; also collapsed the if-chain into one-liners since the multi-line behavior was no longer needed |

Equivalent behavior — same issue body markdown, same conditional branches, just YAML-correct shell construction.

## Verification

- [x] `actionlint` exit 0 on all three (only shellcheck STYLE warnings remain — pre-existing, unrelated)
- [ ] CI re-runs them on merge — proof point

## Why this took two PRs

#639 caught the 3 workflows that were failing on the previous commit. Once those landed, more workflows fired on the next push and surfaced 3 more with the same pattern. With this PR all 6 should be parse-clean.