### PR TITLE
fix(auth): emit RFC 7807 Problem Details on JWT failures

### DIFF
--- a/packages/auth/llms-full.txt
+++ b/packages/auth/llms-full.txt
@@ -154,11 +154,15 @@
     
           if (typeof payload.sub !== "string") {
             request.log.warn("JWT missing required 'sub' claim");
-            return reply.code(401).send({
-              error: "Unauthorized",
-              message: "Invalid token: missing sub",
-              statusCode: 401
-            });
+            return reply.code(401).send(
+              createProblemDetails(
+                401,
+                "Unauthorized",
+                "Invalid token: missing sub",
+                "https://mattbutlerengineering.com/errors/unauthorized",
+                request.url
+              )
+            );
           }
     
           const jwtPayload: JWTPayload = {
@@ -184,11 +188,15 @@
           };
         } catch (error) {
           request.log.warn({ error }, "JWT validation failed");
-          return reply.code(401).send({
-            error: "Unauthorized",
-            message: "Invalid token",
-            statusCode: 401
-          });
+          return reply.code(401).send(
+            createProblemDetails(
+              401,
+              "Unauthorized",
+              "Invalid token",
+              "https://mattbutlerengineering.com/errors/unauthorized",
+              request.url
+            )
+          );
         }
       });
     }

--- a/packages/auth/src/fastify/plugin.ts
+++ b/packages/auth/src/fastify/plugin.ts
@@ -1,6 +1,7 @@
 import { createRemoteJWKSet, jwtVerify } from "jose";
 import fp from "fastify-plugin";
 import type { FastifyInstance, FastifyRequest, FastifyReply, FastifyPluginAsync } from "fastify";
+import { createProblemDetails } from "@mbe/types";
 import type { JWTPayload, AuthUser } from "../types/index.js";
 
 declare module "fastify" {
@@ -70,11 +71,15 @@ async function authPluginImpl(
 
       if (typeof payload.sub !== "string") {
         request.log.warn("JWT missing required 'sub' claim");
-        return reply.code(401).send({
-          error: "Unauthorized",
-          message: "Invalid token: missing sub",
-          statusCode: 401
-        });
+        return reply.code(401).send(
+          createProblemDetails(
+            401,
+            "Unauthorized",
+            "Invalid token: missing sub",
+            "https://mattbutlerengineering.com/errors/unauthorized",
+            request.url
+          )
+        );
       }
 
       const jwtPayload: JWTPayload = {
@@ -100,11 +105,15 @@ async function authPluginImpl(
       };
     } catch (error) {
       request.log.warn({ error }, "JWT validation failed");
-      return reply.code(401).send({
-        error: "Unauthorized",
-        message: "Invalid token",
-        statusCode: 401
-      });
+      return reply.code(401).send(
+        createProblemDetails(
+          401,
+          "Unauthorized",
+          "Invalid token",
+          "https://mattbutlerengineering.com/errors/unauthorized",
+          request.url
+        )
+      );
     }
   });
 }
@@ -117,11 +126,15 @@ export const authPlugin: FastifyPluginAsync<AuthPluginOptions> = fp(authPluginIm
 export async function requireAuth(request: FastifyRequest, reply: FastifyReply) {
   const isBypassed = process.env.AUTH_BYPASS_IN_TESTS === "true" && request.headers["x-auth-bypass"] === "true";
   if (!request.user && !isBypassed) {
-    return reply.code(401).send({
-      error: "Unauthorized",
-      message: "Missing or invalid authorization header",
-      statusCode: 401
-    });
+    return reply.code(401).send(
+      createProblemDetails(
+        401,
+        "Unauthorized",
+        "Missing or invalid authorization header",
+        "https://mattbutlerengineering.com/errors/unauthorized",
+        request.url
+      )
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

The custom `mbe-local/require-rfc-7807-errors` ESLint rule was failing on three error responses in `packages/auth/src/fastify/plugin.ts` (lines 73, 103, 120). They sent `{error, message, statusCode}` instead of the RFC 7807 (now RFC 9457) shape that `packages/auth/CLAUDE.md` documents as the contract:

> Returns RFC 9457 Problem Details on failure via `createProblemDetails`

This was a doc/code drift, not a new bug — the lint rule has been failing on `main` for a while; it was previously hidden by the upstream CI cache failure (#649 reveals it).

## Fix

Each of the 3 spots now calls `createProblemDetails(401, title, detail, type, instance)` from `@mbe/types` (already a declared dep). Because `createProblemDetails` returns a **combined** type — RFC 7807 fields **plus** the legacy `{error, message, statusCode}` — any downstream consumers parsing the old keys keep working unchanged.

```typescript
// Before
reply.code(401).send({
  error: "Unauthorized",
  message: "Invalid token: missing sub",
  statusCode: 401,
});

// After
reply.code(401).send(
  createProblemDetails(
    401,
    "Unauthorized",
    "Invalid token: missing sub",
    "https://mattbutlerengineering.com/errors/unauthorized",
    request.url
  )
);
```

Sites changed:
- L71-78: `payload.sub` not a string
- L101-108: catch on `jwtVerify` failure
- L117-126: `requireAuth` middleware

## Test plan

- [x] `pnpm --dir packages/auth lint` → 0 errors
- [x] `pnpm --dir packages/auth typecheck` → clean
- [x] `pnpm --dir packages/auth test` → 14/14 passing (the legacy keys are preserved by `createProblemDetails`, so test assertions parsing `body.error` / `body.message` still match)
- [ ] CI green after merge

## Order

This PR is independent of #649 (CI infra fix) — both can merge in any order. But the failure was hidden by #649's bug, so realistically: merge #649 first, then this.

## Follow-ups (not in this PR)

- #651 (planned): rialto accessibility test prop drift — 9 TS errors uncovered by #649. Same hidden-by-cache-failure root cause, separate concern (component API drift, not error response shape).