### PR TITLE
fix(smoke): use agent health endpoint instead of auth-protected sessions route

### DIFF
--- a/tests/smoke/smoke.spec.ts
+++ b/tests/smoke/smoke.spec.ts
@@ -46,8 +46,10 @@ test.describe("Post-deploy smoke tests", () => {
     });
 
     test("agent service healthy", async ({ request }) => {
-      const response = await request.get(`${API_URL}/v1/sessions`);
+      const response = await request.get(`${API_URL}/api/gen/health`);
       expect(response.ok()).toBe(true);
+      const body = await response.json();
+      expect(body.status).toBe("ok");
     });
   });
 


### PR DESCRIPTION
## Summary

- `GET /v1/sessions` has `preHandler: [requireAuth]` and returns 401 without a JWT — the "agent service healthy" smoke test was failing on every post-deploy run
- Switch to `GET /api/gen/health`, the public health endpoint registered in `services/agent/src/routes/health.ts` and exposed via DO ingress at `/api/gen/health`
- Also assert `body.status === "ok"` on the agent check, matching the pattern already used for users/reservations

## Test plan

- [ ] Trigger the smoke-tests workflow manually (`workflow_dispatch`) after merge — all API health checks should pass
- [ ] Verify `GET https://api.mattbutlerengineering.com/api/gen/health` returns `{"status":"ok",...}`

Closes #749

https://claude.ai/code/session_01AYemr95ZAhMRVkw1BjzcGq

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYemr95ZAhMRVkw1BjzcGq)_