### PR TITLE
fix(ci): include workspace node_modules in cache + defensive install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,12 @@ jobs:
         id: cache-node-modules
         uses: actions/cache@v4
         with:
-          path: node_modules
+          path: |
+            node_modules
+            packages/*/node_modules
+            apps/*/node_modules
+            services/*/node_modules
+            tools/*/node_modules
           key: node-modules-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies
@@ -143,8 +148,20 @@ jobs:
       - name: Restore node_modules
         uses: actions/cache@v4
         with:
-          path: node_modules
+          path: |
+            node_modules
+            packages/*/node_modules
+            apps/*/node_modules
+            services/*/node_modules
+            tools/*/node_modules
           key: node-modules-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Ensure dependencies installed
+        # Defensive — root-level node_modules cache often hits but
+        # workspace-package node_modules symlinks can go missing,
+        # leaving turbo unable to resolve transitive deps. A frozen
+        # install is a fast no-op on cache hit and a real install on miss.
+        run: pnpm install --frozen-lockfile
 
       - run: pnpm lint
 
@@ -166,8 +183,16 @@ jobs:
       - name: Restore node_modules
         uses: actions/cache@v4
         with:
-          path: node_modules
+          path: |
+            node_modules
+            packages/*/node_modules
+            apps/*/node_modules
+            services/*/node_modules
+            tools/*/node_modules
           key: node-modules-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Ensure dependencies installed
+        run: pnpm install --frozen-lockfile
 
       - name: Restore Prisma clients
         uses: actions/cache@v4
@@ -202,8 +227,16 @@ jobs:
       - name: Restore node_modules
         uses: actions/cache@v4
         with:
-          path: node_modules
+          path: |
+            node_modules
+            packages/*/node_modules
+            apps/*/node_modules
+            services/*/node_modules
+            tools/*/node_modules
           key: node-modules-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Ensure dependencies installed
+        run: pnpm install --frozen-lockfile
 
       - name: Run ADR and Dependency Checks
         run: |
@@ -229,8 +262,16 @@ jobs:
       - name: Restore node_modules
         uses: actions/cache@v4
         with:
-          path: node_modules
+          path: |
+            node_modules
+            packages/*/node_modules
+            apps/*/node_modules
+            services/*/node_modules
+            tools/*/node_modules
           key: node-modules-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Ensure dependencies installed
+        run: pnpm install --frozen-lockfile
 
       - name: Restore Prisma clients
         uses: actions/cache@v4
@@ -295,8 +336,16 @@ jobs:
       - name: Restore node_modules
         uses: actions/cache@v4
         with:
-          path: node_modules
+          path: |
+            node_modules
+            packages/*/node_modules
+            apps/*/node_modules
+            services/*/node_modules
+            tools/*/node_modules
           key: node-modules-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Ensure dependencies installed
+        run: pnpm install --frozen-lockfile
 
       - name: Restore Prisma clients
         uses: actions/cache@v4
@@ -353,8 +402,16 @@ jobs:
       - name: Restore node_modules
         uses: actions/cache@v4
         with:
-          path: node_modules
+          path: |
+            node_modules
+            packages/*/node_modules
+            apps/*/node_modules
+            services/*/node_modules
+            tools/*/node_modules
           key: node-modules-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Ensure dependencies installed
+        run: pnpm install --frozen-lockfile
 
       - name: Restore Prisma clients
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary

CI's `lint`, `typecheck`, `architecture-audit`, `build`, `test`, and `migrations` jobs were all failing on every PR (including newly-opened #644 and #643). Root cause: cache-restore was missing the workspace symlinks.

## Root cause

Each job restored only root `node_modules` from cache:

```yaml
path: node_modules
```

But pnpm workspaces store deps in **two** layers:
- `node_modules/` (root, hoisted)
- `packages/*/node_modules/`, `apps/*/node_modules/`, `services/*/node_modules/`, `tools/*/node_modules/` (per-workspace symlinks into `node_modules/.pnpm/`)

A "cache hit" restored the root layer but the workspace symlinks were silently absent. pnpm/turbo emitted `WARN  Local package.json exists, but node_modules missing` and TypeScript failed across workspaces:

```
src/fastify.ts: error TS2664: Invalid module name in augmentation, module 'fastify' cannot be found.
tsconfig.json: error TS6053: File '@mbe/config/typescript/node' not found.
```

…even though `package.json` correctly declared the deps.

## Fix (per affected job, plus the prepare job that writes the cache)

**1. Cache the workspace symlinks too:**

```yaml
path: |
  node_modules
  packages/*/node_modules
  apps/*/node_modules
  services/*/node_modules
  tools/*/node_modules
```

**2. Add a defensive `pnpm install --frozen-lockfile` after restore:**

Cache hit = fast no-op (~5s). Cache miss = real install. Either way, deps are guaranteed available.

## Jobs patched

- `prepare` (cache write)
- `lint`
- `typecheck`
- `architecture-audit`
- `build`
- `test`
- `migrations`

## Test plan

- [ ] CI runs all 7 jobs to completion (no `node_modules missing` warnings)
- [ ] After merge, rebase #644 + #643 → their CI passes too

## Unblocks

- #644 — feat(acmm): promote to Level 6 (Fully Autonomous)
- #643 — perf(rialto-web): split vendor chunks for better bundle caching
- Future PRs that were inheriting the same failures from main