### PR TITLE
feat(observability): surface per-endpoint error rates in health checks

### DIFF
--- a/services/agent/src/routes/health.ts
+++ b/services/agent/src/routes/health.ts
@@ -90,7 +90,17 @@ const healthHandler = async (request: FastifyRequest): Promise<HealthResponse> =
     }),
   };
 
-  const hasErrors = dbStatus === "error" || slowQueryStatus === "degraded" || auth0Result.status === "degraded" || rateLimitSnapshot.isDegraded;
+  const errorRates = fastify.getErrorRates();
+  const degradedEndpoints = errorRates.endpoints.filter((e) => e.rate > 0.1 && e.total >= 5);
+  checks.error_rates = {
+    status: errorRates.degraded ? "degraded" : "ok",
+    ...{ endpoints: errorRates.endpoints },
+    ...(errorRates.degraded && {
+      message: `High error rate on: ${degradedEndpoints.map((e) => `${e.endpoint} (${Math.round(e.rate * 100)}%)`).join(", ")}`,
+    }),
+  };
+
+  const hasErrors = dbStatus === "error" || slowQueryStatus === "degraded" || auth0Result.status === "degraded" || rateLimitSnapshot.isDegraded || errorRates.degraded;
 
   return {
     status: hasErrors ? "degraded" : "ok",

--- a/services/reservations/src/routes/health.ts
+++ b/services/reservations/src/routes/health.ts
@@ -133,7 +133,17 @@ const healthHandler: HealthRouteHandler = async (request) => {
     }),
   };
 
-  const hasErrors = dbStatus === "error" || slowQueryStatus === "degraded" || auth0Result.status === "degraded" || rateLimitSnapshot.isDegraded;
+  const errorRates = request.server.getErrorRates();
+  const degradedEndpoints = errorRates.endpoints.filter((e) => e.rate > 0.1 && e.total >= 5);
+  checks.error_rates = {
+    status: errorRates.degraded ? "degraded" : "ok",
+    ...{ endpoints: errorRates.endpoints },
+    ...(errorRates.degraded && {
+      message: `High error rate on: ${degradedEndpoints.map((e) => `${e.endpoint} (${Math.round(e.rate * 100)}%)`).join(", ")}`,
+    }),
+  };
+
+  const hasErrors = dbStatus === "error" || slowQueryStatus === "degraded" || auth0Result.status === "degraded" || rateLimitSnapshot.isDegraded || errorRates.degraded;
 
   return {
     status: hasErrors ? "degraded" : "ok",

--- a/services/users/src/routes/health.ts
+++ b/services/users/src/routes/health.ts
@@ -132,7 +132,17 @@ const healthHandler: HealthRouteHandler = async (request) => {
     }),
   };
 
-  const hasErrors = dbStatus === "error" || slowQueryStatus === "degraded" || auth0Result.status === "degraded" || rateLimitSnapshot.isDegraded;
+  const errorRates = request.server.getErrorRates();
+  const degradedEndpoints = errorRates.endpoints.filter((e) => e.rate > 0.1 && e.total >= 5);
+  checks.error_rates = {
+    status: errorRates.degraded ? "degraded" : "ok",
+    ...{ endpoints: errorRates.endpoints },
+    ...(errorRates.degraded && {
+      message: `High error rate on: ${degradedEndpoints.map((e) => `${e.endpoint} (${Math.round(e.rate * 100)}%)`).join(", ")}`,
+    }),
+  };
+
+  const hasErrors = dbStatus === "error" || slowQueryStatus === "degraded" || auth0Result.status === "degraded" || rateLimitSnapshot.isDegraded || errorRates.degraded;
 
   return {
     status: hasErrors ? "degraded" : "ok",


### PR DESCRIPTION
## Summary

- Calls `fastify.getErrorRates()` (from the already-registered `errorRatePlugin_`) in each service's health handler
- Adds an `error_rates` check to the `/health` and public health endpoint responses across all three services (users, reservations, agent)
- Marks the service `degraded` when any endpoint exceeds the 10% error-rate threshold (≥5 requests in the 5-min rolling window)
- No new dependencies or plugin registrations needed — `errorRatePlugin_` was already wired in each `app.ts`

## Test plan

- [ ] Hit `/api/v1/users/health` — confirm `checks.error_rates` appears with `status: "ok"` and `endpoints: []` when traffic is clean
- [ ] Trigger 400/500 responses on an endpoint to push its error rate above 10%, then verify `status: "degraded"` and a descriptive `message` field
- [ ] Confirm overall `status` flips to `"degraded"` when `error_rates` is degraded

Closes #683

https://claude.ai/code/session_01PkQS5C7bE7EuKJ2G2kZEtm

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkQS5C7bE7EuKJ2G2kZEtm)_