### PR TITLE
fix(rialto): align accessibility tests with current component prop APIs

### DIFF
--- a/packages/rialto/src/test/accessibility/forms.accessibility.test.tsx
+++ b/packages/rialto/src/test/accessibility/forms.accessibility.test.tsx
@@ -34,16 +34,18 @@ describe("Accessibility — Form Components", () => {
 
   it("InputGroup", async () => {
     const { container } = render(
-      <InputGroup label="Price">
+      <InputGroup aria-label="Price input group">
         <span>$</span>
-        <Input placeholder="0.00" />
+        <Input placeholder="0.00" aria-label="Amount" />
       </InputGroup>
     );
     expect(await axe(container)).toHaveNoViolations();
   });
 
   it("NumberInput", async () => {
-    const { container } = render(<NumberInput label="Quantity" min={1} max={10} />);
+    const { container } = render(
+      <NumberInput label="Quantity" value={1} onChange={() => {}} min={1} max={10} />
+    );
     expect(await axe(container)).toHaveNoViolations();
   });
 

--- a/packages/rialto/src/test/accessibility/navigation.accessibility.test.tsx
+++ b/packages/rialto/src/test/accessibility/navigation.accessibility.test.tsx
@@ -15,7 +15,7 @@ import { Tree } from "../../components/Tree/Tree";
 
 describe("Accessibility — Navigation Components", () => {
   it("AppBar", async () => {
-    const { container } = render(<AppBar title="Rialto" />);
+    const { container } = render(<AppBar logo={<span>Rialto</span>} aria-label="Main app bar" />);
     expect(await axe(container)).toHaveNoViolations();
   });
 
@@ -27,7 +27,7 @@ describe("Accessibility — Navigation Components", () => {
   it("Navbar", async () => {
     const { container } = render(
       <Navbar
-        brand="Rialto"
+        logo={<span>Rialto</span>}
         links={[
           { id: "1", label: "Home", href: "/" },
           { id: "2", label: "Products", href: "/products" },

--- a/packages/rialto/src/test/accessibility/overlays.accessibility.test.tsx
+++ b/packages/rialto/src/test/accessibility/overlays.accessibility.test.tsx
@@ -20,11 +20,10 @@ describe("Accessibility — Overlay Components", () => {
       <ConfirmDialog
         open
         title="Are you sure?"
+        description="This action cannot be undone."
         onConfirm={noop}
         onCancel={noop}
-      >
-        This action cannot be undone.
-      </ConfirmDialog>
+      />
     );
     expect(await axe(container)).toHaveNoViolations();
   });
@@ -52,8 +51,8 @@ describe("Accessibility — Overlay Components", () => {
       <DropdownMenu
         trigger={<button>Menu</button>}
         items={[
-          { label: "Profile", onClick: noop },
-          { label: "Settings", onClick: noop },
+          { id: "profile", label: "Profile", onSelect: noop },
+          { id: "settings", label: "Settings", onSelect: noop },
         ]}
       />
     );
@@ -62,8 +61,8 @@ describe("Accessibility — Overlay Components", () => {
 
   it("HoverCard", async () => {
     const { container } = render(
-      <HoverCard trigger={<button>Hover me</button>}>
-        <p>Card content</p>
+      <HoverCard content={<p>Card content</p>}>
+        <button>Hover me</button>
       </HoverCard>
     );
     expect(await axe(container)).toHaveNoViolations();
@@ -89,7 +88,7 @@ describe("Accessibility — Overlay Components", () => {
 
   it("Tooltip", async () => {
     const { container } = render(
-      <Tooltip label="Save changes">
+      <Tooltip content="Save changes">
         <button>Save</button>
       </Tooltip>
     );


### PR DESCRIPTION
## Summary

The accessibility tests in `packages/rialto/src/test/accessibility/` had drifted from the components they exercise — calling them with prop names the components no longer accept. 9 TypeScript errors uncovered by the CI cache fix in #649 (these were hidden by the upstream `node_modules missing` failure).

No component changes — the tests were the stale party.

## Per-component fix

Each fix pulled the actual prop name from the component's exported props interface.

### `forms.accessibility.test.tsx`

| Component | Was | Now | Reason |
|---|---|---|---|
| `InputGroup` | `label="Price"` | `aria-label="..."` | `InputGroupProps = HTMLAttributes<HTMLDivElement>` — no `label` prop |
| `NumberInput` | (missing value/onChange) | `value={1} onChange={() => {}}` | "Always controlled — requires `value` and `onChange`" (per JSDoc) |

### `navigation.accessibility.test.tsx`

| Component | Was | Now | Reason |
|---|---|---|---|
| `AppBar` | `title="Rialto"` | `logo={<span>Rialto</span>} aria-label="..."` | AppBarProps takes `logo`/`actions`, not `title` |
| `Navbar` | `brand="Rialto"` | `logo={<span>Rialto</span>}` | NavbarProps takes `logo`, not `brand` |

### `overlays.accessibility.test.tsx`

| Component | Was | Now | Reason |
|---|---|---|---|
| `ConfirmDialog` | `<ConfirmDialog>...children...</ConfirmDialog>` | `description="..."` | No `children` prop; uses `description` |
| `DropdownMenu` items | `{label, onClick}` | `{id, label, onSelect}` | Real `MenuItemDef` shape (per JSDoc example) |
| `HoverCard` | `<HoverCard trigger={btn}>{card}</HoverCard>` | `<HoverCard content={card}>{btn}</HoverCard>` | Card content goes to `content` prop; trigger goes to children |
| `Tooltip` | `label="..."` | `content="..."` | TooltipProps uses `content` |

## Test plan

- [x] `pnpm --dir packages/rialto typecheck` — clean (was 9 errors)
- [x] `pnpm --dir packages/rialto test src/test/accessibility` — 65/65 passing
- [ ] CI green after merge (requires #649 to be merged first, otherwise the cache failure still masks everything)

## Order

Merge ordering for the stack:
1. **#649** (CI infra) — must merge first; without it the rialto job will still fail with `module not found` and these test fixes won't be visible.
2. **#651** (auth RFC 7807) — independent of this PR.
3. **This PR** — depends on #649 being merged first.

## Why these tests had drifted

The accessibility tests are write-once-run-many — they were authored when the components had different props (early prototypes used `label`, `title`, `brand`, `onClick` patterns) and weren't updated as the components stabilized to the current API (`aria-label`, `logo`, `onSelect`, etc.). The CI cache bug protected them from detection until #649.