### PR TITLE
feat(ci): add Node version matrix to test job (ACMM L3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,9 +321,14 @@ jobs:
         run: pnpm size:check
 
   test:
-    name: Test
+    name: Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     needs: [lint, typecheck, architecture-audit]
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 22]
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4/v5
@@ -332,7 +337,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 22
+          node-version: ${{ matrix.node-version }}
           cache: "pnpm"
 
       - name: Restore node_modules


### PR DESCRIPTION
## Summary
- Add Node.js version matrix (20, 22) to the CI Test job
- Tests now run against both LTS versions with `fail-fast: false`
- Satisfies ACMM L3 criterion `acmm:ci-matrix`

Closes #861

## Test plan
- [ ] CI runs Test job for both Node 20 and Node 22
- [ ] Both matrix entries pass or failures are version-specific (not matrix config issues)