### PR TITLE
fix(security): validate webhook inputs to prevent SSRF

### DIFF
--- a/services/agent/src/routes/webhooks.ts
+++ b/services/agent/src/routes/webhooks.ts
@@ -92,6 +92,9 @@ function verifySignature(
 
 // ── Constants ────────────────────────────────────────────────────────
 
+const GITHUB_REPO_RE = /^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/;
+const GITHUB_USERNAME_RE = /^[a-zA-Z0-9-]+$/;
+
 const AGENT_LABEL = "agent";
 const AGENT_COMMAND_PATTERN = /^\/agent\s+(.+)/i;
 const MAX_CI_RETRIES = 3;
@@ -102,6 +105,10 @@ async function checkCollaboratorPermission(
   repository: string,
   githubToken: string
 ): Promise<boolean> {
+  if (!GITHUB_REPO_RE.test(repository) || !GITHUB_USERNAME_RE.test(username)) {
+    return false;
+  }
+
   try {
     const response = await fetch(
       `${GITHUB_API_BASE}/repos/${repository}/collaborators/${username}/permission`,


### PR DESCRIPTION
## Summary
- Validates `repository` and `username` from GitHub webhook payloads against strict regex patterns before interpolating into the GitHub API URL
- Prevents SSRF (CodeQL alert #46) where a crafted payload could redirect the `fetch()` to an arbitrary host, leaking the Bearer token

## Changes
- Added `GITHUB_REPO_RE` (`^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$`) and `GITHUB_USERNAME_RE` (`^[a-zA-Z0-9-]+$`) validation
- `checkCollaboratorPermission()` returns `false` immediately if inputs don't match

Closes #965