### PR TITLE
feat(acmm): add AI state backup workflow and recovery docs (#926)

### DIFF
--- a/.github/workflows/acmm-state-backup.yml
+++ b/.github/workflows/acmm-state-backup.yml
@@ -1,0 +1,45 @@
+name: ACMM State Backup
+
+on:
+  schedule:
+    - cron: '0 8 * * 1'  # Every Monday at 8am UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Archive ACMM state
+        run: |
+          BACKUP_DIR=".claude/acmm/backups"
+          mkdir -p "$BACKUP_DIR"
+          DATE=$(date +%Y-%m-%d)
+
+          # Copy current state with timestamp
+          if [ -f ".claude/acmm/state.json" ]; then
+            cp ".claude/acmm/state.json" "$BACKUP_DIR/state-${DATE}.json"
+          fi
+          if [ -f ".claude/acmm/report.md" ]; then
+            cp ".claude/acmm/report.md" "$BACKUP_DIR/report-${DATE}.md"
+          fi
+
+          # Keep only last 12 backups (3 months)
+          ls -t "$BACKUP_DIR"/state-*.json 2>/dev/null | tail -n +13 | xargs rm -f
+          ls -t "$BACKUP_DIR"/report-*.md 2>/dev/null | tail -n +13 | xargs rm -f
+
+      - name: Commit backup
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .claude/acmm/backups/ || true
+          if git diff --cached --quiet; then
+            echo "No changes to backup"
+          else
+            git commit -m "chore(acmm): weekly state backup $(date +%Y-%m-%d)"
+            git push
+          fi

--- a/docs/acmm/state-recovery.md
+++ b/docs/acmm/state-recovery.md
@@ -1,0 +1,36 @@
+# ACMM State Recovery
+
+## Backup Location
+
+Weekly snapshots are stored in `.claude/acmm/backups/` by the `acmm-state-backup` workflow.
+
+## Recovery Steps
+
+1. **Identify the last good backup:**
+   ```bash
+   ls -la .claude/acmm/backups/state-*.json
+   ```
+
+2. **Restore state:**
+   ```bash
+   cp .claude/acmm/backups/state-YYYY-MM-DD.json .claude/acmm/state.json
+   ```
+
+3. **Re-run the audit to regenerate the report:**
+   ```bash
+   node plugins/acmm/scripts/audit.js
+   ```
+
+4. **Verify restoration:**
+   ```bash
+   cat .claude/acmm/state.json | python3 -m json.tool | head -5
+   ```
+
+## What's Backed Up
+
+- `state.json` — Full ACMM computation state, level history, detected criteria
+- `report.md` — Human-readable scorecard
+
+## Retention
+
+Last 12 weekly backups are kept (approximately 3 months of history).

--- a/plugins/acmm/scripts/sources/acmm.js
+++ b/plugins/acmm/scripts/sources/acmm.js
@@ -750,6 +750,18 @@ const CRITERIA= [
     crossCutting: 'traceability',
   },
 
+  {
+    id: 'acmm:state-backup',
+    source: 'acmm',
+    level: 5,
+    category: 'governance',
+    name: 'AI state backup',
+    description: 'Automated backup of AI state files to prevent data loss.',
+    rationale: 'L5 signal: the system protects its own learning history and progression data from corruption or accidental deletion.',
+    details: 'AI state files (ACMM scores, memory, task ledgers) accumulate value over time. A backup workflow ensures that accidental deletion, bad merges, or state corruption do not destroy the system\'s learning history.',
+    detection: { type: 'any-of', pattern: ['.github/workflows/acmm-state-backup.yml', '.claude/acmm/backups/'] },
+  },
+
   // ── L6 — Autonomous ─────────────────────────────────────────────
   {
     id: 'acmm:auto-issue-gen',


### PR DESCRIPTION
## Summary

- Adds a weekly GitHub Actions workflow (`.github/workflows/acmm-state-backup.yml`) that snapshots `.claude/acmm/state.json` and `report.md` every Monday at 8am UTC, retaining 12 weeks of history
- Adds recovery documentation (`docs/acmm/state-recovery.md`) with step-by-step restore instructions
- Adds an L5 `acmm:state-backup` detection criterion to `plugins/acmm/scripts/sources/acmm.js` so the ACMM audit recognizes the backup infrastructure

Closes #926

## Test plan

- [x] All 8 ACMM test suites pass (detection, computeLevel, cold-start, evals-reader, evals-run, evals-score, flake-rate, pr-outcomes)
- [ ] Verify workflow triggers correctly via `workflow_dispatch` after merge
- [ ] Confirm `acmm:state-backup` criterion is detected by next ACMM audit run