### PR TITLE
feat(acmm): add auto-rollback for agent regressions (#924)

### DIFF
--- a/.github/workflows/auto-rollback.yml
+++ b/.github/workflows/auto-rollback.yml
@@ -1,0 +1,94 @@
+name: Auto-Rollback on Agent Regression
+
+on:
+  workflow_run:
+    workflows: ["Post-Deploy Check"]
+    types:
+      - completed
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  check-and-rollback:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 10
+
+      - name: Identify agent commits
+        id: agent-check
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          # Check if the failing commit was authored by an agent
+          AUTHOR=$(git log -1 --format='%an' "$HEAD_SHA" 2>/dev/null || echo "unknown")
+          BRANCH=$(git log -1 --format='%D' "$HEAD_SHA" 2>/dev/null || echo "")
+
+          IS_AGENT="false"
+          if echo "$BRANCH" | grep -qE '(agent-|worktree-agent-)'; then
+            IS_AGENT="true"
+          fi
+          if echo "$AUTHOR" | grep -qiE '(bot|agent|claude)'; then
+            IS_AGENT="true"
+          fi
+
+          echo "is_agent=$IS_AGENT" >> "$GITHUB_OUTPUT"
+          echo "commit_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "author=$AUTHOR" >> "$GITHUB_OUTPUT"
+
+      - name: Create revert PR
+        if: steps.agent-check.outputs.is_agent == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_SHA: ${{ steps.agent-check.outputs.commit_sha }}
+          COMMIT_AUTHOR: ${{ steps.agent-check.outputs.author }}
+        run: |
+          SHORT_SHA="${COMMIT_SHA:0:7}"
+
+          REVERT_BRANCH="revert/agent-${SHORT_SHA}"
+          git checkout -b "$REVERT_BRANCH"
+
+          if git revert --no-edit "$COMMIT_SHA"; then
+            git push origin "$REVERT_BRANCH"
+
+            gh pr create \
+              --title "revert: auto-rollback agent commit ${SHORT_SHA}" \
+              --body "## Auto-Rollback
+
+          Post-deploy smoke tests failed after agent commit \`${COMMIT_SHA}\`.
+
+          This revert PR was created automatically by the auto-rollback workflow.
+
+          **Original author:** ${COMMIT_AUTHOR}
+          **Failure:** Post-Deploy Check workflow failed
+
+          ### Next Steps
+          1. Review this revert PR
+          2. Merge to restore stability
+          3. Investigate the original change
+          4. File a new issue if the original intent was valid" \
+              --label "agent-regression"
+
+            echo "Revert PR created for agent commit ${SHORT_SHA}"
+          else
+            echo "Could not cleanly revert ${SHORT_SHA} — manual intervention needed"
+            gh issue create \
+              --title "Manual rollback needed: agent commit ${SHORT_SHA} caused regression" \
+              --body "Post-deploy checks failed after agent commit \`${COMMIT_SHA}\` but automatic revert failed (merge conflict). Manual intervention required." \
+              --label "agent-regression,urgent"
+          fi
+
+      - name: Skip non-agent failures
+        if: steps.agent-check.outputs.is_agent != 'true'
+        env:
+          COMMIT_SHA: ${{ steps.agent-check.outputs.commit_sha }}
+          COMMIT_AUTHOR: ${{ steps.agent-check.outputs.author }}
+        run: |
+          echo "Post-deploy failure was not from an agent commit — skipping auto-rollback"
+          echo "Commit: ${COMMIT_SHA}"
+          echo "Author: ${COMMIT_AUTHOR}"

--- a/docs/acmm/auto-rollback.md
+++ b/docs/acmm/auto-rollback.md
@@ -1,0 +1,47 @@
+# Auto-Rollback for Agent Regressions
+
+## How It Works
+
+When the Post-Deploy Check workflow fails:
+
+1. The `auto-rollback.yml` workflow triggers automatically
+2. It checks if the failing commit was authored by an agent (branch name or author)
+3. If agent-authored: creates a revert PR with `agent-regression` label
+4. If revert fails (merge conflict): creates an issue for manual intervention
+5. Non-agent failures are skipped (human-authored code is not auto-reverted)
+
+## Flow
+
+```
+Deploy → Post-Deploy Smoke Tests → FAIL
+                                     ↓
+                              Is agent commit?
+                              ↓            ↓
+                             Yes           No
+                              ↓            ↓
+                        Create revert   Log & skip
+                           PR
+                              ↓
+                     Label: agent-regression
+```
+
+## Labels
+
+| Label | Meaning |
+|-------|---------|
+| `agent-regression` | PR that reverts an agent-caused regression |
+| `urgent` | Auto-revert failed, needs manual intervention |
+
+## Safety
+
+- Only agent commits are auto-reverted — human commits require manual rollback
+- Revert PRs still require review before merge (not auto-merged)
+- If `git revert` fails due to conflicts, an issue is created instead
+- The workflow only triggers on Post-Deploy Check failures, not CI failures
+
+## Testing
+
+To test the workflow without a real failure:
+1. Create a branch that deliberately breaks a smoke test
+2. Merge it via the agent workflow
+3. Verify the revert PR is created

--- a/plugins/acmm/scripts/sources/acmm.js
+++ b/plugins/acmm/scripts/sources/acmm.js
@@ -919,6 +919,17 @@ const CRITERIA= [
     details: 'Token tracking records consumption per session, task, or time period. This data feeds into budget alerting and helps optimize model selection. Without tracking, cost governance is blind.',
     detection: { type: 'any-of', pattern: ['.claude/budget-policy.json', '.claude/acmm/cost-metrics.json', 'docs/acmm/cost-governance.md'] },
   },
+  {
+    id: 'acmm:auto-rollback',
+    source: 'acmm',
+    level: 6,
+    category: 'autonomy',
+    name: 'Automated rollback',
+    description: 'Automated detection and revert of regressions caused by AI-authored changes.',
+    rationale: 'L6 signal: the system not only acts but also undoes mistakes without human initiation.',
+    details: 'Auto-rollback completes the autonomous loop: the system detects regressions from its own PRs (via post-deploy checks) and creates revert PRs automatically. Without this, L6 autonomy is one-directional — the system can break things but not fix them.',
+    detection: { type: 'any-of', pattern: ['.github/workflows/auto-rollback.yml', 'docs/acmm/auto-rollback.md'] },
+  },
 ]
 
 export const acmmSource= {


### PR DESCRIPTION
## Summary

- Add `.github/workflows/auto-rollback.yml` that triggers on Post-Deploy Check failures, identifies agent-authored commits (by branch name or author), and creates revert PRs with `agent-regression` label
- Add `docs/acmm/auto-rollback.md` documenting the flow, labels, and safety guarantees
- Add new L6 `acmm:auto-rollback` criterion to `plugins/acmm/scripts/sources/acmm.js`

Closes #924

## Test plan

- [x] All 72 ACMM tests pass (`node --test plugins/acmm/scripts/__tests__/*.test.js`)
- [x] `agent-regression` GitHub label created
- [ ] Verify workflow triggers correctly on Post-Deploy Check failure (requires live deploy failure)
- [ ] Verify revert PR is created with correct label and body
- [ ] Verify non-agent failures are skipped

## Safety

- Only agent commits are auto-reverted (human commits require manual rollback)
- Revert PRs still require review before merge (not auto-merged)
- If `git revert` fails due to conflicts, an issue is created instead
- The workflow only triggers on Post-Deploy Check failures, not CI failures