### PR TITLE
feat(acmm): add governance and agent task documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,61 @@
+# GitHub Copilot Instructions
+
+> For full project context, see [AGENTS.md](../AGENTS.md) (primary source of truth).
+
+## Project Overview
+
+TypeScript monorepo (`mattbutlerengineering`) using **Turborepo + pnpm**.
+
+- `apps/` — React (Vite) frontends: marketing, hospitality, rialto-web, gen
+- `services/` — Fastify + Prisma backends: users (3001), agent (3003), reservations (3004)
+- `packages/` — Shared libraries: agent-core, api-client, api-versioning, auth, config, observability, rialto (design system), types
+- `infrastructure/` — Pulumi IaC + Docker
+
+## Code Style
+
+- **Immutability first** — never mutate objects in place; return new copies
+- **Functional React** — hooks only, no class components
+- **CSS Modules** with Rialto design tokens (`var(--rialto-*)`) — no Tailwind
+- **Naming:** kebab-case files, camelCase functions/vars, PascalCase types
+- **Imports:** explicit extensions (`.js`/`.ts`), `import type` for type-only imports
+- **File size:** 200-400 lines typical, 800 max
+
+## API Conventions
+
+- RFC 7807 Problem Details for errors
+- Zod schema validation at all service boundaries
+- Fastify route structure with shared JSON schemas
+- Repository pattern for data access
+
+## Testing
+
+- Framework: **Vitest** for unit/integration, **Playwright** for E2E
+- TDD: write tests first (red), implement (green), refactor
+- Target: 80%+ coverage
+- Pattern: `*.test.ts` colocated with source
+
+## Git & Commits
+
+- **Conventional Commits:** `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`
+- Run before committing: `pnpm lint && pnpm typecheck && pnpm test`
+
+## Do Not
+
+- Use `console.log` in production code (use the observability package)
+- Use Tailwind or inline styles (use CSS Modules with Rialto tokens)
+- Hardcode secrets, API keys, or tokens
+- Mutate function arguments or shared state
+- Skip error handling — validate inputs and handle errors at every level
+- Use `any` type — prefer `unknown` with type narrowing
+
+## Database
+
+- Prisma ORM with per-service schemas
+- Migrations version-controlled in `services/*/prisma/migrations/`
+- Dev: `pnpm db:push` from root; Prod: `pnpm db:migrate` from service dir
+
+## Deployment
+
+- Static sites: Cloudflare Workers Static Assets via `wrangler`
+- API services: DigitalOcean App Platform via `doctl`
+- Infrastructure: Pulumi (TypeScript)

--- a/docs/agent-tasks/README.md
+++ b/docs/agent-tasks/README.md
@@ -1,0 +1,127 @@
+# Agent Task Traceability
+
+This directory documents the agent task tracking system used in the mattbutlerengineering monorepo. Every autonomous agent task is logged with intent, inputs, outputs, and outcome for full auditability.
+
+## Task Lifecycle
+
+```
+created → in-progress → completed | failed
+   │           │             │         │
+   │           │             │         └── labeled `agent-failed`, needs triage
+   │           │             └── PR created, labeled `has-pr`
+   │           └── agent working, labeled `in-progress`
+   └── issue filed, labeled `ready` for pickup
+```
+
+### States
+
+| State | GitHub Label | Description |
+|-------|-------------|-------------|
+| **Created** | `ready` | Task identified and available for agent pickup |
+| **In Progress** | `in-progress` | Agent has claimed the task and is working |
+| **Completed** | `has-pr` | Agent finished; PR created and awaiting review/merge |
+| **Failed** | `agent-failed` | Agent could not complete; needs manual review or retry |
+
+### Origin Labels
+
+Tasks are also tagged by how they were created:
+
+| Label | Source |
+|-------|--------|
+| `audit` | Found by `/site-audit` (Playwright + Lighthouse crawl) |
+| `ci-fix` | CI failure detected by `/ci-monitor` |
+| `feature` | Feature decomposed by `/decompose` |
+| `tracking` | Parent issue for multi-part features |
+| `meta-improvement` | Process improvement identified by agents |
+| `acmm` | AI Codebase Maturity Model finding from `/acmm-audit` |
+
+## Task Logging
+
+Every agent task records:
+
+| Field | Description | Where Stored |
+|-------|-------------|--------------|
+| **Intent** | What the agent was asked to do | GitHub Issue title + body |
+| **Inputs** | Issue number, model, budget, source trigger | Issue labels + Langfuse trace metadata |
+| **Outputs** | PR number, files changed, test results | PR body + linked issue |
+| **Outcome** | Success/failure, cost, turns used | Langfuse session metrics + `metrics/*.jsonl` |
+| **Duration** | Wall-clock time from start to PR/failure | Langfuse trace duration |
+
+### Langfuse Observability
+
+Agent sessions are traced to Langfuse Cloud with:
+- **Session traces** — one per `runSession()` call, with task description, model, and budget metadata
+- **Generation spans** — one per SDK turn, with model, input/output, and token usage
+- **Session metrics** — `success` (0/1), `cost_usd`, `num_turns`, `stuck` (0/1), `evaluation_confidence`
+
+## Auditing Agent Work
+
+### List All Agent PRs
+
+```bash
+# PRs created by agents (via GitHub Actions bot)
+gh pr list --author app/github-actions --state all --limit 20
+
+# PRs linked to agent-completed issues
+gh issue list --label has-pr --state all --limit 20
+```
+
+### List Failed Tasks
+
+```bash
+# Issues where agents failed
+gh issue list --label agent-failed --state open
+
+# Review failure details in issue comments
+gh issue view <issue-number> --comments
+```
+
+### List Tasks by Origin
+
+```bash
+# Site audit findings
+gh issue list --label audit --state all
+
+# CI fixes
+gh issue list --label ci-fix --state all
+
+# ACMM compliance items
+gh issue list --label acmm --state all
+
+# Decomposed features
+gh issue list --label feature --state all
+```
+
+### Performance Metrics
+
+```bash
+# Agent performance summary
+mbe stats
+
+# Detailed metrics in JSONL logs
+ls metrics/*.jsonl
+```
+
+The `/progress-tracker` skill runs daily at 5:11 PM PT and generates trend analysis across all agent tasks. Metrics include:
+- Issues created vs. closed (velocity)
+- PR merge rate (quality)
+- Agent failure rate (reliability)
+- Average cost per task (efficiency)
+
+## Task Flow: End-to-End
+
+1. **Discovery:** `/site-audit` or `/acmm-audit` identifies work, files a GitHub issue with the `ready` label
+2. **Pickup:** `/issue-worker` (runs every 2h) picks the oldest `ready` issue, relabels to `in-progress`
+3. **Execution:** `mbe agent run` creates a worktree, implements the fix, runs lint/typecheck/test
+4. **Output:** Agent creates a PR linked to the issue, relabels issue to `has-pr`
+5. **Review:** Tier classification determines review path (see `docs/change-classification.md`)
+6. **Merge:** PR merged after approval; issue auto-closed
+7. **Failure:** If agent fails, issue labeled `agent-failed` for manual triage
+
+## Cross-References
+
+- `CLAUDE.md` — Agent skills, scheduling, and label definitions
+- `docs/governance.md` — Branch protection and review policies
+- `docs/change-classification.md` — Risk tier classification
+- `metrics/` — Raw JSONL performance logs
+- `.claude/skills/` — Skill definitions for each agent capability

--- a/docs/change-classification.md
+++ b/docs/change-classification.md
@@ -1,0 +1,112 @@
+# Change Classification Policy
+
+This document defines how changes are classified by risk level, who reviews each tier, and how to escalate when the classification is unclear.
+
+> For the detailed file-path classification rules and modifiers, see `docs/change-tiers.md`.
+> For what reviewers look for once a tier is assigned, see `docs/review-criteria.md`.
+
+## Risk Tiers
+
+### Tier 1 — Low Risk (Auto-Merge Eligible)
+
+**What qualifies:**
+- Documentation changes (`*.md` outside governance/security files)
+- Test additions with no production code changes
+- Comment and JSDoc updates
+- Changeset files (`.changeset/*.md`)
+- Auto-generated files (`llms.txt`, `llms-full.txt`, exports map)
+- Editor config (`.editorconfig`, `.vscode/*`, `.cursorrules`)
+- Metrics log appends (`metrics/*.jsonl`)
+
+**Review requirement:** Pre-commit hooks only (lint, typecheck, Semgrep). Auto-merge eligible when all CI checks pass.
+
+**Who reviews:** Automated checks only. No human approval needed.
+
+---
+
+### Tier 2 — Medium Risk (1 Reviewer)
+
+**What qualifies:**
+- New components, utilities, or hooks (non-breaking additions)
+- Bug fixes with accompanying tests
+- Changes to app source code (`apps/*/src/`) not touching auth or deploy config
+- New ADRs (`docs/adr/`, status: proposed)
+- DevDependency-only `pnpm.overrides` changes
+- Route handler changes that do not alter auth/validation surface
+
+**Review requirement:** 1 human reviewer approval + all CI checks.
+
+**Who reviews:** Code owner (@mattbutlerengineering). The `code-reviewer` agent provides an initial review applying Tier 1 and 2 criteria from `docs/review-criteria.md`.
+
+---
+
+### Tier 3 — High Risk (2 Reviewers + Specialist)
+
+**What qualifies:**
+- New routes or middleware in `services/*` (auth, validation, error handling)
+- Rialto component contract changes (props, behavior, events)
+- Production dependency changes (`package.json` dependencies)
+- Root-level build/lint config (`eslint.config.js`, `tsconfig*.json`, `turbo.json`)
+- Cloudflare Worker config (`wrangler.toml`)
+- Database migrations that add columns or tables (non-destructive)
+- Pre-commit hook changes (`.husky/*`)
+- Test file deletions or `it.skip`/`describe.skip` additions
+
+**Review requirement:** 1 human reviewer + at least 1 specialist agent review + all CI checks.
+
+**Who reviews:** Code owner (@mattbutlerengineering) plus the relevant specialist agent:
+- `migration-reviewer` — for database schema changes
+- `adr-compliance-reviewer` — for architectural decisions
+- `silent-failure-hunter` — for error handling changes
+
+---
+
+### Tier 4 — Critical (Admin Approval)
+
+**What qualifies:**
+- Destructive database migrations (drop column/table, rename without backfill)
+- Auth and authorization code (`services/users/src/auth/`, `packages/auth/`)
+- Infrastructure changes affecting prod (`infrastructure/pulumi/` prod stack)
+- Governance files (`.github/CODEOWNERS`, merge-gating workflows)
+- Security policy files (`docs/SECURITY-AI.md`)
+- Secret rotation via repo changes (env templates, `wrangler.toml` bindings)
+- Cross-cutting changes touching 5+ services/apps simultaneously
+
+**Review requirement:** All specialist agents + ADR reference in PR body + admin (Matt) personal approval.
+
+**Who reviews:** All relevant specialist agents spawn in parallel. Code owner (@mattbutlerengineering) must personally approve. An ADR documenting the rationale is required.
+
+## How to Classify a Change
+
+1. **Automatic:** The `tier-classifier.yml` workflow runs on PR open and on every push, assigning a `tier:*` label based on file-path rules in `docs/change-tiers.md`.
+2. **Manual override:** If the automatic classification seems wrong, update the PR label and leave a comment explaining why.
+3. **When in doubt:** Escalate to the next higher tier. Over-classifying is safe; under-classifying is risky.
+
+## Escalation Modifiers
+
+These signals automatically escalate a PR regardless of file paths:
+
+| Signal | Effect |
+|--------|--------|
+| PR mentions "secret", "credential", "rotate", "leak", "incident" | Escalate to T4 |
+| PR asks to bypass a check | Escalate to T4 |
+| First PR from a new agent type | Escalate to T4 |
+| Diff > 1000 lines added | Escalate +1 tier |
+| PR from a fork | Escalate +1 tier |
+| Force-push after approval | Escalate +1 tier |
+| Test file removed | Escalate +1 tier |
+
+De-escalation (capped at T2):
+
+| Signal | Effect |
+|--------|--------|
+| Diff < 20 lines, only T1 file globs | De-escalate -1 tier |
+| Dependabot devDependency patch bump | De-escalate -1 tier |
+| Lockfile-only diff with no behavioral change | De-escalate -1 tier |
+
+## Cross-References
+
+- `docs/change-tiers.md` — Detailed file-path classification rules
+- `docs/governance.md` — Branch protection and merge policies
+- `docs/review-criteria.md` — Review rubric for each tier
+- `.github/workflows/tier-classifier.yml` — Automated classification workflow

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,0 +1,96 @@
+# Governance & Branch Protection
+
+This document defines the branch protection rules, review policies, and merge governance for the mattbutlerengineering monorepo.
+
+## Branch Protection: `main`
+
+The `main` branch enforces the following protections:
+
+### Required Status Checks
+
+All PRs must pass these checks before merge:
+
+| Check | Source | Purpose |
+|-------|--------|---------|
+| **Lint** | `ci.yml` | ESLint across workspace |
+| **Typecheck** | `ci.yml` | TypeScript compilation |
+| **Test** | `ci.yml` | Vitest suite (unit + integration) |
+| **Security Scan** | `ci.yml` / Semgrep | SAST via Semgrep rules |
+| **Tier Classifier** | `tier-classifier.yml` | Risk tier label assignment |
+
+### Merge Rules
+
+- **Require pull request reviews:** at least 1 approving review
+- **Require status checks to pass:** all checks listed above
+- **Require linear history:** squash merges preferred
+- **Require signed commits:** recommended but not enforced
+- **No force pushes** to `main`
+- **No deletions** of `main`
+
+### Merge Queue
+
+A merge queue (`merge-queue.yml`) is enabled for verified PRs. PRs that pass all status checks enter the queue and are merged in order, preventing merge conflicts from concurrent approvals.
+
+## CODEOWNERS
+
+Critical paths have explicit ownership defined in `.github/CODEOWNERS`:
+
+| Path | Owner | Rationale |
+|------|-------|-----------|
+| `*` (default) | @mattbutlerengineering | Single-maintainer project |
+| `/infrastructure/` | @mattbutlerengineering | IaC changes affect production |
+| `/.github/` | @mattbutlerengineering | CI/CD and governance |
+| `/services/*/` | @mattbutlerengineering | Backend API surface |
+| `/packages/auth/` | @mattbutlerengineering | Authentication/authorization |
+| `/.claude/skills/` | @mattbutlerengineering | Agent behavior definitions |
+
+## Agent PR Policy
+
+AI agents (Claude Code, Codex, OpenCode) create PRs as part of the autonomous development loop. Their PRs follow these rules:
+
+### Auto-Merge Eligible (Tier 1 only)
+
+When CI passes, these agent PRs may be auto-merged without human review:
+
+- Documentation-only changes (`*.md` outside governance files)
+- Test-only additions (no production code changes)
+- Comment and JSDoc updates
+- Auto-generated files (`llms.txt`, `llms-full.txt`)
+- Editor/tooling config (`.editorconfig`, `.vscode/*`)
+
+### Human Review Required
+
+The following changes always require human review, regardless of agent or author:
+
+| Category | Examples | Minimum Review |
+|----------|----------|----------------|
+| **Security** | Auth middleware, CODEOWNERS, secret templates | Owner + security scan |
+| **Infrastructure** | Pulumi stacks, Dockerfiles, wrangler.toml | Owner approval |
+| **Database migrations** | `prisma/migrations/*`, schema changes | Owner + migration-reviewer agent |
+| **CI/CD workflows** | `.github/workflows/*` | Owner approval |
+| **Production deploy config** | DO app spec, Cloudflare routes | Owner approval |
+| **Dependency changes** | `package.json` deps, `pnpm.overrides` | Owner + dependency review |
+
+### Escalation Path
+
+1. **Agent fails:** Issue labeled `agent-failed` for manual triage
+2. **Reviewer disagrees:** Comment with objection; agent must not force-merge
+3. **Security concern:** Block merge, notify owner, file security issue
+4. **Unclear risk tier:** Escalate to next higher tier
+
+## Audit Trail
+
+All governance decisions are traceable:
+
+- **PR labels** indicate tier classification (`tier:trivial` through `tier:critical`)
+- **Agent sessions** are traced in Langfuse with task metadata
+- **GitHub Issues** track the full lifecycle: `ready` -> `in-progress` -> `has-pr` -> merged/closed
+- **ADRs** in `docs/adr/` document architectural decisions
+
+## Cross-References
+
+- `docs/change-tiers.md` — Detailed classification rules for each risk tier
+- `docs/change-classification.md` — Change classification policy and review routing
+- `docs/review-criteria.md` — What reviewers look for at each tier
+- `docs/SECURITY-AI.md` — Security policies for AI-generated code
+- `.github/CODEOWNERS` — Path-based ownership definitions

--- a/docs/rollback.md
+++ b/docs/rollback.md
@@ -1,0 +1,190 @@
+# Rollback Procedures
+
+This document covers rollback procedures for all deployment targets in the mattbutlerengineering monorepo. Use these when a deploy introduces a regression that cannot be quickly fixed forward.
+
+## Decision: Rollback vs. Fix-Forward
+
+| Scenario | Action | Rationale |
+|----------|--------|-----------|
+| User-facing breakage (500s, blank pages, auth failures) | **Rollback immediately** | Restore service first, investigate later |
+| Performance degradation (slow but functional) | **Fix-forward** | Users can still use the service |
+| Data corruption or security vulnerability | **Rollback immediately** + incident response | Limit blast radius |
+| Visual regression (styling, layout) | **Fix-forward** | Non-blocking for users |
+| Feature bug (new feature broken, old features fine) | **Fix-forward** with feature flag | Isolate the new code path |
+| CI/deploy pipeline broken | **Fix-forward** | Rollback won't help pipeline issues |
+
+**Rule of thumb:** If users are blocked or data is at risk, rollback. If users can work around it, fix-forward.
+
+## Static Sites (Cloudflare Workers)
+
+Apps: `marketing`, `hospitality`, `rialto-web`, `gen`
+
+### Rollback via Wrangler
+
+```bash
+# List recent deployments
+cd apps/<app-name>
+pnpm dlx wrangler@latest pages deployment list
+
+# Rollback to previous deployment
+pnpm dlx wrangler@latest pages deployment rollback
+```
+
+### Rollback via Git Revert
+
+```bash
+# Revert the deploy commit
+git revert <commit-sha>
+git push origin main
+
+# Redeploy (CI will trigger, or deploy manually)
+cd apps/<app-name> && pnpm dlx wrangler@latest deploy
+```
+
+### Cache Invalidation
+
+Cloudflare edge caches HTML aggressively. After rollback:
+- The edge-router Worker serves fresh content on next request (no TTL for HTML — see CDN cache bypass for SPA routes)
+- Static assets use content-hashed filenames, so old assets are still available
+
+## DigitalOcean Services
+
+Services: `users`, `agent`, `reservations`
+
+### Rollback via DO Dashboard
+
+1. Go to DigitalOcean App Platform dashboard
+2. Select the app
+3. Navigate to Activity > Deployments
+4. Click the last known-good deployment
+5. Select "Rollback to this deployment"
+
+### Rollback via CLI
+
+```bash
+# List recent deployments
+doctl apps list-deployments $DO_APP_ID --format ID,Phase,CreatedAt
+
+# Trigger a new deployment at a specific commit
+# (DO rebuilds from the commit, so push the reverted code first)
+git revert <commit-sha>
+git push origin main
+doctl apps create-deployment $DO_APP_ID --wait
+
+# Check deployment logs
+doctl apps logs $DO_APP_ID <component-name> --type=build --deployment <deployment-id>
+```
+
+### Health Verification After Rollback
+
+```bash
+# Liveness check (always 200 — does NOT verify DB)
+curl -s https://api.mattbutlerengineering.com/health
+
+# Full health check (verifies DB connectivity)
+curl -s https://api.mattbutlerengineering.com/api/v1/users/health
+```
+
+The `/health` endpoint returns 200 even when the database is unreachable. Always verify with `/api/v1/users/health` which runs `prisma.$queryRaw` and reports `degraded` with the actual error.
+
+## Database (Prisma Migrations)
+
+### Revert a Migration (Development)
+
+```bash
+# Roll back the last migration
+cd services/<service>
+pnpm prisma migrate reset  # WARNING: drops and recreates the database
+```
+
+### Revert a Migration (Production)
+
+Prisma does not support automatic rollback of applied migrations. For production:
+
+1. **Create a new "down" migration** that reverses the changes:
+   ```bash
+   cd services/<service>
+   pnpm prisma migrate dev --name revert_<migration_name>
+   ```
+2. **Write the reversal SQL manually** in the generated migration file:
+   - Added a column? `ALTER TABLE ... DROP COLUMN ...`
+   - Added a table? `DROP TABLE IF EXISTS ...`
+   - Changed a type? `ALTER TABLE ... ALTER COLUMN ... TYPE ...`
+3. **Test locally** against a copy of production data
+4. **Deploy** via the normal migration pipeline
+
+### Critical: Data-Preserving Rollbacks
+
+For destructive schema changes that have already run in production:
+
+1. Do NOT use `prisma migrate reset` — it destroys all data
+2. Write explicit SQL reversal migrations
+3. Test against a database snapshot first
+4. Consider whether the data can be recovered from backups
+
+## Infrastructure (Pulumi)
+
+```bash
+cd infrastructure/pulumi
+
+# Preview what would change
+pulumi preview --stack prod
+
+# If a recent `pulumi up` caused issues, check the state
+pulumi stack --stack prod
+
+# Roll back by reverting the code and re-running
+git revert <commit-sha>
+pulumi up --stack prod
+
+# If state is corrupted or locked
+pulumi cancel  # Release a stuck lock (use with caution)
+pulumi refresh --stack prod  # Sync state with actual cloud resources
+```
+
+## Emergency Procedure
+
+When all else fails and the site is down:
+
+1. **Revert the commit immediately:**
+   ```bash
+   git revert <commit-sha> --no-edit
+   git push origin main
+   ```
+
+2. **Force deploy all targets:**
+   ```bash
+   # Static sites
+   for app in marketing hospitality rialto-web; do
+     (cd apps/$app && pnpm dlx wrangler@latest deploy) &
+   done
+   wait
+
+   # DO services
+   doctl apps create-deployment $DO_APP_ID --wait
+   ```
+
+3. **Verify recovery:**
+   ```bash
+   # Check static sites
+   curl -s -o /dev/null -w "%{http_code}" https://mattbutlerengineering.com
+   curl -s -o /dev/null -w "%{http_code}" https://mattbutlerengineering.com/hospitality
+   curl -s -o /dev/null -w "%{http_code}" https://mattbutlerengineering.com/rialto
+
+   # Check API health (full, not liveness-only)
+   curl -s https://api.mattbutlerengineering.com/api/v1/users/health
+   ```
+
+4. **Create an incident issue** on GitHub with the `incident` label, documenting:
+   - What broke
+   - When it was detected
+   - What was rolled back
+   - Root cause (if known)
+
+## Cross-References
+
+- `docs/runbooks/deploys-unhealthy.md` — Deploy failure diagnosis
+- `docs/runbooks/services-unhealthy.md` — Service health issues
+- `docs/runbooks/static-sites-unhealthy.md` — Static site issues
+- `CLAUDE.md` — Manual deployment commands
+- `.claude/rules/gotchas.md` — Known deployment traps (Prisma, DO, Cloudflare)


### PR DESCRIPTION
## Summary

- Add 5 documentation files to satisfy unmet ACMM governance criteria, moving the repo from 58/85 toward 63/85 detected criteria

## ACMM Criteria Satisfied

| Criterion | File Created |
|-----------|-------------|
| `acmm:copilot-instructions` | `.github/copilot-instructions.md` |
| `fullsend:branch-protection-doc` | `docs/governance.md` |
| `aef:change-classification` | `docs/change-classification.md` |
| `fullsend:rollback-drill` | `docs/rollback.md` |
| `aef:task-traceability` | `docs/agent-tasks/README.md` |

## What each file covers

- **`.github/copilot-instructions.md`** — Concise GitHub Copilot repo instructions referencing AGENTS.md, covering project conventions (TypeScript/pnpm monorepo, immutability-first, conventional commits, TDD, no console.log)
- **`docs/governance.md`** — Branch protection rules, required status checks, merge queue, CODEOWNERS policy, agent PR auto-merge/human-review policies, escalation paths
- **`docs/change-classification.md`** — 4-tier risk classification (Low/Medium/High/Critical) with review requirements, escalation modifiers, and cross-references to existing `change-tiers.md`
- **`docs/rollback.md`** — Rollback procedures for all deployment targets: Cloudflare static sites, DO services, Prisma migrations, Pulumi infrastructure, and emergency procedures
- **`docs/agent-tasks/README.md`** — Agent task traceability system: lifecycle states, logging fields, Langfuse observability, audit commands, end-to-end task flow

## Test plan

- [ ] Verify each file renders correctly on GitHub
- [ ] Confirm ACMM audit detects the 5 new criteria as satisfied
- [ ] Cross-reference links point to existing files


🤖 Generated with [Claude Code](https://claude.com/claude-code)