### PR TITLE
fix(security): replace wildcard CORS with origin allowlist in edge router

### DIFF
--- a/infrastructure/worker/edge-router.js
+++ b/infrastructure/worker/edge-router.js
@@ -27,6 +27,24 @@ import {
 } from "./circuit-breaker.js";
 import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";
 import depGraph from "./dep-graph.json";
+
+// ── CORS Origin Allowlist ──────────────────────────────────────────────
+// Only these production origins may receive Access-Control-Allow-Origin.
+// If a request's Origin header does not match, the header is omitted entirely.
+const ALLOWED_ORIGINS = new Set([
+  "https://mattbutlerengineering.com",
+  "https://hospitality.mattbutlerengineering.com",
+  "https://gen.mattbutlerengineering.com",
+]);
+
+/**
+ * Return the request's Origin if it is in the allowlist, or null otherwise.
+ */
+function corsOriginFor(request) {
+  const origin = request.headers.get("Origin");
+  return origin && ALLOWED_ORIGINS.has(origin) ? origin : null;
+}
+
 /**
  * Build security headers with a per-request nonce for CSP script-src.
  * The nonce replaces 'unsafe-inline', preventing injected scripts from
@@ -485,13 +503,14 @@ function isHealthAuthorized(request, env) {
 /**
  * Return a coarse health response with no infrastructure details.
  */
-function coarseHealthResponse(status, timestamp, requestId) {
+function coarseHealthResponse(status, timestamp, requestId, request) {
+  const corsOrigin = corsOriginFor(request);
   return new Response(JSON.stringify({ status, timestamp, requestId }), {
     status: 200,
     headers: {
       "Content-Type": "application/json",
       "Cache-Control": "no-store",
-      "Access-Control-Allow-Origin": "*",
+      ...(corsOrigin ? { "Access-Control-Allow-Origin": corsOrigin } : {}),
     },
   });
 }
@@ -557,9 +576,10 @@ async function handleHealthSystem(request, env, requestId) {
 
   // Gate detailed output behind token auth (safe by default)
   if (!isHealthAuthorized(request, env)) {
-    return coarseHealthResponse(status, timestamp, requestId);
+    return coarseHealthResponse(status, timestamp, requestId, request);
   }
 
+  const corsOrigin = corsOriginFor(request);
   return new Response(
     JSON.stringify({
       status,
@@ -572,7 +592,7 @@ async function handleHealthSystem(request, env, requestId) {
       headers: {
         "Content-Type": "application/json",
         "Cache-Control": "no-store",
-        "Access-Control-Allow-Origin": "*",
+        ...(corsOrigin ? { "Access-Control-Allow-Origin": corsOrigin } : {}),
       },
     }
   );
@@ -850,13 +870,14 @@ async function handleHealthLighthouse(env) {
  * The graph is built at CI time by `scripts/generate-dep-graph.mjs` and
  * imported as a static JSON module.  Cached for 5 minutes at the edge.
  */
-function handleHealthDeps() {
+function handleHealthDeps(request) {
+  const corsOrigin = corsOriginFor(request);
   return new Response(JSON.stringify(depGraph), {
     status: 200,
     headers: {
       "Content-Type": "application/json",
       "Cache-Control": "public, max-age=300",
-      "Access-Control-Allow-Origin": "*",
+      ...(corsOrigin ? { "Access-Control-Allow-Origin": corsOrigin } : {}),
     },
   });
 }
@@ -961,7 +982,7 @@ export default {
     }
 
     if (url.pathname === "/health/deps") {
-      return handleHealthDeps();
+      return handleHealthDeps(request);
     }
 
     // ── Feature flags admin API ─────────────────────────────────────

--- a/infrastructure/worker/edge-router.test.js
+++ b/infrastructure/worker/edge-router.test.js
@@ -400,6 +400,33 @@ describe("Edge Router", () => {
       // Should NOT have detailed subsystem info without auth
       expect(body).not.toHaveProperty("subsystems");
     });
+
+    it("omits CORS header when no Origin is sent", async () => {
+      const response = await edgeRouter.fetch(makeRequest("/health/system"), env);
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
+    });
+
+    it("returns CORS header for allowed origin on health/system", async () => {
+      const response = await edgeRouter.fetch(
+        makeRequest("/health/system", {
+          headers: { Origin: "https://hospitality.mattbutlerengineering.com" },
+        }),
+        env
+      );
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
+        "https://hospitality.mattbutlerengineering.com"
+      );
+    });
+
+    it("omits CORS header for disallowed origin on health/system", async () => {
+      const response = await edgeRouter.fetch(
+        makeRequest("/health/system", {
+          headers: { Origin: "https://attacker.example.com" },
+        }),
+        env
+      );
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
+    });
   });
 
   describe("Health endpoint with auth — migration status", () => {
@@ -451,13 +478,36 @@ describe("Edge Router", () => {
       expect(response.status).toBe(200);
       expect(response.headers.get("Content-Type")).toBe("application/json");
       expect(response.headers.get("Cache-Control")).toBe("public, max-age=300");
-      expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+      // No Origin header → no CORS header in response
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
       const body = await response.json();
       expect(body).toHaveProperty("nodes");
       expect(body).toHaveProperty("edges");
       expect(body).toHaveProperty("generatedAt");
       expect(Array.isArray(body.nodes)).toBe(true);
       expect(Array.isArray(body.edges)).toBe(true);
+    });
+
+    it("returns CORS header for allowed origin", async () => {
+      const response = await edgeRouter.fetch(
+        makeRequest("/health/deps", {
+          headers: { Origin: "https://mattbutlerengineering.com" },
+        }),
+        env
+      );
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
+        "https://mattbutlerengineering.com"
+      );
+    });
+
+    it("omits CORS header for disallowed origin", async () => {
+      const response = await edgeRouter.fetch(
+        makeRequest("/health/deps", {
+          headers: { Origin: "https://evil.example.com" },
+        }),
+        env
+      );
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
     });
 
     it("includes node properties (name, type, path)", async () => {


### PR DESCRIPTION
## Summary
- Replaced `Access-Control-Allow-Origin: *` with a strict origin allowlist at all 3 locations in `infrastructure/worker/edge-router.js` (lines 494, 575, 859)
- Added `ALLOWED_ORIGINS` constant and `corsOriginFor(request)` helper that checks the request's `Origin` header against the allowlist
- If the origin matches, the specific origin is reflected back; if not, the header is omitted entirely
- Updated `coarseHealthResponse` and `handleHealthDeps` signatures to accept `request` so they can check the origin
- Updated existing test asserting `Access-Control-Allow-Origin: *` and added 5 new CORS tests covering allowed origins, disallowed origins, and missing origin header

Closes #915

## Test plan
- [x] Existing edge router tests pass (41/42 -- 1 pre-existing failure unrelated to CORS)
- [x] New tests verify: allowed origin gets reflected, disallowed origin gets no header, missing origin gets no header
- [x] No remaining `Access-Control-Allow-Origin: *` in the codebase (`grep` returns empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)