### PR TITLE
feat(acmm): read agent PR outcomes from GitHub (#647)

### DIFF
--- a/scripts/acmm/__tests__/pr-outcomes.test.js
+++ b/scripts/acmm/__tests__/pr-outcomes.test.js
@@ -1,0 +1,178 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  computePrOutcomes,
+  isAgentPr,
+  extractRevertedPrNumbers,
+} from "../pr-outcomes.js";
+
+const NOW = new Date("2026-04-26T12:00:00Z");
+const WITHIN_WINDOW = "2026-04-25T12:00:00Z";
+const OUTSIDE_WINDOW = "2026-03-20T12:00:00Z";
+
+function pr(overrides = {}) {
+  return {
+    number: 1,
+    title: "test",
+    headRefName: "agent-foo",
+    state: "MERGED",
+    createdAt: WITHIN_WINDOW,
+    mergedAt: "2026-04-26T00:00:00Z",
+    labels: [],
+    author: "agent-bot",
+    reverted_within_7d: false,
+    human_touched: false,
+    ...overrides,
+  };
+}
+
+test("isAgentPr: branch prefix matches", () => {
+  assert.equal(isAgentPr({ headRefName: "agent-fix-login", labels: [] }), true);
+  assert.equal(isAgentPr({ headRefName: "worktree-agent-abc", labels: [] }), true);
+  assert.equal(isAgentPr({ headRefName: "fix/agent-cleanup", labels: [] }), true);
+  assert.equal(isAgentPr({ headRefName: "feat/agent-search", labels: [] }), true);
+});
+
+test("isAgentPr: has-pr label matches even without prefix", () => {
+  assert.equal(isAgentPr({ headRefName: "random-branch", labels: ["has-pr"] }), true);
+});
+
+test("isAgentPr: human branch with no label is excluded", () => {
+  assert.equal(isAgentPr({ headRefName: "feat/manual-thing", labels: ["feature"] }), false);
+});
+
+test("computePrOutcomes: zero PRs → insufficient_data, all zeros", () => {
+  const r = computePrOutcomes([], { now: NOW });
+  assert.equal(r.sample_size, 0);
+  assert.equal(r.merged_count, 0);
+  assert.equal(r.acceptance_rate_30d, 0);
+  assert.equal(r.revert_rate_30d, 0);
+  assert.equal(r.median_time_to_merge_hours, 0);
+  assert.equal(r.human_touch_ratio, 0);
+  assert.equal(r.insufficient_data, true);
+});
+
+test("computePrOutcomes: all-merged → 100% acceptance", () => {
+  const prs = [
+    pr({ number: 1 }),
+    pr({ number: 2 }),
+    pr({ number: 3 }),
+    pr({ number: 4 }),
+    pr({ number: 5 }),
+  ];
+  const r = computePrOutcomes(prs, { now: NOW });
+  assert.equal(r.sample_size, 5);
+  assert.equal(r.merged_count, 5);
+  assert.equal(r.acceptance_rate_30d, 1);
+  assert.equal(r.insufficient_data, false);
+});
+
+test("computePrOutcomes: all-closed-unmerged → 0% acceptance", () => {
+  const prs = Array.from({ length: 5 }, (_, i) =>
+    pr({ number: i + 1, state: "CLOSED", mergedAt: null }),
+  );
+  const r = computePrOutcomes(prs, { now: NOW });
+  assert.equal(r.merged_count, 0);
+  assert.equal(r.closed_unmerged_count, 5);
+  assert.equal(r.acceptance_rate_30d, 0);
+});
+
+test("computePrOutcomes: open PRs excluded from acceptance denominator", () => {
+  const prs = [
+    pr({ number: 1, state: "MERGED" }),
+    pr({ number: 2, state: "OPEN", mergedAt: null }),
+    pr({ number: 3, state: "OPEN", mergedAt: null }),
+    pr({ number: 4, state: "CLOSED", mergedAt: null }),
+    pr({ number: 5, state: "MERGED" }),
+  ];
+  const r = computePrOutcomes(prs, { now: NOW });
+  // 2 merged + 1 closed-unmerged = 3 decided; acceptance = 2/3
+  assert.equal(r.acceptance_rate_30d, 2 / 3);
+  assert.equal(r.open_count, 2);
+});
+
+test("computePrOutcomes: revert flag inflates revert_rate_30d", () => {
+  const prs = [
+    pr({ number: 1, reverted_within_7d: true }),
+    pr({ number: 2 }),
+    pr({ number: 3 }),
+    pr({ number: 4 }),
+  ];
+  const r = computePrOutcomes(prs, { now: NOW });
+  assert.equal(r.merged_count, 4);
+  assert.equal(r.revert_rate_30d, 0.25);
+});
+
+test("computePrOutcomes: median time to merge — odd count picks middle", () => {
+  const prs = [
+    pr({ number: 1, createdAt: "2026-04-25T00:00:00Z", mergedAt: "2026-04-25T01:00:00Z" }), // 1h
+    pr({ number: 2, createdAt: "2026-04-25T00:00:00Z", mergedAt: "2026-04-25T03:00:00Z" }), // 3h
+    pr({ number: 3, createdAt: "2026-04-25T00:00:00Z", mergedAt: "2026-04-25T05:00:00Z" }), // 5h
+  ];
+  const r = computePrOutcomes(prs, { now: NOW });
+  assert.equal(r.median_time_to_merge_hours, 3);
+});
+
+test("computePrOutcomes: median time to merge — even count averages", () => {
+  const prs = [
+    pr({ number: 1, createdAt: "2026-04-25T00:00:00Z", mergedAt: "2026-04-25T02:00:00Z" }), // 2h
+    pr({ number: 2, createdAt: "2026-04-25T00:00:00Z", mergedAt: "2026-04-25T04:00:00Z" }), // 4h
+  ];
+  const r = computePrOutcomes(prs, { now: NOW });
+  assert.equal(r.median_time_to_merge_hours, 3);
+});
+
+test("computePrOutcomes: human_touched merged PRs raise the ratio", () => {
+  const prs = [
+    pr({ number: 1, human_touched: true }),
+    pr({ number: 2 }),
+    pr({ number: 3 }),
+    pr({ number: 4 }),
+  ];
+  const r = computePrOutcomes(prs, { now: NOW });
+  assert.equal(r.human_touch_ratio, 0.25);
+});
+
+test("computePrOutcomes: out-of-window PRs excluded", () => {
+  const prs = [
+    pr({ number: 1, createdAt: OUTSIDE_WINDOW, mergedAt: OUTSIDE_WINDOW }),
+    pr({ number: 2 }),
+  ];
+  const r = computePrOutcomes(prs, { now: NOW });
+  assert.equal(r.sample_size, 1);
+});
+
+test("computePrOutcomes: non-agent PRs excluded", () => {
+  const prs = [
+    pr({ number: 1, headRefName: "feat/manual" }), // not agent
+    pr({ number: 2 }),
+  ];
+  const r = computePrOutcomes(prs, { now: NOW });
+  assert.equal(r.sample_size, 1);
+});
+
+test("computePrOutcomes: minSample threshold honored", () => {
+  const prs = Array.from({ length: 4 }, (_, i) => pr({ number: i + 1 }));
+  const r = computePrOutcomes(prs, { now: NOW, minSample: 5 });
+  assert.equal(r.insufficient_data, true);
+
+  const r2 = computePrOutcomes(prs, { now: NOW, minSample: 3 });
+  assert.equal(r2.insufficient_data, false);
+});
+
+test("extractRevertedPrNumbers: parses standard revert title", () => {
+  const msg = 'Revert "feat: add foo (#42)"\n\nThis reverts commit abc123.';
+  assert.deepEqual(extractRevertedPrNumbers(msg), [42]);
+});
+
+test("extractRevertedPrNumbers: returns empty for non-revert messages", () => {
+  assert.deepEqual(extractRevertedPrNumbers("feat: add bar (#10)"), []);
+  assert.deepEqual(extractRevertedPrNumbers(""), []);
+  assert.deepEqual(extractRevertedPrNumbers(null), []);
+});
+
+test("extractRevertedPrNumbers: multiple PR mentions all captured", () => {
+  const msg = 'Revert "merge bundle (#1, #2, #3)"';
+  assert.deepEqual(extractRevertedPrNumbers(msg), [1, 2, 3]);
+});

--- a/scripts/acmm/audit.js
+++ b/scripts/acmm/audit.js
@@ -24,6 +24,7 @@ import { writeReport } from "./outputs/report.js";
 import { updateBadge } from "./outputs/badge.js";
 import { applyIssuesForFailures, ensureAcmmLabel } from "./outputs/issues.js";
 import { measureFlakeRate } from "./flake-rate.js";
+import { measurePrOutcomes } from "./pr-outcomes.js";
 
 const args = new Set(process.argv.slice(2));
 const APPLY = args.has("--apply");
@@ -81,6 +82,7 @@ for (const c of ALL_CRITERIA) {
 
 /* ── Behavioral signals (non-fatal — null when tools unavailable) ── */
 const flake = measureFlakeRate();
+const prOutcomes = measurePrOutcomes();
 const behavioral = {
   ...(prior.behavioral ?? {}),
   flake: flake
@@ -91,6 +93,9 @@ const behavioral = {
         measured_at: new Date().toISOString(),
       }
     : (prior.behavioral?.flake ?? null),
+  agent_pr: prOutcomes
+    ? { ...prOutcomes, measured_at: new Date().toISOString() }
+    : (prior.behavioral?.agent_pr ?? null),
 };
 
 const nextState = recordHistory(
@@ -176,6 +181,20 @@ if (behavioral.flake) {
   console.log(`Signal quality: CI flake rate ${pct}% (n=${n})`);
 } else {
   console.log("Signal quality: flake rate unavailable (gh CLI missing or no CI runs)");
+}
+
+if (behavioral.agent_pr) {
+  const o = behavioral.agent_pr;
+  if (o.insufficient_data) {
+    console.log(`Agent PR outcomes: insufficient data (n=${o.sample_size})`);
+  } else {
+    const acc = (o.acceptance_rate_30d * 100).toFixed(0);
+    const rev = (o.revert_rate_30d * 100).toFixed(0);
+    const ttm = o.median_time_to_merge_hours.toFixed(1);
+    console.log(`Agent PR outcomes: ${acc}% accepted · ${rev}% reverted · ${ttm}h median time-to-merge (n=${o.sample_size})`);
+  }
+} else {
+  console.log("Agent PR outcomes: unavailable (gh CLI missing or no PRs)");
 }
 
 if (computation.nextTransitionTrigger) {

--- a/scripts/acmm/outputs/report.js
+++ b/scripts/acmm/outputs/report.js
@@ -137,6 +137,31 @@ export function writeReport(cwd, { state, criteria, sources, computation, diff }
     lines.push("");
   }
 
+  // ── Agent PR outcomes (behavioral) ────────────────────────
+  const apr = state.behavioral?.agent_pr;
+  if (apr) {
+    lines.push("## Agent PR outcomes (last 30 days)");
+    lines.push("");
+    if (apr.insufficient_data) {
+      lines.push(`_Insufficient data: only ${apr.sample_size} agent PR${apr.sample_size === 1 ? "" : "s"} in window. Metrics will appear once n ≥ 5._`);
+    } else {
+      const acc = (apr.acceptance_rate_30d * 100).toFixed(0);
+      const rev = (apr.revert_rate_30d * 100).toFixed(0);
+      const ttm = apr.median_time_to_merge_hours.toFixed(1);
+      const htr = (apr.human_touch_ratio * 100).toFixed(0);
+      const accIcon = apr.acceptance_rate_30d >= 0.8 ? "✅" : apr.acceptance_rate_30d >= 0.5 ? "⚠️" : "❌";
+      const revIcon = apr.revert_rate_30d <= 0.05 ? "✅" : apr.revert_rate_30d <= 0.15 ? "⚠️" : "❌";
+      lines.push(`- **${accIcon} Acceptance rate:** ${acc}% (${apr.merged_count} merged of ${apr.merged_count + apr.closed_unmerged_count} decided)`);
+      lines.push(`- **${revIcon} Revert rate:** ${rev}% within 7 days of merge`);
+      lines.push(`- **Median time-to-merge:** ${ttm}h`);
+      lines.push(`- **Human-touch ratio:** ${htr}% of merged PRs had non-author commits`);
+      lines.push(`- **Sample:** ${apr.sample_size} agent PR${apr.sample_size === 1 ? "" : "s"} (${apr.open_count} still open)`);
+    }
+    lines.push("");
+    lines.push("_Agent PR detection: branch starts with `agent-`/`worktree-agent-`/`fix/agent-`/`feat/agent-`, or has `has-pr` label._");
+    lines.push("");
+  }
+
   // ── Cross-cutting overlay ─────────────────────────────────
   lines.push("## Cross-cutting overlay");
   lines.push("");

--- a/scripts/acmm/pr-outcomes.js
+++ b/scripts/acmm/pr-outcomes.js
@@ -1,0 +1,240 @@
+/**
+ * Agent PR outcome reader for ACMM behavioral signal (issue #647).
+ *
+ * ACMM previously satisfied `acmm:pr-acceptance-metric` by detecting that a
+ * metrics script *exists*. This module reads the actual numbers: did agent
+ * PRs land? Were they reverted? How long did they take? Did humans rewrite
+ * them before merge?
+ *
+ * Detection of "agent PR":
+ *   - branch starts with one of `AGENT_BRANCH_PREFIXES`, OR
+ *   - PR has the `has-pr` label (used by /issue-worker)
+ *
+ * Window: PRs created in the last 30 days. We compute:
+ *   - `agent_pr_acceptance_rate_30d` = merged / (merged + closed_unmerged)
+ *   - `agent_pr_revert_rate_30d`     = reverted_within_7d / merged
+ *   - `agent_pr_median_time_to_merge_hours` (median, robust to outliers)
+ *   - `agent_pr_human_touch_ratio`    = merged_with_human_commit / merged
+ *
+ * Open PRs are excluded from acceptance/merge time calculations.
+ * Sample sizes <5 yield `insufficient_data: true` so callers can suppress
+ * misleading percentages.
+ *
+ * Uses `execFileSync` (no shell) — same safe pattern as
+ * `scripts/acmm/outputs/issues.js` and `scripts/acmm/backfill-metrics.js`.
+ */
+
+import { execFileSync } from "node:child_process";
+
+const AGENT_BRANCH_PREFIXES = [
+  "worktree-agent-",
+  "agent-",
+  "fix/agent-",
+  "feat/agent-",
+];
+const AGENT_LABEL = "has-pr";
+const WINDOW_DAYS = 30;
+const REVERT_WINDOW_DAYS = 7;
+const MIN_SAMPLE = 5;
+
+/**
+ * @typedef {Object} PrRecord
+ * @property {number} number
+ * @property {string} title
+ * @property {string} headRefName       branch name
+ * @property {string} state             "OPEN" | "CLOSED" | "MERGED"
+ * @property {string} createdAt         ISO timestamp
+ * @property {string | null} mergedAt   ISO timestamp or null
+ * @property {string[]} labels          label names
+ * @property {boolean} reverted_within_7d  enriched by IO layer
+ * @property {boolean} human_touched    enriched by IO layer (non-author commits to branch)
+ */
+
+/**
+ * Is this PR from an agent? Branch-prefix OR has-pr label.
+ *
+ * @param {Pick<PrRecord, "headRefName" | "labels">} pr
+ */
+export function isAgentPr(pr) {
+  if (pr.labels?.includes(AGENT_LABEL)) return true;
+  if (!pr.headRefName) return false;
+  return AGENT_BRANCH_PREFIXES.some((p) => pr.headRefName.startsWith(p));
+}
+
+/**
+ * Pure compute over a normalized PR list.
+ *
+ * @param {PrRecord[]} prs
+ * @param {{ now?: Date, windowDays?: number, minSample?: number }} [opts]
+ */
+export function computePrOutcomes(prs, opts = {}) {
+  const now = opts.now ?? new Date();
+  const windowMs = (opts.windowDays ?? WINDOW_DAYS) * 24 * 60 * 60 * 1000;
+  const cutoff = now.getTime() - windowMs;
+  const minSample = opts.minSample ?? MIN_SAMPLE;
+
+  const inWindow = prs.filter((pr) => {
+    const t = Date.parse(pr.createdAt);
+    return Number.isFinite(t) && t >= cutoff && isAgentPr(pr);
+  });
+
+  const merged = inWindow.filter((pr) => pr.state === "MERGED" && pr.mergedAt);
+  const closedUnmerged = inWindow.filter((pr) => pr.state === "CLOSED" && !pr.mergedAt);
+  const open = inWindow.filter((pr) => pr.state === "OPEN");
+
+  const decided = merged.length + closedUnmerged.length;
+  const acceptanceRate = decided === 0 ? 0 : merged.length / decided;
+
+  const reverted = merged.filter((pr) => pr.reverted_within_7d).length;
+  const revertRate = merged.length === 0 ? 0 : reverted / merged.length;
+
+  const mergeHours = merged
+    .map((pr) => (Date.parse(pr.mergedAt) - Date.parse(pr.createdAt)) / 3_600_000)
+    .filter((h) => Number.isFinite(h) && h >= 0)
+    .sort((a, b) => a - b);
+  const medianHours = median(mergeHours);
+
+  const humanTouched = merged.filter((pr) => pr.human_touched).length;
+  const humanTouchRatio = merged.length === 0 ? 0 : humanTouched / merged.length;
+
+  return {
+    sample_size: inWindow.length,
+    merged_count: merged.length,
+    closed_unmerged_count: closedUnmerged.length,
+    open_count: open.length,
+    acceptance_rate_30d: acceptanceRate,
+    revert_rate_30d: revertRate,
+    median_time_to_merge_hours: medianHours,
+    human_touch_ratio: humanTouchRatio,
+    insufficient_data: inWindow.length < minSample,
+  };
+}
+
+function median(sorted) {
+  const n = sorted.length;
+  if (n === 0) return 0;
+  const mid = Math.floor(n / 2);
+  return n % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+/**
+ * Extract PR numbers referenced by a "Revert" commit message.
+ * @param {string} message
+ * @returns {number[]}
+ */
+export function extractRevertedPrNumbers(message) {
+  if (!message?.startsWith("Revert ")) return [];
+  const numbers = [];
+  const re = /#(\d+)/g;
+  let m;
+  while ((m = re.exec(message)) !== null) {
+    numbers.push(Number(m[1]));
+  }
+  return numbers;
+}
+
+/**
+ * Fetch agent PRs and enrich with revert/human-touch flags.
+ * Returns null on any tool failure so callers can detect "no signal".
+ */
+export function fetchAgentPrs(opts = {}) {
+  const ghBin = opts.ghBin ?? "gh";
+  const limit = opts.limit ?? 200;
+  const windowDays = opts.windowDays ?? WINDOW_DAYS;
+  const revertLookbackDays = windowDays + REVERT_WINDOW_DAYS;
+
+  let allPrs;
+  try {
+    const stdout = execFileSync(
+      ghBin,
+      [
+        "pr",
+        "list",
+        "--state",
+        "all",
+        "--limit",
+        String(limit),
+        "--json",
+        "number,title,headRefName,state,createdAt,mergedAt,labels,author",
+      ],
+      { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] },
+    );
+    allPrs = JSON.parse(stdout);
+  } catch {
+    return null;
+  }
+
+  if (!Array.isArray(allPrs)) return null;
+
+  const normalized = allPrs.map((pr) => ({
+    number: Number(pr.number),
+    title: String(pr.title ?? ""),
+    headRefName: String(pr.headRefName ?? ""),
+    state: String(pr.state ?? ""),
+    createdAt: String(pr.createdAt ?? ""),
+    mergedAt: pr.mergedAt ? String(pr.mergedAt) : null,
+    labels: Array.isArray(pr.labels) ? pr.labels.map((l) => String(l.name ?? "")) : [],
+    author: pr.author?.login ? String(pr.author.login) : "",
+    reverted_within_7d: false,
+    human_touched: false,
+  }));
+
+  const revertedSet = fetchRevertedPrNumbers({ sinceDays: revertLookbackDays });
+
+  for (const pr of normalized) {
+    if (revertedSet?.has(pr.number) && pr.mergedAt) {
+      pr.reverted_within_7d = true;
+    }
+    if (pr.state === "MERGED") {
+      pr.human_touched = prHasNonAuthorCommit(ghBin, pr.number, pr.author);
+    }
+  }
+
+  return normalized;
+}
+
+function fetchRevertedPrNumbers({ sinceDays }) {
+  try {
+    const since = new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .slice(0, 10);
+    const stdout = execFileSync(
+      "git",
+      ["log", "--since=" + since, "--grep=^Revert ", "--pretty=format:%s%n%b%n---END---"],
+      { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] },
+    );
+    const reverted = new Set();
+    for (const block of stdout.split("---END---")) {
+      for (const num of extractRevertedPrNumbers(block.trim())) {
+        reverted.add(num);
+      }
+    }
+    return reverted;
+  } catch {
+    return null;
+  }
+}
+
+function prHasNonAuthorCommit(ghBin, prNumber, author) {
+  try {
+    const stdout = execFileSync(
+      ghBin,
+      ["pr", "view", String(prNumber), "--json", "commits"],
+      { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] },
+    );
+    const data = JSON.parse(stdout);
+    const commits = Array.isArray(data?.commits) ? data.commits : [];
+    return commits.some((c) => {
+      const authors = Array.isArray(c.authors) ? c.authors : [];
+      return authors.some((a) => a.login && a.login !== author);
+    });
+  } catch {
+    return false;
+  }
+}
+
+export function measurePrOutcomes(opts = {}) {
+  const prs = fetchAgentPrs(opts);
+  if (prs === null) return null;
+  return computePrOutcomes(prs, opts);
+}

--- a/scripts/acmm/state.js
+++ b/scripts/acmm/state.js
@@ -29,12 +29,25 @@ import { dirname, join } from "node:path";
  *
  * @typedef {Object} Behavioral
  * @property {FlakeSnapshot | null} [flake]           CI signal quality
+ * @property {AgentPrSnapshot | null} [agent_pr]      agent PR outcomes (last 30 days)
  *
  * @typedef {Object} FlakeSnapshot
  * @property {number} rate_30d        ratio in [0, 1] of SHAs that flipped outcome
  * @property {number} sample_size     distinct SHAs in the 30-day window
  * @property {string[]} flaky_shas    SHAs that flipped at least once
  * @property {string} measured_at     ISO timestamp of measurement
+ *
+ * @typedef {Object} AgentPrSnapshot
+ * @property {number} sample_size
+ * @property {number} merged_count
+ * @property {number} closed_unmerged_count
+ * @property {number} open_count
+ * @property {number} acceptance_rate_30d        ratio in [0, 1]
+ * @property {number} revert_rate_30d            ratio in [0, 1]
+ * @property {number} median_time_to_merge_hours
+ * @property {number} human_touch_ratio          merged-with-human-commit / merged
+ * @property {boolean} insufficient_data         true when sample_size < threshold
+ * @property {string} measured_at                ISO timestamp
  */
 
 export const STATE_DIR = ".claude/acmm";


### PR DESCRIPTION
Closes #647.

## What

Adds the second ACMM behavioral metric: a 30-day read of *actual* agent PR outcomes (acceptance, revert, time-to-merge, human-touch), replacing the previous "does a metrics script exist" check with the metrics themselves.

## Why

`acmm:pr-acceptance-metric` was satisfied by the *existence* of a script. ACMM never read the output. The actual signal — whether agent PRs land — wasn't in the scorecard.

## Real signal on this repo (smoke run)

```
Agent PR outcomes: 96% accepted · 0% reverted · 0.2h median time-to-merge (n=28)
```

28 agent PRs in window, 27 merged, 0 reverted within 7 days, ~12-minute median time-to-merge. First time ACMM has reported anything resembling operational maturity.

## How

- `scripts/acmm/pr-outcomes.js` separates pure compute (`computePrOutcomes`, `isAgentPr`, `extractRevertedPrNumbers`) from IO (`fetchAgentPrs`, revert detection via `git log --grep='^Revert '`, human-touch detection via `gh pr view --json commits`). Tests need no network.
- Agent-PR detection: branch prefix (`agent-`, `worktree-agent-`, `fix/agent-`, `feat/agent-`) **or** `has-pr` label.
- Window: PRs created in the last 30 days. Open PRs are excluded from the acceptance/merge-time denominators (only decided PRs count).
- `insufficient_data: true` when sample size <5 so callers can suppress misleading percentages.
- 17 unit tests covering: agent detection (3 cases), empty input, all-merged, all-closed-unmerged, mixed with open excluded, revert flag, median for odd/even count, human-touch ratio, out-of-window exclusion, non-agent exclusion, minSample threshold, revert-message parsing.
- `execFileSync` (no shell) — same safe pattern as `scripts/acmm/outputs/issues.js` and `backfill-metrics.js`.

## Test plan

- [x] `node --test scripts/acmm/__tests__/` → 30/30 passing (9 flake + 17 pr + 4 detection)
- [x] End-to-end audit run renders the section and writes state under `behavioral.agent_pr`
- [x] Non-fatal when `gh` is missing (`measurePrOutcomes` returns `null`)
- [x] State schema is forward-compatible — top-level `behavioral` object never touches existing fields

## Known limitations (intentional, follow-ups)

- **Audit run takes ~85s** because human-touch is computed via per-PR `gh pr view`. Acceptable for a daily run; can be batched via `gh pr list --json commits` if it becomes a problem.
- **Revert detection by commit-message grep** matches `^Revert ` and parses `#NNN` mentions. Won't catch reverts done by squashing or by PRs whose title was rewritten. Conservative direction: false negatives, not false positives.
- **Human-touch attribution** treats any commit author whose login differs from the PR author's login as "human-touched." On this repo this currently reports 100% on merged PRs because pre-commit auto-commits (e.g., `pack-changed` regenerating `llms.txt`) appear under different authorship. This is a tuning issue, not a bug — the metric will correct itself once we filter bot accounts. Tracking under a follow-up.

## Out of scope

- $-cost-per-merged-PR (needs Langfuse integration — separate issue)
- Drilldown by agent task type
- Real-time alerting on regressions