### PR TITLE
fix(services): enable AJV strict mode by fixing schema generation

### DIFF
--- a/packages/types/src/schemas/json-schema.ts
+++ b/packages/types/src/schemas/json-schema.ts
@@ -28,16 +28,18 @@ import {
 } from "./common.js";
 
 /**
- * Recursively strip `additionalProperties` from a JSON Schema object.
+ * Recursively strip `additionalProperties` and `propertyNames` from a JSON Schema
+ * object.
  *
- * Zod 4's `toJSONSchema` emits `additionalProperties: false` for objects,
- * but Fastify response schemas should remain open (the old hand-written
- * schemas never restricted additional properties).
+ * Zod 4's `toJSONSchema` emits `additionalProperties: false` for objects and
+ * `propertyNames` for `Record<string, unknown>` types. Both cause AJV strict mode
+ * warnings and are unnecessary for Fastify response schemas (the old hand-written
+ * schemas never restricted additional properties or property names).
  */
 function stripAdditionalProperties(obj: Record<string, unknown>): Record<string, unknown> {
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(obj)) {
-    if (key === "additionalProperties") continue;
+    if (key === "additionalProperties" || key === "propertyNames") continue;
     if (value !== null && typeof value === "object" && !Array.isArray(value)) {
       result[key] = stripAdditionalProperties(value as Record<string, unknown>);
     } else if (Array.isArray(value)) {

--- a/services/agent/src/app.ts
+++ b/services/agent/src/app.ts
@@ -31,7 +31,6 @@ export async function buildApp(options: AppOptions = {}): Promise<FastifyInstanc
   const fastify = Fastify({
     logger: options.logger ?? true,
     disableRequestLogging: true,
-    ajv: { customOptions: { strict: false } },
   });
 
   // Register schemas

--- a/services/agent/src/schemas/__snapshots__/schemas.test.ts.snap
+++ b/services/agent/src/schemas/__snapshots__/schemas.test.ts.snap
@@ -114,9 +114,6 @@ exports[`Agent service schemas > SessionEventSchema matches snapshot 1`] = `
       "type": "string",
     },
     "data": {
-      "propertyNames": {
-        "type": "string",
-      },
       "type": "object",
     },
     "id": {

--- a/services/reservations/src/app.ts
+++ b/services/reservations/src/app.ts
@@ -31,11 +31,6 @@ export async function buildApp(options: AppOptions = {}): Promise<FastifyInstanc
   const fastify = Fastify({
     logger: options.logger ?? true,
     disableRequestLogging: true,
-    ajv: {
-      customOptions: {
-        strict: false,
-      },
-    },
   });
 
   // Register schemas

--- a/services/reservations/src/schemas/__snapshots__/schemas.test.ts.snap
+++ b/services/reservations/src/schemas/__snapshots__/schemas.test.ts.snap
@@ -941,9 +941,6 @@ exports[`Reservation service schemas > VenueGroupSchema matches snapshot 1`] = `
     "settings": {
       "anyOf": [
         {
-          "propertyNames": {
-            "type": "string",
-          },
           "type": "object",
         },
         {
@@ -1126,9 +1123,6 @@ exports[`Reservation service schemas > VenueSchema matches snapshot 1`] = `
     "settings": {
       "anyOf": [
         {
-          "propertyNames": {
-            "type": "string",
-          },
           "type": "object",
         },
         {
@@ -1156,9 +1150,6 @@ exports[`Reservation service schemas > VenueSchema matches snapshot 1`] = `
         "settings": {
           "anyOf": [
             {
-              "propertyNames": {
-                "type": "string",
-              },
               "type": "object",
             },
             {

--- a/services/reservations/src/schemas/schema-baseline.json
+++ b/services/reservations/src/schemas/schema-baseline.json
@@ -1,270 +1,105 @@
 {
-  "Error": {
-    "$id": "Error",
+  "TableShapeMetadata": {
+    "$id": "TableShapeMetadata",
     "type": "object",
     "properties": {
-      "error": {
-        "type": "string"
-      },
-      "message": {
-        "type": "string"
-      },
-      "statusCode": {
+      "x": {
         "type": "number"
-      }
-    },
-    "required": [
-      "error",
-      "message",
-      "statusCode"
-    ]
-  },
-  "FloorPlanLayout": {
-    "$id": "FloorPlanLayout",
-    "type": "object",
-    "properties": {
+      },
+      "y": {
+        "type": "number"
+      },
       "width": {
         "type": "number"
       },
       "height": {
         "type": "number"
       },
-      "backgroundImage": {
-        "type": "string"
-      },
-      "gridSize": {
+      "rotation": {
         "type": "number"
       },
-      "showGrid": {
-        "type": "boolean"
+      "shape": {
+        "type": "string",
+        "enum": [
+          "rectangle",
+          "circle",
+          "square"
+        ]
+      },
+      "color": {
+        "type": "string"
       }
     },
     "required": [
+      "x",
+      "y",
       "width",
-      "height"
+      "height",
+      "shape"
     ]
   },
-  "FloorPlan": {
-    "$id": "FloorPlan",
+  "Table": {
+    "$id": "Table",
     "type": "object",
     "properties": {
       "id": {
         "type": "string"
       },
-      "venueId": {
-        "type": "string"
-      },
       "name": {
         "type": "string"
+      },
+      "tableNumber": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "capacity": {
+        "type": "number"
+      },
+      "minCovers": {
+        "type": "number"
+      },
+      "maxCovers": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "location": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ]
       },
       "isActive": {
         "type": "boolean"
       },
-      "layoutJson": {
-        "type": "object",
-        "properties": {
-          "width": {
-            "type": "number"
-          },
-          "height": {
-            "type": "number"
-          },
-          "backgroundImage": {
-            "type": "string"
-          },
-          "gridSize": {
-            "type": "number"
-          },
-          "showGrid": {
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "width",
-          "height"
+      "priority": {
+        "type": "number"
+      },
+      "status": {
+        "type": "string",
+        "enum": [
+          "AVAILABLE",
+          "OCCUPIED",
+          "DIRTY",
+          "READY"
         ]
-      },
-      "tables": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "id": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            },
-            "tableNumber": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "capacity": {
-              "type": "number"
-            },
-            "minCovers": {
-              "type": "number"
-            },
-            "maxCovers": {
-              "anyOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "location": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "isActive": {
-              "type": "boolean"
-            },
-            "priority": {
-              "type": "number"
-            },
-            "status": {
-              "type": "string",
-              "enum": [
-                "AVAILABLE",
-                "OCCUPIED",
-                "DIRTY",
-                "READY"
-              ]
-            },
-            "venueId": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "floorPlanId": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "shapeMetadata": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "x": {
-                      "type": "number"
-                    },
-                    "y": {
-                      "type": "number"
-                    },
-                    "width": {
-                      "type": "number"
-                    },
-                    "height": {
-                      "type": "number"
-                    },
-                    "rotation": {
-                      "type": "number"
-                    },
-                    "shape": {
-                      "type": "string",
-                      "enum": [
-                        "rectangle",
-                        "circle",
-                        "square"
-                      ]
-                    },
-                    "color": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "x",
-                    "y",
-                    "width",
-                    "height",
-                    "shape"
-                  ]
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "createdAt": {
-              "type": "string"
-            },
-            "updatedAt": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "id",
-            "name",
-            "tableNumber",
-            "capacity",
-            "minCovers",
-            "maxCovers",
-            "location",
-            "isActive",
-            "priority",
-            "status",
-            "venueId",
-            "floorPlanId",
-            "shapeMetadata",
-            "createdAt",
-            "updatedAt"
-          ]
-        }
-      },
-      "createdAt": {
-        "type": "string"
-      },
-      "updatedAt": {
-        "type": "string"
-      }
-    },
-    "required": [
-      "id",
-      "venueId",
-      "name",
-      "isActive",
-      "layoutJson",
-      "createdAt",
-      "updatedAt"
-    ]
-  },
-  "Guest": {
-    "$id": "Guest",
-    "type": "object",
-    "properties": {
-      "id": {
-        "type": "string"
       },
       "venueId": {
-        "type": "string"
-      },
-      "email": {
         "anyOf": [
           {
             "type": "string"
@@ -274,7 +109,7 @@
           }
         ]
       },
-      "phone": {
+      "floorPlanId": {
         "anyOf": [
           {
             "type": "string"
@@ -284,49 +119,45 @@
           }
         ]
       },
-      "name": {
-        "type": "string"
-      },
-      "notes": {
+      "shapeMetadata": {
         "anyOf": [
           {
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ]
-      },
-      "visitCount": {
-        "type": "number"
-      },
-      "lifetimeSpend": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ]
-      },
-      "lastVisit": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ]
-      },
-      "tags": {
-        "anyOf": [
-          {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+            "type": "object",
+            "properties": {
+              "x": {
+                "type": "number"
+              },
+              "y": {
+                "type": "number"
+              },
+              "width": {
+                "type": "number"
+              },
+              "height": {
+                "type": "number"
+              },
+              "rotation": {
+                "type": "number"
+              },
+              "shape": {
+                "type": "string",
+                "enum": [
+                  "rectangle",
+                  "circle",
+                  "square"
+                ]
+              },
+              "color": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "x",
+              "y",
+              "width",
+              "height",
+              "shape"
+            ]
           },
           {
             "type": "null"
@@ -342,69 +173,20 @@
     },
     "required": [
       "id",
-      "venueId",
-      "email",
-      "phone",
       "name",
-      "notes",
-      "visitCount",
-      "lifetimeSpend",
-      "lastVisit",
-      "tags",
+      "tableNumber",
+      "capacity",
+      "minCovers",
+      "maxCovers",
+      "location",
+      "isActive",
+      "priority",
+      "status",
+      "venueId",
+      "floorPlanId",
+      "shapeMetadata",
       "createdAt",
       "updatedAt"
-    ]
-  },
-  "GuestSegment": {
-    "$id": "GuestSegment",
-    "type": "object",
-    "properties": {
-      "name": {
-        "type": "string"
-      },
-      "description": {
-        "type": "string"
-      },
-      "count": {
-        "type": "number"
-      }
-    },
-    "required": [
-      "name",
-      "description",
-      "count"
-    ]
-  },
-  "Pagination": {
-    "$id": "Pagination",
-    "type": "object",
-    "properties": {
-      "page": {
-        "type": "number"
-      },
-      "limit": {
-        "type": "number"
-      },
-      "total": {
-        "type": "number"
-      },
-      "totalPages": {
-        "type": "number"
-      },
-      "hasNext": {
-        "type": "boolean"
-      },
-      "hasPrev": {
-        "type": "boolean"
-      }
-    },
-    "required": [
-      "page",
-      "limit",
-      "total",
-      "totalPages",
-      "hasNext",
-      "hasPrev"
     ]
   },
   "Reservation": {
@@ -707,194 +489,56 @@
       "updatedAt"
     ]
   },
-  "Table": {
-    "$id": "Table",
+  "Pagination": {
+    "$id": "Pagination",
     "type": "object",
     "properties": {
-      "id": {
-        "type": "string"
-      },
-      "name": {
-        "type": "string"
-      },
-      "tableNumber": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ]
-      },
-      "capacity": {
+      "page": {
         "type": "number"
       },
-      "minCovers": {
+      "limit": {
         "type": "number"
       },
-      "maxCovers": {
-        "anyOf": [
-          {
-            "type": "number"
-          },
-          {
-            "type": "null"
-          }
-        ]
+      "total": {
+        "type": "number"
       },
-      "location": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ]
+      "totalPages": {
+        "type": "number"
       },
-      "isActive": {
+      "hasNext": {
         "type": "boolean"
       },
-      "priority": {
-        "type": "number"
-      },
-      "status": {
-        "type": "string",
-        "enum": [
-          "AVAILABLE",
-          "OCCUPIED",
-          "DIRTY",
-          "READY"
-        ]
-      },
-      "venueId": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ]
-      },
-      "floorPlanId": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ]
-      },
-      "shapeMetadata": {
-        "anyOf": [
-          {
-            "type": "object",
-            "properties": {
-              "x": {
-                "type": "number"
-              },
-              "y": {
-                "type": "number"
-              },
-              "width": {
-                "type": "number"
-              },
-              "height": {
-                "type": "number"
-              },
-              "rotation": {
-                "type": "number"
-              },
-              "shape": {
-                "type": "string",
-                "enum": [
-                  "rectangle",
-                  "circle",
-                  "square"
-                ]
-              },
-              "color": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "x",
-              "y",
-              "width",
-              "height",
-              "shape"
-            ]
-          },
-          {
-            "type": "null"
-          }
-        ]
-      },
-      "createdAt": {
-        "type": "string"
-      },
-      "updatedAt": {
-        "type": "string"
+      "hasPrev": {
+        "type": "boolean"
       }
     },
     "required": [
-      "id",
-      "name",
-      "tableNumber",
-      "capacity",
-      "minCovers",
-      "maxCovers",
-      "location",
-      "isActive",
-      "priority",
-      "status",
-      "venueId",
-      "floorPlanId",
-      "shapeMetadata",
-      "createdAt",
-      "updatedAt"
+      "page",
+      "limit",
+      "total",
+      "totalPages",
+      "hasNext",
+      "hasPrev"
     ]
   },
-  "TableShapeMetadata": {
-    "$id": "TableShapeMetadata",
+  "Error": {
+    "$id": "Error",
     "type": "object",
     "properties": {
-      "x": {
-        "type": "number"
-      },
-      "y": {
-        "type": "number"
-      },
-      "width": {
-        "type": "number"
-      },
-      "height": {
-        "type": "number"
-      },
-      "rotation": {
-        "type": "number"
-      },
-      "shape": {
-        "type": "string",
-        "enum": [
-          "rectangle",
-          "circle",
-          "square"
-        ]
-      },
-      "color": {
+      "error": {
         "type": "string"
+      },
+      "message": {
+        "type": "string"
+      },
+      "statusCode": {
+        "type": "number"
       }
     },
     "required": [
-      "x",
-      "y",
-      "width",
-      "height",
-      "shape"
+      "error",
+      "message",
+      "statusCode"
     ]
   },
   "VenueGroup": {
@@ -913,10 +557,7 @@
       "settings": {
         "anyOf": [
           {
-            "type": "object",
-            "propertyNames": {
-              "type": "string"
-            }
+            "type": "object"
           },
           {
             "type": "null"
@@ -967,10 +608,7 @@
           "settings": {
             "anyOf": [
               {
-                "type": "object",
-                "propertyNames": {
-                  "type": "string"
-                }
+                "type": "object"
               },
               {
                 "type": "null"
@@ -1142,10 +780,7 @@
       "settings": {
         "anyOf": [
           {
-            "type": "object",
-            "propertyNames": {
-              "type": "string"
-            }
+            "type": "object"
           },
           {
             "type": "null"
@@ -1168,6 +803,362 @@
       "currencyCode",
       "operatingHours",
       "settings",
+      "createdAt",
+      "updatedAt"
+    ]
+  },
+  "Guest": {
+    "$id": "Guest",
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string"
+      },
+      "venueId": {
+        "type": "string"
+      },
+      "email": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "phone": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "name": {
+        "type": "string"
+      },
+      "notes": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "visitCount": {
+        "type": "number"
+      },
+      "lifetimeSpend": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "lastVisit": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "tags": {
+        "anyOf": [
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "createdAt": {
+        "type": "string"
+      },
+      "updatedAt": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "id",
+      "venueId",
+      "email",
+      "phone",
+      "name",
+      "notes",
+      "visitCount",
+      "lifetimeSpend",
+      "lastVisit",
+      "tags",
+      "createdAt",
+      "updatedAt"
+    ]
+  },
+  "GuestSegment": {
+    "$id": "GuestSegment",
+    "type": "object",
+    "properties": {
+      "name": {
+        "type": "string"
+      },
+      "description": {
+        "type": "string"
+      },
+      "count": {
+        "type": "number"
+      }
+    },
+    "required": [
+      "name",
+      "description",
+      "count"
+    ]
+  },
+  "FloorPlanLayout": {
+    "$id": "FloorPlanLayout",
+    "type": "object",
+    "properties": {
+      "width": {
+        "type": "number"
+      },
+      "height": {
+        "type": "number"
+      },
+      "backgroundImage": {
+        "type": "string"
+      },
+      "gridSize": {
+        "type": "number"
+      },
+      "showGrid": {
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "width",
+      "height"
+    ]
+  },
+  "FloorPlan": {
+    "$id": "FloorPlan",
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string"
+      },
+      "venueId": {
+        "type": "string"
+      },
+      "name": {
+        "type": "string"
+      },
+      "isActive": {
+        "type": "boolean"
+      },
+      "layoutJson": {
+        "type": "object",
+        "properties": {
+          "width": {
+            "type": "number"
+          },
+          "height": {
+            "type": "number"
+          },
+          "backgroundImage": {
+            "type": "string"
+          },
+          "gridSize": {
+            "type": "number"
+          },
+          "showGrid": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "width",
+          "height"
+        ]
+      },
+      "tables": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "tableNumber": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "capacity": {
+              "type": "number"
+            },
+            "minCovers": {
+              "type": "number"
+            },
+            "maxCovers": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "location": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "isActive": {
+              "type": "boolean"
+            },
+            "priority": {
+              "type": "number"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "AVAILABLE",
+                "OCCUPIED",
+                "DIRTY",
+                "READY"
+              ]
+            },
+            "venueId": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "floorPlanId": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "shapeMetadata": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "x": {
+                      "type": "number"
+                    },
+                    "y": {
+                      "type": "number"
+                    },
+                    "width": {
+                      "type": "number"
+                    },
+                    "height": {
+                      "type": "number"
+                    },
+                    "rotation": {
+                      "type": "number"
+                    },
+                    "shape": {
+                      "type": "string",
+                      "enum": [
+                        "rectangle",
+                        "circle",
+                        "square"
+                      ]
+                    },
+                    "color": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "x",
+                    "y",
+                    "width",
+                    "height",
+                    "shape"
+                  ]
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "createdAt": {
+              "type": "string"
+            },
+            "updatedAt": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "name",
+            "tableNumber",
+            "capacity",
+            "minCovers",
+            "maxCovers",
+            "location",
+            "isActive",
+            "priority",
+            "status",
+            "venueId",
+            "floorPlanId",
+            "shapeMetadata",
+            "createdAt",
+            "updatedAt"
+          ]
+        }
+      },
+      "createdAt": {
+        "type": "string"
+      },
+      "updatedAt": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "id",
+      "venueId",
+      "name",
+      "isActive",
+      "layoutJson",
       "createdAt",
       "updatedAt"
     ]

--- a/services/users/src/app.ts
+++ b/services/users/src/app.ts
@@ -24,7 +24,6 @@ export async function buildApp(options: AppOptions = {}): Promise<FastifyInstanc
   const fastify = Fastify({
     logger: options.logger ?? true,
     disableRequestLogging: true,
-    ajv: { customOptions: { strict: false } },
   });
 
   // Register schemas


### PR DESCRIPTION
## Summary
- Fix root cause of AJV strict mode warnings: `propertyNames` incorrectly emitted for `Record<string, unknown>` types
- Strip `propertyNames` from generated JSON schemas in `packages/types/src/schemas/json-schema.ts`
- Re-enable AJV strict mode in all three services (agent, reservations, users)
- Update snapshots to reflect the corrected schemas

## Root Cause
Zod 4's `toJSONSchema` was emitting invalid `propertyNames` schemas for `Record<string, unknown>` types. Rather than fixing the schema generation, the services disabled AJV strict mode (commit 7446d98), which hid potential schema validation issues.

## Changes
- **packages/types/src/schemas/json-schema.ts**: Extended `stripAdditionalProperties()` to also remove `propertyNames` from generated schemas
- **services/*/src/app.ts**: Removed `ajv: { customOptions: { strict: false } }` config
- **services/*/src/schemas/__snapshots__/**: Updated snapshots
- **services/reservations/src/schemas/schema-baseline.json**: Regenerated with fixed schemas

## Testing
- All 266 service tests pass (45 users + 152 reservations + 69 agent)
- Lint passes for all services
- Typecheck passes for all services

Fixes #684