### PR TITLE
fix(husky): resolve pre-commit deprecation warnings (#693)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,4 @@
 #!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
 
 pnpm lint-staged
 pnpm --filter @mbe/cli start check-adr --staged

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "overrides": {
       "@anthropic-ai/sdk": ">=0.81.0",
       "tar": ">=7.5.11",
-      "undici": ">=7.24.0",
+      "undici": ">=7.24.0 <8",
       "flatted": ">=3.4.2",
       "effect": ">=3.20.0",
       "rollup": ">=4.59.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ catalogs:
 overrides:
   '@anthropic-ai/sdk': '>=0.81.0'
   tar: '>=7.5.11'
-  undici: '>=7.24.0'
+  undici: '>=7.24.0 <8'
   flatted: '>=3.4.2'
   effect: '>=3.20.0'
   rollup: '>=4.59.0'
@@ -7921,9 +7921,9 @@ packages:
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
-  undici@8.1.0:
-    resolution: {integrity: sha512-E9MkTS4xXLnRPYqxH2e6Hr2/49e7WFDKczKcCaFH4VaZs2iNvHMqeIkyUAD9vM8kujy9TjVrRlQ5KkdEJxB2pw==}
-    engines: {node: '>=22.19.0'}
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -14336,7 +14336,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 8.1.0
+      undici: 7.25.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -14899,7 +14899,7 @@ snapshots:
       semver: 7.7.4
       tar: 7.5.13
       tinyglobby: 0.2.16
-      undici: 8.1.0
+      undici: 7.25.0
       which: 6.0.1
 
   node-releases@2.0.37: {}
@@ -16442,7 +16442,7 @@ snapshots:
 
   undici-types@7.19.2: {}
 
-  undici@8.1.0: {}
+  undici@7.25.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 


### PR DESCRIPTION
Removes deprecated manual husky.sh sourcing from hooks for Husky v9 compatibility.