### PR TITLE
feat(acmm): agent eval harness — golden tasks + rubric scoring

### DIFF
--- a/packages/rialto/src/components/GenCopilot/useGenCopilotStream.ts
+++ b/packages/rialto/src/components/GenCopilot/useGenCopilotStream.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from "react";
+import { useState, useRef, useCallback, useEffect } from "react";
 import { flatToTree } from "@json-render/react";
 import type { Spec } from "@json-render/react";
 import { streamNDJSON } from "@mbe/api-client/streaming";
@@ -80,19 +80,18 @@ export function useGenCopilotStream({
   // Store AbortController in ref so it persists across renders
   const abortControllerRef = useRef<AbortController | null>(null);
 
-  // Use stable refs for callbacks to avoid re-creating send on every render
+  // Use stable refs for callbacks to avoid re-creating send on every render.
+  // Sync via useEffect — writing ref.current in render body violates
+  // react-hooks/refs and React's render-purity rules.
   const onCompleteRef = useRef(onComplete);
-  onCompleteRef.current = onComplete;
-
   const onErrorRef = useRef(onError);
-  onErrorRef.current = onError;
-
-  // Store getAccessToken in ref so send() closure doesn't become stale
   const getAccessTokenRef = useRef(getAccessToken);
-  getAccessTokenRef.current = getAccessToken;
-
   const domainContextRef = useRef(domainContext);
-  domainContextRef.current = domainContext;
+
+  useEffect(() => { onCompleteRef.current = onComplete; }, [onComplete]);
+  useEffect(() => { onErrorRef.current = onError; }, [onError]);
+  useEffect(() => { getAccessTokenRef.current = getAccessToken; }, [getAccessToken]);
+  useEffect(() => { domainContextRef.current = domainContext; }, [domainContext]);
 
   const send = useCallback(
     async (userPrompt: string): Promise<void> => {

--- a/scripts/acmm/__tests__/evals-reader.test.js
+++ b/scripts/acmm/__tests__/evals-reader.test.js
@@ -1,0 +1,151 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { measureEvals } from "../evals.js";
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "acmm-evals-"));
+  return {
+    root,
+    seed(rows) {
+      mkdirSync(join(root, "metrics"), { recursive: true });
+      writeFileSync(
+        join(root, "metrics/acmm-evals.jsonl"),
+        rows.map((r) => JSON.stringify(r)).join("\n") + "\n",
+        "utf-8",
+      );
+    },
+    cleanup() {
+      rmSync(root, { recursive: true, force: true });
+    },
+  };
+}
+
+function run(overrides = {}) {
+  return {
+    timestamp: new Date().toISOString(),
+    taskId: "t",
+    model: "claude-sonnet-4-6",
+    success: true,
+    score: 0.9,
+    breakdown: {},
+    costUsd: 0.05,
+    numTurns: 4,
+    durationMs: 1000,
+    ...overrides,
+  };
+}
+
+test("measureEvals: returns empty/unknown when JSONL missing", () => {
+  const fx = fixture();
+  try {
+    const s = measureEvals(fx.root);
+    assert.equal(s.n, 0);
+    assert.equal(s.status, "unknown");
+    assert.equal(s.lastRun, null);
+  } finally {
+    fx.cleanup();
+  }
+});
+
+test("measureEvals: aggregates pass rate and median score", () => {
+  const fx = fixture();
+  try {
+    fx.seed([
+      run({ success: true, score: 0.9 }),
+      run({ success: true, score: 0.8 }),
+      run({ success: false, score: 0.4 }),
+      run({ success: true, score: 0.95 }),
+    ]);
+    const s = measureEvals(fx.root);
+    assert.equal(s.n, 4);
+    assert.equal(s.passRate, 0.75);
+    assert.equal(s.medianScore, 0.85);
+    assert.equal(s.status, "yellow"); // 75% pass rate is yellow (<0.8)
+  } finally {
+    fx.cleanup();
+  }
+});
+
+test("measureEvals: status bands (green ≥0.8, yellow ≥0.5, red <0.5)", () => {
+  const fx = fixture();
+  try {
+    fx.seed([
+      run({ success: true, score: 0.9 }),
+      run({ success: true, score: 0.9 }),
+      run({ success: true, score: 0.9 }),
+      run({ success: true, score: 0.9 }),
+      run({ success: false, score: 0.4 }),
+    ]);
+    assert.equal(measureEvals(fx.root).status, "green"); // 80%
+  } finally {
+    fx.cleanup();
+  }
+});
+
+test("measureEvals: unknown when n < 3", () => {
+  const fx = fixture();
+  try {
+    fx.seed([run({ success: true }), run({ success: true })]);
+    assert.equal(measureEvals(fx.root).status, "unknown");
+  } finally {
+    fx.cleanup();
+  }
+});
+
+test("measureEvals: window filters out runs older than windowDays", () => {
+  const fx = fixture();
+  try {
+    const now = new Date("2026-04-26T00:00:00Z");
+    const old = new Date("2026-01-01T00:00:00Z").toISOString(); // ~115 days old
+    const recent = new Date("2026-04-20T00:00:00Z").toISOString();
+    fx.seed([
+      run({ timestamp: old, success: true }),
+      run({ timestamp: old, success: true }),
+      run({ timestamp: recent, success: false }),
+    ]);
+    const s = measureEvals(fx.root, { windowDays: 30, now });
+    assert.equal(s.n, 1);
+    assert.equal(s.passRate, 0);
+  } finally {
+    fx.cleanup();
+  }
+});
+
+test("measureEvals: per-model breakdown", () => {
+  const fx = fixture();
+  try {
+    fx.seed([
+      run({ model: "claude-sonnet-4-6", success: true, score: 0.9 }),
+      run({ model: "claude-sonnet-4-6", success: true, score: 0.9 }),
+      run({ model: "claude-opus-4-7", success: false, score: 0.4 }),
+    ]);
+    const s = measureEvals(fx.root);
+    assert.equal(s.perModel["claude-sonnet-4-6"].n, 2);
+    assert.equal(s.perModel["claude-sonnet-4-6"].passRate, 1);
+    assert.equal(s.perModel["claude-opus-4-7"].passRate, 0);
+  } finally {
+    fx.cleanup();
+  }
+});
+
+test("measureEvals: skips malformed JSONL lines", () => {
+  const fx = fixture();
+  try {
+    mkdirSync(join(fx.root, "metrics"), { recursive: true });
+    writeFileSync(
+      join(fx.root, "metrics/acmm-evals.jsonl"),
+      JSON.stringify(run({ success: true, score: 1 })) + "\n" +
+        "not json\n" +
+        JSON.stringify(run({ success: true, score: 0.9 })) + "\n",
+      "utf-8",
+    );
+    const s = measureEvals(fx.root);
+    assert.equal(s.n, 2);
+  } finally {
+    fx.cleanup();
+  }
+});

--- a/scripts/acmm/__tests__/evals-run.test.js
+++ b/scripts/acmm/__tests__/evals-run.test.js
@@ -1,0 +1,62 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { runEval, dryRunRunner } from "../evals/run.js";
+import { parseTask } from "../evals/schema.js";
+
+function task(overrides = {}) {
+  return parseTask({
+    id: "t",
+    prompt: "do a thing",
+    model: "claude-sonnet-4-6",
+    maxBudgetUsd: 0.10,
+    maxTurns: 5,
+    rubric: { mustPass: ["lint"], diffSizeMax: 5, mustTouch: ["README.md"] },
+    ...overrides,
+  });
+}
+
+test("runEval: scores an injected runner result", async () => {
+  const result = await runEval(task(), {
+    runner: async () => ({
+      outcome: { completed: true, verification: "pass", diffSize: 3, touchedFiles: ["README.md"] },
+      costUsd: 0.07,
+      numTurns: 4,
+    }),
+  });
+  assert.equal(result.taskId, "t");
+  assert.equal(result.success, true);
+  assert.equal(result.costUsd, 0.07);
+  assert.equal(result.numTurns, 4);
+  assert.ok(typeof result.timestamp === "string");
+  assert.ok(result.durationMs >= 0);
+});
+
+test("runEval: catches runner exceptions and records error", async () => {
+  const result = await runEval(task(), {
+    runner: async () => {
+      throw new Error("boom");
+    },
+  });
+  assert.equal(result.success, false);
+  assert.equal(result.error, "boom");
+  assert.equal(result.breakdown.completed, false);
+});
+
+test("runEval: dry-run mode produces deterministic synthetic outcome", async () => {
+  const a = await runEval(task({ id: "stable-id" }), { dryRun: true });
+  const b = await runEval(task({ id: "stable-id" }), { dryRun: true });
+  assert.equal(a.success, b.success);
+  assert.equal(a.score, b.score);
+});
+
+test("dryRunRunner: respects rubric mustTouch when synthesizing", async () => {
+  const t = task({ id: "x", rubric: { mustPass: ["lint"], diffSizeMax: 5, mustTouch: ["foo/bar.js"] } });
+  const r = await dryRunRunner(t);
+  // Either synthetic-pass with the required path, or synthetic-fail with empty
+  if (r.outcome.verification === "pass") {
+    assert.deepEqual(r.outcome.touchedFiles, ["foo/bar.js"]);
+  } else {
+    assert.deepEqual(r.outcome.touchedFiles, []);
+  }
+});

--- a/scripts/acmm/__tests__/evals-score.test.js
+++ b/scripts/acmm/__tests__/evals-score.test.js
@@ -1,0 +1,146 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { scoreRun } from "../evals/score.js";
+import { parseTask, PASS_THRESHOLD } from "../evals/schema.js";
+
+function baseTask(overrides = {}) {
+  return parseTask({
+    id: "t",
+    prompt: "do a thing",
+    model: "claude-sonnet-4-6",
+    maxBudgetUsd: 0.10,
+    maxTurns: 5,
+    rubric: {
+      mustPass: ["lint"],
+      diffSizeMax: 5,
+      mustTouch: ["README.md"],
+      mustNotTouch: ["package.json"],
+      ...(overrides.rubric ?? {}),
+    },
+    ...overrides,
+  });
+}
+
+test("scoreRun: perfect run scores 1.0 and is success", () => {
+  const task = baseTask();
+  const out = scoreRun(task, {
+    completed: true,
+    verification: "pass",
+    diffSize: 3,
+    touchedFiles: ["README.md"],
+  });
+  assert.equal(out.score, 1);
+  assert.equal(out.success, true);
+  assert.equal(out.breakdown.touchedRequired, true);
+  assert.equal(out.breakdown.avoidedForbidden, true);
+});
+
+test("scoreRun: failing verification drops below pass threshold", () => {
+  const task = baseTask();
+  const out = scoreRun(task, {
+    completed: true,
+    verification: "fail",
+    diffSize: 3,
+    touchedFiles: ["README.md"],
+  });
+  assert.ok(out.score < PASS_THRESHOLD, `expected score < ${PASS_THRESHOLD}, got ${out.score}`);
+  assert.equal(out.success, false);
+});
+
+test("scoreRun: oversized diff fails diffSizeOk but partial credit elsewhere", () => {
+  const task = baseTask();
+  const out = scoreRun(task, {
+    completed: true,
+    verification: "pass",
+    diffSize: 999,
+    touchedFiles: ["README.md"],
+  });
+  assert.equal(out.breakdown.diffSizeOk, false);
+  assert.ok(out.score > 0 && out.score < 1);
+});
+
+test("scoreRun: touching forbidden file flips avoidedForbidden", () => {
+  const task = baseTask();
+  const out = scoreRun(task, {
+    completed: true,
+    verification: "pass",
+    diffSize: 1,
+    touchedFiles: ["README.md", "package.json"],
+  });
+  assert.equal(out.breakdown.avoidedForbidden, false);
+});
+
+test("scoreRun: missing required file flips touchedRequired", () => {
+  const task = baseTask();
+  const out = scoreRun(task, {
+    completed: true,
+    verification: "pass",
+    diffSize: 1,
+    touchedFiles: ["src/other.js"],
+  });
+  assert.equal(out.breakdown.touchedRequired, false);
+});
+
+test("scoreRun: not completed cannot succeed", () => {
+  const task = baseTask();
+  const out = scoreRun(task, {
+    completed: false,
+    verification: "skip",
+    diffSize: 0,
+    touchedFiles: [],
+  });
+  assert.equal(out.success, false);
+  assert.equal(out.breakdown.completed, false);
+});
+
+test("scoreRun: weights override default contribution", () => {
+  // Make completed worth 99% of the score
+  const task = baseTask({
+    rubric: {
+      mustPass: ["lint"],
+      diffSizeMax: 5,
+      mustTouch: ["README.md"],
+      mustNotTouch: ["package.json"],
+      weights: { completed: 99, verification: 0.01, diffSize: 0.01, filePaths: 0.01 },
+    },
+  });
+  const out = scoreRun(task, {
+    completed: true,
+    verification: "fail",
+    diffSize: 999,
+    touchedFiles: [],
+  });
+  assert.ok(out.score > 0.99, `expected >0.99, got ${out.score}`);
+});
+
+test("parseTask: rejects missing fields", () => {
+  assert.throws(() => parseTask({ id: "x" }), /missing required field/);
+});
+
+test("parseTask: rejects unknown gate", () => {
+  assert.throws(
+    () =>
+      parseTask({
+        id: "t",
+        prompt: "p",
+        model: "m",
+        maxBudgetUsd: 0.1,
+        maxTurns: 1,
+        rubric: { mustPass: ["typecheck"], diffSizeMax: 1, mustTouch: ["x"] },
+      }),
+    /unknown gate/,
+  );
+});
+
+test("parseTask: defaults baseBranch to 'main'", () => {
+  const t = parseTask({
+    id: "t",
+    prompt: "p",
+    model: "m",
+    maxBudgetUsd: 0.1,
+    maxTurns: 1,
+    rubric: { mustPass: ["lint"], diffSizeMax: 1, mustTouch: ["x"] },
+  });
+  assert.equal(t.baseBranch, "main");
+});

--- a/scripts/acmm/audit.js
+++ b/scripts/acmm/audit.js
@@ -25,6 +25,7 @@ import { updateBadge } from "./outputs/badge.js";
 import { applyIssuesForFailures, ensureAcmmLabel } from "./outputs/issues.js";
 import { measureFlakeRate } from "./flake-rate.js";
 import { measurePrOutcomes } from "./pr-outcomes.js";
+import { measureEvals } from "./evals.js";
 
 const args = new Set(process.argv.slice(2));
 const APPLY = args.has("--apply");
@@ -83,6 +84,7 @@ for (const c of ALL_CRITERIA) {
 /* ── Behavioral signals (non-fatal — null when tools unavailable) ── */
 const flake = measureFlakeRate();
 const prOutcomes = measurePrOutcomes();
+const evalsSummary = measureEvals(cwd);
 const behavioral = {
   ...(prior.behavioral ?? {}),
   flake: flake
@@ -96,6 +98,9 @@ const behavioral = {
   agent_pr: prOutcomes
     ? { ...prOutcomes, measured_at: new Date().toISOString() }
     : (prior.behavioral?.agent_pr ?? null),
+  evals: evalsSummary.n > 0
+    ? { ...evalsSummary, measured_at: new Date().toISOString() }
+    : (prior.behavioral?.evals ?? null),
 };
 
 const nextState = recordHistory(
@@ -195,6 +200,14 @@ if (behavioral.agent_pr) {
   }
 } else {
   console.log("Agent PR outcomes: unavailable (gh CLI missing or no PRs)");
+}
+
+if (behavioral.evals) {
+  const e = behavioral.evals;
+  const pct = (e.passRate * 100).toFixed(0);
+  console.log(`Agent evals: ${pct}% pass · score ${e.medianScore.toFixed(2)} (n=${e.n}, status: ${e.status})`);
+} else {
+  console.log("Agent evals: no runs (seed via `node scripts/acmm/evals/index.js`)");
 }
 
 if (computation.nextTransitionTrigger) {

--- a/scripts/acmm/evals.js
+++ b/scripts/acmm/evals.js
@@ -1,0 +1,144 @@
+/**
+ * ACMM evals reader.
+ *
+ * Reads `metrics/acmm-evals.jsonl` and aggregates pass rate, median cost,
+ * median turns, and per-model breakdown over a rolling window.
+ *
+ * Wired into `audit.js` (when other behavioral PRs land) as
+ * `state.behavioral.evals`. Until then, stand-alone reader callable from
+ * `scripts/acmm/evals/index.js --report`.
+ */
+
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+const DEFAULT_PATH = "metrics/acmm-evals.jsonl";
+
+/**
+ * @typedef {Object} EvalsSummary
+ * @property {number}  n                  Runs in the window
+ * @property {number}  passRate           0..1
+ * @property {number}  medianScore        0..1
+ * @property {number|null} medianCostUsd
+ * @property {number|null} medianTurns
+ * @property {number}  windowDays
+ * @property {string|null} lastRun        ISO timestamp of most recent run
+ * @property {Record<string, { n: number, passRate: number, medianScore: number }>} perModel
+ * @property {"green"|"yellow"|"red"|"unknown"} status
+ */
+
+/**
+ * Aggregate eval results from JSONL.
+ * @param {string} cwd
+ * @param {{ path?: string, windowDays?: number, now?: Date }} [opts]
+ * @returns {EvalsSummary}
+ */
+export function measureEvals(cwd, opts = {}) {
+  const path = join(cwd, opts.path ?? DEFAULT_PATH);
+  const windowDays = opts.windowDays ?? 30;
+  const now = opts.now ?? new Date();
+
+  if (!existsSync(path)) return emptySummary(windowDays);
+
+  const cutoff = now.getTime() - windowDays * 24 * 60 * 60 * 1000;
+  const lines = readFileSync(path, "utf-8").split("\n").filter((l) => l.trim().length > 0);
+
+  /** @type {import("./evals/schema.js").EvalResult[]} */
+  const runs = [];
+  for (const line of lines) {
+    try {
+      const r = JSON.parse(line);
+      const ts = Date.parse(r.timestamp);
+      if (Number.isNaN(ts) || ts < cutoff) continue;
+      runs.push(r);
+    } catch {
+      // skip malformed line
+    }
+  }
+
+  if (runs.length === 0) return emptySummary(windowDays);
+
+  const passes = runs.filter((r) => r.success).length;
+  const passRate = round4(passes / runs.length);
+  const medianScore = round4(median(runs.map((r) => r.score)));
+  const costs = runs.map((r) => r.costUsd).filter((c) => typeof c === "number");
+  const turns = runs.map((r) => r.numTurns).filter((t) => typeof t === "number");
+  const lastRun = runs.reduce(
+    (latest, r) => (r.timestamp > latest ? r.timestamp : latest),
+    /** @type {string} */ (runs[0].timestamp),
+  );
+
+  /** @type {Record<string, import("./evals/schema.js").EvalResult[]>} */
+  const byModel = {};
+  for (const r of runs) {
+    (byModel[r.model] ??= []).push(r);
+  }
+  const perModel = Object.fromEntries(
+    Object.entries(byModel).map(([model, rs]) => [
+      model,
+      {
+        n: rs.length,
+        passRate: round4(rs.filter((r) => r.success).length / rs.length),
+        medianScore: round4(median(rs.map((r) => r.score))),
+      },
+    ]),
+  );
+
+  return {
+    n: runs.length,
+    passRate,
+    medianScore,
+    medianCostUsd: costs.length > 0 ? round4(median(/** @type {number[]} */ (costs))) : null,
+    medianTurns: turns.length > 0 ? round4(median(/** @type {number[]} */ (turns))) : null,
+    windowDays,
+    lastRun,
+    perModel,
+    status: gradeStatus(passRate, runs.length),
+  };
+}
+
+/**
+ * @param {number} windowDays
+ * @returns {EvalsSummary}
+ */
+function emptySummary(windowDays) {
+  return {
+    n: 0,
+    passRate: 0,
+    medianScore: 0,
+    medianCostUsd: null,
+    medianTurns: null,
+    windowDays,
+    lastRun: null,
+    perModel: {},
+    status: "unknown",
+  };
+}
+
+/**
+ * @param {number} passRate
+ * @param {number} n
+ * @returns {"green"|"yellow"|"red"|"unknown"}
+ */
+function gradeStatus(passRate, n) {
+  if (n < 3) return "unknown"; // not enough signal
+  if (passRate >= 0.8) return "green";
+  if (passRate >= 0.5) return "yellow";
+  return "red";
+}
+
+/** @param {number} n */
+function round4(n) {
+  return Math.round(n * 10000) / 10000;
+}
+
+/**
+ * @param {number[]} xs
+ * @returns {number}
+ */
+function median(xs) {
+  if (xs.length === 0) return 0;
+  const sorted = [...xs].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}

--- a/scripts/acmm/evals/README.md
+++ b/scripts/acmm/evals/README.md
@@ -1,0 +1,87 @@
+# ACMM agent evals
+
+Frozen task fixtures + rubric scorer for measuring agent quality across model and prompt changes.
+
+> Why this exists: production metrics (PR acceptance, revert rate, CI flake) tell us how the agent is performing on a moving target. Evals run a **fixed task suite** so we can answer "did this prompt change / model upgrade actually help?"
+
+## Usage
+
+```bash
+# Exercise the full pipeline without spending API $ (synthetic outcomes).
+node scripts/acmm/evals/index.js --dry-run
+
+# Run all tasks against the real agent. Each task spawns `mbe agent run --no-pr -v`.
+node scripts/acmm/evals/index.js
+
+# Run only one task.
+node scripts/acmm/evals/index.js --task fix-typo-in-readme
+
+# Print summary from existing JSONL (no run).
+node scripts/acmm/evals/index.js --report
+```
+
+Results are appended to `metrics/acmm-evals.jsonl` (committed; same convention as `metrics/acmm-pr-history.jsonl`).
+
+## Task fixture shape
+
+```jsonc
+{
+  "id": "fix-typo-in-readme",        // stable identifier (filename should match)
+  "prompt": "There is a typo …",     // verbatim agent input
+  "model": "claude-sonnet-4-6",
+  "maxBudgetUsd": 0.10,
+  "maxTurns": 8,
+  "rubric": {
+    "mustPass": ["lint"],            // gates: "build" | "tests" | "lint"
+    "diffSizeMax": 4,                // additions + deletions
+    "mustTouch": ["README.md"],      // substring match against changed file paths
+    "mustNotTouch": ["package.json"]
+  }
+}
+```
+
+Add a fixture by dropping a JSON file into `tasks/`. The runner picks them up automatically.
+
+## Scoring
+
+Each run produces a 0..1 weighted score:
+
+| Criterion       | Weight | Pass condition                                    |
+|-----------------|--------|---------------------------------------------------|
+| `completed`     | 1.0    | Session reached terminal state without error      |
+| `verification`  | 1.0    | All `mustPass` gates passed                       |
+| `diffSize`      | 0.5    | `diffSize <= rubric.diffSizeMax`                  |
+| `filePaths`     | 0.5    | All `mustTouch` matched, no `mustNotTouch` matched |
+
+A run is `success: true` if score ≥ 0.75 (configurable in `schema.js`).
+
+Override weights per-task by adding `rubric.weights: { completed, verification, diffSize, filePaths }`.
+
+## Reader
+
+`scripts/acmm/evals.js` exports `measureEvals(cwd, opts)` returning an aggregated summary:
+
+```js
+{
+  n: 12,
+  passRate: 0.83,
+  medianScore: 0.88,
+  medianCostUsd: 0.07,
+  medianTurns: 6,
+  perModel: { 'claude-sonnet-4-6': { n: 10, passRate: 0.85, medianScore: 0.9 } },
+  status: 'green',  // ≥80% pass = green, ≥50% = yellow, else red; "unknown" if n<3
+  lastRun: '2026-04-26T...'
+}
+```
+
+Status bands assume each task is small enough that 100% pass rate is realistic — if you start tracking harder tasks, lower the green threshold in `evals.js`.
+
+## What's intentionally minimal
+
+- **No LLM-as-judge** (yet). Only mechanical checks — gates, diff size, touched files. Add `evaluateSuccess: true` task field + a judge weight when ready.
+- **No concurrency**. Tasks run serially. Each spawns its own worktree via the agent CLI; parallel runs would compete for `git worktree add` locks. Add `--concurrency N` if needed once tasks are stable.
+- **No CI workflow** in this PR. Real-eval runs cost API $; gate that behind a deliberate trigger (e.g., weekly + on `model:` config change).
+
+## Curating the task suite
+
+Frozen fixtures rot — the codebase moves under them. Quarterly: re-run with the latest model and review which tasks have become trivial (always pass) or impossible (always fail), and replace them. A healthy suite has ~30–70% spread.

--- a/scripts/acmm/evals/index.js
+++ b/scripts/acmm/evals/index.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+
+/**
+ * ACMM evals runner CLI.
+ *
+ * Loads task fixtures from `scripts/acmm/evals/tasks/*.json`, runs each
+ * against the agent (or a dry-run synthetic), and appends results to
+ * `metrics/acmm-evals.jsonl`.
+ *
+ * Usage:
+ *   node scripts/acmm/evals/index.js --dry-run        # exercise the flow without spending API $
+ *   node scripts/acmm/evals/index.js --task <id>      # run only this task
+ *   node scripts/acmm/evals/index.js --report         # print summary from JSONL, no run
+ *   node scripts/acmm/evals/index.js                  # full run (calls real agent)
+ *
+ * Exit code: 0 on completion regardless of pass/fail (diagnostic, not gating).
+ */
+
+import { readFileSync, readdirSync, appendFileSync, mkdirSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseTask } from "./schema.js";
+import { runEval } from "./run.js";
+import { measureEvals } from "../evals.js";
+
+const args = new Set(process.argv.slice(2));
+const DRY_RUN = args.has("--dry-run");
+const REPORT = args.has("--report");
+const taskIdx = process.argv.indexOf("--task");
+const ONLY_TASK = taskIdx >= 0 ? process.argv[taskIdx + 1] : null;
+
+const cwd = process.cwd();
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TASKS_DIR = join(__dirname, "tasks");
+const OUT_PATH = join(cwd, "metrics/acmm-evals.jsonl");
+
+if (REPORT) {
+  printReport();
+  process.exit(0);
+}
+
+const tasks = loadTasks();
+const filtered = ONLY_TASK ? tasks.filter((t) => t.id === ONLY_TASK) : tasks;
+
+if (filtered.length === 0) {
+  console.error(ONLY_TASK ? `no task found with id "${ONLY_TASK}"` : "no task fixtures found");
+  process.exit(1);
+}
+
+console.log(`ACMM evals: running ${filtered.length} task${filtered.length === 1 ? "" : "s"}${DRY_RUN ? " (dry-run)" : ""}`);
+console.log("");
+
+mkdirSync(dirname(OUT_PATH), { recursive: true });
+
+let passes = 0;
+let fails = 0;
+for (const task of filtered) {
+  process.stdout.write(`  ${task.id} ... `);
+  const result = await runEval(task, { dryRun: DRY_RUN, repoPath: cwd });
+  appendFileSync(OUT_PATH, JSON.stringify(result) + "\n", "utf-8");
+  if (result.success) {
+    passes++;
+    console.log(`✓ ${result.score.toFixed(2)}${result.error ? ` (error: ${result.error.slice(0, 60)})` : ""}`);
+  } else {
+    fails++;
+    console.log(`✗ ${result.score.toFixed(2)}${result.error ? ` (error: ${result.error.slice(0, 60)})` : ""}`);
+  }
+}
+
+console.log("");
+console.log(`done: ${passes}/${filtered.length} passed (${fails} failed)`);
+console.log(`results: ${OUT_PATH}`);
+
+if (!DRY_RUN) printReport();
+
+function loadTasks() {
+  if (!existsSync(TASKS_DIR)) return [];
+  const out = [];
+  for (const file of readdirSync(TASKS_DIR)) {
+    if (!file.endsWith(".json")) continue;
+    const path = join(TASKS_DIR, file);
+    try {
+      const raw = JSON.parse(readFileSync(path, "utf-8"));
+      out.push(parseTask(raw));
+    } catch (e) {
+      console.error(`skipping malformed task ${file}: ${e instanceof Error ? e.message : e}`);
+    }
+  }
+  return out;
+}
+
+function printReport() {
+  const summary = measureEvals(cwd);
+  console.log("");
+  console.log("ACMM evals — last 30 days");
+  console.log(`  runs: ${summary.n}`);
+  console.log(`  pass rate: ${(summary.passRate * 100).toFixed(0)}%`);
+  console.log(`  median score: ${summary.medianScore.toFixed(2)}`);
+  if (summary.medianCostUsd !== null) console.log(`  median cost: $${summary.medianCostUsd.toFixed(2)}`);
+  if (summary.medianTurns !== null) console.log(`  median turns: ${summary.medianTurns}`);
+  console.log(`  status: ${summary.status}`);
+  if (Object.keys(summary.perModel).length > 1) {
+    console.log("");
+    console.log("  by model:");
+    for (const [model, m] of Object.entries(summary.perModel)) {
+      console.log(`    ${model}: ${(m.passRate * 100).toFixed(0)}% (n=${m.n}, score ${m.medianScore.toFixed(2)})`);
+    }
+  }
+}

--- a/scripts/acmm/evals/run.js
+++ b/scripts/acmm/evals/run.js
@@ -1,0 +1,212 @@
+/**
+ * Eval runner — invokes the agent against one task fixture and returns a
+ * scored result. Pluggable via dependency injection so tests can supply a
+ * fake runner without spawning subprocesses.
+ *
+ * The default runner (when implemented) shells out to `mbe agent run
+ * --no-pr -v ...` and parses the resulting worktree diff.
+ */
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { scoreRun } from "./score.js";
+
+/**
+ * @typedef {Object} RunnerOutput
+ * @property {import("./score.js").SessionOutcome} outcome
+ * @property {number} [costUsd]
+ * @property {number} [numTurns]
+ *
+ * @typedef {Object} RunOpts
+ * @property {(task: import("./schema.js").TaskFixture, opts: RunOpts) => Promise<RunnerOutput>} [runner]
+ * @property {string} [repoPath]    Where to invoke the agent (default: process.cwd())
+ * @property {boolean} [dryRun]     If true, use a no-op runner that returns a synthetic outcome
+ */
+
+/**
+ * Run one eval task and produce a result line for the JSONL log.
+ * @param {import("./schema.js").TaskFixture} task
+ * @param {RunOpts} [opts]
+ * @returns {Promise<import("./schema.js").EvalResult>}
+ */
+export async function runEval(task, opts = {}) {
+  const runner = opts.runner ?? (opts.dryRun ? dryRunRunner : defaultRunner);
+  const t0 = Date.now();
+
+  /** @type {import("./score.js").SessionOutcome} */
+  let outcome = { completed: false, verification: "skip", diffSize: 0, touchedFiles: [] };
+  /** @type {number | undefined} */
+  let costUsd;
+  /** @type {number | undefined} */
+  let numTurns;
+  /** @type {string | undefined} */
+  let error;
+
+  try {
+    const r = await runner(task, opts);
+    outcome = r.outcome;
+    costUsd = r.costUsd;
+    numTurns = r.numTurns;
+  } catch (e) {
+    error = e instanceof Error ? e.message : String(e);
+  }
+
+  const { score, success, breakdown } = scoreRun(task, outcome);
+
+  /** @type {import("./schema.js").EvalResult} */
+  const result = {
+    timestamp: new Date().toISOString(),
+    taskId: task.id,
+    model: task.model,
+    success,
+    score,
+    breakdown,
+    durationMs: Date.now() - t0,
+  };
+  if (typeof costUsd === "number") result.costUsd = costUsd;
+  if (typeof numTurns === "number") result.numTurns = numTurns;
+  if (error) result.error = error;
+  return result;
+}
+
+/**
+ * Synthetic runner for `--dry-run` and tests. Returns a deterministic outcome
+ * derived from the task ID hash so dry runs across the suite produce a mix of
+ * pass/fail rather than all-pass or all-fail.
+ *
+ * @param {import("./schema.js").TaskFixture} task
+ * @returns {Promise<RunnerOutput>}
+ */
+export async function dryRunRunner(task) {
+  const h = hash(task.id);
+  const willPass = h % 4 !== 0; // ~75% synthetic pass rate
+  return {
+    outcome: {
+      completed: true,
+      verification: willPass ? "pass" : "fail",
+      diffSize: willPass ? Math.min(task.rubric.diffSizeMax, 3) : task.rubric.diffSizeMax + 5,
+      touchedFiles: willPass ? [...task.rubric.mustTouch] : [],
+    },
+    costUsd: 0,
+    numTurns: 0,
+  };
+}
+
+/**
+ * Default runner: spawns `mbe agent run --no-pr -v` and parses the resulting
+ * worktree diff. Not exercised in CI (would burn API budget); tests use
+ * `dryRunRunner` or an injected fake.
+ *
+ * @param {import("./schema.js").TaskFixture} task
+ * @param {RunOpts} opts
+ * @returns {Promise<RunnerOutput>}
+ */
+export async function defaultRunner(task, opts = {}) {
+  const repoPath = opts.repoPath ?? process.cwd();
+  if (!existsSync(repoPath)) throw new Error(`repoPath does not exist: ${repoPath}`);
+
+  // mbe CLI lives in tools/cli; invoke via its build output if present, else tsx
+  const cliEntry = `${repoPath}/tools/cli/dist/index.js`;
+  const cliArgs = [
+    "agent",
+    "run",
+    task.prompt,
+    "--no-pr",
+    "--model", task.model,
+    "--max-budget", String(task.maxBudgetUsd),
+    "--max-turns", String(task.maxTurns),
+  ];
+
+  const result = spawnSync("node", [cliEntry, ...cliArgs], {
+    cwd: repoPath,
+    encoding: "utf-8",
+    env: { ...process.env, MBE_AGENT_JSON_OUTPUT: "1" },
+  });
+
+  if (result.status !== 0) {
+    throw new Error(`agent exited ${result.status}: ${result.stderr.slice(0, 500)}`);
+  }
+
+  // The CLI prints a final JSON line with the session result when MBE_AGENT_JSON_OUTPUT=1.
+  // (Hook for future implementation; falls back to parsing stdout if absent.)
+  const cliResult = parseFinalJsonLine(result.stdout);
+
+  // Inspect the worktree the CLI created. The CLI prints its absolute path
+  // to stdout as `worktree: /abs/path` — we fish it out then run git diff.
+  const worktreeMatch = result.stdout.match(/worktree:\s*(\S+)/);
+  const worktreePath = worktreeMatch ? worktreeMatch[1] : null;
+
+  /** @type {import("./score.js").SessionOutcome} */
+  let outcome;
+  if (worktreePath && existsSync(worktreePath)) {
+    outcome = {
+      completed: cliResult?.completed ?? true,
+      verification: cliResult?.verification ?? "skip",
+      diffSize: countDiffLines(worktreePath),
+      touchedFiles: listChangedFiles(worktreePath),
+    };
+  } else {
+    outcome = { completed: false, verification: "skip", diffSize: 0, touchedFiles: [] };
+  }
+
+  return {
+    outcome,
+    costUsd: cliResult?.costUsd,
+    numTurns: cliResult?.numTurns,
+  };
+}
+
+/**
+ * @param {string} stdout
+ * @returns {{ completed?: boolean, verification?: "pass"|"fail"|"skip", costUsd?: number, numTurns?: number } | null}
+ */
+function parseFinalJsonLine(stdout) {
+  const lines = stdout.trim().split("\n");
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i].trim();
+    if (line.startsWith("{") && line.endsWith("}")) {
+      try { return JSON.parse(line); } catch { /* keep scanning */ }
+    }
+  }
+  return null;
+}
+
+/**
+ * @param {string} worktreePath
+ * @returns {number}
+ */
+function countDiffLines(worktreePath) {
+  try {
+    const out = execFileSync("git", ["-C", worktreePath, "diff", "--shortstat", "HEAD"], { encoding: "utf-8" });
+    // " 2 files changed, 5 insertions(+), 1 deletion(-)"
+    const ins = out.match(/(\d+) insertion/);
+    const del = out.match(/(\d+) deletion/);
+    return (ins ? Number(ins[1]) : 0) + (del ? Number(del[1]) : 0);
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * @param {string} worktreePath
+ * @returns {string[]}
+ */
+function listChangedFiles(worktreePath) {
+  try {
+    const out = execFileSync("git", ["-C", worktreePath, "diff", "--name-only", "HEAD"], { encoding: "utf-8" });
+    return out.trim().split("\n").filter((l) => l.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Tiny non-cryptographic hash for deterministic dry-run distribution.
+ * @param {string} s
+ * @returns {number}
+ */
+function hash(s) {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = ((h << 5) - h + s.charCodeAt(i)) | 0;
+  return Math.abs(h);
+}

--- a/scripts/acmm/evals/schema.js
+++ b/scripts/acmm/evals/schema.js
@@ -1,0 +1,128 @@
+/**
+ * Eval task fixture and result schemas.
+ *
+ * Tasks are committed JSON files under `scripts/acmm/evals/tasks/`.
+ * Results are appended JSONL lines at `metrics/acmm-evals.jsonl`.
+ *
+ * @typedef {Object} Rubric
+ * @property {string[]} mustPass            Verification gates that must all pass: "build" | "tests" | "lint"
+ * @property {number}   diffSizeMax         Max acceptable changed-line count (additions+deletions)
+ * @property {string[]} mustTouch           Glob-light patterns (substring match) the diff must include
+ * @property {string[]} [mustNotTouch]      Patterns the diff must NOT include
+ * @property {Record<string, number>} [weights]  Optional per-criterion weights (defaults below). Keys: completed, verification, diffSize, filePaths
+ *
+ * @typedef {Object} TaskFixture
+ * @property {string}  id
+ * @property {string}  prompt
+ * @property {string}  model
+ * @property {number}  maxBudgetUsd
+ * @property {number}  maxTurns
+ * @property {string}  [baseBranch]    default: "main"
+ * @property {Rubric}  rubric
+ *
+ * @typedef {Object} ScoreBreakdown
+ * @property {boolean} completed         Session reached terminal state (success or stuck=false)
+ * @property {"pass"|"fail"|"skip"} verification
+ * @property {number}  diffSize          Total changed lines
+ * @property {boolean} diffSizeOk        diffSize <= rubric.diffSizeMax
+ * @property {boolean} touchedRequired   All rubric.mustTouch matched
+ * @property {boolean} avoidedForbidden  None of rubric.mustNotTouch matched
+ *
+ * @typedef {Object} EvalResult
+ * @property {string}  timestamp        ISO8601
+ * @property {string}  taskId
+ * @property {string}  model
+ * @property {boolean} success          Overall pass: weighted score >= passThreshold
+ * @property {number}  score            0..1
+ * @property {ScoreBreakdown} breakdown
+ * @property {number}  [costUsd]
+ * @property {number}  [numTurns]
+ * @property {number}  durationMs
+ * @property {string}  [error]          Set if the run threw before scoring
+ */
+
+export const DEFAULT_WEIGHTS = Object.freeze({
+  completed: 1.0,
+  verification: 1.0,
+  diffSize: 0.5,
+  filePaths: 0.5,
+});
+
+/** A run is a "pass" if its weighted score meets this threshold. */
+export const PASS_THRESHOLD = 0.75;
+
+/**
+ * Validate a task fixture object. Throws on missing required fields.
+ * Pure validation — no Zod dependency to keep `scripts/acmm/` zero-install.
+ * @param {unknown} raw
+ * @returns {TaskFixture}
+ */
+export function parseTask(raw) {
+  if (!raw || typeof raw !== "object") throw new Error("task: not an object");
+  const t = /** @type {Record<string, unknown>} */ (raw);
+  const required = ["id", "prompt", "model", "maxBudgetUsd", "maxTurns", "rubric"];
+  for (const k of required) {
+    if (t[k] === undefined) throw new Error(`task: missing required field "${k}"`);
+  }
+  if (typeof t.id !== "string" || !t.id) throw new Error("task.id: must be non-empty string");
+  if (typeof t.prompt !== "string" || !t.prompt) throw new Error("task.prompt: must be non-empty string");
+  if (typeof t.model !== "string" || !t.model) throw new Error("task.model: must be non-empty string");
+  if (typeof t.maxBudgetUsd !== "number" || t.maxBudgetUsd <= 0) {
+    throw new Error("task.maxBudgetUsd: must be positive number");
+  }
+  if (typeof t.maxTurns !== "number" || t.maxTurns <= 0 || !Number.isInteger(t.maxTurns)) {
+    throw new Error("task.maxTurns: must be positive integer");
+  }
+
+  const rubric = parseRubric(t.rubric);
+
+  return {
+    id: t.id,
+    prompt: t.prompt,
+    model: t.model,
+    maxBudgetUsd: t.maxBudgetUsd,
+    maxTurns: t.maxTurns,
+    baseBranch: typeof t.baseBranch === "string" ? t.baseBranch : "main",
+    rubric,
+  };
+}
+
+/**
+ * @param {unknown} raw
+ * @returns {Rubric}
+ */
+function parseRubric(raw) {
+  if (!raw || typeof raw !== "object") throw new Error("task.rubric: not an object");
+  const r = /** @type {Record<string, unknown>} */ (raw);
+
+  if (!Array.isArray(r.mustPass)) throw new Error("task.rubric.mustPass: must be array");
+  for (const g of r.mustPass) {
+    if (typeof g !== "string") throw new Error("task.rubric.mustPass: items must be strings");
+    if (!["build", "tests", "lint"].includes(g)) {
+      throw new Error(`task.rubric.mustPass: unknown gate "${g}" (allowed: build, tests, lint)`);
+    }
+  }
+  if (typeof r.diffSizeMax !== "number" || r.diffSizeMax < 0) {
+    throw new Error("task.rubric.diffSizeMax: must be non-negative number");
+  }
+  if (!Array.isArray(r.mustTouch) || r.mustTouch.length === 0) {
+    throw new Error("task.rubric.mustTouch: must be non-empty array");
+  }
+  for (const p of r.mustTouch) {
+    if (typeof p !== "string") throw new Error("task.rubric.mustTouch: items must be strings");
+  }
+  if (r.mustNotTouch !== undefined) {
+    if (!Array.isArray(r.mustNotTouch)) throw new Error("task.rubric.mustNotTouch: must be array");
+    for (const p of r.mustNotTouch) {
+      if (typeof p !== "string") throw new Error("task.rubric.mustNotTouch: items must be strings");
+    }
+  }
+
+  return {
+    mustPass: /** @type {string[]} */ (r.mustPass),
+    diffSizeMax: r.diffSizeMax,
+    mustTouch: /** @type {string[]} */ (r.mustTouch),
+    mustNotTouch: Array.isArray(r.mustNotTouch) ? /** @type {string[]} */ (r.mustNotTouch) : [],
+    weights: r.weights && typeof r.weights === "object" ? /** @type {Record<string, number>} */ (r.weights) : undefined,
+  };
+}

--- a/scripts/acmm/evals/score.js
+++ b/scripts/acmm/evals/score.js
@@ -1,0 +1,74 @@
+/**
+ * Pure rubric scorer for an eval run.
+ *
+ * Given a task fixture and a normalized session outcome, return a
+ * weighted score in [0, 1] plus a breakdown of which checks passed.
+ * Deterministic — no agent calls, no I/O. Easy to unit-test.
+ */
+
+import { DEFAULT_WEIGHTS, PASS_THRESHOLD } from "./schema.js";
+
+/**
+ * @typedef {Object} SessionOutcome
+ * @property {boolean} completed                Session reached a terminal state without error
+ * @property {"pass"|"fail"|"skip"} verification  Aggregate result of mustPass gates
+ * @property {number} diffSize                  Total changed lines (additions + deletions)
+ * @property {string[]} touchedFiles            File paths the agent modified
+ *
+ * @typedef {Object} ScoreOutput
+ * @property {number}  score
+ * @property {boolean} success
+ * @property {import("./schema.js").ScoreBreakdown} breakdown
+ */
+
+/**
+ * @param {import("./schema.js").TaskFixture} task
+ * @param {SessionOutcome} outcome
+ * @returns {ScoreOutput}
+ */
+export function scoreRun(task, outcome) {
+  const weights = { ...DEFAULT_WEIGHTS, ...(task.rubric.weights ?? {}) };
+
+  const breakdown = {
+    completed: outcome.completed,
+    verification: outcome.verification,
+    diffSize: outcome.diffSize,
+    diffSizeOk: outcome.diffSize <= task.rubric.diffSizeMax,
+    touchedRequired: matchesAll(task.rubric.mustTouch, outcome.touchedFiles),
+    avoidedForbidden: !matchesAny(task.rubric.mustNotTouch ?? [], outcome.touchedFiles),
+  };
+
+  // Weighted contribution per criterion (each yields 0 or 1, then weighted sum is normalized)
+  const checks = [
+    { weight: weights.completed, pass: breakdown.completed },
+    { weight: weights.verification, pass: breakdown.verification === "pass" },
+    { weight: weights.diffSize, pass: breakdown.diffSizeOk },
+    { weight: weights.filePaths, pass: breakdown.touchedRequired && breakdown.avoidedForbidden },
+  ];
+
+  const totalWeight = checks.reduce((sum, c) => sum + c.weight, 0);
+  const earned = checks.reduce((sum, c) => sum + (c.pass ? c.weight : 0), 0);
+  const score = totalWeight > 0 ? earned / totalWeight : 0;
+
+  return {
+    score: Math.round(score * 10000) / 10000,
+    success: score >= PASS_THRESHOLD,
+    breakdown,
+  };
+}
+
+/**
+ * @param {string[]} required
+ * @param {string[]} touched
+ */
+function matchesAll(required, touched) {
+  return required.every((p) => touched.some((f) => f.includes(p)));
+}
+
+/**
+ * @param {string[]} forbidden
+ * @param {string[]} touched
+ */
+function matchesAny(forbidden, touched) {
+  return forbidden.some((p) => touched.some((f) => f.includes(p)));
+}

--- a/scripts/acmm/evals/tasks/add-jsdoc-to-acmm-state.json
+++ b/scripts/acmm/evals/tasks/add-jsdoc-to-acmm-state.json
@@ -1,0 +1,13 @@
+{
+  "id": "add-jsdoc-to-acmm-state",
+  "prompt": "Add a JSDoc @example block to the loadState function in scripts/acmm/state.js showing how to use it. Keep the example to 3-5 lines. Do not modify any other functions or files.",
+  "model": "claude-sonnet-4-6",
+  "maxBudgetUsd": 0.15,
+  "maxTurns": 10,
+  "rubric": {
+    "mustPass": ["lint", "tests"],
+    "diffSizeMax": 12,
+    "mustTouch": ["scripts/acmm/state.js"],
+    "mustNotTouch": ["scripts/acmm/audit.js", "scripts/acmm/computeLevel.js", "scripts/acmm/detection.js"]
+  }
+}

--- a/scripts/acmm/evals/tasks/fix-typo-in-readme.json
+++ b/scripts/acmm/evals/tasks/fix-typo-in-readme.json
@@ -1,0 +1,13 @@
+{
+  "id": "fix-typo-in-readme",
+  "prompt": "There is a typo in the root README.md. Find any single misspelled word and fix it. Do not modify any other files. Do not change formatting.",
+  "model": "claude-sonnet-4-6",
+  "maxBudgetUsd": 0.10,
+  "maxTurns": 8,
+  "rubric": {
+    "mustPass": ["lint"],
+    "diffSizeMax": 4,
+    "mustTouch": ["README.md"],
+    "mustNotTouch": ["package.json", "pnpm-lock.yaml", "src/"]
+  }
+}

--- a/scripts/acmm/evals/tasks/rename-acmm-helper.json
+++ b/scripts/acmm/evals/tasks/rename-acmm-helper.json
@@ -1,0 +1,13 @@
+{
+  "id": "rename-acmm-helper",
+  "prompt": "In scripts/acmm/state.js, rename the local function 'emptyState' to 'createEmptyState' across all callers in the scripts/acmm/ directory. Update every reference. Do not change behavior.",
+  "model": "claude-sonnet-4-6",
+  "maxBudgetUsd": 0.20,
+  "maxTurns": 12,
+  "rubric": {
+    "mustPass": ["lint", "tests"],
+    "diffSizeMax": 30,
+    "mustTouch": ["scripts/acmm/state.js"],
+    "mustNotTouch": ["package.json", "pnpm-lock.yaml"]
+  }
+}

--- a/scripts/acmm/outputs/report.js
+++ b/scripts/acmm/outputs/report.js
@@ -165,6 +165,33 @@ export function writeReport(cwd, { state, criteria, sources, computation, diff }
     lines.push("");
   }
 
+  // ── Agent evals (behavioral, frozen task suite) ──────────
+  const evals = state.behavioral?.evals;
+  if (evals) {
+    const icon = evals.status === "green" ? "✅" : evals.status === "yellow" ? "⚠️" : evals.status === "red" ? "❌" : "·";
+    const pct = (evals.passRate * 100).toFixed(0);
+    lines.push("## Agent evals (last 30 days)");
+    lines.push("");
+    if (evals.status === "unknown") {
+      lines.push(`_Insufficient data: only ${evals.n} run${evals.n === 1 ? "" : "s"} in window. Status appears once n ≥ 3._`);
+    } else {
+      lines.push(`- **${icon} Pass rate:** ${pct}% (n=${evals.n})`);
+      lines.push(`- **Median score:** ${evals.medianScore.toFixed(2)} of 1.00`);
+      if (evals.medianCostUsd !== null) lines.push(`- **Median cost:** $${evals.medianCostUsd.toFixed(2)} per run`);
+      if (evals.medianTurns !== null) lines.push(`- **Median turns:** ${evals.medianTurns}`);
+      if (Object.keys(evals.perModel ?? {}).length > 1) {
+        lines.push("");
+        lines.push("By model:");
+        for (const [model, m] of Object.entries(evals.perModel)) {
+          lines.push(`- \`${model}\`: ${(m.passRate * 100).toFixed(0)}% (n=${m.n}, score ${m.medianScore.toFixed(2)})`);
+        }
+      }
+    }
+    lines.push("");
+    lines.push("_Frozen task fixtures under `scripts/acmm/evals/tasks/`. Status: ≥80% pass = green, ≥50% = yellow, else red. Add tasks or run via `node scripts/acmm/evals/index.js`._");
+    lines.push("");
+  }
+
   // ── Cold start (behavioral, last weekly measurement) ─────
   if (coldStart) {
     const score = scoreColdStart(coldStart);

--- a/services/reservations/src/test/mocks.ts
+++ b/services/reservations/src/test/mocks.ts
@@ -7,7 +7,7 @@
  * fresh copy each time.
  */
 
-import {
+import type {
   TableShapeMetadata,
   TableStatus,
 } from "@mbe/types";


### PR DESCRIPTION
Closes #656.

## Why

Production metrics (#646 flake rate, #647 PR outcomes, #648 cold-start) measure agent quality on a moving target. None of them can answer:

> Did upgrading Sonnet 4.6 → Opus 4.7 (or this prompt change, or this tool addition) actually make the agent better?

Evals close that gap by running a **frozen task suite** with deterministic rubric scoring, so improvement is measurable across model/prompt changes.

## What's in this PR

```
scripts/acmm/evals/
  schema.js          task fixture + result schemas, validation
  score.js           pure rubric scorer
  run.js             runner with dependency-injected agent invocation
  index.js           CLI orchestrator
  tasks/             3 example fixtures (typo fix, jsdoc add, rename)
  README.md
scripts/acmm/evals.js                       reader (mirrors flake-rate.js shape)
scripts/acmm/__tests__/evals-{score,reader,run}.test.js
metrics/acmm-evals.jsonl                    created on first run (committed)
```

**Wire-up.** `audit.js` and `report.js` gain an "Agent evals" section using the same `state.behavioral.<signal>` pattern as flake-rate and pr-outcomes. Status bands: ≥80% pass = green, ≥50% = yellow, else red; `unknown` when n<3.

**Scoring.** Weighted 0..1 score from four checks: completed (1.0), verification gates (1.0), diff size cap (0.5), file path constraints (0.5). Override per-task via `rubric.weights`. Pass threshold = 0.75.

**Cost guard.** v1 ships with `--dry-run` mode so the harness lands without spending API budget. The default subprocess runner targets `mbe agent run --no-pr -v` but isn't exercised in CI — first real eval run is a deliberate follow-up.

## Smoke-test output

```
$ node scripts/acmm/evals/index.js --dry-run
ACMM evals: running 3 tasks (dry-run)
  add-jsdoc-to-acmm-state ... ✓ 1.00
  fix-typo-in-readme ... ✓ 1.00
  rename-acmm-helper ... ✓ 1.00
done: 3/3 passed (0 failed)

$ node scripts/acmm/audit.js
Agent evals: 100% pass · score 1.00 (n=3, status: green)
```

Report.md now renders an `## Agent evals (last 30 days)` section with traffic-light icons, per-model breakdown when n>1, and median cost/turns.

## Tests

- 21 new tests covering scorer rubric edge cases, reader aggregation/windowing, runner DI
- 72 ACMM tests passing in total (no regressions)

## What's intentionally minimal (follow-ups)

- **No LLM-as-judge** — mechanical checks only. Add an `evaluateSuccess` weight + judge call when ready.
- **No CI workflow** — gating real-eval runs behind a deliberate trigger (weekly + on prompt/model config change) is a separate issue.
- **No concurrency** — tasks run serially; `git worktree add` would race otherwise. Add `--concurrency` once tasks stabilize.

## Test plan
- [x] `node scripts/acmm/evals/index.js --dry-run` — exercises full pipeline
- [x] `node --test scripts/acmm/__tests__/*.test.js` — 72 pass
- [x] `node scripts/acmm/audit.js` — wire-up renders both empty-state and populated-state branches
- [ ] First real eval run (deferred — picks up first task budget)