### PR TITLE
feat(ci-safety-nets): close 3 gaps from the auth+rialto+ci-cache PR stack

### DIFF
--- a/.claude/agents/rialto-prop-drift-detector.md
+++ b/.claude/agents/rialto-prop-drift-detector.md
@@ -1,0 +1,106 @@
+---
+name: rialto-prop-drift-detector
+description: Use this agent when files in `packages/rialto/src/components/**` are added or modified, OR when accessibility / unit tests in `packages/rialto/src/test/**` or `packages/rialto/src/**/*.test.tsx` reference rialto components. Diffs each test file's component prop usage against the component's exported `*Props` interface to catch the class of bug that bit us in commit `e08792a` (April 2026) — accessibility tests calling `<AppBar title="...">` long after the component switched to `<AppBar logo={...}>`. Goes beyond TypeScript's own check by surfacing **which test files need updating** in one pass and **which props were removed/renamed** between component and test, instead of leaving the dev to read 9+ scattered TS errors.
+tools: Read, Grep, Glob, Bash
+---
+
+You are a prop-drift detector for the `@mattbutlerengineering/rialto` design system. Your job is to catch test-vs-component prop signature mismatches BEFORE they reach CI typecheck.
+
+## Why you exist
+
+In April 2026, the CI workspace-symlink cache bug (#649) hid pre-existing typecheck failures in rialto for an unknown duration. When the cache was fixed, 9 TS errors surfaced at once across `forms.accessibility.test.tsx`, `navigation.accessibility.test.tsx`, and `overlays.accessibility.test.tsx` — all the same root cause: tests were authored when components had different prop signatures (`label`, `title`, `brand`, `onClick`) and never updated when the components stabilized to the current API (`aria-label`, `logo`, `onSelect`, `content`, etc.).
+
+That fix took ~30 minutes to triage. With this agent, the same drift would have been a 1-line warning at edit time.
+
+## Input
+
+You are spawned with either:
+- A list of changed files (typically `git diff --name-only origin/main...HEAD`), or
+- A specific path under `packages/rialto/`.
+
+If neither is provided, default to scanning **all** rialto component + test files.
+
+## Workflow
+
+### 1. Identify components in scope
+
+```bash
+ls packages/rialto/src/components/ | head -50
+```
+
+For each component folder (e.g. `AppBar/`):
+- Read `<Name>.tsx` (the implementation file).
+- Extract the exported `*Props` interface — the `export interface FooProps extends ...` or `export type FooProps = ...` declaration.
+- Note: rialto extends native HTML attributes via `Pick<>` patterns (e.g. `Pick<HTMLAttributes<HTMLElement>, "id" | "aria-label" | "className" | "style">`). Read these expansions carefully — `label`/`title`/`brand` are **not** native HTML attrs, so they must be explicitly declared in the props interface to be valid.
+
+### 2. Find every test referencing rialto components
+
+```bash
+find packages/rialto/src -name "*.test.tsx" -o -name "*.test.ts"
+```
+
+For each test file, grep for JSX usage of components: `<ComponentName ...>`. Use a tolerant matcher — props can be on the same line or wrapped across multiple lines.
+
+### 3. Diff usage against declared props
+
+For each `<Component prop="...">` usage:
+- Extract the prop names being passed.
+- Compare against the component's `*Props` interface.
+- Flag any prop **passed in test but absent from `*Props`** as drift.
+- Flag any **required prop** (no `?` in the interface) **omitted from test** as drift.
+- Flag children-vs-content mismatches: components that accept children (`children: ReactNode`) vs. those that take a `content` prop slot — the rialto convention puts trigger as children, content as a named prop (e.g. `<HoverCard content={...}>{trigger}</HoverCard>`).
+
+### 4. Specific gotchas to remember
+
+| Component | Common drift pattern |
+|---|---|
+| `InputGroup` | `InputGroupProps = HTMLAttributes<HTMLDivElement>` — no `label` prop. Tests passing `label="..."` are wrong; should use `aria-label`. |
+| `NumberInput` | "Always controlled" per JSDoc — `value` and `onChange` are required. Tests omitting them are wrong. |
+| `AppBar` | Takes `logo` (ReactNode) + `actions`, NOT `title`. |
+| `Navbar` | Takes `logo` (ReactNode), NOT `brand`. |
+| `Tooltip` | Takes `content`, NOT `label`. |
+| `HoverCard` | `content={card}>{trigger}` — NOT `trigger={btn}>{card}`. |
+| `ConfirmDialog` | Takes `description="..."`, NOT children. |
+| `DropdownMenu`/`ContextMenu` items | Use `MenuItemDef` shape: `{id, label, onSelect, ...}` — NOT `{label, onClick}`. |
+
+### 5. Output
+
+Per-file report. For each drift, output:
+
+```
+DRIFT: packages/rialto/src/test/accessibility/forms.accessibility.test.tsx:46
+  Component: NumberInput
+  Issue: Required props missing
+  Test passes: { label, min, max }
+  Component requires: value, onChange
+  Source of truth: packages/rialto/src/components/NumberInput/NumberInput.tsx
+  Suggested fix: <NumberInput label="Quantity" value={1} onChange={() => {}} min={1} max={10} />
+```
+
+End with a one-line summary:
+
+```
+✗ 9 drift(s) found across 3 test files. Run `pnpm --dir packages/rialto typecheck` to see TS errors.
+```
+
+OR
+
+```
+✓ No drift detected — test prop usage matches component interfaces.
+```
+
+### 6. What NOT to flag
+
+- Native HTML attributes that exist via `extends HTMLAttributes<...>` — `className`, `id`, `aria-*`, `style`, `data-*`, etc.
+- `key` and `ref` — React internals, not part of `*Props`.
+- Comment-only changes.
+- Type-only mismatches that TypeScript would catch identically (e.g. wrong primitive type) — let `tsc` handle those; you exist for the **structural** drift TS reports as 9 separate errors but is really one "we renamed the prop" theme.
+- Composition where a child component is wrapped in a custom test helper — assume the helper preserves contract.
+
+### 7. When to also surface a component-side fix
+
+If a test passes a prop that **looks intentional** but isn't on the props interface (e.g., the test passes `data-testid` and the component should forward it via `...props` spread but doesn't), suggest both: "Either update the test to remove the prop, OR update the component to extend `HTMLAttributes` so `data-*` flows through."
+
+## Output guarantee
+
+Emit findings in stable, machine-parseable format (one DRIFT block per issue) so a future automation can grep them. Always end with the count + binary summary so the caller can branch on green/red without parsing the body.

--- a/.claude/hooks/pre-push-typecheck.sh
+++ b/.claude/hooks/pre-push-typecheck.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Pre-push CI guard: when Claude Code is about to run `git push`, run pnpm
+# typecheck across the workspace first. Catches the class of failure that
+# bit us in the auth + rialto + ci-cache PR stack — pre-existing TS errors
+# on main that no local check surfaced before we shipped.
+#
+# Wired in via .claude/settings.json PreToolUse Bash matcher.
+# Receives the about-to-execute command on stdin via $CLAUDE_BASH_COMMAND.
+#
+# Behavior:
+#   - Only fires when the command contains "git push"
+#   - Runs `pnpm -r --parallel typecheck` from repo root
+#   - Exit 0 → allow the push
+#   - Exit 2 → block (Claude Code halts the tool call and surfaces the message)
+#
+# Skip mechanisms:
+#   - $SKIP_PUSH_TYPECHECK=1 → bypass entirely (use sparingly; defeats the guard)
+#   - --no-verify in the git command → bypass (matches git's own convention)
+set -uo pipefail
+
+cmd="${CLAUDE_BASH_COMMAND:-}"
+
+# Only intercept git push; everything else passes through.
+case "$cmd" in
+  *"git push"*) ;;
+  *) exit 0 ;;
+esac
+
+# Skip on explicit bypass (env or --no-verify in the command).
+if [[ "${SKIP_PUSH_TYPECHECK:-}" == "1" ]] || [[ "$cmd" == *"--no-verify"* ]]; then
+  exit 0
+fi
+
+# Skip if not actually a workspace push (e.g., docs-only changes detected by git).
+# Cheap heuristic: only proceed when there are unpushed commits to typecheck.
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  exit 0
+fi
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root" || exit 0
+
+# Find the upstream branch; if none configured, skip (typecheck wouldn't
+# have a fair baseline anyway — first push of a new branch).
+upstream=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)
+if [[ -z "$upstream" ]]; then
+  exit 0
+fi
+
+# Cheap diff check: skip when no .ts/.tsx changes in the unpushed commits.
+# Avoids a 30-60s typecheck on docs-only or config-only branches.
+if ! git diff --name-only "${upstream}..HEAD" 2>/dev/null | grep -qE '\.(ts|tsx)$'; then
+  exit 0
+fi
+
+echo "[pre-push-typecheck] running pnpm -r --parallel typecheck before push…" >&2
+if ! pnpm -r --parallel typecheck >&2; then
+  cat >&2 <<'EOF'
+
+BLOCK: typecheck failed locally. CI would fail too.
+Fix the type errors above before pushing, or set SKIP_PUSH_TYPECHECK=1
+to bypass (only for genuinely-blocked situations — defeats the guard).
+EOF
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,6 +19,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/pre-push-typecheck.sh",
+            "timeout": 120
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/.claude/skills/local-ci-precheck/SKILL.md
+++ b/.claude/skills/local-ci-precheck/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: local-ci-precheck
+description: "Run the same lint + typecheck + architecture-audit checks CI runs, locally and in parallel. Catches workspace-package issues (missing deps, prop drift, lint rule violations) before pushing — the failures CI would surface in 5 minutes show up in 30 seconds. Use before opening or pushing to a PR."
+user-invocable: true
+disable-model-invocation: true
+---
+
+# /local-ci-precheck
+
+Mirror of the CI workflow's blocking checks (`lint`, `typecheck`, `architecture-audit`), run in parallel from your shell. Designed for the workflow gap that bit us hard in commits `e928d65`/`65e99ac`/`a1c2db2` (April 2026): pre-existing lint and typecheck errors on `main` were invisible because (a) the CI workspace-symlink cache bug ate them and (b) `pnpm typecheck` wasn't part of the pre-commit hook. By the time CI told us, three separate fixes had to land in a chicken-and-egg PR stack.
+
+This skill closes that gap: run it before push, get the same red/green CI gives you — without burning a full GitHub Actions cycle.
+
+## When to invoke
+
+- **Before `git push` on a feature branch** — catches what CI would catch
+- **After a non-trivial refactor** that touched multiple workspaces
+- **After bumping a shared package** (rialto, types, config) that downstream packages consume
+- **Before merging a PR** — final sanity that nothing drifted since the last CI run
+
+## What it runs
+
+In parallel, from the repo root:
+
+| Step | Command | Mirrors CI job |
+|------|---------|---------------|
+| 1 | `pnpm install --frozen-lockfile` | `prepare` |
+| 2 | `pnpm lint` | `lint` |
+| 3 | `pnpm typecheck` | `typecheck` |
+| 4 | `pnpm --filter @mbe/cli build && pnpm --filter @mbe/cli start check-adr && pnpm --filter @mbe/cli start check-deps` | `architecture-audit` |
+
+Steps 2–4 run in parallel after step 1 completes. Total time on a warm cache: ~30s (vs ~5 min for a CI round-trip).
+
+## Invocation
+
+```bash
+# Full check (default)
+/local-ci-precheck
+
+# Just typecheck (fastest single check; what catches most refactor breaks)
+/local-ci-precheck --typecheck-only
+
+# Just lint (catches custom rule violations like require-rfc-7807-errors)
+/local-ci-precheck --lint-only
+
+# Skip install (if you just installed)
+/local-ci-precheck --skip-install
+```
+
+Implementation pattern (Bash):
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+if [[ "${1:-}" != "--skip-install" ]]; then
+  echo "→ pnpm install --frozen-lockfile"
+  pnpm install --frozen-lockfile
+fi
+
+# Run the three blocking checks in parallel; fail-fast on any.
+fail=0
+{
+  pnpm lint 2>&1 | sed 's/^/[lint] /' &
+  lint_pid=$!
+  pnpm typecheck 2>&1 | sed 's/^/[typecheck] /' &
+  type_pid=$!
+  ( pnpm --filter @mbe/cli build && \
+    pnpm --filter @mbe/cli start check-adr && \
+    pnpm --filter @mbe/cli start check-deps ) 2>&1 | sed 's/^/[arch-audit] /' &
+  arch_pid=$!
+
+  wait $lint_pid || fail=1
+  wait $type_pid || fail=1
+  wait $arch_pid || fail=1
+}
+
+if (( fail )); then
+  echo ""
+  echo "✗ /local-ci-precheck: at least one CI-blocking check failed."
+  echo "  Fix above before pushing — these will block PR merge."
+  exit 1
+fi
+
+echo ""
+echo "✓ /local-ci-precheck: all CI-blocking checks pass."
+```
+
+## Output guarantees
+
+- Exits **0** when CI would pass — push with confidence.
+- Exits **1** when CI would block — fix before pushing.
+- Each line is prefixed with `[lint]`, `[typecheck]`, or `[arch-audit]` so parallel output is readable.
+
+## Why this isn't just "run pnpm lint && pnpm typecheck"
+
+- Parallelism — three checks at once, not three sequential waits.
+- Same install path as CI (`--frozen-lockfile`) so a stale lockfile gets caught here, not in CI.
+- Includes the architecture-audit step which most devs forget about.
+- Standardized prefix output — when any check fails you immediately see which one.
+- Forces no model invocation (`disable-model-invocation: true`) — this is a side-effect-y check the user runs themselves; Claude shouldn't fire it mid-conversation as guesswork.
+
+## Pairs with
+
+- The `pre-push` Bash hook in `.claude/settings.json` — that hook auto-fires this on `git push`, but you can run `/local-ci-precheck` manually anytime mid-iteration without committing.
+- `/site-audit` — covers the runtime/UX dimension; this covers the build-time/types dimension.
+- `/ci-monitor` — for after the push, when you need to check what CI is doing on the remote.
+
+## Future enhancements
+
+- **Test job too** — currently skipped because tests can be slow; add `--include-tests` flag.
+- **Smart filtering** — only run the workspaces affected by HEAD vs. origin/main.
+- **Coverage delta** — flag PR-level coverage drops once a coverage gate workflow exists.


### PR DESCRIPTION
## Summary

Three independent guards, all targeting the same class of failure that wasted ~30 min of triage during the recent CI fix sequence (#649 + #651 + #652): pre-existing lint/typecheck errors on main went undetected because the workspace-symlink cache bug ate them, `pnpm typecheck` wasn't part of pre-commit, and test prop usage drifted from component prop interfaces invisibly.

## What landed

### 1. `/local-ci-precheck` skill
**File**: `.claude/skills/local-ci-precheck/SKILL.md`

User-invocable slash command that runs the same `lint` + `typecheck` + `architecture-audit` jobs CI runs, in parallel, in ~30s. Same red/green CI gives — without burning a 5-min Actions cycle. `disable-model-invocation: true` because it's a side-effect-y check the user runs themselves; Claude shouldn't fire it mid-conversation as guesswork.

### 2. `pre-push-typecheck` hook
**Files**: `.claude/hooks/pre-push-typecheck.sh`, `.claude/settings.json`

PreToolUse `Bash` matcher that intercepts `git push` commands, runs `pnpm -r --parallel typecheck`, blocks (exit 2) on failure. Smart-skips:
- Non-`git push` commands → exit 0 immediately
- No `.ts`/`.tsx` changes vs upstream → exit 0 (avoids 30-60s typecheck on docs-only branches)
- `--no-verify` in the command or `SKIP_PUSH_TYPECHECK=1` → bypass

Would have caught both the auth RFC 7807 lint drift (#651) and the rialto prop drift (#652) before push.

### 3. `rialto-prop-drift-detector` subagent
**File**: `.claude/agents/rialto-prop-drift-detector.md`

Subagent that diffs each rialto test file's component prop usage against the component's exported `*Props` interface. Catches the `AppBar.title → AppBar.logo` class of bug as **one structured report** instead of 9 scattered TS errors. Includes a gotchas table seeded with the specific drifts from #652 (`Tooltip.label → content`, `ConfirmDialog` children → `description`, `MenuItemDef` shape, etc.) so the agent inherits today's lessons.

## Test plan

- [x] `python3 -m json.tool .claude/settings.json` → valid
- [x] Hook smoke tests:
  - `CLAUDE_BASH_COMMAND="ls -la" bash .claude/hooks/pre-push-typecheck.sh` → exit 0 (skips non-push)
  - `CLAUDE_BASH_COMMAND="git push origin main" bash .claude/hooks/pre-push-typecheck.sh` → exit 0 (skips when no .ts changes vs upstream)
  - `SKIP_PUSH_TYPECHECK=1 CLAUDE_BASH_COMMAND="git push origin main" bash .claude/hooks/pre-push-typecheck.sh` → exit 0 (env bypass works)
- [ ] After merge: trigger the hook on a real `git push` with a deliberate type error to confirm the block path

## Costs / tradeoffs

- **Hook latency on every push**: ~30s on a ~50-package workspace when there are .ts changes; instant when there aren't. Mitigated by the diff-against-upstream short-circuit. Configurable bypass via env var.
- **One more skill in the catalog**: minimal cognitive load since it's user-only (no model invocation).
- **Subagent maintenance**: the gotchas table will need refreshing as rialto evolves. Acceptable since the alternative (no detection) costs more per drift.

## Origin

These three are the top recommendations from `/claude-code-setup:claude-automation-recommender`, ranked by direct relevance to issues this session uncovered. The other recommendations (DigitalOcean MCP, install-validator hook, pr-stack-coordinator subagent) are queued for follow-up but not in this PR.