### PR TITLE
fix(security): add rate-limit registration check to auth plugin

### DIFF
--- a/packages/auth/src/fastify/plugin.test.ts
+++ b/packages/auth/src/fastify/plugin.test.ts
@@ -330,4 +330,48 @@ describe("Auth Plugin", () => {
       );
     });
   });
+
+  describe("rate-limit registration check", () => {
+    it("logs a warning when rateLimit decorator is missing", async () => {
+      const warnSpy = vi.fn();
+      const warnApp = Fastify({
+        logger: { level: "warn" },
+      });
+      // Override the log.warn to capture calls
+      warnApp.log.warn = warnSpy;
+
+      await warnApp.register(testRoutesPlugin);
+      await warnApp.ready();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Auth plugin registered without rate limiting")
+      );
+
+      await warnApp.close();
+    });
+
+    it("does not log a warning when rateLimit decorator is present", async () => {
+      const warnSpy = vi.fn();
+      const limitApp = Fastify({
+        logger: { level: "warn" },
+      });
+      limitApp.log.warn = warnSpy;
+
+      // Simulate @fastify/rate-limit by decorating with rateLimit
+      limitApp.decorate("rateLimit", () => {});
+
+      await limitApp.register(testRoutesPlugin);
+      await limitApp.ready();
+
+      // Ensure the specific rate-limit warning was NOT emitted
+      const rateLimitWarnings = warnSpy.mock.calls.filter(
+        (call: unknown[]) =>
+          typeof call[0] === "string" &&
+          call[0].includes("Auth plugin registered without rate limiting")
+      );
+      expect(rateLimitWarnings).toHaveLength(0);
+
+      await limitApp.close();
+    });
+  });
 });

--- a/packages/auth/src/fastify/plugin.ts
+++ b/packages/auth/src/fastify/plugin.ts
@@ -32,6 +32,11 @@ function createProblemDetails(status: number, title: string, detail: string) {
 
 /**
  * Fastify plugin for JWT validation using OIDC provider's JWKS.
+ *
+ * **Rate limiting:** This plugin does NOT enforce rate limiting itself.
+ * Consumers MUST register `@fastify/rate-limit` (or equivalent) before
+ * registering this plugin. An `onReady` hook will log a warning if the
+ * `rateLimit` decorator is missing at startup.
  */
 async function authPluginImpl(
   fastify: FastifyInstance,
@@ -42,6 +47,19 @@ async function authPluginImpl(
   const jwksUri = `${authority.replace(/\/$/, "")}/.well-known/jwks.json`;
   const JWKS = createRemoteJWKSet(new URL(jwksUri));
 
+  // Warn if rate limiting has not been registered by the consuming service.
+  // The auth plugin delegates rate limiting to consumers (e.g., @fastify/rate-limit).
+  fastify.addHook("onReady", async () => {
+    if (!fastify.hasDecorator("rateLimit")) {
+      fastify.log.warn(
+        "Auth plugin registered without rate limiting — register @fastify/rate-limit before @mbe/auth to protect auth endpoints"
+      );
+    }
+  });
+
+  // CodeQL js/missing-rate-limiting: rate limiting is the consumer's responsibility.
+  // Consuming services (e.g., services/users) register @fastify/rate-limit globally
+  // before this plugin, so all routes — including this onRequest hook — are covered.
   fastify.addHook("onRequest", async (request: FastifyRequest, reply: FastifyReply) => {
     // 1. Explicit Test Bypass
     // Check if bypass mode is enabled AND the request opted in via header.


### PR DESCRIPTION
## Summary
- Adds an `onReady` hook to the auth Fastify plugin that warns when `@fastify/rate-limit` has not been registered, addressing CodeQL `js/missing-rate-limiting` finding at line 45
- Adds inline documentation (JSDoc + CodeQL suppression comment) clarifying that rate limiting is the consumer's responsibility
- Adds two tests verifying the warning behavior (emitted when missing, suppressed when present)

## Context
The auth plugin's `onRequest` hook (line 45) was flagged by CodeQL because it exposes endpoint handling without rate limiting. However, the consuming services (e.g., `services/users`) already register `@fastify/rate-limit` globally before the auth plugin, so all routes are covered. The fix makes this contract explicit with a runtime check and documentation.

Closes #936

## Test plan
- [x] Existing auth plugin tests pass (16/16)
- [x] New test: warns when `rateLimit` decorator is missing
- [x] New test: no warning when `rateLimit` decorator is present
- [x] Typecheck passes
- [ ] CI passes