### PR TITLE
feat(marketing): add manifest.json and full PWA support (#328)

### DIFF
--- a/apps/marketing/llms.txt
+++ b/apps/marketing/llms.txt
@@ -8,7 +8,7 @@
       }
     </item>
     <item priority="high">
-      export const TECH_STACK: import("/Users/mbutler/github/mattbutlerengineering/apps/...;
+      export const TECH_STACK: import("/Users/mbutler/github/issue-328/apps/marketing/sr...;
     </item>
   </file>
   <file path="src/data/projects.ts">
@@ -21,7 +21,7 @@
       }
     </item>
     <item priority="high">
-      export const PROJECTS: import("/Users/mbutler/github/mattbutlerengineering/apps/...;
+      export const PROJECTS: import("/Users/mbutler/github/issue-328/apps/marketing/sr...;
     </item>
   </file>
   </section>

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -33,6 +33,7 @@
     "react-router-dom": "catalog:"
   },
   "devDependencies": {
+    "vite-plugin-pwa": "^1.2.0",
     "@axe-core/playwright": "^4.11.2",
     "@mbe/config": "workspace:*",
     "@playwright/test": "^1.59.1",

--- a/apps/marketing/vite.config.ts
+++ b/apps/marketing/vite.config.ts
@@ -1,11 +1,36 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { sentryVitePlugin } from "@sentry/vite-plugin";
+import { VitePWA } from "vite-plugin-pwa";
 import { resolve } from "path";
 
 export default defineConfig({
   plugins: [
     react(),
+    VitePWA({
+      registerType: "autoUpdate",
+      includeAssets: ["favicon.svg", "apple-touch-icon.png", "robots.txt"],
+      manifest: {
+        name: "Matt Butler Engineering",
+        short_name: "MBE",
+        description: "Software engineering solutions for hospitality and beyond",
+        theme_color: "#ffffff",
+        background_color: "#ffffff",
+        display: "standalone",
+        icons: [
+          {
+            src: "favicon.svg",
+            sizes: "any",
+            type: "image/svg+xml",
+          },
+          {
+            src: "apple-touch-icon.png",
+            sizes: "180x180",
+            type: "image/png",
+          },
+        ],
+      },
+    }),
     sentryVitePlugin({
       org: process.env.SENTRY_ORG,
       project: process.env.SENTRY_PROJECT,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,6 +323,9 @@ importers:
       vite:
         specifier: 'catalog:'
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      vite-plugin-pwa:
+        specifier: ^1.2.0
+        version: 1.2.0(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0)
 
   apps/rialto-web:
     dependencies:


### PR DESCRIPTION
Adds vite-plugin-pwa to the marketing site with a web manifest and auto-updating service worker.