### PR TITLE
fix(deploy): copy packages/config in runner stage of users + reservations Dockerfiles

### DIFF
--- a/services/reservations/Dockerfile
+++ b/services/reservations/Dockerfile
@@ -67,6 +67,7 @@ COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY packages/types/package.json ./packages/types/
 COPY packages/auth/package.json ./packages/auth/
 COPY packages/api-versioning/package.json ./packages/api-versioning/
+COPY packages/config/package.json ./packages/config/
 COPY packages/observability/package.json ./packages/observability/
 COPY packages/sentry/package.json ./packages/sentry/
 COPY services/reservations/package.json ./services/reservations/

--- a/services/users/Dockerfile
+++ b/services/users/Dockerfile
@@ -67,6 +67,7 @@ COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY packages/types/package.json ./packages/types/
 COPY packages/auth/package.json ./packages/auth/
 COPY packages/api-versioning/package.json ./packages/api-versioning/
+COPY packages/config/package.json ./packages/config/
 COPY packages/observability/package.json ./packages/observability/
 COPY packages/sentry/package.json ./packages/sentry/
 COPY services/users/package.json ./services/users/


### PR DESCRIPTION
## Problem

Deploy API Services workflow fails on every push to main. The DigitalOcean App Platform build for `reservations-api` errors with:

```
ERR_PNPM_WORKSPACE_PKG_NOT_FOUND  In services/reservations:
"@mbe/config@workspace:*" is in the dependencies but no package named "@mbe/config" is present in the workspace
```

Reproducer: [run 24966980941, job 73103522869](https://github.com/mattbutlerengineering/mattbutlerengineering/actions/runs/24966980941/job/73103522869). Other components (`users-api`, `agent-api`, `db-migrate-reservations`) show `BuildRateLimit` — that's a downstream effect of `reservations-api` consuming concurrent build slots while it failed.

## Root cause

Both `services/reservations/Dockerfile` and `services/users/Dockerfile` are multi-stage. The **builder** stages copy `packages/config/package.json` before `pnpm install`. The **runner** stages do not, but still run `pnpm install --frozen-lockfile --prod --ignore-scripts` (so they can install the runtime deps + `pg`).

pnpm validates workspace topology before install — it fails fast on a missing workspace package even with `--prod`. So the runner install bails immediately.

`services/agent/Dockerfile` already has the COPY in both stages, which is why agent-api never tripped this.

## Fix

One additional `COPY packages/config/package.json ./packages/config/` line in the runner stage of each affected Dockerfile.

```diff
   COPY packages/types/package.json ./packages/types/
   COPY packages/auth/package.json ./packages/auth/
   COPY packages/api-versioning/package.json ./packages/api-versioning/
+  COPY packages/config/package.json ./packages/config/
   COPY packages/observability/package.json ./packages/observability/
   COPY packages/sentry/package.json ./packages/sentry/
```

No build-time impact (the runner doesn't compile @mbe/config — it's a config package, not a runtime dep). The COPY just satisfies pnpm's workspace validation. agent-api's existing extra COPY is the canonical pattern here.

## Test plan
- [x] `git diff --stat` — 2 files changed, 2 insertions
- [ ] DO redeploys on merge — reservations-api and users-api builds reach the install step and pass
- [ ] Deploy API Services workflow turns green