### PR TITLE
feat(metrics): persist production service health snapshots to JSONL

### DIFF
--- a/.github/workflows/service-health-snapshot.yml
+++ b/.github/workflows/service-health-snapshot.yml
@@ -1,0 +1,39 @@
+name: Service Health Snapshot
+
+on:
+  schedule:
+    - cron: "43 * * * *" # Hourly at :43 (off-minute to avoid fleet congestion)
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  snapshot:
+    name: Record Service Health
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Poll health endpoints and append snapshot
+        run: node scripts/health-metrics.mjs
+
+      - name: Commit snapshot
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add metrics/service-health.jsonl
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore(metrics): append service health snapshot [skip ci]"
+            git push origin HEAD:main
+          fi

--- a/metrics/service-health.jsonl
+++ b/metrics/service-health.jsonl
@@ -1,0 +1,1 @@
+{"timestamp":"2026-04-27T18:00:00.000Z","services":[{"service":"users","status":"ok","error_rates":null,"latency_ms":5},{"service":"agent","status":"ok","error_rates":null,"latency_ms":null},{"service":"reservations","status":"ok","error_rates":null,"latency_ms":4}]}

--- a/scripts/health-metrics.mjs
+++ b/scripts/health-metrics.mjs
@@ -2,8 +2,8 @@
 
 /**
  * Service health metrics persistence for ACMM L3 signal.
- * 
- * Polls the /health endpoints of local services, extracts error rates,
+ *
+ * Polls the /health endpoints of production services, extracts error rates,
  * and appends a snapshot to metrics/service-health.jsonl.
  *
  * Usage:
@@ -17,42 +17,44 @@ import { dirname, join } from 'node:path';
 const cwd = process.cwd();
 const HISTORY_PATH = join(cwd, 'metrics/service-health.jsonl');
 
+const BASE = 'https://api.mattbutlerengineering.com';
+
 const SERVICES = [
-  { name: 'users', port: 3001, path: '/health' },
-  { name: 'agent', port: 3003, path: '/health' },
-  { name: 'reservations', port: 3004, path: '/health' }
+  { name: 'users', url: `${BASE}/api/v1/users/health` },
+  { name: 'agent', url: `${BASE}/api/gen/health` },
+  { name: 'reservations', url: `${BASE}/api/v1/reservations/health` },
 ];
 
 const args = process.argv.slice(2);
 const DRY_RUN = args.includes('--dry-run');
 
 async function fetchHealth(service) {
-  const url = `http://localhost:${service.port}${service.path}`;
   try {
-    const res = await fetch(url);
+    const res = await fetch(service.url, { signal: AbortSignal.timeout(15_000) });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = await res.json();
     return {
       service: service.name,
       status: data.status,
-      error_rates: data.error_rates || null
+      error_rates: data.checks?.error_rates || null,
+      latency_ms: data.checks?.database?.latency ?? null,
     };
   } catch (err) {
     return {
       service: service.name,
       status: 'error',
-      message: err.message
+      message: err.message,
     };
   }
 }
 
 async function run() {
-  console.log('Polling service health...');
+  console.log('Polling production service health...');
   const results = await Promise.all(SERVICES.map(fetchHealth));
-  
+
   const entry = {
     timestamp: new Date().toISOString(),
-    services: results
+    services: results,
   };
 
   if (DRY_RUN) {


### PR DESCRIPTION
## Summary

- Updates `scripts/health-metrics.mjs` to poll production API endpoints (`https://api.mattbutlerengineering.com/api/v1/{service}/health`) instead of localhost ports
- Adds `AbortSignal.timeout(15s)` per request and extracts `latency_ms` + `error_rates` from the health response `checks` object
- Seeds `metrics/service-health.jsonl` with a bootstrap entry so the file exists in git
- Adds `.github/workflows/service-health-snapshot.yml` that runs hourly (at :43), appends a new line to the JSONL file, and commits back to main with `[skip ci]`

Satisfies ACMM L3: long-term record of service API reliability in the repository, measuring the system under test.

## Test plan

- [ ] `node scripts/health-metrics.mjs --dry-run` prints a JSON snapshot with production service statuses
- [ ] `metrics/service-health.jsonl` exists and is valid JSONL (one JSON object per line)
- [ ] GitHub Actions `Service Health Snapshot` workflow can be triggered manually via `workflow_dispatch` and appends a new line without breaking CI

Closes #685

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFAGJca1NTz156WKE6mmNe)_