### PR TITLE
fix(security): validate CORS_ORIGINS env against origin allowlist

### DIFF
--- a/services/agent/src/app.ts
+++ b/services/agent/src/app.ts
@@ -20,6 +20,31 @@ import { genUiRoutes } from "./routes/gen-ui.js";
 import { genChatRoutes } from "./routes/gen-chat.js";
 import { genSpecsRoutes } from "./routes/gen-specs.js";
 
+/**
+ * Validates CORS origins from the CORS_ORIGINS env var against an allowlist.
+ * Accepts *.mattbutlerengineering.com in all environments and localhost
+ * origins only in development. Returns only the origins that pass validation.
+ */
+function validateCorsOrigins(origins: string[]): string[] {
+  const validPatterns = [
+    /^https:\/\/([a-z-]+\.)?mattbutlerengineering\.com$/,
+    ...(process.env.NODE_ENV === "development"
+      ? [/^http:\/\/localhost:\d+$/]
+      : []),
+  ];
+
+  const validated: string[] = [];
+  for (const origin of origins) {
+    const trimmed = origin.trim();
+    if (validPatterns.some((p) => p.test(trimmed))) {
+      validated.push(trimmed);
+    } else {
+      console.warn(`[CORS] Rejected invalid origin from CORS_ORIGINS: ${trimmed}`);
+    }
+  }
+  return validated;
+}
+
 export interface AppOptions {
   logger?: boolean | object;
 }
@@ -52,10 +77,21 @@ export async function buildApp(options: AppOptions = {}): Promise<FastifyInstanc
     "https://gen.mattbutlerengineering.com",
   ];
 
-  const corsOrigins = process.env.CORS_ORIGINS?.split(",") || [
+  const defaultOrigins = [
     ...prodOrigins,
     ...(process.env.NODE_ENV === "development" ? defaultDevOrigins : []),
   ];
+
+  const envOrigins = process.env.CORS_ORIGINS?.split(",");
+  const validatedEnv = envOrigins ? validateCorsOrigins(envOrigins) : null;
+
+  if (validatedEnv && validatedEnv.length === 0) {
+    console.warn("[CORS] All CORS_ORIGINS were rejected; falling back to defaults");
+  }
+
+  const corsOrigins = validatedEnv && validatedEnv.length > 0
+    ? validatedEnv
+    : defaultOrigins;
 
   await fastify.register(cors, {
     origin: corsOrigins,

--- a/services/reservations/src/app.ts
+++ b/services/reservations/src/app.ts
@@ -20,6 +20,31 @@ import { eventRoutes } from "./routes/events.js";
 import { floorPlanRoutes } from "./routes/floor-plans.js";
 import { guestRoutes } from "./routes/guests.js";
 
+/**
+ * Validates CORS origins from the CORS_ORIGINS env var against an allowlist.
+ * Accepts *.mattbutlerengineering.com in all environments and localhost
+ * origins only in development. Returns only the origins that pass validation.
+ */
+function validateCorsOrigins(origins: string[]): string[] {
+  const validPatterns = [
+    /^https:\/\/([a-z-]+\.)?mattbutlerengineering\.com$/,
+    ...(process.env.NODE_ENV === "development"
+      ? [/^http:\/\/localhost:\d+$/]
+      : []),
+  ];
+
+  const validated: string[] = [];
+  for (const origin of origins) {
+    const trimmed = origin.trim();
+    if (validPatterns.some((p) => p.test(trimmed))) {
+      validated.push(trimmed);
+    } else {
+      console.warn(`[CORS] Rejected invalid origin from CORS_ORIGINS: ${trimmed}`);
+    }
+  }
+  return validated;
+}
+
 export interface AppOptions {
   logger?: boolean | object;
 }
@@ -52,10 +77,21 @@ export async function buildApp(options: AppOptions = {}): Promise<FastifyInstanc
     "https://gen.mattbutlerengineering.com",
   ];
 
-  const corsOrigins = process.env.CORS_ORIGINS?.split(",") || [
+  const defaultOrigins = [
     ...prodOrigins,
     ...(process.env.NODE_ENV === "development" ? defaultDevOrigins : []),
   ];
+
+  const envOrigins = process.env.CORS_ORIGINS?.split(",");
+  const validatedEnv = envOrigins ? validateCorsOrigins(envOrigins) : null;
+
+  if (validatedEnv && validatedEnv.length === 0) {
+    console.warn("[CORS] All CORS_ORIGINS were rejected; falling back to defaults");
+  }
+
+  const corsOrigins = validatedEnv && validatedEnv.length > 0
+    ? validatedEnv
+    : defaultOrigins;
 
   await fastify.register(cors, {
     origin: corsOrigins,

--- a/services/users/src/app.ts
+++ b/services/users/src/app.ts
@@ -13,6 +13,31 @@ import { healthRoutes } from "./routes/health.js";
 import { readinessRoutes } from "./routes/ready.js";
 import { userRoutes } from "./routes/users.js";
 
+/**
+ * Validates CORS origins from the CORS_ORIGINS env var against an allowlist.
+ * Accepts *.mattbutlerengineering.com in all environments and localhost
+ * origins only in development. Returns only the origins that pass validation.
+ */
+function validateCorsOrigins(origins: string[]): string[] {
+  const validPatterns = [
+    /^https:\/\/([a-z-]+\.)?mattbutlerengineering\.com$/,
+    ...(process.env.NODE_ENV === "development"
+      ? [/^http:\/\/localhost:\d+$/]
+      : []),
+  ];
+
+  const validated: string[] = [];
+  for (const origin of origins) {
+    const trimmed = origin.trim();
+    if (validPatterns.some((p) => p.test(trimmed))) {
+      validated.push(trimmed);
+    } else {
+      console.warn(`[CORS] Rejected invalid origin from CORS_ORIGINS: ${trimmed}`);
+    }
+  }
+  return validated;
+}
+
 export interface AppOptions {
   logger?: boolean | object;
 }
@@ -45,10 +70,21 @@ export async function buildApp(options: AppOptions = {}): Promise<FastifyInstanc
     "https://gen.mattbutlerengineering.com",
   ];
 
-  const corsOrigins = process.env.CORS_ORIGINS?.split(",") || [
+  const defaultOrigins = [
     ...prodOrigins,
     ...(process.env.NODE_ENV === "development" ? defaultDevOrigins : []),
   ];
+
+  const envOrigins = process.env.CORS_ORIGINS?.split(",");
+  const validatedEnv = envOrigins ? validateCorsOrigins(envOrigins) : null;
+
+  if (validatedEnv && validatedEnv.length === 0) {
+    console.warn("[CORS] All CORS_ORIGINS were rejected; falling back to defaults");
+  }
+
+  const corsOrigins = validatedEnv && validatedEnv.length > 0
+    ? validatedEnv
+    : defaultOrigins;
 
   await fastify.register(cors, {
     origin: corsOrigins,


### PR DESCRIPTION
## Summary

- Adds `validateCorsOrigins()` function to all 3 Fastify services (users, reservations, agent) that validates each origin from `CORS_ORIGINS` env var against an allowlist
- Allows `*.mattbutlerengineering.com` (HTTPS) in all environments and `localhost:*` (HTTP) only when `NODE_ENV=development`
- Falls back to hardcoded defaults when all env origins are rejected, with `console.warn` for security visibility
- Uses immutable patterns throughout (no mutation of `corsOrigins`)

## What changed

Each service's `app.ts` now:
1. Splits `CORS_ORIGINS` into an array
2. Runs each origin through regex validation
3. Logs rejected origins via `console.warn`
4. Falls back to production + dev defaults if all origins fail validation or env var is unset

## Test plan

- [x] TypeScript typecheck passes (users clean; reservations/agent have pre-existing unrelated failures)
- [x] All existing tests pass (users 45/45; reservations/agent passing tests unaffected)
- [x] Pre-commit hooks pass (eslint, ADR check, pack-changed)
- [ ] Verify in staging that production origins are accepted
- [ ] Verify that setting `CORS_ORIGINS=https://evil.com` results in rejection + fallback

Closes #916