### PR TITLE
perf(marketing): add vendor chunk splitting for react and framer-motion

### DIFF
--- a/apps/marketing/vite.config.ts
+++ b/apps/marketing/vite.config.ts
@@ -18,9 +18,19 @@ export default defineConfig({
     sourcemap: true,
     rollupOptions: {
       output: {
-        manualChunks: {
-          "vendor-react": ["react", "react-dom", "react-router-dom"],
-          "vendor-motion": ["framer-motion"],
+        manualChunks(id) {
+          if (!id.includes("node_modules")) return undefined;
+          if (
+            id.includes("/node_modules/react/") ||
+            id.includes("/node_modules/react-dom/") ||
+            id.includes("/node_modules/react-router-dom/")
+          ) {
+            return "vendor-react";
+          }
+          if (id.includes("/node_modules/framer-motion/")) {
+            return "vendor-motion";
+          }
+          return undefined;
         },
       },
     },

--- a/apps/marketing/vite.config.ts
+++ b/apps/marketing/vite.config.ts
@@ -16,6 +16,14 @@ export default defineConfig({
   ],
   build: {
     sourcemap: true,
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          "vendor-react": ["react", "react-dom", "react-router-dom"],
+          "vendor-motion": ["framer-motion"],
+        },
+      },
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

- Adds `manualChunks` to `apps/marketing/vite.config.ts`, mirroring the pattern already used in `apps/rialto-web`
- Splits `framer-motion` (~150 kB gzipped) into its own chunk so it no longer blocks the initial vendor bundle parse
- Splits `react`/`react-dom`/`react-router-dom` into a stable `vendor-react` chunk for better long-term caching

## Test plan

- [ ] Verify `pnpm --dir apps/marketing build` produces separate `vendor-react` and `vendor-motion` chunk files in `dist/assets/`
- [ ] Confirm homepage loads and animations render correctly in a preview deploy

Closes #660

https://claude.ai/code/session_014mi6rVVKYpuaTapzQ6gSrU

---
_Generated by [Claude Code](https://claude.ai/code/session_014mi6rVVKYpuaTapzQ6gSrU)_