### PR TITLE
feat(acmm): add MCP server and code intelligence detection criteria (#920)

### DIFF
--- a/plugins/acmm/scripts/__tests__/detection.test.js
+++ b/plugins/acmm/scripts/__tests__/detection.test.js
@@ -82,6 +82,48 @@ test("detect: glob type throws (not implemented)", () => {
   fx.cleanup();
 });
 
+test("detect: mcp-server-config — .mcp.json present", () => {
+  const fx = fixture();
+  fx.file(".mcp.json", "{}");
+  const c = {
+    id: "acmm:mcp-server-config",
+    detection: { type: "any-of", pattern: [".mcp.json", ".claude/mcp.json", ".cursor/mcp.json", "mcp.json"] },
+  };
+  assert.equal(detect(fx.root, c), true);
+  fx.cleanup();
+});
+
+test("detect: mcp-server-config — no MCP config present", () => {
+  const fx = fixture();
+  const c = {
+    id: "acmm:mcp-server-config",
+    detection: { type: "any-of", pattern: [".mcp.json", ".claude/mcp.json", ".cursor/mcp.json", "mcp.json"] },
+  };
+  assert.equal(detect(fx.root, c), false);
+  fx.cleanup();
+});
+
+test("detect: code-graph — llms.txt present", () => {
+  const fx = fixture();
+  fx.file("llms.txt", "# index");
+  const c = {
+    id: "acmm:code-graph",
+    detection: { type: "any-of", pattern: [".vscode/settings.json", "tags", "TAGS", ".ctags", ".tree-sitter/", "llms.txt", "llms-full.txt"] },
+  };
+  assert.equal(detect(fx.root, c), true);
+  fx.cleanup();
+});
+
+test("detect: code-graph — no code intelligence files present", () => {
+  const fx = fixture();
+  const c = {
+    id: "acmm:code-graph",
+    detection: { type: "any-of", pattern: [".vscode/settings.json", "tags", "TAGS", ".ctags", ".tree-sitter/", "llms.txt", "llms-full.txt"] },
+  };
+  assert.equal(detect(fx.root, c), false);
+  fx.cleanup();
+});
+
 test("detectAll: returns set of detected ids only", () => {
   const fx = fixture();
   fx.file("README.md");

--- a/plugins/acmm/scripts/sources/acmm.js
+++ b/plugins/acmm/scripts/sources/acmm.js
@@ -665,6 +665,28 @@ const CRITERIA= [
     detection: { type: 'any-of', pattern: ['task-log.jsonl', '.claude/task-log.jsonl'] },
     crossCutting: 'traceability',
   },
+  {
+    id: 'acmm:mcp-server-config',
+    source: 'acmm',
+    level: 4,
+    category: 'readiness',
+    name: 'MCP server configuration',
+    description: 'Model Context Protocol servers configured for AI tool access.',
+    rationale: 'L4 signal: the AI has access to project-relevant tools (databases, APIs, deployment consoles) beyond the file system.',
+    details: 'MCP servers give the AI programmatic access to external systems. Without them, the AI is limited to file system operations and cannot query databases, check deployments, or interact with project management tools.',
+    detection: { type: 'any-of', pattern: ['.mcp.json', '.claude/mcp.json', '.cursor/mcp.json', 'mcp.json'] },
+  },
+  {
+    id: 'acmm:code-graph',
+    source: 'acmm',
+    level: 4,
+    category: 'readiness',
+    name: 'Code intelligence tooling',
+    description: 'LSP, AST, or code graph tooling that helps AI navigate the codebase.',
+    rationale: 'L4 signal: the AI can navigate complex type hierarchies and dependency graphs efficiently, not just read file text.',
+    details: 'Code intelligence tools (LSP configs, tags files, tree-sitter grammars, or code graph generators) help the AI understand codebase structure beyond raw text. This enables faster navigation, better refactoring, and more accurate changes.',
+    detection: { type: 'any-of', pattern: ['.vscode/settings.json', 'tags', 'TAGS', '.ctags', '.tree-sitter/', 'llms.txt', 'llms-full.txt'] },
+  },
 
   // ── L5 — Semi-Automated ────────────────────────────
   {


### PR DESCRIPTION
## Summary

Closes #920

- Adds `acmm:mcp-server-config` (L4 readiness) — detects MCP server configurations (`.mcp.json`, `.claude/mcp.json`, `.cursor/mcp.json`, `mcp.json`)
- Adds `acmm:code-graph` (L4 readiness) — detects code intelligence tooling (`.vscode/settings.json`, `tags`, `TAGS`, `.ctags`, `.tree-sitter/`, `llms.txt`, `llms-full.txt`)
- Adds 4 new detection tests (positive and negative cases for each criterion)

Both criteria should already pass in this repo since `.mcp.json` (10+ servers) and `llms.txt` exist.

## Test plan

- [x] All 11 detection tests pass (`node --test plugins/acmm/scripts/__tests__/detection.test.js`)
- [ ] Run `/acmm-audit` and verify both new criteria show as met