### PR TITLE
feat(acmm): add P0 risk tier configs for all three services

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,9 @@
 /services/agent/                     @mattbutlerengineering
 /services/reservations/              @mattbutlerengineering
 /services/users/                     @mattbutlerengineering
+/services/users/         @mattbutlerengineering
+/services/reservations/  @mattbutlerengineering
+/services/agent/         @mattbutlerengineering
 
 # ── Apps ──────────────────────────────────────
 /apps/                               @mattbutlerengineering

--- a/services/agent/.claude/risk-config.json
+++ b/services/agent/.claude/risk-config.json
@@ -1,0 +1,6 @@
+{
+  "tier": "P0",
+  "rationale": "Agent orchestration service executing code in worktrees with API budget consumption",
+  "blast_radius": "compromised agent can drain budget, exfiltrate code via worktree, or write to consumer apps via PR",
+  "rollback_strategy": "see docs/RUNBOOK.md; terminate in-flight sessions before rollback to prevent split-brain"
+}

--- a/services/reservations/.claude/risk-config.json
+++ b/services/reservations/.claude/risk-config.json
@@ -1,0 +1,6 @@
+{
+  "tier": "P0",
+  "rationale": "Production booking transaction service handling guest data and reservation state",
+  "blast_radius": "all reservations across all venues; SSE divergence breaks downstream consumers",
+  "rollback_strategy": "see docs/RUNBOOK.md; consider SSE replay for in-flight events"
+}

--- a/services/users/.claude/risk-config.json
+++ b/services/users/.claude/risk-config.json
@@ -1,0 +1,6 @@
+{
+  "tier": "P0",
+  "rationale": "Production user identity service handling PII, authentication, and access tokens",
+  "blast_radius": "all authenticated users across the platform; compromise = total identity compromise",
+  "rollback_strategy": "see docs/RUNBOOK.md; redeploy previous DO deployment ID"
+}


### PR DESCRIPTION
## Summary
- Creates `.claude/risk-config.json` for `services/users`, `services/reservations`, and `services/agent`
- All declared P0 with rationale, blast radius, and rollback strategy

## Acceptance Criteria
- [x] All three `risk-config.json` files exist and validate as JSON
- [x] Each has correct tier (P0), rationale, blast_radius, rollback_strategy
- [x] Audit detects `acmm:risk-assessment-config` for all three services

Closes #731