### PR TITLE
fix(deploy): --ignore-scripts on runner-stage 'pnpm add pg'

### DIFF
--- a/services/agent/Dockerfile
+++ b/services/agent/Dockerfile
@@ -96,7 +96,7 @@ COPY services/agent/package.json ./services/agent/
 # Install production dependencies only (Prisma client is copied from builder)
 ENV NODE_ENV=production
 RUN pnpm install --frozen-lockfile --prod --ignore-scripts && \
-    pnpm add pg --filter @mbe/agent-service
+    pnpm add pg --filter @mbe/agent-service --ignore-scripts
 
 # Copy compiled workspace packages
 COPY --from=builder /app/packages/types/dist ./packages/types/dist

--- a/services/reservations/Dockerfile
+++ b/services/reservations/Dockerfile
@@ -75,7 +75,7 @@ COPY services/reservations/package.json ./services/reservations/
 # Install production dependencies only (Prisma client is copied from builder)
 ENV NODE_ENV=production
 RUN pnpm install --frozen-lockfile --prod --ignore-scripts && \
-    pnpm add pg --filter @mbe/reservations-service
+    pnpm add pg --filter @mbe/reservations-service --ignore-scripts
 
 # Copy compiled workspace packages
 COPY --from=builder /app/packages/types/dist ./packages/types/dist

--- a/services/users/Dockerfile
+++ b/services/users/Dockerfile
@@ -75,7 +75,7 @@ COPY services/users/package.json ./services/users/
 # Install production dependencies only (Prisma client is copied from builder)
 ENV NODE_ENV=production
 RUN pnpm install --frozen-lockfile --prod --ignore-scripts && \
-    pnpm add pg --filter @mbe/users-service
+    pnpm add pg --filter @mbe/users-service --ignore-scripts
 
 # Copy compiled workspace packages
 COPY --from=builder /app/packages/types/dist ./packages/types/dist


### PR DESCRIPTION
## Problem

After [#669](https://github.com/mattbutlerengineering/mattbutlerengineering/pull/669) unblocked workspace resolution, the next layer of the DigitalOcean deploy failure surfaced — `users-api` build now errors with:

```
. prepare$ husky
. prepare: sh: husky: not found
ELIFECYCLE  Command failed.
error building image: error building stage: failed to execute command: waiting for process to exit: exit status 1
```

Reproducer: deployment `391104d7-31cf-4eb0-bd33-36522b6a9666` (run [24967216361](https://github.com/mattbutlerengineering/mattbutlerengineering/actions/runs/24967216361)).

## Root cause

In each service's runner stage:

```dockerfile
RUN pnpm install --frozen-lockfile --prod --ignore-scripts && \
    pnpm add pg --filter @mbe/<svc>-service
```

The first command correctly passes `--ignore-scripts` so it skips the workspace-root `prepare: husky` script. The second command (`pnpm add pg`) does not — pnpm runs lifecycle scripts on add, the root `prepare` fires, husky isn't installed (devDep, correctly skipped by `--prod`), and the build aborts.

`agent-api` had the same pattern but its build was rate-limited in earlier runs and would have failed on the next attempt.

## Fix

One-character change × 3 files: append `--ignore-scripts` to the `pnpm add pg` command in all three Dockerfiles.

Long-term cleanup (out of scope here): move `pg` into each service's `dependencies` so the regular install resolves it and we can drop the separate `pnpm add` step entirely. That's a follow-up issue worth filing if this pattern recurs.

## Test plan
- [x] Diff is 3 lines (`+--ignore-scripts` on each runner-stage `pnpm add` invocation)
- [ ] DO redeploys on merge — all three service builds pass install + pnpm-add and proceed to runtime
- [ ] Deploy API Services workflow turns green