### PR TITLE
feat: add Semgrep MCP for AI-powered security scanning (#355)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,36 @@ Quick reference:
 - **Patterns:** `*.test.ts` for unit/integration.
 - **Mandate:** All logic changes must be verified via automated tests.
 - **UI:** Playwright for E2E and visual regression.
+
+## Security Scanning (Semgrep)
+
+Semgrep provides Static Application Security Testing (SAST) integrated into the AI development loop.
+
+### MCP Integration
+Semgrep MCP server (`@semgrep/mcp`) is configured in `.mcp.json`, giving agents access to:
+- Code scanning for 30+ languages
+- Security-focused rulesets (Code, Secrets, Supply Chain)
+- Natural language vulnerability explanations
+- CI/CD integration
+
+### Pre-commit Security Checks
+The `.husky/pre-commit` hook runs `semgrep --config semgrep.yml --error` on staged files before commit.
+
+### Configuration
+- **Rules file:** `semgrep.yml` (root) — covers CWE-top vulnerabilities
+- **Categories:** Code injection, SQL injection, XSS, hardcoded secrets, missing auth, insecure JWT
+- **Registry rules:** `semgrep --config "p/security-audit"` for extended coverage
+
+### Running Manually
+```bash
+semgrep --config semgrep.yml --error .           # Custom rules
+semgrep --config "p/security-audit" --error .  # Semgrep registry rules
+```
+
+### Skip in Emergencies
+```bash
+SKIP=semgrep git commit -m "emergency fix"
+```
 ## Model Governance
 To ensure cost-efficiency and technical integrity, follow this model tiering strategy:
 - **Tier 1: Haiku / Gemini Flash** - Lightweight chores, linting, dependency bumps, typos (< $0.05).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,3 +138,28 @@ When `LANGFUSE_PUBLIC_KEY` is unset, Langfuse is not loaded — zero overhead.
 The Langfuse MCP server (`.mcp.json`) gives Claude Code access to:
 - `get-prompts` — List prompts in the Langfuse project
 - `get-prompt` — Fetch a specific prompt by name
+
+## Security Scanning (Semgrep)
+
+Semgrep MCP server is configured in `.mcp.json` for AI-powered static analysis.
+
+### What's enabled
+- **30+ languages** supported (JavaScript, TypeScript, Python, Go, etc.)
+- **Security rulesets**: Code, Secrets, Supply Chain
+- **Pre-commit hook**: Runs `semgrep --config semgrep.yml --error` on staged files
+- **MCP integration**: Agents can invoke Semgrep scans via `@semgrep/mcp`
+
+### Configuration
+- Rules file: `semgrep.yml` (root) — covers CWE-top, OWASP, secrets, injection
+- Pre-commit: `.husky/pre-commit` runs security scan before commit
+- Custom rules cover: eval/Function injection, SQL injection, XSS, hardcoded secrets, missing auth
+
+### Running manually
+```bash
+semgrep --config semgrep.yml --error .
+semgrep --config "p/security-audit" --error .  # Use Semgrep registry rules
+```
+
+### Skipping (emergencies only)
+```bash
+SKIP=semgrep git commit -m "emergency fix"

--- a/semgrep.yml
+++ b/semgrep.yml
@@ -1,14 +1,110 @@
 rules:
+  # Code injection patterns
   - id: avoid-eval
     pattern: eval(...)
-    message: "Avoid using eval() as it can lead to security vulnerabilities."
+    message: "Avoid using eval() as it can lead to code injection vulnerabilities."
     languages: [javascript, typescript]
     severity: ERROR
+    metadata:
+      category: security
+      cwe: "CWE-95"
+
+  - id: avoid-function-constructor
+    pattern: new Function(...)
+    message: "Avoid using Function constructor as it can lead to code injection."
+    languages: [javascript, typescript]
+    severity: ERROR
+    metadata:
+      category: security
+      cwe: "CWE-95"
+
+  # Hardcoded secrets
   - id: avoid-hardcoded-secrets
     pattern: |
       $S = "..."
-    message: "Potential hardcoded secret detected."
+    message: "Potential hardcoded secret detected. Use environment variables instead."
     languages: [javascript, typescript, python]
+    severity: ERROR
+    metadata:
+      category: security
+      cwe: "CWE-798"
+
+  # SQL injection
+  - id: avoid-sql-string-concat
+    pattern: |
+      $DB.query($QUERY + $VAR)
+    message: "SQL query built with string concatenation. Use parameterized queries instead."
+    languages: [javascript, typescript]
+    severity: ERROR
+    metadata:
+      category: security
+      cwe: "CWE-89"
+
+  # XSS vulnerabilities
+  - id: avoid-dangerouslysetinnerhtml
+    pattern: dangerouslySetInnerHTML = ...
+    message: "dangerouslySetInnerHTML can lead to XSS vulnerabilities. Sanitize input first."
+    languages: [javascript, typescript]
     severity: WARNING
+    metadata:
+      category: security
+      cwe: "CWE-79"
+
+  # Insecure random
+  - id: avoid-math-random-for-security
+    pattern: Math.random(...)
+    message: "Math.random() is not cryptographically secure. Use crypto.getRandomValues() for security-sensitive operations."
+    languages: [javascript, typescript]
+    severity: WARNING
+    metadata:
+      category: security
+      cwe: "CWE-338"
+
+  # Missing auth checks
+  - id: fastify-route-missing-auth
+    pattern: |
+      $APP.$METHOD($PATH, async (...) => {...})
+    message: "Route handler without authentication. Consider adding requireAuth() or verifyJWT."
+    languages: [javascript, typescript]
+    severity: WARNING
+    paths:
+      include:
+        - "services/**/*route*.ts"
+        - "services/**/*handler*.ts"
+    metadata:
+      category: security
+
+  # Environment variable exposure
+  - id: avoid-logging-secrets
+    pattern: |
+      console.log(..., $SECRET, ...)
+    message: "Potential secret logged to console. Avoid logging sensitive data."
+    languages: [javascript, typescript]
+    severity: ERROR
+    metadata:
+      category: security
+      cwe: "CWE-532"
+
+  # Insecure JWT handling
+  - id: jwt-verify-missing-audience
+    pattern: |
+      jwt.verify($TOKEN, $SECRET, {...})
+    message: "JWT verification without audience or issuer check. Verify these claims for proper validation."
+    languages: [javascript, typescript]
+    severity: WARNING
+    metadata:
+      category: security
+      cwe: "CWE-287"
+
+  # Dependency confusion
+  - id: npm-install-script
+    pattern: |
+      "preinstall": "..."
+    message: "preinstall scripts can be used for dependency confusion attacks. Review carefully."
+    languages: [json]
+    severity: WARNING
+    paths:
+      include:
+        - "**/package.json"
     metadata:
       category: security


### PR DESCRIPTION
## Summary
- Add comprehensive Semgrep security rules in `semgrep.yml` covering CWE-top vulnerabilities
- Document Semgrep integration in `CLAUDE.md` and `AGENTS.md`
- Pre-commit hook already configured in `.husky/pre-commit`
- MCP server already configured in `.mcp.json`

## Changes
- **semgrep.yml**: Enhanced with 10 security rules (eval injection, Function constructor, SQL injection, XSS, hardcoded secrets, missing auth, insecure JWT, dependency confusion)
- **CLAUDE.md**: Added Security Scanning section with configuration, usage, and emergency skip instructions
- **AGENTS.md**: Added Security Scanning section for all AI agents

## Related Issue
Closes #355

## Tasks Completed
- [x] Install Semgrep MCP server (already in `.mcp.json`)
- [x] Configure security ruleset (`semgrep.yml`)
- [x] Add to pre-commit hooks (already in `.husky/pre-commit`)
- [x] Document in CLAUDE.md security section