### PR TITLE
fix(marketing): forward Authorization header in Vite proxy

### DIFF
--- a/apps/marketing/llms.txt
+++ b/apps/marketing/llms.txt
@@ -17,7 +17,7 @@
         title: string;
         description: string;
         tags: string[];
-        href?: string;
+        href?: string | undefined;
       }
     </item>
     <item priority="high">

--- a/apps/marketing/vite.config.ts
+++ b/apps/marketing/vite.config.ts
@@ -29,6 +29,12 @@ export default defineConfig({
         target: "http://localhost:3001",
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, ""),
+        onProxyReq: (proxyReq, req) => {
+          const auth = req.headers["authorization"];
+          if (auth) {
+            proxyReq.setHeader("Authorization", auth);
+          }
+        },
       },
     },
   },

--- a/apps/marketing/vite.config.ts
+++ b/apps/marketing/vite.config.ts
@@ -29,11 +29,12 @@ export default defineConfig({
         target: "http://localhost:3001",
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, ""),
-        onProxyReq: (proxyReq, req) => {
-          const auth = req.headers["authorization"];
-          if (auth) {
-            proxyReq.setHeader("Authorization", auth);
-          }
+        configure: (proxy) => {
+          proxy.on("proxyReq", (proxyReq, req) => {
+            if (req.headers["authorization"]) {
+              proxyReq.setHeader("Authorization", req.headers["authorization"]);
+            }
+          });
         },
       },
     },

--- a/packages/sentry/llms-full.txt
+++ b/packages/sentry/llms-full.txt
@@ -1,0 +1,63 @@
+<codebase path="packages/sentry">
+  <section priority="medium" role="src">
+  <file path="src/react.ts">
+    export interface InitOptions {
+      readonly appName: string;
+      readonly dsn: string;
+    }
+    export function initSentry(options: InitOptions): void {
+      const config = resolveConfig(options.dsn);
+      if (!config.enabled) {
+        return;
+      }
+    
+      Sentry.init({
+        dsn: config.dsn,
+        environment: config.environment,
+        release: config.release,
+        replaysSessionSampleRate: 0,
+        replaysOnErrorSampleRate: 0,
+        integrations: [],
+      });
+    
+      Sentry.setTag("app", options.appName);
+    }
+  </file>
+  <file path="src/node.ts">
+    interface SentryUser {
+      readonly id: string;
+      readonly email?: string;
+    }
+    function isSentryUser(value: unknown): value is SentryUser {
+      return (
+        value != null &&
+        typeof value === "object" &&
+        "id" in value &&
+        typeof (value as SentryUser).id === "string"
+      );
+    }
+  </file>
+  <file path="src/config.ts">
+    export interface SentryConfig {
+      readonly dsn: string;
+      readonly environment: string;
+      readonly release: string | undefined;
+      readonly enabled: boolean;
+    }
+    export function resolveConfig(dsn: string | undefined): SentryConfig {
+      const resolvedDsn = dsn ?? "";
+      return {
+        dsn: resolvedDsn,
+        environment:
+          (typeof process !== "undefined" ? process.env.SENTRY_ENVIRONMENT : undefined) ??
+          (typeof process !== "undefined" ? process.env.NODE_ENV : undefined) ??
+          "development",
+        release:
+          (typeof process !== "undefined" ? process.env.SENTRY_RELEASE : undefined) ??
+          (typeof process !== "undefined" ? process.env.npm_package_version : undefined),
+        enabled: resolvedDsn.length > 0,
+      };
+    }
+  </file>
+  </section>
+</codebase>

--- a/packages/sentry/llms.txt
+++ b/packages/sentry/llms.txt
@@ -1,38 +1,39 @@
 <codebase path="packages/sentry">
+  <section priority="medium" role="src">
   <file path="src/react.ts">
-    export interface InitOptions {
-      readonly appName: string;
-      readonly dsn: string;
-    }
-    export function initSentry(options: InitOptions): void { /* implementation omitted */ }
-    export function handleErrorBoundary(error: Error, errorInfo: ErrorInfo): void { /* implementation omitted */ }
+    <item priority="low">
+      interface InitOptions {
+        appName: string;
+        dsn: string;
+      }
+    </item>
+    <item priority="high">
+      export function initSentry(options: InitOptions): void { /* ... */ }
+    </item>
   </file>
   <file path="src/node.ts">
-    interface SentryUser {
-      readonly id: string;
-      readonly email?: string;
-    }
-    function isSentryUser(value: unknown): value is SentryUser { /* implementation omitted */ }
-    function getRequestUser(request: FastifyRequest): SentryUser | undefined { /* implementation omitted */ }
-    export interface InitOptions {
-      readonly serviceName: string;
-    }
-    interface SentryReplyMeta {
-      readonly __sentryErrorCaptured?: boolean;
-    }
-    export function initSentry(options: InitOptions): void { /* implementation omitted */ }
-    function setSentryContext(scope: Sentry.Scope, request: FastifyRequest): void { /* implementation omitted */ }
-    export const sentryFastifyPlugin: (fastify: import("/Users/mbutler/github/mattbutlerengineering/node_modules/.pnpm/fastify@5.8.4/node_modules/fastify/types/instance").FastifyInstance<import("/Users/mbutler/github/mattbutlerengineering/node_modules/.pnpm/fastify@5.8.4/node_modules/fastify/types/utils").RawServerDefault, import("node:http").IncomingMessage, import("node:http").ServerResponse<import("node:http").IncomingMessage>, import("/Users/mbutler/github/mattbutlerengineering/node_modules/.pnpm/fastify@5.8.4/node_modules/fastify/types/logger").FastifyBaseLogger, import("/Users/mbutler/github/mattbutlerengineering/node_modules/.pnpm/fastify@5.8.4/node_modules/fastify/types/type-provider").FastifyTypeProviderDefault>) => Promise<void>;
-  </file>
-  <file path="src/index.ts">
+    <item priority="high">
+      interface SentryUser {
+        id: string;
+        email?: string | undefined;
+      }
+    </item>
+    <item priority="medium">
+      function isSentryUser(value: unknown): value is SentryUser { /* ... */ }
+    </item>
   </file>
   <file path="src/config.ts">
-    export interface SentryConfig {
-      readonly dsn: string;
-      readonly environment: string;
-      readonly release: string | undefined;
-      readonly enabled: boolean;
-    }
-    export function resolveConfig(dsn: string | undefined): SentryConfig { /* implementation omitted */ }
+    <item priority="low">
+      interface SentryConfig {
+        dsn: string;
+        environment: string;
+        release: string | undefined;
+        enabled: boolean;
+      }
+    </item>
+    <item priority="high">
+      export function resolveConfig(dsn: string | undefined): SentryConfig { /* ... */ }
+    </item>
   </file>
+  </section>
 </codebase>


### PR DESCRIPTION
## Summary
- Forward Authorization header through Vite dev proxy so authenticated users can hit API endpoints

## Changes
- apps/marketing/vite.config.ts: Add onProxyReq hook to forward auth headers