### PR TITLE
feat(acmm): add AI output quality standards and metrics (#922)

### DIFF
--- a/docs/acmm/explanation-standards.md
+++ b/docs/acmm/explanation-standards.md
@@ -1,0 +1,53 @@
+# AI Explanation Quality Standards
+
+## Purpose
+
+Define what makes a good agent-authored PR description, commit message, and issue comment. These standards help measure AI output quality beyond binary pass/fail.
+
+## PR Description Rubric
+
+Agent PRs must include:
+
+| Section | Required | Description |
+|---------|----------|-------------|
+| Summary | Yes | 1-3 bullet points describing what changed and why |
+| Test plan | Yes | How the change was verified (tests, manual, both) |
+| Risk assessment | For complex changes | What could break, blast radius |
+| Related issues | Yes | Links to the GitHub issue(s) being addressed |
+
+### Scoring
+
+| Score | Criteria |
+|-------|----------|
+| 3 (Excellent) | All sections present, reasoning is clear, trade-offs explained |
+| 2 (Adequate) | Summary and test plan present, reasoning implied but not explicit |
+| 1 (Minimal) | Only a summary, no test plan or reasoning |
+| 0 (Missing) | No description or auto-generated boilerplate only |
+
+## Commit Message Rubric
+
+Follow Conventional Commits format. Quality criteria:
+
+| Score | Criteria |
+|-------|----------|
+| 3 | Correct type, descriptive subject, body explains WHY |
+| 2 | Correct type, descriptive subject, no body |
+| 1 | Generic subject ("fix bug", "update file") |
+| 0 | No message or meaningless message |
+
+## Self-Correction Metrics
+
+Track these per agent PR:
+
+| Metric | Definition | Target |
+|--------|------------|--------|
+| First-attempt CI pass rate | PRs that pass CI on first push | >80% |
+| Fix-up commit count | Additional commits after initial push | <2 per PR |
+| Revert rate | PRs that get reverted within 7 days | <5% |
+
+## Measurement
+
+Metrics are derived from GitHub API data:
+- PR descriptions: score manually or via LLM evaluation
+- Self-correction: count commits per PR after initial push
+- First-attempt: check if first CI run on the PR passed

--- a/plugins/acmm/scripts/sources/acmm.js
+++ b/plugins/acmm/scripts/sources/acmm.js
@@ -749,6 +749,28 @@ const CRITERIA= [
     detection: { type: 'any-of', pattern: ['.github/workflows/audit-trail.yml', '.github/workflows/ai-attribution.yml'] },
     crossCutting: 'traceability',
   },
+  {
+    id: 'acmm:explanation-standards',
+    source: 'acmm',
+    level: 4,
+    category: 'feedback-loop',
+    name: 'Explanation quality standards',
+    description: 'Rubric defining quality expectations for AI-authored PRs and commits.',
+    rationale: 'L4 signal: acceptance rate measures outcome but not understanding; explanation rubrics help audit AI intent.',
+    details: 'An explanation quality rubric defines what makes a good agent PR description (reasoning, test plan, risk) and commit message. Without it, AI output quality is measured only by CI pass/fail, masking poor explanations that make future maintenance harder.',
+    detection: { type: 'any-of', pattern: ['docs/acmm/explanation-standards.md', 'docs/review-criteria.md', '.github/prompts/review.md'] },
+  },
+  {
+    id: 'acmm:self-correction-metric',
+    source: 'acmm',
+    level: 5,
+    category: 'observability',
+    name: 'Self-correction tracking',
+    description: 'Metrics tracking AI fix-up cycles, first-attempt success, and revert rates.',
+    rationale: 'L5 signal: the system monitors its own output quality beyond binary acceptance, enabling self-improvement.',
+    details: 'Self-correction metrics track how often AI PRs need fix-up commits after initial push, what percentage pass CI on the first attempt, and how often they get reverted. These signals differentiate a clean one-shot PR from a messy multi-attempt one.',
+    detection: { type: 'any-of', pattern: ['docs/acmm/explanation-standards.md', 'plugins/acmm/scripts/pr-outcomes.js'] },
+  },
 
   // ── L6 — Autonomous ─────────────────────────────────────────────
   {


### PR DESCRIPTION
## Summary

- Add `docs/acmm/explanation-standards.md` defining a quality rubric for agent-authored PR descriptions (4-point scale), commit messages, and self-correction metrics (first-attempt CI pass rate, fix-up commit count, revert rate)
- Add two new ACMM detection criteria to `plugins/acmm/scripts/sources/acmm.js`:
  - `acmm:explanation-standards` (L4, feedback-loop) — detects explanation quality rubric files
  - `acmm:self-correction-metric` (L5, observability) — detects self-correction tracking via explanation standards or pr-outcomes script

Closes #922

## Test plan

- [x] All 72 ACMM plugin tests pass (`node --test plugins/acmm/scripts/__tests__/*.test.js`)
- [x] New criteria use valid `any-of` detection patterns matching existing conventions
- [x] `crossCutting` property preserved on adjacent audit-trail criterion