### PR TITLE
fix(deploy): drop redundant pnpm add pg from agent and reservations Dockerfiles

### DIFF
--- a/services/agent/Dockerfile
+++ b/services/agent/Dockerfile
@@ -95,8 +95,7 @@ COPY services/agent/package.json ./services/agent/
 
 # Install production dependencies only (Prisma client is copied from builder)
 ENV NODE_ENV=production
-RUN pnpm install --frozen-lockfile --prod --ignore-scripts && \
-    pnpm add pg --filter @mbe/agent-service --ignore-scripts
+RUN pnpm install --frozen-lockfile --prod --ignore-scripts
 
 # Copy compiled workspace packages
 COPY --from=builder /app/packages/types/dist ./packages/types/dist

--- a/services/reservations/Dockerfile
+++ b/services/reservations/Dockerfile
@@ -74,8 +74,7 @@ COPY services/reservations/package.json ./services/reservations/
 
 # Install production dependencies only (Prisma client is copied from builder)
 ENV NODE_ENV=production
-RUN pnpm install --frozen-lockfile --prod --ignore-scripts && \
-    pnpm add pg --filter @mbe/reservations-service --ignore-scripts
+RUN pnpm install --frozen-lockfile --prod --ignore-scripts
 
 # Copy compiled workspace packages
 COPY --from=builder /app/packages/types/dist ./packages/types/dist


### PR DESCRIPTION
## Summary

- Removes `pnpm add pg --filter ... --ignore-scripts` from `services/agent/Dockerfile` and `services/reservations/Dockerfile`
- `pg` is already declared in each service's `dependencies` in `package.json`, so `pnpm install --frozen-lockfile --prod` resolves it without the extra step
- `services/users/Dockerfile` was already clean (no `pnpm add pg` line)

## Why

Two prior Dockerfile failures (#669, #670) traced to this pattern. Any future pnpm version drift or lockfile quirk can silently break the extra `pnpm add` call since it bypasses `--frozen-lockfile`. Removing the redundant step eliminates the failure surface entirely.

## Test plan

- [ ] DO build of agent service succeeds with simplified Dockerfile
- [ ] DO build of reservations service succeeds with simplified Dockerfile
- [ ] `pnpm --filter @mbe/agent-service test` passes
- [ ] `pnpm --filter @mbe/reservations-service test` passes

Closes #671

https://claude.ai/code/session_01Xe1jNvPTP9Vp79djuC1a9n

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xe1jNvPTP9Vp79djuC1a9n)_