### PR TITLE
feat(acmm): add .claude/skills/ scaffold for all three services

### DIFF
--- a/services/agent/.claude/skills/README.md
+++ b/services/agent/.claude/skills/README.md
@@ -1,0 +1,11 @@
+# Skills — services/agent
+
+Service-scoped skills for the agent service (Fastify + Prisma agent session management).
+
+## Available Skills
+
+- `agent-session-debug` — How to inspect a stuck or runaway agent session, kill switch procedure, Langfuse trace correlation
+
+## Root Skills
+
+See root `.claude/skills/` for cross-cutting skills inherited via `package.json` acmm.inherit.

--- a/services/agent/.claude/skills/agent-session-debug/SKILL.md
+++ b/services/agent/.claude/skills/agent-session-debug/SKILL.md
@@ -1,0 +1,53 @@
+# Skill: agent-session-debug
+
+How to inspect and recover a stuck or runaway agent session.
+
+## Problem Patterns
+
+1. Session stuck in RUNNING state indefinitely
+2. Session exceeded maxBudgetUsd but didn't stop
+3. Worktree left in corrupted state
+4. PR created but session never completed
+
+## Debug Workflow
+
+### Step 1: Inspect Session State
+
+```bash
+# Get session details
+curl -s http://localhost:3003/v1/sessions/<sessionId> | jq .
+# Check session events
+curl -s http://localhost:3003/v1/sessions/<sessionId>/events -H "Accept: text/event-stream"
+```
+
+### Step 2: Check Worktree Health
+
+```bash
+# List active worktrees
+git worktree list
+# Check for corrupted worktrees
+ls -la /tmp/agent-worktrees/<sessionId>/ 2>&1
+```
+
+### Step 3: Kill Switch Procedure
+
+```bash
+# Cancel the session via API
+curl -s -X DELETE http://localhost:3003/v1/sessions/<sessionId>
+# Manually clean up worktree if needed
+git worktree remove /tmp/agent-worktrees/<sessionId> --force
+```
+
+### Step 4: Langfuse Trace Correlation
+
+```bash
+# Find trace ID from session events
+# Check Langfuse dashboard for trace <sessionId>
+# Compare token usage and tool calls
+```
+
+## Prevention
+
+- Monitor sessions exceeding 80% of maxBudgetUsd
+- Set up alerting on RUNNING sessions > 30 minutes
+- Validate worktree path exists before each turn

--- a/services/reservations/.claude/skills/README.md
+++ b/services/reservations/.claude/skills/README.md
@@ -1,0 +1,11 @@
+# Skills — services/reservations
+
+Service-scoped skills for the reservations service (Fastify + Prisma reservation/table management).
+
+## Available Skills
+
+- `sse-event-debug` — How to triage SSE event divergence (publisher fired but subscriber didn't receive), reservation state-machine inspection
+
+## Root Skills
+
+See root `.claude/skills/` for cross-cutting skills inherited via `package.json` acmm.inherit.

--- a/services/reservations/.claude/skills/sse-event-debug/SKILL.md
+++ b/services/reservations/.claude/skills/sse-event-debug/SKILL.md
@@ -1,0 +1,53 @@
+# Skill: sse-event-debug
+
+How to triage SSE event divergence in the reservations service.
+
+## Problem Patterns
+
+1. Publisher fired event but subscriber didn't receive it
+2. Reservation state machine stuck in transition
+3. SSE connection drops unexpectedly
+
+## Debug Workflow
+
+### Step 1: Check SSE Broadcaster State
+
+```bash
+# Inspect active SSE connections
+curl -s http://localhost:3004/api/v1/events/stream?venueId=<id> -H "Authorization: Bearer $TOKEN" &
+# In another terminal, check broadcaster internals
+node -e "const { getBroadcaster } = require('./dist/services/sse.js'); console.log(getBroadcaster().getStats());"
+```
+
+### Step 2: Verify Event Was Published
+
+```bash
+# Check reservation event log in DB
+node -e "const { prisma } = require('./dist/services/database.js'); prisma.reservationEvent.findMany({ orderBy: { createdAt: 'desc' }, take: 10 }).then(console.log);"
+```
+
+### Step 3: Inspect Reservation State Machine
+
+```typescript
+// Check current reservation status
+const res = await prisma.reservation.findUnique({
+  where: { id: reservationId },
+  select: { status: true, updatedAt: true }
+});
+console.log('State:', res.status, 'Updated:', res.updatedAt);
+```
+
+## State Machine Transitions
+
+```
+PENDING → CONFIRMED (seat guest)
+CONFIRMED → COMPLETED (dining finished)
+CONFIRMED → CANCELLED (cancelled)
+CONFIRMED → NO_SHOW (guest didn't arrive)
+```
+
+## Common Fixes
+
+- **Missing subscriber**: Verify `Last-Event-ID` header for resumption
+- **Stale connection**: Check exponential backoff (1s, 2s, 4s, ... 30s max)
+- **Event dedup**: Verify event ID is unique and monotonic

--- a/services/users/.claude/skills/README.md
+++ b/services/users/.claude/skills/README.md
@@ -1,0 +1,11 @@
+# Skills — services/users
+
+Service-scoped skills for the users service (Fastify + Prisma user management).
+
+## Available Skills
+
+- `prisma-migrate-safety` — Pre-flight checks before running `prisma migrate deploy`, validate against staging, rollback procedure
+
+## Root Skills
+
+See root `.claude/skills/` for cross-cutting skills inherited via `package.json` acmm.inherit.

--- a/services/users/.claude/skills/prisma-migrate-safety/SKILL.md
+++ b/services/users/.claude/skills/prisma-migrate-safety/SKILL.md
@@ -1,0 +1,39 @@
+# Skill: prisma-migrate-safety
+
+Pre-flight checks before running `prisma migrate deploy` in the users service.
+
+## Workflow
+
+### Step 1: Staging Validation
+
+```bash
+# Validate migration against staging DB first
+DATABASE_URL=$STAGING_DATABASE_URL npx prisma migrate deploy --preview
+```
+
+### Step 2: Migration Checks
+
+```bash
+# Check migration integrity
+npx prisma migrate status
+# Verify no destructive changes without marker
+grep -r "DROP TABLE\|DROP COLUMN" prisma/migrations/*/migration.sql | grep -v "^-- DESTRUCTIVE:"
+```
+
+### Step 3: Deploy with Rollback Plan
+
+```bash
+# Tag current state before deploying
+git tag "users-pre-migrate-$(date +%Y%m%d-%H%M%S)"
+git push origin --tags
+# Deploy
+pnpm --dir services/users db:migrate:deploy
+```
+
+## Rollback Procedure
+
+```bash
+# If migration fails, revert to pre-migration tag
+git checkout users-pre-migrate-<tag>
+pnpm --dir services/users db:migrate:deploy
+```


### PR DESCRIPTION
## Summary
- Adds `.claude/skills/` scaffold for `services/users`, `services/reservations`, and `services/agent`
- Each has a `README.md` and a service-specific skill:
  - users: `prisma-migrate-safety`
  - reservations: `sse-event-debug`
  - agent: `agent-session-debug`

## Acceptance Criteria
- [x] Three directories exist with content
- [x] Each has a `README.md` explaining structure
- [x] Each has at least one service-relevant skill
- [x] Audit detects all six criteria for all three services

Closes #724