### PR TITLE
fix(a11y): add aria-label to ProjectCard external links

### DIFF
--- a/apps/marketing/src/components/ProjectCard.tsx
+++ b/apps/marketing/src/components/ProjectCard.tsx
@@ -31,6 +31,7 @@ export function ProjectCard({ project }: ProjectCardProps) {
               className={styles.buttonLink}
               target="_blank"
               rel="noopener noreferrer"
+              aria-label={`${project.title} (opens in new tab)`}
             >
               View live
             </a>


### PR DESCRIPTION
## Summary

- Adds `aria-label={`${project.title} (opens in new tab)`}` to the external link in `ProjectCard`, matching the existing pattern in `ContactSection`
- Fixes WCAG 2.1 SC 3.2.2 — screen reader users now get a predictable warning before their browsing context changes

## Test plan

- [ ] Verify screen reader announces project title + "opens in new tab" on the Projects section links
- [ ] Confirm no visual regression on the homepage

Closes #659

https://claude.ai/code/session_01BAMYu5zgvVvQHvt9JbEypN

---
_Generated by [Claude Code](https://claude.ai/code/session_01BAMYu5zgvVvQHvt9JbEypN)_