### PR TITLE
fix(security): suppress false-positive CodeQL alerts

### DIFF
--- a/packages/auth/src/fastify/plugin.ts
+++ b/packages/auth/src/fastify/plugin.ts
@@ -60,6 +60,7 @@ async function authPluginImpl(
   // CodeQL js/missing-rate-limiting: rate limiting is the consumer's responsibility.
   // Consuming services (e.g., services/users) register @fastify/rate-limit globally
   // before this plugin, so all routes — including this onRequest hook — are covered.
+  // lgtm[js/missing-rate-limiting]
   fastify.addHook("onRequest", async (request: FastifyRequest, reply: FastifyReply) => {
     // 1. Explicit Test Bypass
     // Check if bypass mode is enabled AND the request opted in via header.

--- a/services/reservations/src/routes/events.ts
+++ b/services/reservations/src/routes/events.ts
@@ -204,6 +204,7 @@ export async function eventRoutes(fastify: FastifyInstance): Promise<void> {
       // The response will be ended when the client disconnects or timeout fires
 
       // TEST-ONLY: automatically close after N ms to allow app.inject to complete in tests
+      // lgtm[js/resource-exhaustion]
       if (process.env.NODE_ENV === "test" && testClose) {
         setTimeout(() => {
           if (!reply.raw.writableEnded) {


### PR DESCRIPTION
## Summary
- Add `lgtm[js/missing-rate-limiting]` suppression to `packages/auth/src/fastify/plugin.ts` — rate limiting is the consumer's responsibility (documented in PR #940)
- Add `lgtm[js/resource-exhaustion]` suppression to `services/reservations/src/routes/events.ts` — the flagged `setTimeout` only runs when `NODE_ENV === "test"`

## Test plan
- [ ] Verify CodeQL alerts are suppressed on next scan
- [ ] Confirm no logic changes — only comment additions

Closes #953