### PR TITLE
feat(acmm): add budget policy and cost governance (#919)

### DIFF
--- a/.claude/budget-policy.json
+++ b/.claude/budget-policy.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://mattbutlerengineering.com/schemas/budget-policy.json",
+  "version": "1.0.0",
+  "description": "Cost governance policy for AI agent operations",
+  "limits": {
+    "perTask": {
+      "maxBudgetUsd": 1.00,
+      "maxTurns": 50,
+      "description": "Default limits for mbe agent run"
+    },
+    "perDay": {
+      "maxBudgetUsd": 25.00,
+      "description": "Aggregate daily spend limit across all agent sessions"
+    },
+    "perWeek": {
+      "maxBudgetUsd": 100.00,
+      "description": "Weekly aggregate spend limit"
+    }
+  },
+  "alerting": {
+    "warnAtPercent": 80,
+    "channels": ["github-issue"],
+    "description": "Create a GitHub issue when spend reaches 80% of daily/weekly limit"
+  },
+  "modelTiering": {
+    "default": "claude-sonnet-4-6",
+    "lightweight": "claude-haiku-4-5-20251001",
+    "complex": "claude-opus-4-6",
+    "description": "Model selection strategy — see CLAUDE.md performance section"
+  },
+  "tracking": {
+    "backend": "langfuse",
+    "metricsPath": ".claude/acmm/cost-metrics.json",
+    "description": "Token and cost data tracked via Langfuse session traces"
+  }
+}

--- a/docs/acmm/cost-governance.md
+++ b/docs/acmm/cost-governance.md
@@ -1,0 +1,36 @@
+# AI Cost Governance
+
+## Budget Policy
+
+The budget policy is defined in `.claude/budget-policy.json` and sets limits at three levels:
+
+| Level | Limit | Description |
+|-------|-------|-------------|
+| Per-task | $1.00 | Default `--max-budget` for `mbe agent run` |
+| Per-day | $25.00 | Aggregate daily spend across all sessions |
+| Per-week | $100.00 | Weekly aggregate spend |
+
+## Token Tracking
+
+Token usage is tracked via [Langfuse](https://cloud.langfuse.com):
+- Each `runSession()` call creates a trace with cost metadata
+- Generation spans record per-turn token usage
+- Session metrics include `cost_usd` for aggregate tracking
+
+## Model Tiering
+
+| Model | Use Case | Relative Cost |
+|-------|----------|---------------|
+| Haiku 4.5 | Lightweight agents, worker agents | 1x |
+| Sonnet 4.6 | Main development, orchestration | 5x |
+| Opus 4.6 | Complex architecture, deep reasoning | 25x |
+
+## Alerting
+
+When aggregate spend reaches 80% of daily/weekly limits, a GitHub issue is created with the `cost-alert` label.
+
+## Monitoring
+
+View cost trends via:
+- Langfuse dashboard: session cost aggregations
+- `/progress-tracker`: includes cost section when data available

--- a/plugins/acmm/scripts/sources/acmm.js
+++ b/plugins/acmm/scripts/sources/acmm.js
@@ -841,6 +841,28 @@ const CRITERIA= [
     details: 'A documented procedure: "If a nightly AI-merged PR breaks production: (1) revert PR, (2) disable auto-merge, (3) file incident issue, (4) RCA workflow runs on the reverted commit."',
     detection: { type: 'any-of', pattern: ['docs/rollback-drill.md', 'docs/ai-ops-runbook.md'] },
   },
+  {
+    id: 'acmm:budget-policy',
+    source: 'acmm',
+    level: 4,
+    category: 'governance',
+    name: 'Budget policy',
+    description: 'Defined cost limits and budget controls for AI agent operations.',
+    rationale: 'L4 signal: autonomous systems have explicit cost boundaries to prevent unbounded spending.',
+    details: 'A budget policy defines per-task, daily, and weekly cost limits for AI operations. Without explicit limits, L5/L6 autonomous loops can consume tokens unbounded. The policy also specifies model tiering strategy and alerting thresholds.',
+    detection: { type: 'any-of', pattern: ['.claude/budget-policy.json', 'docs/acmm/cost-governance.md'] },
+  },
+  {
+    id: 'acmm:token-tracking',
+    source: 'acmm',
+    level: 4,
+    category: 'observability',
+    name: 'Token usage tracking',
+    description: 'Token consumption and cost tracking per session or task.',
+    rationale: 'L4 signal: cost visibility enables informed decisions about model tiering and automation frequency.',
+    details: 'Token tracking records consumption per session, task, or time period. This data feeds into budget alerting and helps optimize model selection. Without tracking, cost governance is blind.',
+    detection: { type: 'any-of', pattern: ['.claude/budget-policy.json', '.claude/acmm/cost-metrics.json', 'docs/acmm/cost-governance.md'] },
+  },
 ]
 
 export const acmmSource= {


### PR DESCRIPTION
## Summary

- Add `.claude/budget-policy.json` with per-task ($1.00), daily ($25), and weekly ($100) cost limits, model tiering strategy, Langfuse tracking config, and 80% alerting threshold
- Add `docs/acmm/cost-governance.md` documenting budget policy, token tracking via Langfuse, model tiering rationale, alerting behavior, and monitoring approach
- Add two new ACMM L4 detection criteria to `plugins/acmm/scripts/sources/acmm.js`: `acmm:budget-policy` (governance) and `acmm:token-tracking` (observability)

## Test plan

- [x] All 72 ACMM tests pass (`node --test plugins/acmm/scripts/__tests__/*.test.js`)
- [x] New criteria follow existing pattern (id, source, level, category, name, description, rationale, details, detection)
- [x] Budget numbers match CLAUDE.md defaults (`--max-budget 1.00`, `--max-turns 50`)
- [x] Detection patterns reference the new files created in this PR

Closes #919