### PR TITLE
feat(acmm): measure CI flake rate as behavioral signal (#646)

### DIFF
--- a/scripts/acmm/__tests__/flake-rate.test.js
+++ b/scripts/acmm/__tests__/flake-rate.test.js
@@ -1,0 +1,120 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { computeFlakeRate } from "../flake-rate.js";
+
+const NOW = new Date("2026-04-26T12:00:00Z");
+const WITHIN_WINDOW = "2026-04-25T12:00:00Z"; // 1 day ago
+const OUTSIDE_WINDOW = "2026-03-20T12:00:00Z"; // ~37 days ago
+
+test("computeFlakeRate: empty input → zero rate, zero sample, no flakes", () => {
+  const r = computeFlakeRate([], { now: NOW });
+  assert.equal(r.flake_rate_30d, 0);
+  assert.equal(r.flake_sample_size, 0);
+  assert.deepEqual(r.flaky_shas, []);
+});
+
+test("computeFlakeRate: all-success → zero rate", () => {
+  const runs = [
+    { headSha: "aaa", conclusion: "success", createdAt: WITHIN_WINDOW },
+    { headSha: "bbb", conclusion: "success", createdAt: WITHIN_WINDOW },
+    { headSha: "ccc", conclusion: "success", createdAt: WITHIN_WINDOW },
+  ];
+  const r = computeFlakeRate(runs, { now: NOW });
+  assert.equal(r.flake_rate_30d, 0);
+  assert.equal(r.flake_sample_size, 3);
+  assert.deepEqual(r.flaky_shas, []);
+});
+
+test("computeFlakeRate: all-failure (no flips) → zero rate, sample counted", () => {
+  const runs = [
+    { headSha: "aaa", conclusion: "failure", createdAt: WITHIN_WINDOW },
+    { headSha: "bbb", conclusion: "failure", createdAt: WITHIN_WINDOW },
+  ];
+  const r = computeFlakeRate(runs, { now: NOW });
+  assert.equal(r.flake_rate_30d, 0);
+  assert.equal(r.flake_sample_size, 2);
+  assert.deepEqual(r.flaky_shas, []);
+});
+
+test("computeFlakeRate: SHA with both success and failure → flake", () => {
+  const runs = [
+    { headSha: "aaa", conclusion: "failure", createdAt: WITHIN_WINDOW },
+    { headSha: "aaa", conclusion: "success", createdAt: WITHIN_WINDOW },
+    { headSha: "bbb", conclusion: "success", createdAt: WITHIN_WINDOW },
+  ];
+  const r = computeFlakeRate(runs, { now: NOW });
+  assert.equal(r.flake_sample_size, 2);
+  assert.equal(r.flake_rate_30d, 0.5); // 1 flake out of 2 SHAs
+  assert.deepEqual(r.flaky_shas, ["aaa"]);
+});
+
+test("computeFlakeRate: multiple flips on same SHA collapse to one flake", () => {
+  const runs = [
+    { headSha: "aaa", conclusion: "failure", createdAt: WITHIN_WINDOW },
+    { headSha: "aaa", conclusion: "success", createdAt: WITHIN_WINDOW },
+    { headSha: "aaa", conclusion: "failure", createdAt: WITHIN_WINDOW },
+    { headSha: "aaa", conclusion: "success", createdAt: WITHIN_WINDOW },
+  ];
+  const r = computeFlakeRate(runs, { now: NOW });
+  assert.equal(r.flake_sample_size, 1);
+  assert.equal(r.flake_rate_30d, 1); // 1 flaky SHA / 1 SHA
+  assert.deepEqual(r.flaky_shas, ["aaa"]);
+});
+
+test("computeFlakeRate: outside-window runs are excluded", () => {
+  const runs = [
+    { headSha: "old1", conclusion: "failure", createdAt: OUTSIDE_WINDOW },
+    { headSha: "old1", conclusion: "success", createdAt: OUTSIDE_WINDOW },
+    { headSha: "new1", conclusion: "success", createdAt: WITHIN_WINDOW },
+  ];
+  const r = computeFlakeRate(runs, { now: NOW });
+  assert.equal(r.flake_sample_size, 1);
+  assert.equal(r.flake_rate_30d, 0);
+  assert.deepEqual(r.flaky_shas, []); // old flake outside window doesn't count
+});
+
+test("computeFlakeRate: malformed records (missing fields) are skipped silently", () => {
+  const runs = [
+    { headSha: "", conclusion: "success", createdAt: WITHIN_WINDOW },
+    { headSha: "aaa", conclusion: "", createdAt: WITHIN_WINDOW },
+    { headSha: "bbb", conclusion: "success", createdAt: "not-a-date" },
+    { headSha: "ccc", conclusion: "success", createdAt: WITHIN_WINDOW },
+  ];
+  const r = computeFlakeRate(runs, { now: NOW });
+  assert.equal(r.flake_sample_size, 1); // only ccc survives
+  assert.equal(r.flake_rate_30d, 0);
+});
+
+test("computeFlakeRate: cancelled/skipped conclusions don't count as flips", () => {
+  // Only success-vs-failure flips count; cancelled is noise, not a signal
+  const runs = [
+    { headSha: "aaa", conclusion: "cancelled", createdAt: WITHIN_WINDOW },
+    { headSha: "aaa", conclusion: "success", createdAt: WITHIN_WINDOW },
+    { headSha: "bbb", conclusion: "skipped", createdAt: WITHIN_WINDOW },
+    { headSha: "bbb", conclusion: "failure", createdAt: WITHIN_WINDOW },
+  ];
+  const r = computeFlakeRate(runs, { now: NOW });
+  assert.equal(r.flake_sample_size, 2);
+  assert.equal(r.flake_rate_30d, 0);
+  assert.deepEqual(r.flaky_shas, []);
+});
+
+test("computeFlakeRate: custom window honored", () => {
+  const runs = [
+    // 3 days ago: would be in default 30d window, out of custom 1d window
+    {
+      headSha: "aaa",
+      conclusion: "success",
+      createdAt: new Date(NOW.getTime() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+    },
+    // 1 hour ago: in any reasonable window
+    {
+      headSha: "bbb",
+      conclusion: "success",
+      createdAt: new Date(NOW.getTime() - 60 * 60 * 1000).toISOString(),
+    },
+  ];
+  const r = computeFlakeRate(runs, { now: NOW, windowDays: 1 });
+  assert.equal(r.flake_sample_size, 1);
+});

--- a/scripts/acmm/audit.js
+++ b/scripts/acmm/audit.js
@@ -23,6 +23,7 @@ import { loadState, saveState, recordHistory } from "./state.js";
 import { writeReport } from "./outputs/report.js";
 import { updateBadge } from "./outputs/badge.js";
 import { applyIssuesForFailures, ensureAcmmLabel } from "./outputs/issues.js";
+import { measureFlakeRate } from "./flake-rate.js";
 
 const args = new Set(process.argv.slice(2));
 const APPLY = args.has("--apply");
@@ -78,6 +79,20 @@ for (const c of ALL_CRITERIA) {
   };
 }
 
+/* ── Behavioral signals (non-fatal — null when tools unavailable) ── */
+const flake = measureFlakeRate();
+const behavioral = {
+  ...(prior.behavioral ?? {}),
+  flake: flake
+    ? {
+        rate_30d: flake.flake_rate_30d,
+        sample_size: flake.flake_sample_size,
+        flaky_shas: flake.flaky_shas,
+        measured_at: new Date().toISOString(),
+      }
+    : (prior.behavioral?.flake ?? null),
+};
+
 const nextState = recordHistory(
   {
     ...prior,
@@ -88,6 +103,7 @@ const nextState = recordHistory(
     checks: results,
     detectedIds: [...detectedIds],
     computation,
+    behavioral,
   },
   computation.level,
   detectedCount,
@@ -153,6 +169,14 @@ console.log("");
 console.log(`Prerequisites (soft): ${computation.prerequisites.met}/${computation.prerequisites.total}`);
 console.log(`Cross-cutting learning: ${computation.crossCutting.learning.met}/${computation.crossCutting.learning.total}`);
 console.log(`Cross-cutting traceability: ${computation.crossCutting.traceability.met}/${computation.crossCutting.traceability.total}`);
+
+if (behavioral.flake) {
+  const pct = (behavioral.flake.rate_30d * 100).toFixed(1);
+  const n = behavioral.flake.sample_size;
+  console.log(`Signal quality: CI flake rate ${pct}% (n=${n})`);
+} else {
+  console.log("Signal quality: flake rate unavailable (gh CLI missing or no CI runs)");
+}
 
 if (computation.nextTransitionTrigger) {
   console.log("");

--- a/scripts/acmm/flake-rate.js
+++ b/scripts/acmm/flake-rate.js
@@ -1,0 +1,126 @@
+/**
+ * CI flake-rate measurement for ACMM behavioral signal (issue #646).
+ *
+ * Test-signal quality is the #1 blocker for AI autonomy: if `pnpm test` fails
+ * randomly, an agent can't distinguish regression from flake. ACMM normally
+ * checks whether `vitest.config.ts` exists; this script measures whether the
+ * suite *gives reliable signal*.
+ *
+ * Approach:
+ *   1. Query the last N completed runs of the CI workflow on `main` via
+ *      `gh run list --workflow=ci.yml --branch=main --limit=N --json …`.
+ *   2. A "flake" is a `headSha` that produced both a failed and a successful
+ *      run (across attempts). The ratio of such SHAs to total SHAs over the
+ *      last 30 days is the flake rate.
+ *   3. The ratio is reported, never enforced — observability first.
+ *
+ * Failure modes are non-fatal: if `gh` is missing or returns nothing, the
+ * caller logs a warning and skips reporting rather than aborting the audit.
+ */
+
+import { execFileSync } from "node:child_process";
+
+const DEFAULT_WORKFLOW = "ci.yml";
+const DEFAULT_BRANCH = "main";
+const DEFAULT_LIMIT = 100;
+const WINDOW_DAYS = 30;
+
+/**
+ * Compute flake rate from a flat list of run records.
+ *
+ * @param {Array<{ headSha: string, conclusion: string, createdAt: string }>} runs
+ * @param {{ now?: Date, windowDays?: number }} [opts]
+ * @returns {{ flake_rate_30d: number, flake_sample_size: number, flaky_shas: string[] }}
+ *   - `flake_rate_30d`: ratio in [0, 1] (NaN-safe; 0 when sample size 0)
+ *   - `flake_sample_size`: count of distinct SHAs in window
+ *   - `flaky_shas`: SHAs that flipped outcome at least once (sorted)
+ */
+export function computeFlakeRate(runs, opts = {}) {
+  const now = opts.now ?? new Date();
+  const windowMs = (opts.windowDays ?? WINDOW_DAYS) * 24 * 60 * 60 * 1000;
+  const cutoff = now.getTime() - windowMs;
+
+  const inWindow = runs.filter((r) => {
+    const t = Date.parse(r.createdAt);
+    return Number.isFinite(t) && t >= cutoff;
+  });
+
+  // headSha → set of distinct conclusions seen
+  const shaOutcomes = new Map();
+  for (const r of inWindow) {
+    if (!r.headSha || !r.conclusion) continue;
+    const set = shaOutcomes.get(r.headSha) ?? new Set();
+    set.add(r.conclusion);
+    shaOutcomes.set(r.headSha, set);
+  }
+
+  const flaky = [];
+  for (const [sha, outcomes] of shaOutcomes) {
+    if (outcomes.has("success") && outcomes.has("failure")) flaky.push(sha);
+  }
+  flaky.sort();
+
+  const sample = shaOutcomes.size;
+  const rate = sample === 0 ? 0 : flaky.length / sample;
+
+  return {
+    flake_rate_30d: rate,
+    flake_sample_size: sample,
+    flaky_shas: flaky,
+  };
+}
+
+/**
+ * Fetch raw CI run data via `gh run list`.
+ *
+ * Returns `null` (not an empty array) on any failure so callers can
+ * distinguish "no signal" from "tool unavailable" and skip reporting.
+ *
+ * @param {{ workflow?: string, branch?: string, limit?: number, ghBin?: string }} [opts]
+ * @returns {Array<{ headSha: string, conclusion: string, createdAt: string }> | null}
+ */
+export function fetchRuns(opts = {}) {
+  const workflow = opts.workflow ?? DEFAULT_WORKFLOW;
+  const branch = opts.branch ?? DEFAULT_BRANCH;
+  const limit = opts.limit ?? DEFAULT_LIMIT;
+  const ghBin = opts.ghBin ?? "gh";
+
+  try {
+    const stdout = execFileSync(
+      ghBin,
+      [
+        "run",
+        "list",
+        `--workflow=${workflow}`,
+        `--branch=${branch}`,
+        `--limit=${limit}`,
+        "--json",
+        "headSha,conclusion,createdAt,attempt,databaseId",
+      ],
+      { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] },
+    );
+    const parsed = JSON.parse(stdout);
+    if (!Array.isArray(parsed)) return null;
+    return parsed
+      .filter((r) => r && typeof r === "object")
+      .map((r) => ({
+        headSha: String(r.headSha ?? ""),
+        conclusion: String(r.conclusion ?? ""),
+        createdAt: String(r.createdAt ?? ""),
+      }));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Top-level convenience: fetch + compute. Returns `null` if `gh` failed.
+ *
+ * @param {{ workflow?: string, branch?: string, limit?: number, ghBin?: string, now?: Date, windowDays?: number }} [opts]
+ * @returns {ReturnType<typeof computeFlakeRate> | null}
+ */
+export function measureFlakeRate(opts = {}) {
+  const runs = fetchRuns(opts);
+  if (runs === null) return null;
+  return computeFlakeRate(runs, opts);
+}

--- a/scripts/acmm/outputs/report.js
+++ b/scripts/acmm/outputs/report.js
@@ -122,6 +122,21 @@ export function writeReport(cwd, { state, criteria, sources, computation, diff }
   }
   lines.push("");
 
+  // ── Signal quality (behavioral, beyond path-existence) ───
+  const flake = state.behavioral?.flake;
+  if (flake) {
+    const pct = (flake.rate_30d * 100).toFixed(1);
+    const n = flake.sample_size;
+    const icon = n < 5 ? "·" : flake.rate_30d < 0.01 ? "✅" : flake.rate_30d <= 0.05 ? "⚠️" : "❌";
+    const note = n < 5 ? " (insufficient data)" : "";
+    lines.push("## Signal quality");
+    lines.push("");
+    lines.push(`- **${icon} CI flake rate (30d):** ${pct}% (n=${n})${note}`);
+    lines.push("");
+    lines.push("_A flake = same commit produced both ✅ and ❌ on different runs. Healthy: <1%, watch: 1–5%, broken: >5%._");
+    lines.push("");
+  }
+
   // ── Cross-cutting overlay ─────────────────────────────────
   lines.push("## Cross-cutting overlay");
   lines.push("");

--- a/scripts/acmm/state.js
+++ b/scripts/acmm/state.js
@@ -25,6 +25,16 @@ import { dirname, join } from "node:path";
  * @property {object} [computation]       full computeLevel output
  * @property {HistoryEntry[]} history
  * @property {Record<string, number>} issuesCreated   criterionId → GitHub issue number
+ * @property {Behavioral} [behavioral]                behavioral signals beyond path-existence
+ *
+ * @typedef {Object} Behavioral
+ * @property {FlakeSnapshot | null} [flake]           CI signal quality
+ *
+ * @typedef {Object} FlakeSnapshot
+ * @property {number} rate_30d        ratio in [0, 1] of SHAs that flipped outcome
+ * @property {number} sample_size     distinct SHAs in the 30-day window
+ * @property {string[]} flaky_shas    SHAs that flipped at least once
+ * @property {string} measured_at     ISO timestamp of measurement
  */
 
 export const STATE_DIR = ".claude/acmm";


### PR DESCRIPTION
Closes #646.

## What

Adds the first ACMM behavioral metric beyond path-existence: a 30-day CI flake rate. A flake = same `headSha` produced both `success` and `failure` across runs/attempts.

## Why

Test-signal quality is the #1 blocker for AI autonomy: if `pnpm test` randomly fails 5% of the time, an agent can't tell regression from flake. ACMM previously only checked whether `vitest.config.ts` *exists*; this measures whether the suite *gives reliable signal*.

## How

- `scripts/acmm/flake-rate.js` separates pure compute (`computeFlakeRate`) from I/O (`fetchRuns` shells out to `gh`), so tests don't need the network.
- 9 unit tests in `scripts/acmm/__tests__/flake-rate.test.js` cover: empty input, all-success, all-failure (no flips), success+failure flip, repeated flips collapsing, out-of-window exclusion, malformed records, cancelled/skipped not counting, and custom windows.
- Wired into `audit.js`: each run snapshots into `state.json` under a new top-level `behavioral.flake` field. Forward-compatible with existing state via `loadState`'s `{...emptyState(), ...parsed}` merge.
- Renders a "Signal quality" section in `.claude/acmm/report.md` with traffic-light icons (✅ <1%, ⚠️ 1–5%, ❌ >5%, · n<5).
- Non-fatal: when `gh` is unavailable or returns nothing, falls back to the prior measurement instead of aborting the audit.

## Verification

End-to-end smoke test on this repo:

```
$ node scripts/acmm/audit.js
…
Signal quality: CI flake rate 0.0% (n=91)
```

Real signal — first time ACMM has reported anything beyond a presence count.

```
$ node --test scripts/acmm/__tests__/
# tests 22  # pass 22  # fail 0
```

## Out of scope (separate follow-ups)

- Per-test flake attribution (which test is flaky)
- Workflow-level retry policy changes
- Adding flake rate as a level-gating criterion (observability first; gate later once trusted)

## Test plan

- [x] Unit tests cover the rerun-flip detection logic
- [x] End-to-end audit run renders the section and writes state
- [x] Non-fatal when `gh` is missing (fetchRuns returns null on error)
- [x] State schema is forward-compatible with existing audits