### PR TITLE
feat(acmm): add per-service CODEOWNERS lines

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,9 @@
 /services/agent/                     @mattbutlerengineering
 /services/reservations/              @mattbutlerengineering
 /services/users/                     @mattbutlerengineering
+/services/users/         @mattbutlerengineering
+/services/reservations/  @mattbutlerengineering
+/services/agent/         @mattbutlerengineering
 
 # ── Apps ──────────────────────────────────────
 /apps/                               @mattbutlerengineering


### PR DESCRIPTION
## Summary
- Adds explicit per-service CODEOWNERS lines for users, reservations, and agent services

## Acceptance Criteria
- [x] `.github/CODEOWNERS` includes per-service lines below generic `/services/` line
- [x] Existing CODEOWNERS patterns are not broken

Closes #732