### PR TITLE
fix(ci): pin undici override below 8 to keep jsdom 29 working

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "overrides": {
       "@anthropic-ai/sdk": ">=0.81.0",
       "tar": ">=7.5.11",
-      "undici": ">=7.24.0",
+      "undici": ">=7.24.0 <8",
       "flatted": ">=3.4.2",
       "effect": ">=3.20.0",
       "rollup": ">=4.59.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ catalogs:
 overrides:
   '@anthropic-ai/sdk': '>=0.81.0'
   tar: '>=7.5.11'
-  undici: '>=7.24.0'
+  undici: '>=7.24.0 <8'
   flatted: '>=3.4.2'
   effect: '>=3.20.0'
   rollup: '>=4.59.0'
@@ -7921,9 +7921,9 @@ packages:
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
-  undici@8.1.0:
-    resolution: {integrity: sha512-E9MkTS4xXLnRPYqxH2e6Hr2/49e7WFDKczKcCaFH4VaZs2iNvHMqeIkyUAD9vM8kujy9TjVrRlQ5KkdEJxB2pw==}
-    engines: {node: '>=22.19.0'}
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -14336,7 +14336,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 8.1.0
+      undici: 7.25.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -14899,7 +14899,7 @@ snapshots:
       semver: 7.7.4
       tar: 7.5.13
       tinyglobby: 0.2.16
-      undici: 8.1.0
+      undici: 7.25.0
       which: 6.0.1
 
   node-releases@2.0.37: {}
@@ -16442,7 +16442,7 @@ snapshots:
 
   undici-types@7.19.2: {}
 
-  undici@8.1.0: {}
+  undici@7.25.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 


### PR DESCRIPTION
## Summary

- Test job is failing on every PR (and on main) because jsdom 29's worker boot reaches into `undici/lib/handler/wrap-handler.js`, a path that exists in undici 7.x but was removed/relocated in undici 8.x.
- Root cause: `pnpm.overrides` had `"undici": ">=7.24.0"` (open range), which resolved to `undici@8.1.0` — exactly the trap documented in `.claude/rules/gotchas.md`.
- Fix: tighten the range to `">=7.24.0 <8"`. Lockfile now resolves `undici@7.25.0`, which still contains `wrap-handler.js` and keeps the original CVE patch floor.

Reference failure: https://github.com/mattbutlerengineering/mattbutlerengineering/actions/runs/25030521065/job/73311130588 (PR #802) — error: `Cannot find module 'undici/lib/handler/wrap-handler.js'` from jsdom-dispatcher across all hospitality `*.test.tsx` files.

## Test plan

- [x] `pnpm install` resolves `undici@7.25.0`
- [x] `pnpm --dir apps/hospitality exec vitest run src/nav-sections.test.ts` passes locally (was failing in CI)
- [ ] CI Test job goes green on this PR
- [ ] Confirm baseline turns green on main after merge — unblocks #802 and other open PRs