### PR TITLE
fix(rialto-web): convert manualChunks to function for Rolldown (#665)

### DIFF
--- a/apps/rialto-web/vite.config.ts
+++ b/apps/rialto-web/vite.config.ts
@@ -18,10 +18,22 @@ export default defineConfig({
     sourcemap: true,
     rollupOptions: {
       output: {
-        manualChunks: {
-          "vendor-react": ["react", "react-dom", "react-router-dom"],
-          "vendor-motion": ["framer-motion"],
-          "vendor-icons": ["lucide-react"],
+        manualChunks(id) {
+          if (!id.includes("node_modules")) return undefined;
+          if (
+            id.includes("/node_modules/react/") ||
+            id.includes("/node_modules/react-dom/") ||
+            id.includes("/node_modules/react-router-dom/")
+          ) {
+            return "vendor-react";
+          }
+          if (id.includes("/node_modules/framer-motion/")) {
+            return "vendor-motion";
+          }
+          if (id.includes("/node_modules/lucide-react/")) {
+            return "vendor-icons";
+          }
+          return undefined;
         },
       },
     },


### PR DESCRIPTION
Closes #665.

## Summary

Vite 8 ships Rolldown as the default bundler. Rolldown's `manualChunks` only accepts the **function** form; the **object** form introduced in #643 is rejected with `Expected Function but received Object`, breaking every PR's Deploy Preview build.

Converting to the function form is API-equivalent and produces the same `vendor-react`, `vendor-motion`, and `vendor-icons` chunks.

Failing run referenced in the issue: [run 24961933361 / job 73089986659](https://github.com/mattbutlerengineering/mattbutlerengineering/actions/runs/24961933361/job/73089986659).

## Test Plan

- [x] `pnpm --dir apps/rialto-web build` succeeds
- [x] `dist/assets/` contains `vendor-react-*.js` (181.84 kB)
- [x] `dist/assets/` contains `vendor-motion-*.js` (133.24 kB)
- [x] `dist/assets/` contains `vendor-icons-*.js` (20.78 kB)
- [x] Same packages (`react`, `react-dom`, `react-router-dom`, `framer-motion`, `lucide-react`) bundled into the same chunk names as before
- [ ] CI Deploy Preview job passes on this PR