### PR TITLE
feat(acmm): add app-scoped .claude/settings.json for rialto-web

### DIFF
--- a/apps/rialto-web/.claude/settings.json
+++ b/apps/rialto-web/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pnpm --dir apps/rialto-web dev)",
+      "Bash(pnpm --dir apps/rialto-web build)",
+      "Bash(pnpm --dir apps/rialto-web preview)",
+      "Bash(pnpm --dir apps/rialto-web lint)",
+      "Bash(pnpm --dir apps/rialto-web typecheck)",
+      "Bash(pnpm --dir apps/rialto-web test:a11y)",
+      "Bash(pnpm test:visual)",
+      "Bash(pnpm dlx wrangler@latest deploy --config apps/rialto-web/wrangler.toml)",
+      "Bash(node scripts/acmm/audit.js --project apps/rialto-web)"
+    ],
+    "deny": [
+      "Bash(**import** from ../../packages/rialto/src/**)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Creates `apps/rialto-web/.claude/settings.json` with app-scoped permissions

## Acceptance Criteria
- [x] `apps/rialto-web/.claude/settings.json` exists and is valid JSON
- [x] Permission allowlist covers app-scoped commands
- [x] Deny-list rule blocking imports from `packages/rialto/src`
- [x] Audit detects 4 criteria

Closes #715