### PR TITLE
fix(ci): add explicit permissions to all GitHub Actions workflows

### DIFF
--- a/.github/workflows/adr-check.yml
+++ b/.github/workflows/adr-check.yml
@@ -11,6 +11,10 @@ on:
   push:
     branches: [main]
 
+
+permissions:
+  contents: read
+
 jobs:
   check-adr:
     name: ADR compliance

--- a/.github/workflows/agent-task.yml
+++ b/.github/workflows/agent-task.yml
@@ -27,6 +27,8 @@ on:
         default: false
         type: boolean
 
+permissions: {}
+
 jobs:
   run-agent:
     runs-on: ubuntu-latest

--- a/.github/workflows/audit-scout.yml
+++ b/.github/workflows/audit-scout.yml
@@ -4,6 +4,9 @@ on:
     - cron: '41 17 1 * *' # 1st of month, 10:41am PT (17:41 UTC)
   workflow_dispatch: {} # Manual trigger
 
+permissions:
+  contents: read
+
 jobs:
   scout:
     runs-on: ubuntu-latest

--- a/.github/workflows/audit-sweep.yml
+++ b/.github/workflows/audit-sweep.yml
@@ -4,6 +4,9 @@ on:
     - cron: '23 16 * * 1' # Monday 9:23am PT (16:23 UTC)
   workflow_dispatch: {} # Manual trigger
 
+permissions:
+  contents: read
+
 jobs:
   sweep:
     runs-on: ubuntu-latest

--- a/.github/workflows/backup-verify.yml
+++ b/.github/workflows/backup-verify.yml
@@ -5,6 +5,10 @@ on:
     - cron: "11 3 * * 0" # Sunday 3:11 AM UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   verify-backup:
     name: Verify Database Backup

--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -11,6 +11,9 @@ on:
         default: "true"
         type: boolean
 
+permissions:
+  contents: write
+
 jobs:
   cleanup-branches:
     name: Cleanup merged branches

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+permissions:
+  contents: read
+
 jobs:
   prepare:
     name: Prepare

--- a/.github/workflows/circuit-breaker.yml
+++ b/.github/workflows/circuit-breaker.yml
@@ -14,6 +14,8 @@ on:
         default: 'false'
         type: boolean
 
+permissions: {}
+
 jobs:
   circuit-breaker:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependency-freshness.yml
+++ b/.github/workflows/dependency-freshness.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 0 1 * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   check-outdated:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-static.yml
+++ b/.github/workflows/deploy-static.yml
@@ -16,6 +16,9 @@ concurrency:
   group: deploy-static-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   circuit-check:
     name: Circuit Breaker Check

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -5,6 +5,9 @@ on:
     - cron: "43 6 * * 1" # Weekly Monday 6:43 AM UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lighthouse:
     name: Lighthouse Audit

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -20,6 +20,9 @@ on:
           - load
           - stress
 
+permissions:
+  contents: read
+
 jobs:
   load-test:
     name: Run ${{ inputs.scenario || 'load' }} load tests

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -11,6 +11,10 @@ concurrency:
   group: mutation-testing
   cancel-in-progress: false
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   # ──────────────────────────────────────────────────────────────────────────
   # Mutation Testing — periodic validation of test quality

--- a/.github/workflows/pulumi-up.yml
+++ b/.github/workflows/pulumi-up.yml
@@ -22,6 +22,9 @@ concurrency:
   group: pulumi-deploy-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Deploy Infrastructure

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   gitleaks:
     name: Gitleaks Secret Scan

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -7,6 +7,8 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   smoke:
     name: Smoke Tests

--- a/.github/workflows/synthetic-monitoring.yml
+++ b/.github/workflows/synthetic-monitoring.yml
@@ -10,6 +10,10 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   health-check:
     name: System Health Check

--- a/.github/workflows/uptime-snapshot.yml
+++ b/.github/workflows/uptime-snapshot.yml
@@ -5,6 +5,8 @@ on:
     - cron: "17 0 * * *" # Daily at 00:17 UTC (off-minute to avoid fleet congestion)
   workflow_dispatch: # Manual trigger
 
+permissions: {}
+
 jobs:
   snapshot:
     name: Record Health Snapshot


### PR DESCRIPTION
## Summary
- Adds explicit top-level `permissions:` blocks to all 18 GitHub Actions workflows that were missing them
- Workflows that already had job-level permissions (circuit-breaker, smoke-tests) get `permissions: {}` at top level to restrict defaults while preserving their job-level grants
- Follows principle of least privilege: `contents: read` for read-only workflows, `contents: write` for branch-cleanup, `issues: write` where `gh issue create` is used, etc.

### Workflows updated

| Workflow | Permissions added |
|----------|------------------|
| adr-check | `contents: read` |
| agent-task | `{}` (empty — only calls external API) |
| audit-scout | `contents: read` |
| audit-sweep | `contents: read` |
| backup-verify | `contents: read`, `issues: write` |
| branch-cleanup | `contents: write` |
| ci | `contents: read` |
| circuit-breaker | `{}` (job-level permissions preserved) |
| dependency-freshness | `contents: read`, `issues: write` |
| deploy-static | `contents: read` |
| lighthouse | `contents: read` |
| load-test | `contents: read` |
| mutation-testing | `contents: read`, `pull-requests: write` |
| pulumi-up | `contents: read` |
| secret-scan | `contents: read` |
| smoke-tests | `{}` (job-level permissions preserved) |
| synthetic-monitoring | `contents: read`, `issues: write` |
| uptime-snapshot | `{}` (empty — only calls external APIs) |

Closes #938

## Test plan
- [ ] Verify all workflow YAML files parse correctly (validated locally with PyYAML)
- [ ] Spot-check that workflows with job-level permissions (circuit-breaker, smoke-tests) still have those intact
- [ ] Confirm CI workflow runs successfully on this PR