### PR TITLE
feat(acmm): add AI service fallback strategy (#944)

### DIFF
--- a/.claude/fallback-policy.json
+++ b/.claude/fallback-policy.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://mattbutlerengineering.com/schemas/fallback-policy.json",
+  "version": "1.0.0",
+  "description": "Defines behavior when AI services are unavailable or degraded",
+  "retryPolicy": {
+    "maxRetries": 3,
+    "initialDelayMs": 1000,
+    "maxDelayMs": 30000,
+    "backoffMultiplier": 2,
+    "retryableErrors": ["rate_limit", "overloaded", "timeout", "connection_error"]
+  },
+  "degradedMode": {
+    "onApiUnavailable": "queue-and-notify",
+    "onRateLimit": "backoff-and-retry",
+    "onBudgetExhausted": "stop-and-notify",
+    "notificationChannel": "github-issue"
+  },
+  "circuitBreaker": {
+    "failureThreshold": 5,
+    "resetTimeoutMs": 300000,
+    "halfOpenRequests": 1,
+    "description": "After 5 consecutive failures, stop for 5 minutes before retrying"
+  },
+  "scheduledTasks": {
+    "onFailure": "skip-and-log",
+    "maxConsecutiveSkips": 3,
+    "escalation": "Create GitHub issue with 'agent-health' label after 3 consecutive skips"
+  }
+}

--- a/docs/acmm/ai-service-fallback.md
+++ b/docs/acmm/ai-service-fallback.md
@@ -1,0 +1,72 @@
+# AI Service Fallback Strategy
+
+## Overview
+
+Defines how the system behaves when the AI service (Claude API) is unavailable, rate-limited, or degraded. L6 autonomous loops must degrade gracefully, not break silently.
+
+## Failure Modes
+
+| Failure | Detection | Response |
+|---------|-----------|----------|
+| API unavailable (5xx) | HTTP status code | Retry with exponential backoff |
+| Rate limited (429) | HTTP status code | Backoff with delay from response headers |
+| Timeout | No response within 60s | Retry up to 3 times |
+| Budget exhausted | Cost tracking exceeds limit | Stop session, create notification |
+| Consecutive failures | 5+ failures in a row | Circuit breaker opens for 5 minutes |
+
+## Retry Policy
+
+```
+Attempt 1: immediate
+Attempt 2: wait 1s
+Attempt 3: wait 2s
+Attempt 4: wait 4s (max 30s)
+```
+
+Retryable errors: `rate_limit`, `overloaded`, `timeout`, `connection_error`
+Non-retryable: `invalid_request`, `authentication_error`, `budget_exhausted`
+
+## Circuit Breaker
+
+Prevents hammering a failed API:
+
+```
+CLOSED (normal) -> 5 failures -> OPEN (blocked for 5min) -> HALF-OPEN (1 request) -> success -> CLOSED
+                                                                                   -> failure -> OPEN
+```
+
+## Scheduled Task Behavior
+
+| Scenario | Behavior |
+|----------|----------|
+| Single failure | Skip this run, log, try next scheduled time |
+| 3 consecutive skips | Create GitHub issue with `agent-health` label |
+| API down for 24h+ | All scheduled tasks paused, single tracking issue created |
+
+## Notification
+
+When degraded mode triggers:
+1. Log to `.claude/acmm/fallback-events.json`
+2. Create GitHub issue with `agent-health` label (if threshold exceeded)
+3. Include: failure count, duration, last error, affected scheduled tasks
+
+## Configuration
+
+Policy is defined in `.claude/fallback-policy.json`. Key settings:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `maxRetries` | 3 | Max retry attempts per request |
+| `failureThreshold` | 5 | Consecutive failures before circuit opens |
+| `resetTimeoutMs` | 300000 | Time before circuit half-opens (5 min) |
+| `maxConsecutiveSkips` | 3 | Scheduled task skips before escalation |
+
+## Current Implementation Status
+
+| Component | Status |
+|-----------|--------|
+| Retry logic in agent-core | Partial -- basic retry exists |
+| Circuit breaker | Not implemented |
+| Fallback policy config | Added (this PR) |
+| Scheduled task resilience | Not implemented |
+| Notification on failure | Not implemented |

--- a/plugins/acmm/scripts/sources/acmm.js
+++ b/plugins/acmm/scripts/sources/acmm.js
@@ -861,6 +861,17 @@ const CRITERIA= [
     details: 'Agent attestation covers how AI-authored commits are identified (branch naming, bot accounts, GPG signing) and how the audit trail connects git history to session traces. Without this, agent changes are indistinguishable from human changes.',
     detection: { type: 'any-of', pattern: ['docs/acmm/agent-attestation.md', 'docs/security/agent-identity.md'] },
   },
+  {
+    id: 'acmm:ai-service-fallback',
+    source: 'acmm',
+    level: 5,
+    category: 'governance',
+    name: 'AI service fallback policy',
+    description: 'Defined behavior for when AI APIs are unavailable or degraded.',
+    rationale: 'L5 signal: autonomous systems must degrade gracefully when their AI service is down, not break silently.',
+    details: 'A fallback policy defines retry strategies, circuit breakers, and escalation paths for AI API failures. Without this, L6 autonomous loops stop silently when the API is unavailable, and scheduled tasks skip without notification.',
+    detection: { type: 'any-of', pattern: ['.claude/fallback-policy.json', 'docs/acmm/ai-service-fallback.md'] },
+  },
 
   // ── L6 — Autonomous ─────────────────────────────────────────────
   {


### PR DESCRIPTION
## Summary

- Add `.claude/fallback-policy.json` defining retry, circuit breaker, degraded mode, and scheduled task behavior when the Claude API is unavailable
- Add `docs/acmm/ai-service-fallback.md` documenting failure modes, retry policy, circuit breaker state machine, and implementation status
- Add `acmm:ai-service-fallback` L5 governance criterion to the ACMM plugin detection system

## Test plan

- [x] All ACMM detection tests pass (`node --test plugins/acmm/scripts/__tests__/detection.test.js`)
- [x] All ACMM computeLevel tests pass (`node --test plugins/acmm/scripts/__tests__/computeLevel.test.js`)
- [x] New criterion follows established format (id, source, level, category, name, description, rationale, details, detection)
- [x] Detection pattern matches the two new files

Closes #944