### PR TITLE
fix(ci): add pull-requests:write permission to Comment Preview URL job

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -114,6 +114,8 @@ jobs:
     if: needs.detect-changes.outputs.any_changed == 'true'
     name: Comment Preview URL
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Post preview comment
         env:


### PR DESCRIPTION
## Summary

- Adds `permissions: pull-requests: write` to the `comment-preview` job in `preview-deploy.yml`
- GitHub Actions defaults pull-request permissions to `read`; the `gh pr comment` call requires `write` to post comments back to the PR
- Every open PR was seeing the `Comment Preview URL` job fail in ~4 seconds — this is the root cause

## Test plan

- [ ] Open a PR that touches `apps/**` or `packages/rialto/**`
- [ ] Verify `Comment Preview URL` job completes successfully and posts a preview URL comment

Closes #736

https://claude.ai/code/session_0192zAUBZdj2jYeoSLvdF6bm

---
_Generated by [Claude Code](https://claude.ai/code/session_0192zAUBZdj2jYeoSLvdF6bm)_