### PR TITLE
feat(acmm): add .claude/skills/ scaffold for rialto-web

### DIFF
--- a/apps/rialto-web/.claude/memory/MEMORY.md
+++ b/apps/rialto-web/.claude/memory/MEMORY.md
@@ -1,0 +1,13 @@
+# Memory
+
+## Active
+
+## Feedback
+
+## References
+
+<!--
+  Showcase-scoped memory for apps/rialto-web (Rialto design system showcase).
+  Accumulates agent corrections and preferences specific to this app.
+  Patterns: visual regression triage, component import conventions, screenshot review workflows.
+-->

--- a/apps/rialto-web/.claude/skills/README.md
+++ b/apps/rialto-web/.claude/skills/README.md
@@ -1,0 +1,13 @@
+# Skills — apps/rialto-web
+
+Showcase site for the Rialto design system.
+
+## Available Skills
+
+- `rialto-visual-diff-review` — When a visual regression spec fails, how to triage (intentional design change vs. regression), how to update screenshots if intentional, how to file an issue if not
+
+## Root Skills
+
+See root `.claude/skills/` for cross-cutting skills inherited via `package.json` acmm.inherit.
+- `/ship-loop` — full local cycle (audit → fix → push → CI → deploy)
+- `/site-audit` — crawl live site with smoke/sweep/scout modes

--- a/apps/rialto-web/.claude/skills/rialto-visual-diff-review/SKILL.md
+++ b/apps/rialto-web/.claude/skills/rialto-visual-diff-review/SKILL.md
@@ -1,0 +1,56 @@
+# Skill: rialto-visual-diff-review
+
+When a visual regression spec fails, triage and resolve.
+
+## Problem Patterns
+
+1. Visual diff shows intentional design change (new component, updated styling)
+2. Visual diff shows regression (broken layout, missing element)
+3. Screenshot stale (component changed but screenshot not updated)
+
+## Triage Workflow
+
+### Step 1: Review the Diff
+
+```bash
+# Open the failing spec
+pnpm test:visual
+
+# Review diff PNGs in apps/rialto-web/e2e/screenshots/
+# Compare light-*.png vs light-*-diff.png
+```
+
+### Step 2: Classify the Change
+
+| Pattern | Action |
+|---------|--------|
+| Intentional design change | Update screenshot, update spec if needed |
+| Regression (broken layout) | File issue or fix immediately |
+| Stale screenshot | Update screenshot |
+
+### Step 3: Update Screenshots (if intentional)
+
+```bash
+# Update specific screenshot
+npx playwright test apps/rialto-web/e2e/visual.spec.ts --update-snapshots
+
+# Verify the updated screenshot looks correct
+open apps/rialto-web/e2e/screenshots/<updated>.png
+```
+
+### Step 4: File Issue (if regression)
+
+```bash
+# Create issue with screenshot attached
+gh issue create --repo mattbutlerengineering/mattbutlerengineering \
+  --title "Visual regression: <component> <description>" \
+  --label "bug,acmm-rialto-web" \
+  --body "Visual diff shows <description>. Screenshot attached." \
+  --attach apps/rialto-web/e2e/screenshots/<file>-diff.png
+```
+
+## Prevention
+
+- Run `pnpm test:visual` before claiming UI work is complete
+- New components require a visual spec in `e2e/visual.spec.ts`
+- Always review diff PNGs, not just pass/fail status


### PR DESCRIPTION
## Summary
- Creates `apps/rialto-web/.claude/skills/` with README.md and `rialto-visual-diff-review` skill.

## Acceptance Criteria
- [x] `.claude/skills/` directory exists
- [x] README.md explains structure and points to root skills
- [x] Has `rialto-visual-diff-review` skill
- [x] Audit detects 6 criteria

Closes #716