### PR TITLE
feat(acmm): measure cold-start time via weekly workflow (#648)

### DIFF
--- a/.github/workflows/acmm-cold-start.yml
+++ b/.github/workflows/acmm-cold-start.yml
@@ -1,0 +1,143 @@
+name: ACMM Cold Start
+
+# Weekly measurement of cold-start ergonomics: time from `git clone` to a
+# green test run. This is what every fresh agent session pays.
+#
+# ACMM otherwise checks whether `vitest.config.ts` exists; this measures
+# whether `pnpm install && pnpm test` actually works on a clean runner
+# in a reasonable amount of time.
+#
+# Output: opens a PR adding a record to `metrics/acmm-cold-start.json`.
+# The `acmm-audit` script reads the most recent record and renders a
+# "Cold start" section in the scorecard.
+
+on:
+  schedule:
+    # Sunday 06:00 UTC — outside business hours, low contention
+    - cron: '0 6 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: acmm-cold-start
+  cancel-in-progress: true
+
+jobs:
+  measure:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout (no caches)
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+
+      # Note: NO `cache: pnpm` — we want cold-start, not cache-warm.
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Time pnpm install
+        id: install
+        run: |
+          start=$(date +%s)
+          set +e
+          pnpm install --frozen-lockfile
+          install_status=$?
+          set -e
+          end=$(date +%s)
+          install_seconds=$((end - start))
+          echo "install_seconds=$install_seconds" >> "$GITHUB_OUTPUT"
+          echo "install_status=$install_status" >> "$GITHUB_OUTPUT"
+
+      - name: Time pnpm test
+        id: test
+        if: steps.install.outputs.install_status == '0'
+        run: |
+          start=$(date +%s)
+          set +e
+          pnpm test
+          test_status=$?
+          set -e
+          end=$(date +%s)
+          test_seconds=$((end - start))
+          echo "test_seconds=$test_seconds" >> "$GITHUB_OUTPUT"
+          echo "test_status=$test_status" >> "$GITHUB_OUTPUT"
+
+      - name: Compose record
+        env:
+          INSTALL_S: ${{ steps.install.outputs.install_seconds }}
+          INSTALL_STATUS: ${{ steps.install.outputs.install_status }}
+          TEST_S: ${{ steps.test.outputs.test_seconds || '0' }}
+          TEST_STATUS: ${{ steps.test.outputs.test_status || '-1' }}
+        run: |
+          TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          export TS
+          node -e '
+            const fs = require("node:fs");
+            const path = "metrics/acmm-cold-start.json";
+            const installS = Number(process.env.INSTALL_S || 0);
+            const testS = Number(process.env.TEST_S || 0);
+            const record = {
+              ts: process.env.TS,
+              install_seconds: installS,
+              test_seconds: testS,
+              total_seconds: installS + testS,
+              test_passed: process.env.TEST_STATUS === "0",
+              install_passed: process.env.INSTALL_STATUS === "0",
+              commit: process.env.GITHUB_SHA,
+            };
+            let history = [];
+            if (fs.existsSync(path)) {
+              try { history = JSON.parse(fs.readFileSync(path, "utf8")); }
+              catch { history = []; }
+            }
+            if (!Array.isArray(history)) history = [];
+            history.push(record);
+            history = history.slice(-26);
+            fs.mkdirSync("metrics", { recursive: true });
+            fs.writeFileSync(path, JSON.stringify(history, null, 2) + "\n");
+            console.log("Wrote", path, "with", history.length, "records (latest:", JSON.stringify(record), ")");
+          '
+
+      - name: Open PR with cold-start measurement
+        env:
+          INSTALL_S: ${{ steps.install.outputs.install_seconds }}
+          INSTALL_STATUS: ${{ steps.install.outputs.install_status }}
+          TEST_S: ${{ steps.test.outputs.test_seconds || 'skipped' }}
+          TEST_STATUS: ${{ steps.test.outputs.test_status || 'n/a' }}
+        run: |
+          if git diff --quiet metrics/acmm-cold-start.json 2>/dev/null; then
+            echo "No metric change to commit"
+            exit 0
+          fi
+
+          DATE="$(date +%Y-%m-%d)"
+          BRANCH="chore/acmm-cold-start-${DATE}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add metrics/acmm-cold-start.json
+          git commit -m "chore(acmm): cold-start measurement ${DATE}"
+          git push -u origin "$BRANCH"
+
+          BODY="Auto-generated weekly cold-start measurement.
+
+          - install: ${INSTALL_S}s (status: ${INSTALL_STATUS})
+          - test: ${TEST_S}s (status: ${TEST_STATUS})
+
+          See \`metrics/acmm-cold-start.json\` for the full record."
+
+          gh pr create \
+            --title "chore(acmm): cold-start measurement ${DATE}" \
+            --body "$BODY" \
+            --label "acmm,meta-improvement"

--- a/scripts/acmm/__tests__/cold-start.test.js
+++ b/scripts/acmm/__tests__/cold-start.test.js
@@ -1,0 +1,108 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { loadLatestColdStart, latestRecord, scoreColdStart } from "../cold-start.js";
+
+function tmpDir() {
+  const root = mkdtempSync(join(tmpdir(), "acmm-coldstart-"));
+  return {
+    root,
+    write(rel, body) {
+      const p = join(root, rel);
+      mkdirSync(join(p, ".."), { recursive: true });
+      writeFileSync(p, body);
+    },
+    cleanup() {
+      rmSync(root, { recursive: true, force: true });
+    },
+  };
+}
+
+test("loadLatestColdStart: missing file → null", () => {
+  const fx = tmpDir();
+  assert.equal(loadLatestColdStart(fx.root), null);
+  fx.cleanup();
+});
+
+test("loadLatestColdStart: empty array → null", () => {
+  const fx = tmpDir();
+  fx.write("metrics/acmm-cold-start.json", "[]");
+  assert.equal(loadLatestColdStart(fx.root), null);
+  fx.cleanup();
+});
+
+test("loadLatestColdStart: malformed JSON → null (non-fatal)", () => {
+  const fx = tmpDir();
+  fx.write("metrics/acmm-cold-start.json", "not json {[");
+  assert.equal(loadLatestColdStart(fx.root), null);
+  fx.cleanup();
+});
+
+test("loadLatestColdStart: returns most recent record (last in array)", () => {
+  const fx = tmpDir();
+  const records = [
+    { ts: "2026-04-01T06:00:00Z", install_seconds: 30, test_seconds: 60, total_seconds: 90, test_passed: true, commit: "old" },
+    { ts: "2026-04-08T06:00:00Z", install_seconds: 45, test_seconds: 120, total_seconds: 165, test_passed: true, commit: "new" },
+  ];
+  fx.write("metrics/acmm-cold-start.json", JSON.stringify(records));
+  const r = loadLatestColdStart(fx.root);
+  assert.equal(r.ts, "2026-04-08T06:00:00Z");
+  assert.equal(r.total_seconds, 165);
+  assert.equal(r.commit, "new");
+  fx.cleanup();
+});
+
+test("latestRecord: pure helper handles empty + non-array input", () => {
+  assert.equal(latestRecord([]), null);
+  assert.equal(latestRecord(null), null);
+  assert.equal(latestRecord(undefined), null);
+});
+
+test("scoreColdStart: null → unknown", () => {
+  assert.equal(scoreColdStart(null), "unknown");
+});
+
+test("scoreColdStart: test failed → broken regardless of timing", () => {
+  assert.equal(
+    scoreColdStart({ total_seconds: 60, test_passed: false }),
+    "broken",
+  );
+});
+
+test("scoreColdStart: total <5min and tests pass → healthy", () => {
+  assert.equal(
+    scoreColdStart({ total_seconds: 4 * 60, test_passed: true }),
+    "healthy",
+  );
+});
+
+test("scoreColdStart: total 5–15min → watch", () => {
+  assert.equal(
+    scoreColdStart({ total_seconds: 10 * 60, test_passed: true }),
+    "watch",
+  );
+});
+
+test("scoreColdStart: total >15min → broken", () => {
+  assert.equal(
+    scoreColdStart({ total_seconds: 20 * 60, test_passed: true }),
+    "broken",
+  );
+});
+
+test("scoreColdStart: boundary at exactly 5min → healthy", () => {
+  assert.equal(
+    scoreColdStart({ total_seconds: 5 * 60, test_passed: true }),
+    "healthy",
+  );
+});
+
+test("scoreColdStart: boundary at exactly 15min → watch", () => {
+  assert.equal(
+    scoreColdStart({ total_seconds: 15 * 60, test_passed: true }),
+    "watch",
+  );
+});

--- a/scripts/acmm/cold-start.js
+++ b/scripts/acmm/cold-start.js
@@ -1,0 +1,88 @@
+/**
+ * Cold-start measurement reader for ACMM behavioral signal (issue #648).
+ *
+ * The actual measurement runs on a fresh GitHub Actions runner via
+ * `.github/workflows/acmm-cold-start.yml`. That workflow appends a record to
+ * `metrics/acmm-cold-start.json`, then opens a PR — humans review before the
+ * record lands on main.
+ *
+ * This module just *reads* that file when an audit run happens locally,
+ * surfacing the most recent measurement in the scorecard. We never measure
+ * cold-start on a developer's hot-cached machine; only the CI runner does.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export const COLD_START_PATH = "metrics/acmm-cold-start.json";
+
+/**
+ * @typedef {Object} ColdStartRecord
+ * @property {string} ts                 ISO timestamp of measurement
+ * @property {number} install_seconds
+ * @property {number} test_seconds
+ * @property {number} total_seconds
+ * @property {boolean} test_passed
+ * @property {boolean} [install_passed]
+ * @property {string} [commit]           SHA the measurement was taken on
+ */
+
+/**
+ * Read the metric file and return the most recent record, or null if the
+ * file is missing/unreadable/empty. Non-fatal — never throws.
+ *
+ * @param {string} cwd
+ * @returns {ColdStartRecord | null}
+ */
+export function loadLatestColdStart(cwd) {
+  const p = join(cwd, COLD_START_PATH);
+  if (!existsSync(p)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(p, "utf-8"));
+    if (!Array.isArray(parsed) || parsed.length === 0) return null;
+    return normalizeRecord(parsed[parsed.length - 1]);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Pick the latest record from an in-memory history (pure helper for tests).
+ *
+ * @param {ColdStartRecord[]} history
+ * @returns {ColdStartRecord | null}
+ */
+export function latestRecord(history) {
+  if (!Array.isArray(history) || history.length === 0) return null;
+  return normalizeRecord(history[history.length - 1]);
+}
+
+/**
+ * Score a record into a traffic-light bucket.
+ *
+ * Thresholds derived from the issue: total <5min ✅, 5–15min ⚠️, >15min or
+ * test failed ❌.
+ *
+ * @param {ColdStartRecord | null} rec
+ * @returns {"healthy" | "watch" | "broken" | "unknown"}
+ */
+export function scoreColdStart(rec) {
+  if (!rec) return "unknown";
+  if (!rec.test_passed) return "broken";
+  if (rec.total_seconds <= 5 * 60) return "healthy";
+  if (rec.total_seconds <= 15 * 60) return "watch";
+  return "broken";
+}
+
+function normalizeRecord(r) {
+  if (!r || typeof r !== "object") return null;
+  return {
+    ts: String(r.ts ?? ""),
+    install_seconds: Number(r.install_seconds ?? 0),
+    test_seconds: Number(r.test_seconds ?? 0),
+    total_seconds: Number(r.total_seconds ?? 0),
+    test_passed: Boolean(r.test_passed),
+    install_passed: r.install_passed === undefined ? true : Boolean(r.install_passed),
+    commit: r.commit ? String(r.commit) : undefined,
+  };
+}

--- a/scripts/acmm/outputs/report.js
+++ b/scripts/acmm/outputs/report.js
@@ -14,6 +14,8 @@
 import { writeFileSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 
+import { loadLatestColdStart, scoreColdStart } from "../cold-start.js";
+
 /**
  * @param {string} cwd
  * @param {Object} args
@@ -26,6 +28,7 @@ import { dirname, join } from "node:path";
 export function writeReport(cwd, { state, criteria, sources, computation, diff }) {
   const detectedSet = new Set(state.detectedIds ?? []);
   const date = new Date().toISOString().slice(0, 10);
+  const coldStart = loadLatestColdStart(cwd);
 
   const lines = [];
 
@@ -162,6 +165,23 @@ export function writeReport(cwd, { state, criteria, sources, computation, diff }
     lines.push("");
   }
 
+  // ── Cold start (behavioral, last weekly measurement) ─────
+  if (coldStart) {
+    const score = scoreColdStart(coldStart);
+    const icon = { healthy: "✅", watch: "⚠️", broken: "❌", unknown: "·" }[score];
+    const measured = coldStart.ts ? coldStart.ts.slice(0, 10) : "unknown date";
+    lines.push("## Cold start");
+    lines.push("");
+    lines.push(`_Last measured ${measured}${coldStart.commit ? ` at \`${coldStart.commit.slice(0, 7)}\`` : ""}._`);
+    lines.push("");
+    lines.push(`- **${icon} Total:** ${formatSeconds(coldStart.total_seconds)} (clone → green tests)`);
+    lines.push(`  - install: ${formatSeconds(coldStart.install_seconds)}`);
+    lines.push(`  - test: ${formatSeconds(coldStart.test_seconds)} ${coldStart.test_passed ? "✓" : "✗ FAILED"}`);
+    lines.push("");
+    lines.push("_Healthy: <5min · Watch: 5–15min · Broken: >15min or test failed. Measured weekly on a clean GitHub Actions runner with no caches._");
+    lines.push("");
+  }
+
   // ── Cross-cutting overlay ─────────────────────────────────
   lines.push("## Cross-cutting overlay");
   lines.push("");
@@ -245,4 +265,16 @@ function remediationHint(patterns) {
   const action = isDir ? `mkdir -p ${canonical}` : `touch ${canonical}`;
   if (patterns.length === 1) return `\`${action}\``;
   return `\`${action}\` (or any of: ${patterns.slice(1).map((p) => `\`${p}\``).join(", ")})`;
+}
+
+/**
+ * Format a duration in seconds as `Nm Ss` (or just `Ns` under a minute).
+ * @param {number} seconds
+ */
+function formatSeconds(seconds) {
+  const s = Math.max(0, Math.round(Number(seconds) || 0));
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  const rem = s % 60;
+  return rem === 0 ? `${m}m` : `${m}m ${rem}s`;
 }


### PR DESCRIPTION
Closes #648.

## What

Adds the third ACMM behavioral metric: time from `git clone` to a green test run. Every fresh agent session pays this cost; ACMM was blind to it because path-existence checks never run anything.

## How

- **`.github/workflows/acmm-cold-start.yml`** — Sunday 06:00 UTC weekly run on a clean `ubuntu-latest` with **no** `cache: pnpm` (the whole point is cold-start, not cache-warm). Times `pnpm install` and `pnpm test` separately, appends a record to `metrics/acmm-cold-start.json`, then opens a PR for human review (not a direct push to main). History trimmed to 26 weeks.
- **`scripts/acmm/cold-start.js`** — pure reader: `loadLatestColdStart`, `latestRecord`, `scoreColdStart`. Non-fatal when the metric file is missing (steady state until the first weekly run lands).
- **12 unit tests** covering missing file, empty array, malformed JSON (returns `null`, never throws), most-recent selection, and `scoreColdStart` bucket boundaries.
- **`scripts/acmm/outputs/report.js`** — renders a "Cold start" section with traffic-light icons (✅ <5min, ⚠️ 5–15min, ❌ >15min or test failed). Section is omitted entirely when no measurement exists.

## Storage location — deliberate deviation from issue spec

The issue specified `.claude/acmm/cold-start.json`, but `.claude/acmm/` is gitignored on this repo (it's local audit scratch). I used `metrics/acmm-cold-start.json` to match the existing tracked-data convention (`metrics/acmm-pr-history.jsonl`). The PR-opening flow in the workflow needs the file tracked so the bot can commit it back.

## Verification

End-to-end fixture test (with a stub measurement record):

```
$ node scripts/acmm/audit.js
…
report: …/.claude/acmm/report.md
$ grep -A 8 "## Cold start" .claude/acmm/report.md
## Cold start

_Last measured 2026-04-19 at \`abc123d\`._

- **✅ Total:** 2m 45s (clone → green tests)
  - install: 45s
  - test: 2m ✓

_Healthy: <5min · Watch: 5–15min · Broken: >15min or test failed. Measured weekly on a clean GitHub Actions runner with no caches._
```

Without a fixture file, the section is omitted cleanly.

```
$ node --test scripts/acmm/__tests__/
# tests 25  # pass 25  # fail 0
$ docker run --rm rhysd/actionlint .github/workflows/acmm-cold-start.yml
(clean)
```

## Out of scope

- Per-package cold start (only monorepo-root) — separate follow-up if needed
- Cache-warm comparison
- Including `pnpm build` time
- Posting metric to a dashboard
- Using a level-gating threshold (observability first; gate later once trusted)

## Test plan

- [x] Workflow yaml is `actionlint` clean
- [x] Reader returns `null` (not throws) on missing/malformed/empty JSON
- [x] Report section is omitted when no measurement exists
- [x] Score buckets honor 5min and 15min boundaries (boundary tests included)
- [x] History is capped at 26 weeks (in workflow)