### PR TITLE
fix(ci): root-cause permanent fix for blocked PRs (auto-merge + comment-preview)

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -17,31 +17,31 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Authenticate gh CLI
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "${GITHUB_TOKEN}" | gh auth login --with-token
+      # Note: Do NOT add `gh auth login --with-token` here. The gh CLI
+      # auto-picks GITHUB_TOKEN from env and exits 1 when --with-token
+      # is invoked while the env var is set ("The value of the
+      # GITHUB_TOKEN environment variable is being used for
+      # authentication."). The step below relies on env-based auth.
 
       - name: Enable auto-merge for verified agent PRs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          # If triggered by a PR event, we can target that PR specifically if it has the right labels.
-          # If scheduled or dispatch, we scan all open PRs with 'has-pr'.
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            PR_NUMBERS="${{ github.event.pull_request.number }}"
+          # If triggered by a PR event, target that PR specifically.
+          # If scheduled or dispatch, scan all open PRs with 'has-pr'.
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            PR_NUMBERS="$EVENT_PR_NUMBER"
           else
             PR_NUMBERS=$(gh pr list --label "has-pr" --state open --json number -q '.[].number')
           fi
 
           for pr in $PR_NUMBERS; do
             echo "Checking PR #$pr..."
-            
-            # Fetch labels for the PR
+
             LABELS=$(gh pr view "$pr" --json labels -q '.labels[].name')
-            
-            # Check for 'has-pr' and 'needs-review'
+
             HAS_PR=false
             NEEDS_REVIEW=false
             for label in $LABELS; do

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -12,6 +12,10 @@ concurrency:
   group: preview-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   detect-changes:
     if: github.event.action != 'closed'
@@ -115,6 +119,13 @@ jobs:
     name: Comment Preview URL
     runs-on: ubuntu-latest
     steps:
+      # gh CLI's `pr comment` discovers repo context from a local git repo,
+      # so it fails with "fatal: not a git repository" without a checkout.
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
       - name: Post preview comment
         env:
           GH_TOKEN: ${{ github.token }}
@@ -151,6 +162,11 @@ jobs:
     name: Cleanup Preview
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
       - name: Delete preview Workers
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.MBE_CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary

Permanent root-cause fix for the two systemic CI failures that have been failing on every open PR (`auto-merge` and `Comment Preview URL`).

### 1. `merge-queue.yml` — `auto-merge` job

```
echo "${GITHUB_TOKEN}" | gh auth login --with-token
=> The value of the GITHUB_TOKEN environment variable is being used for authentication.
=> ##[error]Process completed with exit code 1.
```

`gh` already auto-authenticates from `GITHUB_TOKEN` and explicitly errors when `--with-token` is invoked while the env var is set. Removing the step lets the next step's env-based auth do its thing.

While there, hardened the run script by moving `github.event_name` and `github.event.pull_request.number` into `env:` vars (avoids template-injection footguns; the security hook flagged the file and the inline `${{ }}` substitutions are the kind of thing it warns about).

### 2. `preview-deploy.yml` — `comment-preview` job

```
gh pr comment "$PR_NUM" --body "$BODY"
=> failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

`gh pr comment` discovers repo context via local git. The job had no `actions/checkout`. Added one (with `persist-credentials: false`); did the same for the `cleanup` job for parity.

Also added the workflow-level `permissions: pull-requests: write` block that was missing on `main` (PR #738 was an attempt at this same fix; this consolidates it).

## Why a fresh branch instead of #697 / #738

#697 (`fix/ci-workflow-fixes`) had the merge-queue fix but is itself blocked by the comment-preview failure → infinite loop. #738 only addresses permissions. This PR is rebased on `main` and contains all three fixes in one commit so it can be admin-merged to unblock everything.

## Test plan

- [x] Existing `merge-queue.yml` failure log: `gh auth login --with-token` exits 1 — fix removes that step
- [x] Existing `comment-preview` failure log: `fatal: not a git repository` — fix adds checkout
- [x] No new untrusted-input substitutions added; in fact, two existing `${{ }}` inlines moved to `env:`
- [ ] After merge, observe `auto-merge` and `Comment Preview URL` checks pass on subsequent PR pushes