### PR TITLE
feat(acmm): add CODEOWNERS line and showcase-tier risk config for rialto-web (P3)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,6 +21,7 @@
 # ── Apps ──────────────────────────────────────
 /apps/                               @mattbutlerengineering
 /apps/hospitality/                   @mattbutlerengineering
+/apps/rialto-web/         @mattbutlerengineering
 
 # ── Shared packages ───────────────────────────
 /packages/agent-core/                @mattbutlerengineering

--- a/apps/rialto-web/.claude/risk-config.json
+++ b/apps/rialto-web/.claude/risk-config.json
@@ -1,0 +1,6 @@
+{
+  "tier": "P3",
+  "rationale": "Showcase site for the rialto design system; no user data, no business logic, no auth",
+  "blast_radius": "Broken docs only — no production user impact",
+  "rollback_strategy": "Redeploy previous wrangler version; visual regression detects most issues pre-deploy"
+}


### PR DESCRIPTION
## Summary
- Adds per-app CODEOWNERS line for rialto-web
- Adds P3 risk-config.json (showcase tier)

## Acceptance Criteria
- [x] `.github/CODEOWNERS` includes `/apps/rialto-web/  @mattbutlerengineering`
- [x] `apps/rialto-web/.claude/risk-config.json` exists with P3 tier
- [x] Audit detects `acmm:risk-assessment-config`

Closes #718