### PR TITLE
feat: add .editorconfig and .github/prompts catalog (ACMM L2)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+indent_size = 4
+
+[Makefile]
+indent_style = tab

--- a/.github/prompts/bug-fix.md
+++ b/.github/prompts/bug-fix.md
@@ -1,0 +1,17 @@
+# Bug Investigation
+
+Investigate and fix the reported bug using systematic debugging.
+
+## Steps
+1. Reproduce the issue — identify the exact input and expected vs actual output
+2. Trace the code path from entry point to failure
+3. Write a failing test that captures the bug
+4. Fix the root cause (not symptoms)
+5. Verify the test passes
+6. Check for similar patterns elsewhere in the codebase
+
+## Project context
+- Backend services use Fastify + Prisma in `services/`
+- Frontend apps use React + Vite in `apps/`
+- Shared packages in `packages/`
+- Run tests with `pnpm --dir <package-path> test`

--- a/.github/prompts/component.md
+++ b/.github/prompts/component.md
@@ -1,0 +1,19 @@
+# New Rialto Component
+
+Create a new component in the `@mattbutlerengineering/rialto` design system.
+
+## Structure
+Components live in `packages/rialto/src/components/<ComponentName>/`.
+
+## Files to create
+- `index.tsx` — component implementation
+- `<ComponentName>.test.tsx` — unit tests
+- `<ComponentName>.stories.tsx` — Storybook stories
+- `<ComponentName>.module.css` — CSS modules (if needed)
+
+## Requirements
+- WCAG AA accessible (proper ARIA, keyboard nav, color contrast)
+- Export props interface as `<ComponentName>Props`
+- No `setState` inside `useEffect` body — use render-time derivation
+- Add to barrel export in `packages/rialto/src/index.ts`
+- Run `pnpm --dir packages/rialto build` after adding

--- a/.github/prompts/migration.md
+++ b/.github/prompts/migration.md
@@ -1,0 +1,17 @@
+# Database Migration
+
+Create a Prisma database migration for a service.
+
+## Steps
+1. Edit the schema at `services/<name>/prisma/schema.prisma`
+2. Generate migration: `pnpm --dir services/<name> db:migrate -- --name <description>`
+3. Review the generated SQL in `services/<name>/prisma/migrations/`
+4. Regenerate the client: `pnpm --dir services/<name> db:generate`
+5. Update any affected route handlers or repositories
+6. Run tests: `pnpm --dir services/<name> test`
+
+## Safety checks
+- No destructive operations (DROP TABLE, DROP COLUMN) without explicit approval
+- Add columns as nullable or with defaults to avoid breaking existing rows
+- Keep Prisma version in sync between client and migrate Dockerfile
+- Prisma 7 uses `prisma.config.ts` for connection URL — no `url` in schema

--- a/.github/prompts/new-endpoint.md
+++ b/.github/prompts/new-endpoint.md
@@ -1,0 +1,19 @@
+# New API Endpoint
+
+Add a new endpoint to a Fastify service.
+
+## Structure
+Services live in `services/<name>/src/routes/`. Each route file exports a Fastify plugin.
+
+## Steps
+1. Create route file in `services/<name>/src/routes/<resource>.ts`
+2. Define JSON Schema for request params, body, and response
+3. Register the route plugin in `services/<name>/src/app.ts`
+4. Add integration tests in `services/<name>/src/routes/__tests__/`
+5. Run `pnpm --dir services/<name> test` to verify
+
+## Patterns
+- Use `@mbe/api-client` for inter-service calls (ADR-001)
+- Use repository pattern for data access
+- Validate all input with Fastify schemas
+- Return consistent envelope: `{ success, data, error }`

--- a/.github/prompts/review.md
+++ b/.github/prompts/review.md
@@ -1,0 +1,18 @@
+# PR Review
+
+Review this pull request against the project's coding standards.
+
+## Checklist
+- Immutable data patterns (no in-place mutation)
+- Error handling at system boundaries
+- Functions under 50 lines, files under 800 lines
+- No hardcoded secrets or credentials
+- Input validation on external data
+- Conventional commit messages
+- Test coverage for new functionality
+
+## Focus areas
+- Check `services/*/src/routes/` for proper Fastify schema validation
+- Check `packages/rialto/src/` for accessibility (WCAG AA)
+- Check for proper use of `@mbe/api-client` (ADR-001)
+- Verify no `setState` inside `useEffect` body in React components


### PR DESCRIPTION
## Summary
- Add `.editorconfig` for cross-editor consistency (2-space indent, LF, UTF-8, trim trailing whitespace)
- Add `.github/prompts/` catalog with 5 reusable prompt templates: review, bug-fix, new-endpoint, component, migration

Satisfies ACMM L2 criteria `acmm:editor-config` and `acmm:prompts-catalog`.

Closes #857, closes #856

## Test plan
- [ ] Verify `.editorconfig` matches project conventions
- [ ] Verify prompt templates reference actual project paths and patterns