### PR TITLE
feat(agent-core): extend model-router with runtime and feedback-driven routing

### DIFF
--- a/packages/agent-core/llms-full.txt
+++ b/packages/agent-core/llms-full.txt
@@ -725,7 +725,7 @@
                             prNumber: pr.number,
                             branchName: wt.branchName,
                             repoPath: wt.path,
-                            model: config.model,
+                            model: getFeedbackLoopModel(config.model),
                             maxRetries: config.feedbackLoop.maxRetries ?? 2,
                             pollIntervalMs: config.feedbackLoop.pollIntervalMs ?? 30_000,
                             pollTimeoutMs: config.feedbackLoop.pollTimeoutMs ?? 300_000,

--- a/packages/agent-core/llms.txt
+++ b/packages/agent-core/llms.txt
@@ -138,8 +138,8 @@
   <file path="src/quality-gates.ts">
     <item priority="low">
       interface QualityGatesResult {
-        evaluation?: import("/Users/mbutler/github/mattbutlerengineering/packa...;
-        securityReview?: import("/Users/mbutler/github/mattbutlerengineering/packa...;
+        evaluation?: import("/Users/mbutler/github/mattbutlerengineering/.work...;
+        securityReview?: import("/Users/mbutler/github/mattbutlerengineering/.work...;
         staticAnalysisClean: boolean;
         errors: string[];
       }
@@ -224,7 +224,7 @@
   </file>
   <file path="src/observability.ts">
     <item priority="high">
-      export const observabilityTracer: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const observabilityTracer: import("/Users/mbutler/github/mattbutlerengineering/.work...;
     </item>
     <item priority="high">
       export function categorizeFailure(

--- a/packages/agent-core/src/__tests__/model-router.test.ts
+++ b/packages/agent-core/src/__tests__/model-router.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { routeModel, routeModelWithReason, resolveModelId } from "../model-router.js";
-import type { IssueInput, ModelTier } from "../model-router.js";
+import {
+  routeModel,
+  routeModelWithReason,
+  resolveModelId,
+  getFeedbackLoopModel,
+} from "../model-router.js";
+import type { IssueInput, ModelTier, RoutingContext } from "../model-router.js";
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -244,5 +249,206 @@ describe("priority ordering", () => {
       body: "No architectural concerns here.",
     });
     expect(routeModel(issue)).toBe("sonnet");
+  });
+});
+
+// ── New haiku title patterns ──────────────────────────────────────────
+
+describe("haiku tier — new lightweight title patterns", () => {
+  it("routes docs: title to haiku", () => {
+    expect(routeModel(makeIssue({ title: "docs: update README with new env vars" }))).toBe("haiku");
+  });
+
+  it("routes test: title to haiku", () => {
+    expect(routeModel(makeIssue({ title: "test: add coverage for auth edge cases" }))).toBe("haiku");
+  });
+
+  it("routes chore(lint): title to haiku", () => {
+    expect(routeModel(makeIssue({ title: "chore(lint): fix ESLint violations in utils" }))).toBe(
+      "haiku"
+    );
+  });
+
+  it("routes chore(style): title to haiku", () => {
+    expect(routeModel(makeIssue({ title: "chore(style): apply Prettier formatting" }))).toBe(
+      "haiku"
+    );
+  });
+
+  it("is case-insensitive for new patterns", () => {
+    expect(routeModel(makeIssue({ title: "DOCS: fix typo in API reference" }))).toBe("haiku");
+    expect(routeModel(makeIssue({ title: "TEST: add snapshot tests" }))).toBe("haiku");
+  });
+
+  it("does not route docs-scoped body content to haiku (title must match)", () => {
+    const issue = makeIssue({ title: "fix: address docs link", body: "Update docs references" });
+    expect(routeModel(issue)).not.toBe("haiku");
+  });
+});
+
+// ── RoutingContext: source file paths signal ──────────────────────────
+
+describe("RoutingContext — source file path signals", () => {
+  it("routes to haiku when task touches only 1 test file", () => {
+    const ctx: RoutingContext = {
+      sourceFilePaths: ["packages/agent-core/src/__tests__/model-router.test.ts"],
+    };
+    expect(routeModel(makeIssue({ title: "Fix failing unit test" }), ctx)).toBe("haiku");
+  });
+
+  it("routes to haiku when task touches 2 docs files", () => {
+    const ctx: RoutingContext = {
+      sourceFilePaths: ["docs/api-reference.md", "README.md"],
+    };
+    expect(routeModel(makeIssue({ title: "Update API docs" }), ctx)).toBe("haiku");
+  });
+
+  it("does not route to haiku when test file count exceeds 2", () => {
+    const ctx: RoutingContext = {
+      sourceFilePaths: [
+        "packages/a/src/__tests__/a.test.ts",
+        "packages/b/src/__tests__/b.test.ts",
+        "packages/c/src/__tests__/c.test.ts",
+      ],
+    };
+    expect(routeModel(makeIssue({ title: "Fix tests" }), ctx)).not.toBe("haiku");
+  });
+
+  it("does not route to haiku when files include non-test/docs sources", () => {
+    const ctx: RoutingContext = {
+      sourceFilePaths: [
+        "packages/agent-core/src/model-router.ts",
+        "packages/agent-core/src/__tests__/model-router.test.ts",
+      ],
+    };
+    expect(routeModel(makeIssue({ title: "Update router" }), ctx)).not.toBe("haiku");
+  });
+
+  it("upgrades feature to opus when >15 source files", () => {
+    const ctx: RoutingContext = {
+      sourceFilePaths: Array.from({ length: 16 }, (_, i) => `packages/svc/src/module${i}.ts`),
+    };
+    const issue = makeIssue({ labels: ["feature"], title: "Add multi-module refactor" });
+    expect(routeModel(issue, ctx)).toBe("opus");
+  });
+
+  it("does not upgrade haiku title to opus even with many files", () => {
+    const ctx: RoutingContext = {
+      sourceFilePaths: Array.from({ length: 20 }, (_, i) => `packages/svc/src/module${i}.ts`),
+    };
+    const issue = makeIssue({ title: "chore(deps): bump react", labels: ["feature"] });
+    expect(routeModel(issue, ctx)).toBe("haiku");
+  });
+
+  it("does not upgrade default (non-feature) to opus with many files", () => {
+    const ctx: RoutingContext = {
+      sourceFilePaths: Array.from({ length: 20 }, (_, i) => `packages/svc/src/module${i}.ts`),
+    };
+    const issue = makeIssue({ title: "Fix login bug" });
+    expect(routeModel(issue, ctx)).toBe("sonnet");
+  });
+
+  it("does not upgrade feature to opus at exactly 15 files (boundary)", () => {
+    const ctx: RoutingContext = {
+      sourceFilePaths: Array.from({ length: 15 }, (_, i) => `packages/svc/src/module${i}.ts`),
+    };
+    const issue = makeIssue({ labels: ["feature"], title: "Add bulk export" });
+    expect(routeModel(issue, ctx)).toBe("sonnet");
+  });
+});
+
+// ── RoutingContext: failure escalation ───────────────────────────────
+
+describe("RoutingContext — failure escalation", () => {
+  it("escalates haiku to sonnet when pastFailureTier is haiku", () => {
+    const ctx: RoutingContext = { pastFailureTier: "haiku" };
+    const issue = makeIssue({ title: "chore(deps): bump lodash" });
+    expect(routeModel(issue, ctx)).toBe("sonnet");
+  });
+
+  it("escalation reason mentions haiku failure", () => {
+    const ctx: RoutingContext = { pastFailureTier: "haiku" };
+    const issue = makeIssue({ title: "docs: fix README" });
+    const result = routeModelWithReason(issue, ctx);
+    expect(result.tier).toBe("sonnet");
+    expect(result.reason).toMatch(/escalated.*haiku/i);
+  });
+
+  it("does not escalate sonnet even when pastFailureTier is sonnet", () => {
+    const ctx: RoutingContext = { pastFailureTier: "sonnet" };
+    const issue = makeIssue({ title: "Fix login bug" });
+    expect(routeModel(issue, ctx)).toBe("sonnet");
+  });
+
+  it("does not escalate opus even when pastFailureTier is opus", () => {
+    const ctx: RoutingContext = { pastFailureTier: "opus" };
+    const issue = makeIssue({ labels: ["feature"], title: "Redesign architecture" });
+    expect(routeModel(issue, ctx)).toBe("opus");
+  });
+});
+
+// ── RoutingContext: budget safety valve ──────────────────────────────
+
+describe("RoutingContext — budget-aware downgrade", () => {
+  it("downgrades opus to sonnet when remaining budget < $0.30", () => {
+    const ctx: RoutingContext = { remainingBudgetUsd: 0.25 };
+    const issue = makeIssue({ labels: ["feature"], title: "Redesign auth architecture" });
+    expect(routeModel(issue, ctx)).toBe("sonnet");
+  });
+
+  it("downgrade reason mentions budget amount", () => {
+    const ctx: RoutingContext = { remainingBudgetUsd: 0.15 };
+    const issue = makeIssue({ labels: ["feature"], title: "Redesign auth architecture" });
+    const result = routeModelWithReason(issue, ctx);
+    expect(result.tier).toBe("sonnet");
+    expect(result.reason).toMatch(/budget/i);
+    expect(result.reason).toContain("0.15");
+  });
+
+  it("does not downgrade opus when budget is exactly $0.30 (boundary)", () => {
+    const ctx: RoutingContext = { remainingBudgetUsd: 0.30 };
+    const issue = makeIssue({ labels: ["feature"], title: "Redesign auth architecture" });
+    expect(routeModel(issue, ctx)).toBe("opus");
+  });
+
+  it("does not downgrade opus when budget is above $0.30", () => {
+    const ctx: RoutingContext = { remainingBudgetUsd: 1.50 };
+    const issue = makeIssue({ labels: ["feature"], title: "Redesign auth architecture" });
+    expect(routeModel(issue, ctx)).toBe("opus");
+  });
+
+  it("does not downgrade sonnet when budget is low", () => {
+    const ctx: RoutingContext = { remainingBudgetUsd: 0.10 };
+    const issue = makeIssue({ title: "Fix login redirect" });
+    expect(routeModel(issue, ctx)).toBe("sonnet");
+  });
+
+  it("budget downgrade wins over failure escalation when both apply", () => {
+    // If haiku would escalate to sonnet (pastFailureTier), and sonnet would then be
+    // checked for budget, the budget valve only applies to opus — sonnet stays sonnet.
+    const ctx: RoutingContext = { pastFailureTier: "haiku", remainingBudgetUsd: 0.05 };
+    const issue = makeIssue({ title: "chore(deps): bump vitest" });
+    // escalated to sonnet, budget valve doesn't apply to sonnet → stays sonnet
+    expect(routeModel(issue, ctx)).toBe("sonnet");
+  });
+});
+
+// ── getFeedbackLoopModel ─────────────────────────────────────────────
+
+describe("getFeedbackLoopModel", () => {
+  it("downgrades opus parent to sonnet", () => {
+    expect(getFeedbackLoopModel("claude-opus-4-6")).toBe("claude-sonnet-4-6");
+  });
+
+  it("downgrades sonnet parent to haiku", () => {
+    expect(getFeedbackLoopModel("claude-sonnet-4-6")).toBe("claude-haiku-4-5-20251001");
+  });
+
+  it("keeps haiku at haiku (floor)", () => {
+    expect(getFeedbackLoopModel("claude-haiku-4-5-20251001")).toBe("claude-haiku-4-5-20251001");
+  });
+
+  it("returns unknown model IDs unchanged", () => {
+    expect(getFeedbackLoopModel("some-unknown-model")).toBe("some-unknown-model");
   });
 });

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -218,8 +218,8 @@ export { extractIssueIntent, IssueIntentSchema } from "./intent-extractor.js";
 export type { IssueIntent } from "./intent-extractor.js";
 
 // Model routing
-export { routeModel, routeModelWithReason, resolveModelId } from "./model-router.js";
-export type { ModelTier, IssueInput, ModelRoutingResult } from "./model-router.js";
+export { routeModel, routeModelWithReason, resolveModelId, getFeedbackLoopModel } from "./model-router.js";
+export type { ModelTier, IssueInput, ModelRoutingResult, RoutingContext } from "./model-router.js";
 
 // PR risk classification
 export { isLowRiskPR } from "./pr-risk-classifier.js";

--- a/packages/agent-core/src/model-router.ts
+++ b/packages/agent-core/src/model-router.ts
@@ -8,6 +8,19 @@ export interface IssueInput {
   readonly body: string;
 }
 
+/**
+ * Optional runtime context that extends static issue metadata for routing.
+ * All fields are optional — existing callers without context are unaffected.
+ */
+export interface RoutingContext {
+  /** Remaining session budget in USD. Used to downgrade opus when budget is tight. */
+  readonly remainingBudgetUsd?: number;
+  /** Resolved source file paths for this task. Used for file-count signals. */
+  readonly sourceFilePaths?: readonly string[];
+  /** Model tier that was used when a similar task previously failed. Used for escalation. */
+  readonly pastFailureTier?: ModelTier;
+}
+
 export interface ModelRoutingResult {
   readonly tier: ModelTier;
   readonly modelId: string;
@@ -22,16 +35,32 @@ const MODEL_IDS: Record<ModelTier, string> = {
   opus: "claude-opus-4-6",
 } as const;
 
+/** Budget threshold below which an opus routing is downgraded to sonnet. */
+const OPUS_MIN_BUDGET_USD = 0.30;
+
+/** Source file count above which a feature task is upgraded to opus. */
+const LARGE_CHANGE_FILE_THRESHOLD = 15;
+
 /**
  * Title prefixes that indicate a lightweight, automatable change.
- * These match conventional-commits style prefixes for dependency bumps
- * and security-only patches.
+ * Covers dependency bumps, security patches, docs, tests, and style fixes.
  */
 const HAIKU_TITLE_PATTERNS: readonly RegExp[] = [
   /^chore\(deps[\w-]*\):/i,
   /^fix\(security\):/i,
   /^chore\(deps\):/i,
+  /^docs:/i,
+  /^test:/i,
+  /^chore\(lint\):/i,
+  /^chore\(style\):/i,
 ];
+
+/**
+ * Path patterns that identify test or documentation files.
+ * Used to detect tasks that only touch test/docs paths (≤2 files → haiku).
+ */
+const TEST_OR_DOCS_PATH =
+  /(?:__tests__|\/tests?\/|\/docs\/|\.test\.[tj]sx?$|\.spec\.[tj]sx?$|README|CHANGELOG|\.md$)/i;
 
 /**
  * Keywords in the issue body or title that signal architectural complexity,
@@ -51,21 +80,35 @@ const OPUS_COMPLEXITY_KEYWORDS: readonly RegExp[] = [
   /\bcross.?cutting\b/i,
 ];
 
+// ── Tier downgrade map (used by feedback loop) ───────────────────────
+
+const TIER_DOWNGRADE: Record<ModelTier, ModelTier> = {
+  opus: "sonnet",
+  sonnet: "haiku",
+  haiku: "haiku",
+};
+
 // ── Routing logic ────────────────────────────────────────────────────
 
 /**
  * Determine the appropriate model tier for an issue based on its labels,
- * title, and body content.
+ * title, body content, and optional runtime context.
  *
  * Priority order (first match wins):
- * 1. Dependency bumps / security-only fixes → haiku
- * 2. CI fixes → sonnet
- * 3. Features with architecture/complexity keywords → opus
- * 4. Feature label (simple scope) → sonnet
- * 5. Default → sonnet
+ * 1. Dependency bumps / security / docs / test / lint / style → haiku
+ * 2. Task touches only test or docs files (≤2 paths) → haiku
+ * 3. CI fixes → sonnet
+ * 4. Features with architecture/complexity keywords → opus
+ * 5. Feature touching >15 source files → opus
+ * 6. Feature label (simple scope) → sonnet
+ * 7. Default → sonnet
+ *
+ * Post-processing (applied after base tier):
+ * - haiku + previously failed at haiku → escalate to sonnet
+ * - opus + remaining budget < $0.30 → downgrade to sonnet
  */
-export function routeModel(issue: IssueInput): ModelTier {
-  const { tier } = routeModelWithReason(issue);
+export function routeModel(issue: IssueInput, ctx?: RoutingContext): ModelTier {
+  const { tier } = routeModelWithReason(issue, ctx);
   return tier;
 }
 
@@ -73,38 +116,69 @@ export function routeModel(issue: IssueInput): ModelTier {
  * Same as `routeModel` but also returns the model ID and the reason
  * for the routing decision. Useful for logging and observability.
  */
-export function routeModelWithReason(issue: IssueInput): ModelRoutingResult {
+export function routeModelWithReason(
+  issue: IssueInput,
+  ctx?: RoutingContext
+): ModelRoutingResult {
   const labels = issue.labels.map((l) => l.toLowerCase());
   const titleLower = issue.title.toLowerCase();
   const bodyLower = issue.body.toLowerCase();
 
-  // 1. Dependency bumps and security-only fixes → haiku (~30s)
+  // 1. Dependency bumps, security, docs, tests, lint, style → haiku (~30s)
   for (const pattern of HAIKU_TITLE_PATTERNS) {
     if (pattern.test(issue.title)) {
-      return buildResult("haiku", `Title matches lightweight pattern: ${pattern.source}`);
+      return applyContextAdjustments(
+        buildResult("haiku", `Title matches lightweight pattern: ${pattern.source}`),
+        ctx
+      );
     }
   }
 
-  // 2. CI fixes → sonnet (~2 min)
-  if (labels.includes("ci-fix")) {
-    return buildResult("sonnet", "Issue has ci-fix label");
+  // 2. Task touches only test or docs files (≤2 paths) → haiku
+  if (ctx?.sourceFilePaths && isTestOrDocsOnlyTask(ctx.sourceFilePaths)) {
+    return applyContextAdjustments(
+      buildResult("haiku", "Task touches only test or docs files (≤2 paths)"),
+      ctx
+    );
   }
 
-  // 3. Feature with architectural/complex keywords → opus (~5-10 min)
+  // 3. CI fixes → sonnet (~2 min)
+  if (labels.includes("ci-fix")) {
+    return applyContextAdjustments(buildResult("sonnet", "Issue has ci-fix label"), ctx);
+  }
+
+  // 4. Feature with architectural/complex keywords → opus (~5-10 min)
   if (labels.includes("feature")) {
     const combinedText = `${titleLower} ${bodyLower}`;
     for (const keyword of OPUS_COMPLEXITY_KEYWORDS) {
       if (keyword.test(combinedText)) {
-        return buildResult("opus", `Feature with complexity keyword: ${keyword.source}`);
+        return applyContextAdjustments(
+          buildResult("opus", `Feature with complexity keyword: ${keyword.source}`),
+          ctx
+        );
       }
     }
 
-    // 4. Feature label but no complexity signals → sonnet (~3-5 min)
-    return buildResult("sonnet", "Feature label with simple scope");
+    // 5. Feature touching many files → opus
+    if (ctx?.sourceFilePaths && ctx.sourceFilePaths.length > LARGE_CHANGE_FILE_THRESHOLD) {
+      return applyContextAdjustments(
+        buildResult(
+          "opus",
+          `Feature touching ${ctx.sourceFilePaths.length} source files (>${LARGE_CHANGE_FILE_THRESHOLD})`
+        ),
+        ctx
+      );
+    }
+
+    // 6. Feature label but no complexity signals → sonnet (~3-5 min)
+    return applyContextAdjustments(buildResult("sonnet", "Feature label with simple scope"), ctx);
   }
 
-  // 5. Default → sonnet
-  return buildResult("sonnet", "Default routing: no specific pattern matched");
+  // 7. Default → sonnet
+  return applyContextAdjustments(
+    buildResult("sonnet", "Default routing: no specific pattern matched"),
+    ctx
+  );
 }
 
 /**
@@ -114,8 +188,65 @@ export function resolveModelId(tier: ModelTier): string {
   return MODEL_IDS[tier];
 }
 
+/**
+ * Return the model ID to use for a feedback-loop fix session.
+ * Fix sessions are tightly scoped (one comment, one CI failure), so they
+ * run one tier below the parent: opus → sonnet, sonnet → haiku, haiku → haiku.
+ */
+export function getFeedbackLoopModel(parentModelId: string): string {
+  const tier = (Object.entries(MODEL_IDS) as [ModelTier, string][]).find(
+    ([, id]) => id === parentModelId
+  )?.[0];
+  if (!tier) return parentModelId;
+  return MODEL_IDS[TIER_DOWNGRADE[tier]];
+}
+
 // ── Helpers ──────────────────────────────────────────────────────────
 
 function buildResult(tier: ModelTier, reason: string): ModelRoutingResult {
   return { tier, modelId: MODEL_IDS[tier], reason };
+}
+
+/**
+ * Apply runtime context adjustments after the base tier is determined.
+ *
+ * - Failure escalation: haiku previously failed on a similar task → use sonnet
+ * - Budget safety valve: opus chosen but budget is too low → downgrade to sonnet
+ */
+function applyContextAdjustments(
+  result: ModelRoutingResult,
+  ctx?: RoutingContext
+): ModelRoutingResult {
+  if (!ctx) return result;
+
+  // Escalate if haiku previously failed on a similar task
+  if (result.tier === "haiku" && ctx.pastFailureTier === "haiku") {
+    return buildResult(
+      "sonnet",
+      "Escalated from haiku: previous attempt at haiku tier failed for similar task"
+    );
+  }
+
+  // Budget safety valve: opus requires ~$0.40–1.50; skip it when budget is tight
+  if (
+    result.tier === "opus" &&
+    ctx.remainingBudgetUsd !== undefined &&
+    ctx.remainingBudgetUsd < OPUS_MIN_BUDGET_USD
+  ) {
+    return buildResult(
+      "sonnet",
+      `Budget-constrained downgrade from opus: $${ctx.remainingBudgetUsd.toFixed(2)} remaining (minimum $${OPUS_MIN_BUDGET_USD})`
+    );
+  }
+
+  return result;
+}
+
+/**
+ * Return true when the task's resolved source paths consist entirely of
+ * test or documentation files (≤2 paths). These tasks rarely require
+ * more reasoning than haiku provides.
+ */
+function isTestOrDocsOnlyTask(paths: readonly string[]): boolean {
+  return paths.length > 0 && paths.length <= 2 && paths.every((p) => TEST_OR_DOCS_PATH.test(p));
 }

--- a/packages/agent-core/src/session-runner.ts
+++ b/packages/agent-core/src/session-runner.ts
@@ -38,6 +38,7 @@ import {
   loadMemory,
 } from "./failure-memory.js";
 import { runFeedbackLoop } from "./feedback-loop.js";
+import { getFeedbackLoopModel } from "./model-router.js";
 import { withRetry, ContextWindowExhaustedError } from "./retry.js";
 import {
   categorizeFailure,
@@ -532,7 +533,7 @@ export async function runSession(
                         prNumber: pr.number,
                         branchName: wt.branchName,
                         repoPath: wt.path,
-                        model: config.model,
+                        model: getFeedbackLoopModel(config.model),
                         maxRetries: config.feedbackLoop.maxRetries ?? 2,
                         pollIntervalMs: config.feedbackLoop.pollIntervalMs ?? 30_000,
                         pollTimeoutMs: config.feedbackLoop.pollTimeoutMs ?? 300_000,


### PR DESCRIPTION
## Summary

Implements all six improvements from issue #674 to extend `model-router.ts` beyond static keyword matching.

- **New haiku title patterns** — `docs:`, `test:`, `chore(lint):`, `chore(style):` now route to haiku instead of falling through to sonnet
- **Source file path signals** — `RoutingContext.sourceFilePaths` adds two new rules: ≤2 test/docs-only files → haiku; `feature` + >15 files → opus
- **Failure escalation** — `RoutingContext.pastFailureTier`: if a similar task previously failed at haiku, the next attempt escalates to sonnet
- **Budget safety valve** — `RoutingContext.remainingBudgetUsd`: opus downgrades to sonnet when remaining budget < $0.30
- **Feedback-loop model downgrade** — `getFeedbackLoopModel()` returns one tier below the parent (opus→sonnet, sonnet→haiku, haiku→haiku); wired into `session-runner.ts`
- **Backward compatible** — `RoutingContext` is optional; all existing callers compile and behave identically without changes

## Test plan

- [ ] All 618 tests pass (`pnpm test` in `packages/agent-core`)
- [ ] Typecheck clean (`pnpm typecheck`)
- [ ] Lint clean (`pnpm lint`)
- [ ] 28 new tests covering all new branches: new haiku patterns, sourceFilePaths signals, failure escalation, budget downgrade, `getFeedbackLoopModel`

Closes #674