### PR TITLE
fix(security): eliminate remaining ReDoS patterns in agent-core

### DIFF
--- a/packages/agent-core/src/observability.ts
+++ b/packages/agent-core/src/observability.ts
@@ -25,11 +25,23 @@ const API_ERROR_SIGNALS: readonly RegExp[] = [
   /enotfound/i,
 ];
 
-const BUDGET_SIGNALS: readonly RegExp[] = [
+/**
+ * Check whether substrings `a` and `b` both appear in `str` (case-insensitive),
+ * with `a` occurring before `b`. Replaces `.*` regex patterns to avoid ReDoS.
+ */
+function containsInOrder(str: string, a: string, b: string): boolean {
+  const lower = str.toLowerCase();
+  const idx = lower.indexOf(a);
+  return idx !== -1 && lower.indexOf(b, idx + a.length) !== -1;
+}
+
+type BudgetSignal = RegExp | ((str: string) => boolean);
+
+const BUDGET_SIGNALS: readonly BudgetSignal[] = [
   /budget/i,
-  /cost.*exceeded/i,
-  /exceeded.*budget/i,
-  /max.*budget/i,
+  (str: string) => containsInOrder(str, "cost", "exceeded"),
+  (str: string) => containsInOrder(str, "exceeded", "budget"),
+  (str: string) => containsInOrder(str, "max", "budget"),
 ];
 
 const TOOL_ERROR_SIGNALS: readonly RegExp[] = [
@@ -61,8 +73,9 @@ export function categorizeFailure(
     if (pattern.test(combined)) return "rate_limited";
   }
 
-  for (const pattern of BUDGET_SIGNALS) {
-    if (pattern.test(combined)) return "budget_exceeded";
+  for (const signal of BUDGET_SIGNALS) {
+    const matched = typeof signal === "function" ? signal(combined) : signal.test(combined);
+    if (matched) return "budget_exceeded";
   }
 
   for (const pattern of TOOL_ERROR_SIGNALS) {

--- a/packages/agent-core/src/success-evaluator.ts
+++ b/packages/agent-core/src/success-evaluator.ts
@@ -110,8 +110,9 @@ export function shouldEvaluate(diff: string, config: ShouldEvaluateConfig = {}):
     .filter((line) => line.startsWith("diff --git "))
     .map((line) => {
       // e.g. "diff --git a/src/foo.test.ts b/src/foo.test.ts"
-      const match = line.match(/diff --git a\/.+ b\/(.+)$/);
-      return match ? match[1] : "";
+      // Use string splitting instead of regex to avoid ReDoS on greedy `.+`
+      const parts = line.split(" b/");
+      return parts.length > 1 ? parts[parts.length - 1] : "";
     })
     .filter(Boolean);
 


### PR DESCRIPTION
## Summary
- Replace greedy `.+` regex in `success-evaluator.ts` with string splitting (`line.split(" b/")`) to extract file paths from git diff headers without backtracking risk
- Replace `.*` regex patterns in `observability.ts` budget signal detection with a linear-time `containsInOrder()` helper using `indexOf`
- Safe patterns (e.g., `/rate[_\s-]?limit/i`) left unchanged as they have no nested quantifiers

Closes #952

## Test plan
- [x] `pnpm --dir packages/agent-core typecheck` passes
- [x] `pnpm --dir packages/agent-core test` passes (618/618)
- [ ] CI green