### PR TITLE
feat(acmm): add AI onboarding benchmark (#921)

### DIFF
--- a/docs/acmm/onboarding-benchmark.md
+++ b/docs/acmm/onboarding-benchmark.md
@@ -1,0 +1,51 @@
+# AI Onboarding Benchmark
+
+## Purpose
+
+Measure how quickly a fresh AI session can complete known tasks in this repo. Unlike file-presence detection, this benchmark measures actual AI readiness — can the AI navigate the codebase and produce working code efficiently?
+
+## Running the Benchmark
+
+### 1. List available tasks
+
+```bash
+node scripts/acmm/onboarding-bench.js --list
+```
+
+### 2. Run a task
+
+Start a fresh AI session (new conversation, no prior context). Give the AI the task description and time how long it takes.
+
+### 3. Record results
+
+```bash
+node scripts/acmm/onboarding-bench.js --record <task-id> <turns> <seconds>
+```
+
+## Benchmark Tasks
+
+| ID | Difficulty | Expected Turns | Expected Time | What It Tests |
+|----|-----------|---------------|--------------|---------------|
+| health-endpoint | Easy | 5 | 2min | Basic service navigation |
+| add-test | Easy | 8 | 3min | Test patterns, coverage |
+| fix-type-error | Medium | 6 | 2.5min | TypeScript understanding |
+| add-component | Medium | 15 | 5min | Design system conventions |
+| cross-package-feature | Hard | 25 | 10min | Monorepo navigation, cross-package deps |
+
+## Scoring
+
+| Metric | Pass | Over |
+|--------|------|------|
+| Turns vs expected | <=1.0x | >1.0x |
+| Time vs expected | <=1.0x | >1.0x |
+
+## Results
+
+Results are stored in `.claude/acmm/onboarding-results.json` and can be tracked over time to measure improvement as CLAUDE.md and project documentation evolve.
+
+## Improving Scores
+
+If a benchmark task takes too many turns:
+1. Check if the relevant CLAUDE.md or package docs are missing information
+2. Add the missing context
+3. Re-run the benchmark to verify improvement

--- a/plugins/acmm/scripts/sources/acmm.js
+++ b/plugins/acmm/scripts/sources/acmm.js
@@ -688,6 +688,18 @@ const CRITERIA= [
     detection: { type: 'any-of', pattern: ['.vscode/settings.json', 'tags', 'TAGS', '.ctags', '.tree-sitter/', 'llms.txt', 'llms-full.txt'] },
   },
 
+  {
+    id: 'acmm:onboarding-benchmark',
+    source: 'acmm',
+    level: 4,
+    category: 'readiness',
+    name: 'Onboarding benchmark',
+    description: 'Benchmark script that measures time-to-first-contribution for fresh AI sessions.',
+    rationale: 'L4 signal: file-presence alone does not ensure the AI can navigate the codebase; benchmarks measure actual readiness.',
+    details: 'An onboarding benchmark defines known tasks and expected completion times. Running these tasks in fresh AI sessions measures how well project documentation enables the AI to work independently. Improvements to CLAUDE.md and package docs should reduce benchmark times.',
+    detection: { type: 'any-of', pattern: ['scripts/acmm/onboarding-bench.js', 'docs/acmm/onboarding-benchmark.md'] },
+  },
+
   // ── L5 — Semi-Automated ────────────────────────────
   {
     id: 'acmm:github-actions-ai',

--- a/scripts/acmm/onboarding-bench.js
+++ b/scripts/acmm/onboarding-bench.js
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+/**
+ * ACMM Onboarding Benchmark
+ *
+ * Measures how quickly a fresh AI session can complete known tasks.
+ * Run manually by starting a new AI session and timing the tasks below.
+ *
+ * Usage: node scripts/acmm/onboarding-bench.js [--list | --record <task-id> <turns> <seconds>]
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const RESULTS_PATH = join(__dirname, '../../.claude/acmm/onboarding-results.json');
+
+const BENCHMARK_TASKS = [
+  {
+    id: 'health-endpoint',
+    name: 'Add a health endpoint',
+    description: 'Add a GET /health endpoint to an existing Fastify service that returns { status: "ok", timestamp: Date.now() }',
+    targetPackage: 'services/users',
+    expectedTurns: 5,
+    expectedSeconds: 120,
+    difficulty: 'easy',
+  },
+  {
+    id: 'add-test',
+    name: 'Add a unit test',
+    description: 'Write a unit test for an existing utility function, achieving >80% branch coverage',
+    targetPackage: 'packages/config',
+    expectedTurns: 8,
+    expectedSeconds: 180,
+    difficulty: 'easy',
+  },
+  {
+    id: 'fix-type-error',
+    name: 'Fix a type error',
+    description: 'Identify and fix a TypeScript strict-mode error introduced by enabling noUncheckedIndexedAccess',
+    targetPackage: 'packages/rialto',
+    expectedTurns: 6,
+    expectedSeconds: 150,
+    difficulty: 'medium',
+  },
+  {
+    id: 'add-component',
+    name: 'Create a Rialto component',
+    description: 'Create a new Badge component following Rialto patterns (CSS Modules, forwardRef, tokens, accessibility test)',
+    targetPackage: 'packages/rialto',
+    expectedTurns: 15,
+    expectedSeconds: 300,
+    difficulty: 'medium',
+  },
+  {
+    id: 'cross-package-feature',
+    name: 'Cross-package feature',
+    description: 'Add a new API endpoint in services/users AND consume it from apps/hospitality with proper typing',
+    targetPackage: 'services/users + apps/hospitality',
+    expectedTurns: 25,
+    expectedSeconds: 600,
+    difficulty: 'hard',
+  },
+];
+
+function listTasks() {
+  console.log('ACMM Onboarding Benchmark Tasks\n');
+  console.log('Run each task in a fresh AI session and record turns + time.\n');
+  for (const task of BENCHMARK_TASKS) {
+    console.log(`  ${task.id} (${task.difficulty})`);
+    console.log(`    ${task.name}`);
+    console.log(`    ${task.description}`);
+    console.log(`    Target: ${task.targetPackage}`);
+    console.log(`    Expected: ${task.expectedTurns} turns, ${task.expectedSeconds}s`);
+    console.log('');
+  }
+}
+
+function recordResult(taskId, turns, seconds) {
+  const task = BENCHMARK_TASKS.find((t) => t.id === taskId);
+  if (!task) {
+    console.error(`Unknown task: ${taskId}. Run --list to see available tasks.`);
+    process.exit(1);
+  }
+
+  const results = existsSync(RESULTS_PATH)
+    ? JSON.parse(readFileSync(RESULTS_PATH, 'utf8'))
+    : { benchmarks: [] };
+
+  const result = {
+    taskId,
+    turns: Number(turns),
+    seconds: Number(seconds),
+    date: new Date().toISOString(),
+    turnsVsExpected: (Number(turns) / task.expectedTurns).toFixed(2),
+    timeVsExpected: (Number(seconds) / task.expectedSeconds).toFixed(2),
+  };
+
+  results.benchmarks.push(result);
+  writeFileSync(RESULTS_PATH, JSON.stringify(results, null, 2) + '\n');
+
+  const turnsScore = Number(result.turnsVsExpected) <= 1.0 ? 'PASS' : 'OVER';
+  const timeScore = Number(result.timeVsExpected) <= 1.0 ? 'PASS' : 'OVER';
+
+  console.log(`Recorded: ${taskId}`);
+  console.log(`  Turns: ${turns} (${turnsScore} — ${result.turnsVsExpected}x expected)`);
+  console.log(`  Time: ${seconds}s (${timeScore} — ${result.timeVsExpected}x expected)`);
+}
+
+const args = process.argv.slice(2);
+if (args[0] === '--list' || args.length === 0) {
+  listTasks();
+} else if (args[0] === '--record' && args.length === 4) {
+  recordResult(args[1], args[2], args[3]);
+} else {
+  console.log('Usage:');
+  console.log('  node scripts/acmm/onboarding-bench.js --list');
+  console.log('  node scripts/acmm/onboarding-bench.js --record <task-id> <turns> <seconds>');
+}


### PR DESCRIPTION
## Summary

- Adds `scripts/acmm/onboarding-bench.js` — a benchmark protocol that defines 5 graded tasks (easy to hard) for measuring how quickly a fresh AI session can complete known work in this repo
- Adds `docs/acmm/onboarding-benchmark.md` — documentation covering usage, scoring, and improvement workflow
- Adds L4 readiness criterion `acmm:onboarding-benchmark` to `plugins/acmm/scripts/sources/acmm.js`

## Details

Unlike file-presence detection, the onboarding benchmark measures **actual AI readiness** — whether the AI can navigate the codebase and produce working code within expected turn/time budgets. Tasks range from adding a health endpoint (easy, 5 turns) to cross-package features (hard, 25 turns). Results are recorded to `.claude/acmm/onboarding-results.json` for tracking improvements over time.

## Test plan

- [x] `node scripts/acmm/onboarding-bench.js --list` outputs all 5 tasks with descriptions
- [x] All 8 ACMM plugin test files pass (`node --test plugins/acmm/scripts/__tests__/*.test.js`)
- [x] New criterion follows existing format in `acmm.js` (level 4, category readiness, any-of detection)

Closes #921