### PR TITLE
feat(acmm): add .claude/settings.json for all three services

### DIFF
--- a/services/agent/.claude/settings.json
+++ b/services/agent/.claude/settings.json
@@ -1,0 +1,25 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pnpm --dir services/agent dev)",
+      "Bash(pnpm --dir services/agent build)",
+      "Bash(pnpm --dir services/agent test)",
+      "Bash(pnpm --dir services/agent test:watch)",
+      "Bash(pnpm --dir services/agent test:coverage)",
+      "Bash(pnpm --dir services/agent lint)",
+      "Bash(pnpm --dir services/agent typecheck)",
+      "Bash(pnpm --dir services/agent prisma:generate)",
+      "Bash(pnpm --dir services/agent prisma:push)",
+      "Bash(pnpm --dir services/agent prisma:migrate)",
+      "Bash(pnpm --dir services/agent prisma:studio)",
+      "Bash(pnpm --dir services/agent db:generate)",
+      "Bash(pnpm --dir services/agent db:push)",
+      "Bash(pnpm --dir services/agent db:migrate)",
+      "Bash(pnpm --dir services/agent db:studio)",
+      "Bash(pnpm --dir services/agent agent:run)",
+      "Bash(mbe agent run*)",
+      "Bash(mbe agent orchestrate*)",
+      "Bash(node scripts/accm/audit.js --project services/agent)"
+    ]
+  }
+}

--- a/services/reservations/.claude/settings.json
+++ b/services/reservations/.claude/settings.json
@@ -1,0 +1,27 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pnpm --dir services/reservations dev)",
+      "Bash(pnpm --dir services/reservations build)",
+      "Bash(pnpm --dir services/reservations test)",
+      "Bash(pnpm --dir services/reservations test:watch)",
+      "Bash(pnpm --dir services/reservations test:coverage)",
+      "Bash(pnpm --dir services/reservations lint)",
+      "Bash(pnpm --dir services/reservations typecheck)",
+      "Bash(pnpm --dir services/reservations prisma:generate)",
+      "Bash(pnpm --dir services/reservations prisma:push)",
+      "Bash(pnpm --dir services/reservations prisma:migrate)",
+      "Bash(pnpm --dir services/reservations prisma:studio)",
+      "Bash(pnpm --dir services/reservations db:generate)",
+      "Bash(pnpm --dir services/reservations db:push)",
+      "Bash(pnpm --dir services/reservations db:migrate)",
+      "Bash(pnpm --dir services/reservations db:studio)",
+      "Bash(node scripts/acmm/audit.js --project services/reservations)"
+    ],
+    "deny": [
+      "Bash(**drop**)",
+      "Bash(**TRUNCATE**)",
+      "Bash(**DELETE FROM**)"
+    ]
+  }
+}

--- a/services/users/.claude/settings.json
+++ b/services/users/.claude/settings.json
@@ -1,0 +1,27 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pnpm --dir services/users dev)",
+      "Bash(pnpm --dir services/users build)",
+      "Bash(pnpm --dir services/users test)",
+      "Bash(pnpm --dir services/users test:watch)",
+      "Bash(pnpm --dir services/users test:coverage)",
+      "Bash(pnpm --dir services/users lint)",
+      "Bash(pnpm --dir services/users typecheck)",
+      "Bash(pnpm --dir services/users prisma:generate)",
+      "Bash(pnpm --dir services/users prisma:push)",
+      "Bash(pnpm --dir services/users prisma:migrate)",
+      "Bash(pnpm --dir services/users prisma:studio)",
+      "Bash(pnpm --dir services/users db:generate)",
+      "Bash(pnpm --dir services/users db:push)",
+      "Bash(pnpm --dir services/users db:migrate)",
+      "Bash(pnpm --dir services/users db:studio)",
+      "Bash(node scripts/acmm/audit.js --project services/users)"
+    ],
+    "deny": [
+      "Bash(**drop**)",
+      "Bash(**TRUNCATE**)",
+      "Bash(**DELETE FROM**)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` for `services/users`, `services/reservations`, and `services/agent`
- Permission allowlists scoped to each service (dev, build, test, lint, typecheck, prisma commands)
- Deny-list rules blocking direct destructive DB writes outside Prisma client

## Acceptance Criteria
- [x] Three `.claude/settings.json` files exist and validate as JSON
- [x] Permission allowlists scoped to each service
- [x] Deny-list rule blocking direct DB writes for users + reservations
- [x] Audit detects all four criteria (layered-safety, mechanical-enforcement, structural-gates, cross-repo-skills)

Closes #723