### PR TITLE
fix(ci): silence false-positive SC2016 in migrate Dockerfile

### DIFF
--- a/infrastructure/migrate/Dockerfile
+++ b/infrastructure/migrate/Dockerfile
@@ -23,6 +23,9 @@ COPY services/agent/prisma.config.ts ./services/agent/prisma.config.ts
 # Inline migration script (avoids .dockerignore excluding infrastructure/).
 # SERVICE_NAME selects which service's migrations to run; cd into the service
 # dir so Prisma 7 auto-discovers prisma.config.ts (which provides DATABASE_URL).
+# Single quotes around the printf format are intentional — $SERVICE_NAME must
+# be written literally into /migrate.sh, not expanded at Docker build time.
+# hadolint ignore=SC2016
 RUN printf '#!/bin/sh\nset -e\nif [ -z "$SERVICE_NAME" ]; then\n  echo "ERROR: SERVICE_NAME env var is required" >&2\n  exit 1\nfi\necho "Running $SERVICE_NAME migrations..."\ncd "/app/services/$SERVICE_NAME"\nprisma migrate deploy\necho "$SERVICE_NAME migrations complete."\n' > /migrate.sh && chmod +x /migrate.sh
 
 CMD ["/migrate.sh"]


### PR DESCRIPTION
## Summary

The CI **Dockerfile Lint** job fails on `infrastructure/migrate/Dockerfile:26` with:

```
SC2016 info: Expressions don't expand in single quotes, use double quotes for that.
```

This is a **false positive**. The single quotes around the `printf` format string are intentional — we want `$SERVICE_NAME` written literally into `/migrate.sh`, not expanded at Docker build time. Switching to double quotes would break the script.

## Fix

Added a `# hadolint ignore=SC2016` inline directive with a comment explaining the reasoning.

## Verification

```
$ docker run --rm -i hadolint/hadolint < infrastructure/migrate/Dockerfile
(no output)
$ echo $?
0
```