### PR TITLE
feat(acmm): add AGENTS.md scoped to the hospitality app

### DIFF
--- a/apps/hospitality/AGENTS.md
+++ b/apps/hospitality/AGENTS.md
@@ -1,6 +1,6 @@
-# AGENTS.md - Cross-Tool Agent Rules for Hospitality App
+# AGENTS.md — apps/hospitality/
 
-> Tool-agnostic agent rules. Applies to all AI coding agents (Claude, Gemini, Cursor, etc.).
+Cross-tool agent rules for the Hospitality app (React + Rialto + Konva).
 
 ## Critical Constraints
 


### PR DESCRIPTION
## Summary
- Creates tool-agnostic AGENTS.md for hospitality (35+ lines)
- Documents 6 critical constraints from CLAUDE.md
- Includes app-specific commands, context files, tech stack

## Acceptance Criteria
- [x] `apps/hospitality/AGENTS.md` exists, ≥30 lines
- [x] Content is tool-agnostic (no vendor-specific refs)
- [x] Includes 6 critical constraints from CLAUDE.md
- [x] Includes app-specific commands
- [x] References ./CLAUDE.md and ./docs/ARCHITECTURE.md
- [x] Audit detects `acmm:agents-md` and `aef:cross-tool-config`

Closes #700