### PR TITLE
fix(deploy): add @prisma/client-runtime-utils as explicit service dep

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -846,6 +846,9 @@ importers:
       '@prisma/client':
         specifier: ^7.8.0
         version: 7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3)
+      '@prisma/client-runtime-utils':
+        specifier: ^7.8.0
+        version: 7.8.0
       '@scalar/fastify-api-reference':
         specifier: ^1.52.6
         version: 1.52.6
@@ -922,6 +925,9 @@ importers:
       '@prisma/client':
         specifier: ^7.8.0
         version: 7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3)
+      '@prisma/client-runtime-utils':
+        specifier: ^7.8.0
+        version: 7.8.0
       '@scalar/fastify-api-reference':
         specifier: ^1.52.6
         version: 1.52.6
@@ -998,6 +1004,9 @@ importers:
       '@prisma/client':
         specifier: ^7.8.0
         version: 7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3)
+      '@prisma/client-runtime-utils':
+        specifier: ^7.8.0
+        version: 7.8.0
       '@scalar/fastify-api-reference':
         specifier: ^1.52.6
         version: 1.52.6

--- a/services/agent/package.json
+++ b/services/agent/package.json
@@ -35,6 +35,7 @@
     "@mbe/types": "workspace:*",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
+    "@prisma/client-runtime-utils": "^7.8.0",
     "@scalar/fastify-api-reference": "^1.52.6",
     "ai": "^6.0.168",
     "fastify": "catalog:",

--- a/services/reservations/package.json
+++ b/services/reservations/package.json
@@ -33,6 +33,7 @@
     "@mbe/types": "workspace:*",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
+    "@prisma/client-runtime-utils": "^7.8.0",
     "@scalar/fastify-api-reference": "^1.52.6",
     "fastify": "catalog:",
     "jose": "^6.2.2",

--- a/services/users/package.json
+++ b/services/users/package.json
@@ -33,6 +33,7 @@
     "@mbe/types": "workspace:*",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
+    "@prisma/client-runtime-utils": "^7.8.0",
     "@scalar/fastify-api-reference": "^1.52.6",
     "fastify": "catalog:",
     "jose": "^6.2.2",


### PR DESCRIPTION
Closes #672.

## Summary

After #669 (workspace COPY) and #670 (`--ignore-scripts`) landed, all DO API service builds succeed but the runtime crashes on container start:

```
Error: Cannot find module '@prisma/client-runtime-utils'
Require stack:
- /app/services/users/dist/generated/prisma/runtime/client.js
- /app/services/users/dist/generated/prisma/index.js
```

Reproducer: deployment `de37581c-df21-43e9-aa53-4a43c46c3abc`.

## Root cause

`@prisma/client-runtime-utils@7.8.0` is a real transitive of `@prisma/client@7.8.0`, but pnpm's strict node-linker only symlinks it into `@prisma/client`'s own `.pnpm/` slot — not into each service's `services/<svc>/node_modules/`. The generated Prisma client (COPY'd from `services/<svc>/src/generated/prisma/` to `services/<svc>/dist/generated/prisma/` in the runner stage) calls `require('@prisma/client-runtime-utils')` from a path where Node's CJS walk-up resolver can't find the nested symlink.

## Fix (Option A from the issue)

Declare `@prisma/client-runtime-utils: ^7.8.0` as a direct dependency in each of the three services. pnpm now creates a top-level symlink at `services/<svc>/node_modules/@prisma/client-runtime-utils`, which Node's resolver finds from any path under the service.

Verified locally — `require.resolve('@prisma/client-runtime-utils')` returns `node_modules/.pnpm/@prisma+client-runtime-utils@7.8.0/...` from each of `@mbe/users-service`, `@mbe/reservations-service`, and `@mbe/agent-service`. Lockfile diff is clean: 3 new importer entries, no version churn elsewhere. `pnpm --filter @mbe/users-service test` → 50/50 pass.

## Test plan

- [ ] CI green on this PR (lint/typecheck/test baseline still passes)
- [ ] After merge, `doctl apps create-deployment $DO_APP_ID --wait` succeeds for all three services
- [ ] `users-api`, `reservations-api`, `agent-api` containers boot without `MODULE_NOT_FOUND`
- [ ] `GET /api/v1/users/health` returns 200 with `database.status: "ok"`