### PR TITLE
fix(ci): lazy DATABASE_URL in prisma.config so generate works without DB

### DIFF
--- a/services/agent/prisma.config.ts
+++ b/services/agent/prisma.config.ts
@@ -1,8 +1,15 @@
-import { defineConfig, env } from "prisma/config";
+import { defineConfig } from "prisma/config";
+
+// Lazy DATABASE_URL: prisma/config's env() helper throws at load time when
+// the var is unset, breaking `prisma generate` in CI where no database is
+// configured. The placeholder lets load succeed; verbs that actually open a
+// connection (db push, migrate dev/deploy) will fail with a proper connection
+// error if DATABASE_URL was never set.
+const url =
+  process.env.DATABASE_URL ??
+  "postgresql://placeholder:placeholder@localhost:5432/placeholder";
 
 export default defineConfig({
   schema: "prisma/schema.prisma",
-  datasource: {
-    url: env("DATABASE_URL"),
-  },
+  datasource: { url },
 });

--- a/services/reservations/prisma.config.ts
+++ b/services/reservations/prisma.config.ts
@@ -1,8 +1,15 @@
-import { defineConfig, env } from "prisma/config";
+import { defineConfig } from "prisma/config";
+
+// Lazy DATABASE_URL: prisma/config's env() helper throws at load time when
+// the var is unset, breaking `prisma generate` in CI where no database is
+// configured. The placeholder lets load succeed; verbs that actually open a
+// connection (db push, migrate dev/deploy) will fail with a proper connection
+// error if DATABASE_URL was never set.
+const url =
+  process.env.DATABASE_URL ??
+  "postgresql://placeholder:placeholder@localhost:5432/placeholder";
 
 export default defineConfig({
   schema: "prisma/schema.prisma",
-  datasource: {
-    url: env("DATABASE_URL"),
-  },
+  datasource: { url },
 });

--- a/services/users/prisma.config.ts
+++ b/services/users/prisma.config.ts
@@ -1,8 +1,15 @@
-import { defineConfig, env } from "prisma/config";
+import { defineConfig } from "prisma/config";
+
+// Lazy DATABASE_URL: prisma/config's env() helper throws at load time when
+// the var is unset, breaking `prisma generate` in CI where no database is
+// configured. The placeholder lets load succeed; verbs that actually open a
+// connection (db push, migrate dev/deploy) will fail with a proper connection
+// error if DATABASE_URL was never set.
+const url =
+  process.env.DATABASE_URL ??
+  "postgresql://placeholder:placeholder@localhost:5432/placeholder";
 
 export default defineConfig({
   schema: "prisma/schema.prisma",
-  datasource: {
-    url: env("DATABASE_URL"),
-  },
+  datasource: { url },
 });


### PR DESCRIPTION
## Summary

Unblocks the CI **Prepare** job, which was failing in 33 seconds with:

```
Failed to load config file ".../services/users" as a TypeScript/JavaScript module.
Error: PrismaConfigEnvError: Cannot resolve environment variable: DATABASE_URL.
```

`prisma/config`'s `env()` helper throws at config-load time when the variable is unset. CI only runs `prisma generate` (client generation, no DB connection needed) but still has to load the config — so the throw blocks everything that depends on the Prepare job.

## Approach

Switched all 3 services' `prisma.config.ts` from:

```ts
import { defineConfig, env } from "prisma/config";
export default defineConfig({
  schema: "prisma/schema.prisma",
  datasource: { url: env("DATABASE_URL") },
});
```

To:

```ts
import { defineConfig } from "prisma/config";
const url = process.env.DATABASE_URL ?? "postgresql://placeholder:...";
export default defineConfig({
  schema: "prisma/schema.prisma",
  datasource: { url },
});
```

## Effects

| Verb | Before | After |
|---|---|---|
| `prisma generate` | ❌ throws | ✅ succeeds (no DB needed) |
| `prisma validate` | ❌ throws | ✅ succeeds |
| `prisma db push` | ❌ throws | ❌ fails on connect (intended) |
| `prisma migrate dev/deploy` | ❌ throws | ❌ fails on connect (intended) |

Production unchanged: DO sets `DATABASE_URL` for all 3 services, so the placeholder never gets used in real environments.

## Verification

```
$ unset DATABASE_URL
$ pnpm --filter @mbe/users-service db:generate
✔ Generated Prisma Client (v7.8.0) to ./src/generated/prisma in 54ms
$ pnpm --filter @mbe/reservations-service db:generate
✔ Generated Prisma Client
$ pnpm --filter @mbe/agent-service db:generate
✔ Generated Prisma Client
```

CI Prepare job should now pass.