### PR TITLE
feat(acmm): add .claude/memory/ index for all three services

### DIFF
--- a/services/agent/.claude/memory/MEMORY.md
+++ b/services/agent/.claude/memory/MEMORY.md
@@ -1,0 +1,13 @@
+# Memory
+
+## Active
+
+## Feedback
+
+## References
+
+<!--
+  Service-scoped memory for services/agent (Fastify + Prisma agent session management).
+  Accumulates agent corrections and preferences specific to this service.
+  Patterns: agent session lifecycle, worktree management, SSE streaming, model routing.
+-->

--- a/services/reservations/.claude/memory/MEMORY.md
+++ b/services/reservations/.claude/memory/MEMORY.md
@@ -1,0 +1,13 @@
+# Memory
+
+## Active
+
+## Feedback
+
+## References
+
+<!--
+  Service-scoped memory for services/reservations (Fastify + Prisma reservation/table management).
+  Accumulates agent corrections and preferences specific to this service.
+  Patterns: SSE event broadcasting, reservation lifecycle, table status transitions.
+-->

--- a/services/users/.claude/memory/MEMORY.md
+++ b/services/users/.claude/memory/MEMORY.md
@@ -1,0 +1,13 @@
+# Memory
+
+## Active
+
+## Feedback
+
+## References
+
+<!--
+  Service-scoped memory for services/users (Fastify + Prisma user management service).
+  Accumulates agent corrections and preferences specific to this service.
+  Patterns: Prisma migration workflow, user CRUD routes, Auth0 JWT verification.
+-->


### PR DESCRIPTION
## Summary
- Creates `.claude/memory/MEMORY.md` for `services/users`, `services/reservations`, and `services/agent`
- Each file has service-scoped memory stubs with `# Memory`, `## Active`, `## Feedback`, `## References` sections
- Closes `acmm:correction-capture` and `acmm:positive-reinforcement` for each service

## Acceptance Criteria
- [x] `services/users/.claude/memory/`, `services/reservations/.claude/memory/`, `services/agent/.claude/memory/` exist
- [x] Each contains a `MEMORY.md` with proper sections
- [x] Audit detects both criteria for all three services

Closes #722