### PR TITLE
perf(rialto-web): split vendor chunks for better bundle caching

### DIFF
--- a/apps/rialto-web/vite.config.ts
+++ b/apps/rialto-web/vite.config.ts
@@ -16,6 +16,15 @@ export default defineConfig({
   ],
   build: {
     sourcemap: true,
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          "vendor-react": ["react", "react-dom", "react-router-dom"],
+          "vendor-motion": ["framer-motion"],
+          "vendor-icons": ["lucide-react"],
+        },
+      },
+    },
   },
   css: {
     modules: {


### PR DESCRIPTION
## Summary

- Adds `rollupOptions.output.manualChunks` to `apps/rialto-web/vite.config.ts`
- Splits `react`/`react-dom`/`react-router-dom`, `framer-motion`, and `lucide-react` into dedicated vendor chunks
- Vendor code changes far less often than app code — isolating it lets the browser cache those chunks independently across deploys

## Context

Lighthouse desktop audit scored `/rialto` at **0.66 performance** (threshold: 0.9), flagging 444 KiB of unused JavaScript on initial load. Investigation found:

- Route-level code splitting with `React.lazy` is already correctly implemented for all 60+ component pages
- The unused JS is primarily the large vendor libraries (`framer-motion` ~119 KiB, `react`/`react-dom`, `lucide-react`) bundled into the main `index` chunk
- The `framer-motion` chunk is loaded eagerly because `RialtoProvider`, `GlobalNav`, and `Footer` (all part of the app shell) depend on it

This PR addresses the chunk organisation gap. The remaining performance headroom (reducing framer-motion eager load) requires upstream changes to the rialto library (e.g. `LazyMotion` + `domAnimation` feature splitting), which is tracked separately.

## Test plan

- [ ] Run `pnpm --dir apps/rialto-web build` and confirm three new named vendor chunks appear in `dist/assets/`: `vendor-react-*.js`, `vendor-motion-*.js`, `vendor-icons-*.js`
- [ ] Verify the app loads and navigates correctly in a local `vite preview`
- [ ] Re-run Lighthouse and confirm the performance score improves (vendor chunks are now cacheable across deploys)

Closes #621

https://claude.ai/code/session_01EKvgJqY879Deh84u8oxf3P

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKvgJqY879Deh84u8oxf3P)_