### PR TITLE
fix(agent): use RFC 7807 envelope in gen-* test mocks (#662)

### DIFF
--- a/services/agent/llms-full.txt
+++ b/services/agent/llms-full.txt
@@ -1,4 +1,122 @@
 <codebase path="services/agent">
+  <section priority="medium" role="prisma">
+  <file path="prisma/seed.ts">
+    async function main() {
+      console.log("Seeding agent database...");
+    
+      const now = new Date();
+      const fiveMinAgo = new Date(now.getTime() - 5 * 60_000);
+      const tenMinAgo = new Date(now.getTime() - 10 * 60_000);
+      const thirtyMinAgo = new Date(now.getTime() - 30 * 60_000);
+      const oneHourAgo = new Date(now.getTime() - 60 * 60_000);
+    
+      // --- Succeeded Session 1: Bug fix ---
+      const session1 = await prisma.session.create({
+        data: {
+          status: "SUCCEEDED",
+          taskDescription: "Fix login button not responding on mobile viewport",
+          branchName: "agent/fix-mobile-login",
+          baseBranch: "main",
+          model: "claude-sonnet-4-6",
+          maxTurns: 50,
+          maxBudgetUsd: 1.0,
+          createPr: true,
+          prUrl: "https://github.com/mattbutlerengineering/mattbutlerengineering/pull/400",
+          prNumber: 400,
+          resultText: "Fixed mobile login button by correcting CSS media query breakpoint",
+          costUsd: 0.42,
+          inputTokens: 15200,
+          outputTokens: 4800,
+          numTurns: 8,
+          durationMs: 45000,
+          errors: [],
+          startedAt: oneHourAgo,
+          completedAt: thirtyMinAgo,
+        },
+      });
+    
+      await prisma.sessionEvent.createMany({
+        data: [
+          { sessionId: session1.id, type: "turn:start", data: { turn: 1 }, createdAt: oneHourAgo },
+          { sessionId: session1.id, type: "file:modified", data: { path: "apps/hospitality/src/components/LoginButton.tsx" }, createdAt: new Date(oneHourAgo.getTime() + 10_000) },
+          { sessionId: session1.id, type: "turn:end", data: { turn: 8, costUsd: 0.42 }, createdAt: thirtyMinAgo },
+          { sessionId: session1.id, type: "pr:created", data: { prUrl: "https://github.com/mattbutlerengineering/mattbutlerengineering/pull/400", prNumber: 400 }, createdAt: thirtyMinAgo },
+        ],
+      });
+    
+      // --- Succeeded Session 2: Feature ---
+      const session2 = await prisma.session.create({
+        data: {
+          status: "SUCCEEDED",
+          taskDescription: "Add tooltip component to design system",
+          branchName: "agent/add-tooltip",
+          baseBranch: "main",
+          model: "claude-sonnet-4-6",
+          maxTurns: 50,
+          maxBudgetUsd: 1.0,
+          createPr: true,
+          prUrl: "https://github.com/mattbutlerengineering/mattbutlerengineering/pull/405",
+          prNumber: 405,
+          resultText: "Created Tooltip component with accessibility support and animations",
+          costUsd: 0.78,
+          inputTokens: 28500,
+          outputTokens: 9200,
+          numTurns: 14,
+          durationMs: 82000,
+          errors: [],
+          startedAt: thirtyMinAgo,
+          completedAt: fiveMinAgo,
+        },
+      });
+    
+      await prisma.sessionEvent.createMany({
+        data: [
+          { sessionId: session2.id, type: "turn:start", data: { turn: 1 }, createdAt: thirtyMinAgo },
+          { sessionId: session2.id, type: "file:created", data: { path: "packages/rialto/src/components/Tooltip.tsx" }, createdAt: new Date(thirtyMinAgo.getTime() + 20_000) },
+          { sessionId: session2.id, type: "file:created", data: { path: "packages/rialto/src/components/Tooltip.test.tsx" }, createdAt: new Date(thirtyMinAgo.getTime() + 40_000) },
+          { sessionId: session2.id, type: "turn:end", data: { turn: 14, costUsd: 0.78 }, createdAt: fiveMinAgo },
+          { sessionId: session2.id, type: "pr:created", data: { prUrl: "https://github.com/mattbutlerengineering/mattbutlerengineering/pull/405", prNumber: 405 }, createdAt: fiveMinAgo },
+        ],
+      });
+    
+      // --- Failed Session ---
+      const session3 = await prisma.session.create({
+        data: {
+          status: "FAILED",
+          taskDescription: "Migrate database to use UUID v7 for all primary keys",
+          branchName: "agent/uuid-v7-migration",
+          baseBranch: "main",
+          model: "claude-sonnet-4-6",
+          maxTurns: 50,
+          maxBudgetUsd: 1.0,
+          createPr: false,
+          resultText: "Failed: migration affected too many tables, exceeded budget",
+          costUsd: 1.0,
+          inputTokens: 42000,
+          outputTokens: 12000,
+          numTurns: 50,
+          durationMs: 180000,
+          errors: [{ message: "Budget exceeded", turn: 50, timestamp: tenMinAgo.toISOString() }],
+          startedAt: oneHourAgo,
+          completedAt: tenMinAgo,
+        },
+      });
+    
+      await prisma.sessionEvent.createMany({
+        data: [
+          { sessionId: session3.id, type: "turn:start", data: { turn: 1 }, createdAt: oneHourAgo },
+          { sessionId: session3.id, type: "file:modified", data: { path: "services/users/prisma/schema.prisma" }, createdAt: new Date(oneHourAgo.getTime() + 15_000) },
+          { sessionId: session3.id, type: "error", data: { message: "Budget exceeded", turn: 50 }, createdAt: tenMinAgo },
+        ],
+      });
+    
+      console.log("Seeded agent database:", {
+        sessions: [session1.id, session2.id, session3.id],
+        events: "11 total",
+      });
+    }
+  </file>
+  </section>
   <section priority="medium" role="src">
   <file path="src/index.ts">
     async function main() {
@@ -143,124 +261,6 @@
       await fastify.register(genSpecsRoutes);
     
       return fastify;
-    }
-  </file>
-  </section>
-  <section priority="medium" role="prisma">
-  <file path="prisma/seed.ts">
-    async function main() {
-      console.log("Seeding agent database...");
-    
-      const now = new Date();
-      const fiveMinAgo = new Date(now.getTime() - 5 * 60_000);
-      const tenMinAgo = new Date(now.getTime() - 10 * 60_000);
-      const thirtyMinAgo = new Date(now.getTime() - 30 * 60_000);
-      const oneHourAgo = new Date(now.getTime() - 60 * 60_000);
-    
-      // --- Succeeded Session 1: Bug fix ---
-      const session1 = await prisma.session.create({
-        data: {
-          status: "SUCCEEDED",
-          taskDescription: "Fix login button not responding on mobile viewport",
-          branchName: "agent/fix-mobile-login",
-          baseBranch: "main",
-          model: "claude-sonnet-4-6",
-          maxTurns: 50,
-          maxBudgetUsd: 1.0,
-          createPr: true,
-          prUrl: "https://github.com/mattbutlerengineering/mattbutlerengineering/pull/400",
-          prNumber: 400,
-          resultText: "Fixed mobile login button by correcting CSS media query breakpoint",
-          costUsd: 0.42,
-          inputTokens: 15200,
-          outputTokens: 4800,
-          numTurns: 8,
-          durationMs: 45000,
-          errors: [],
-          startedAt: oneHourAgo,
-          completedAt: thirtyMinAgo,
-        },
-      });
-    
-      await prisma.sessionEvent.createMany({
-        data: [
-          { sessionId: session1.id, type: "turn:start", data: { turn: 1 }, createdAt: oneHourAgo },
-          { sessionId: session1.id, type: "file:modified", data: { path: "apps/hospitality/src/components/LoginButton.tsx" }, createdAt: new Date(oneHourAgo.getTime() + 10_000) },
-          { sessionId: session1.id, type: "turn:end", data: { turn: 8, costUsd: 0.42 }, createdAt: thirtyMinAgo },
-          { sessionId: session1.id, type: "pr:created", data: { prUrl: "https://github.com/mattbutlerengineering/mattbutlerengineering/pull/400", prNumber: 400 }, createdAt: thirtyMinAgo },
-        ],
-      });
-    
-      // --- Succeeded Session 2: Feature ---
-      const session2 = await prisma.session.create({
-        data: {
-          status: "SUCCEEDED",
-          taskDescription: "Add tooltip component to design system",
-          branchName: "agent/add-tooltip",
-          baseBranch: "main",
-          model: "claude-sonnet-4-6",
-          maxTurns: 50,
-          maxBudgetUsd: 1.0,
-          createPr: true,
-          prUrl: "https://github.com/mattbutlerengineering/mattbutlerengineering/pull/405",
-          prNumber: 405,
-          resultText: "Created Tooltip component with accessibility support and animations",
-          costUsd: 0.78,
-          inputTokens: 28500,
-          outputTokens: 9200,
-          numTurns: 14,
-          durationMs: 82000,
-          errors: [],
-          startedAt: thirtyMinAgo,
-          completedAt: fiveMinAgo,
-        },
-      });
-    
-      await prisma.sessionEvent.createMany({
-        data: [
-          { sessionId: session2.id, type: "turn:start", data: { turn: 1 }, createdAt: thirtyMinAgo },
-          { sessionId: session2.id, type: "file:created", data: { path: "packages/rialto/src/components/Tooltip.tsx" }, createdAt: new Date(thirtyMinAgo.getTime() + 20_000) },
-          { sessionId: session2.id, type: "file:created", data: { path: "packages/rialto/src/components/Tooltip.test.tsx" }, createdAt: new Date(thirtyMinAgo.getTime() + 40_000) },
-          { sessionId: session2.id, type: "turn:end", data: { turn: 14, costUsd: 0.78 }, createdAt: fiveMinAgo },
-          { sessionId: session2.id, type: "pr:created", data: { prUrl: "https://github.com/mattbutlerengineering/mattbutlerengineering/pull/405", prNumber: 405 }, createdAt: fiveMinAgo },
-        ],
-      });
-    
-      // --- Failed Session ---
-      const session3 = await prisma.session.create({
-        data: {
-          status: "FAILED",
-          taskDescription: "Migrate database to use UUID v7 for all primary keys",
-          branchName: "agent/uuid-v7-migration",
-          baseBranch: "main",
-          model: "claude-sonnet-4-6",
-          maxTurns: 50,
-          maxBudgetUsd: 1.0,
-          createPr: false,
-          resultText: "Failed: migration affected too many tables, exceeded budget",
-          costUsd: 1.0,
-          inputTokens: 42000,
-          outputTokens: 12000,
-          numTurns: 50,
-          durationMs: 180000,
-          errors: [{ message: "Budget exceeded", turn: 50, timestamp: tenMinAgo.toISOString() }],
-          startedAt: oneHourAgo,
-          completedAt: tenMinAgo,
-        },
-      });
-    
-      await prisma.sessionEvent.createMany({
-        data: [
-          { sessionId: session3.id, type: "turn:start", data: { turn: 1 }, createdAt: oneHourAgo },
-          { sessionId: session3.id, type: "file:modified", data: { path: "services/users/prisma/schema.prisma" }, createdAt: new Date(oneHourAgo.getTime() + 15_000) },
-          { sessionId: session3.id, type: "error", data: { message: "Budget exceeded", turn: 50 }, createdAt: tenMinAgo },
-        ],
-      });
-    
-      console.log("Seeded agent database:", {
-        sessions: [session1.id, session2.id, session3.id],
-        events: "11 total",
-      });
     }
   </file>
   </section>

--- a/services/agent/llms.txt
+++ b/services/agent/llms.txt
@@ -1,4 +1,11 @@
 <codebase path="services/agent">
+  <section priority="medium" role="prisma">
+  <file path="prisma/seed.ts">
+    <item priority="low">
+      async function main() { /* ... */ }
+    </item>
+  </file>
+  </section>
   <section priority="medium" role="src">
   <file path="src/index.ts">
     <item priority="low">
@@ -13,13 +20,6 @@
     </item>
     <item priority="high">
       export async function buildApp(options: AppOptions = {}): Promise<FastifyInstance> { /* ... */ }
-    </item>
-  </file>
-  </section>
-  <section priority="medium" role="prisma">
-  <file path="prisma/seed.ts">
-    <item priority="low">
-      async function main() { /* ... */ }
     </item>
   </file>
   </section>
@@ -132,12 +132,12 @@
   </file>
   <file path="src/routes/sessions.ts">
     <item priority="high">
-      export const sessionRoutes: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const sessionRoutes: import("/Users/mbutler/github/mattbutlerengineering/.work...;
     </item>
   </file>
   <file path="src/routes/session-events.ts">
     <item priority="high">
-      export const sessionEventsRoutes: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const sessionEventsRoutes: import("/Users/mbutler/github/mattbutlerengineering/.work...;
     </item>
   </file>
   <file path="src/routes/remediation.ts">
@@ -154,7 +154,7 @@
   </file>
   <file path="src/routes/ready.ts">
     <item priority="high">
-      export const readinessRoutes: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const readinessRoutes: import("/Users/mbutler/github/mattbutlerengineering/.work...;
     </item>
   </file>
   <file path="src/routes/orchestrate.ts">
@@ -179,22 +179,22 @@
   </file>
   <file path="src/routes/health.ts">
     <item priority="high">
-      export const healthRoutes: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const healthRoutes: import("/Users/mbutler/github/mattbutlerengineering/.work...;
     </item>
   </file>
   <file path="src/routes/gen-ui.ts">
     <item priority="high">
-      export const genUiRoutes: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const genUiRoutes: import("/Users/mbutler/github/mattbutlerengineering/.work...;
     </item>
   </file>
   <file path="src/routes/gen-specs.ts">
     <item priority="high">
-      export const genSpecsRoutes: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const genSpecsRoutes: import("/Users/mbutler/github/mattbutlerengineering/.work...;
     </item>
   </file>
   <file path="src/routes/gen-chat.ts">
     <item priority="high">
-      export const genChatRoutes: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const genChatRoutes: import("/Users/mbutler/github/mattbutlerengineering/.work...;
     </item>
   </file>
   </section>

--- a/services/agent/src/routes/gen-chat.test.ts
+++ b/services/agent/src/routes/gen-chat.test.ts
@@ -73,7 +73,12 @@ describe("POST /api/gen/chat", () => {
   it("returns 401 without auth", async () => {
     const { requireAuth } = await import("@mbe/auth/fastify");
     vi.mocked(requireAuth).mockImplementationOnce(async (_req, reply) => {
-      reply.code(401).send({ error: "Authentication required" });
+      reply.code(401).send({
+        type: "https://mattbutlerengineering.com/errors/unauthorized",
+        title: "Unauthorized",
+        status: 401,
+        detail: "Authentication required",
+      });
     });
 
     const response = await app.inject({

--- a/services/agent/src/routes/gen-specs.test.ts
+++ b/services/agent/src/routes/gen-specs.test.ts
@@ -139,7 +139,12 @@ describe("Gen Specs Routes", () => {
     it("returns 401 without auth", async () => {
       const { requireAuth } = await import("@mbe/auth/fastify");
       vi.mocked(requireAuth).mockImplementationOnce(async (_req, reply) => {
-        reply.code(401).send({ error: "Authentication required" });
+        reply.code(401).send({
+          type: "https://mattbutlerengineering.com/errors/unauthorized",
+          title: "Unauthorized",
+          status: 401,
+          detail: "Authentication required",
+        });
       });
 
       const response = await app.inject({
@@ -174,7 +179,12 @@ describe("Gen Specs Routes", () => {
     it("returns 401 without auth", async () => {
       const { requireAuth } = await import("@mbe/auth/fastify");
       vi.mocked(requireAuth).mockImplementationOnce(async (_req, reply) => {
-        reply.code(401).send({ error: "Authentication required" });
+        reply.code(401).send({
+          type: "https://mattbutlerengineering.com/errors/unauthorized",
+          title: "Unauthorized",
+          status: 401,
+          detail: "Authentication required",
+        });
       });
 
       const response = await app.inject({

--- a/services/agent/src/routes/gen-ui.test.ts
+++ b/services/agent/src/routes/gen-ui.test.ts
@@ -73,7 +73,12 @@ describe("POST /api/gen/ui", () => {
   it("returns 401 without auth", async () => {
     const { requireAuth } = await import("@mbe/auth/fastify");
     vi.mocked(requireAuth).mockImplementationOnce(async (_req, reply) => {
-      reply.code(401).send({ error: "Authentication required" });
+      reply.code(401).send({
+        type: "https://mattbutlerengineering.com/errors/unauthorized",
+        title: "Unauthorized",
+        status: 401,
+        detail: "Authentication required",
+      });
     });
 
     const response = await app.inject({


### PR DESCRIPTION
## Summary

- Replaces bare `{ error: "..." }` send bodies in the `requireAuth` mocks for `gen-chat`, `gen-specs`, and `gen-ui` tests with the project's standard RFC 7807 Problem Details envelope (`type`/`title`/`status`/`detail`).
- Uses the existing `https://mattbutlerengineering.com/errors/unauthorized` type URL — same convention used by `packages/auth/src/fastify/plugin.ts`.
- Unblocks main CI: the `mbe-local/require-rfc-7807-errors` ESLint rule (added in #651) was failing on these three test files.

Closes #662.

## Test plan

- [x] `pnpm --dir services/agent lint` — clean
- [x] `pnpm --dir services/agent test` — 73/73 passing (assertions only check `statusCode`, not body shape, so no test updates needed)