### PR TITLE
fix(security): suppress false-positive rate-limiting CodeQL alerts

### DIFF
--- a/services/agent/src/routes/health.ts
+++ b/services/agent/src/routes/health.ts
@@ -134,6 +134,7 @@ export const healthRoutes: FastifyPluginAsync = async (fastify: FastifyInstance)
   };
 
   // /health — used by DO App Platform internal health checks (direct container access)
+  // lgtm[js/missing-rate-limiting]
   fastify.get<{ Reply: HealthResponse }>(
     "/health",
     { schema: { ...healthSchema, operationId: "getAgentHealth" } },
@@ -142,6 +143,7 @@ export const healthRoutes: FastifyPluginAsync = async (fastify: FastifyInstance)
 
   // /api/gen/health — public path via DO ingress (preservePathPrefix: true, prefix "/api/gen")
   // Required for synthetic monitoring hitting api.mattbutlerengineering.com/api/gen/health
+  // lgtm[js/missing-rate-limiting]
   fastify.get<{ Reply: HealthResponse }>(
     "/api/gen/health",
     { schema: { ...healthSchema, operationId: "getAgentHealthApiGen" } },

--- a/services/agent/src/routes/remediation.ts
+++ b/services/agent/src/routes/remediation.ts
@@ -79,6 +79,7 @@ export const remediationRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
+    // lgtm[js/missing-rate-limiting]
     async (request, reply) => {
       // 1. Verify webhook secret
       const secret = process.env.REMEDIATION_WEBHOOK_SECRET;

--- a/services/agent/src/routes/webhooks.ts
+++ b/services/agent/src/routes/webhooks.ts
@@ -177,6 +177,7 @@ export const webhookRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
+    // lgtm[js/missing-rate-limiting]
     async (request, reply) => {
       const secret = process.env.GITHUB_WEBHOOK_SECRET;
       if (!secret) {

--- a/services/reservations/src/routes/health.ts
+++ b/services/reservations/src/routes/health.ts
@@ -163,13 +163,16 @@ const healthHandler: HealthRouteHandler = async (request) => {
 
 export const healthRoutes: FastifyPluginAsync = async (fastify) => {
   // /health — used by DO App Platform internal health checks (direct container access)
+  // lgtm[js/missing-rate-limiting]
   fastify.get("/health", { schema: { ...healthSchema, operationId: "getHealth" } }, healthHandler);
 
   // /api/health — public path via DO ingress (preservePathPrefix: true, prefix "/api")
   // Required for post-deploy verification workflow hitting api.mattbutlerengineering.com/api/health
+  // lgtm[js/missing-rate-limiting]
   fastify.get("/api/health", { schema: { ...healthSchema, operationId: "getHealthApi" } }, healthHandler);
 
   // /api/v1/reservations/health — public path via DO ingress (preservePathPrefix: true, prefix "/api/v1/reservations")
   // Must be registered here (not in reservationRoutes) to avoid falling through to /:id param route
+  // lgtm[js/missing-rate-limiting]
   fastify.get("/api/v1/reservations/health", { schema: { ...healthSchema, operationId: "getHealthApiReservations" } }, healthHandler);
 };

--- a/services/users/src/routes/health.ts
+++ b/services/users/src/routes/health.ts
@@ -172,8 +172,10 @@ export const healthRoutes: FastifyPluginAsync = async (fastify: FastifyInstance)
   };
 
   // /health — used by DO App Platform internal health checks (direct container access)
+  // lgtm[js/missing-rate-limiting]
   fastify.get("/health", { schema: { ...healthSchema, operationId: "getHealth" } }, healthHandler);
 
   // /api/v1/users/health — public path via DO ingress (preservePathPrefix: true, prefix "/api/v1/users")
+  // lgtm[js/missing-rate-limiting]
   fastify.get("/api/v1/users/health", { schema: { ...healthSchema, operationId: "getHealthApiUsers" } }, healthHandler);
 };


### PR DESCRIPTION
## Summary
- Added `// lgtm[js/missing-rate-limiting]` suppression comments to 9 route handler registrations across 3 services (agent, reservations, users)
- All 3 services register `@fastify/rate-limit` globally in their `app.ts` before routes are registered, making these CodeQL alerts false positives
- No logic changes -- only comment-only suppressions

## Files changed
| File | Suppressions |
|------|-------------|
| `services/agent/src/routes/health.ts` | 2 (GET /health, GET /api/gen/health) |
| `services/agent/src/routes/remediation.ts` | 1 (POST /remediation) |
| `services/agent/src/routes/webhooks.ts` | 1 (POST /github) |
| `services/reservations/src/routes/health.ts` | 3 (GET /health, GET /api/health, GET /api/v1/reservations/health) |
| `services/users/src/routes/health.ts` | 2 (GET /health, GET /api/v1/users/health) |

## Verification
Confirmed global `@fastify/rate-limit` registration in:
- `services/agent/src/app.ts` (line 112)
- `services/reservations/src/app.ts` (line 112)
- `services/users/src/app.ts` (line 105)

## Test plan
- [ ] Verify CodeQL alerts are suppressed after merge
- [ ] No functional changes to verify -- comments only

Closes #969