### PR TITLE
fix(security): SSRF in webhook collaborator permission check (#965)

### DIFF
--- a/services/agent/src/routes/webhooks.test.ts
+++ b/services/agent/src/routes/webhooks.test.ts
@@ -214,6 +214,152 @@ describe("Webhook Routes", () => {
       });
     });
 
+    describe("SSRF protection in collaborator permission check", () => {
+      const makeIssuePayload = (repo: string, sender: string) => ({
+        action: "labeled",
+        label: { name: "agent" },
+        issue: {
+          number: 99,
+          title: "SSRF test issue",
+          body: "Test body",
+          html_url: `https://github.com/${repo}/issues/99`,
+          labels: [{ name: "agent" }],
+        },
+        repository: {
+          full_name: repo,
+          default_branch: "main",
+        },
+        sender: { login: sender, type: "User" },
+      });
+
+      it("rejects repository with path traversal (../../evil.com)", async () => {
+        const payload = makeIssuePayload("../../evil.com", "alice");
+        const payloadStr = JSON.stringify(payload);
+        const signature = signPayload(payloadStr, WEBHOOK_SECRET);
+
+        await app.inject({
+          method: "POST",
+          url: "/v1/webhooks/github",
+          payload,
+          headers: {
+            "x-github-event": "issues",
+            "x-hub-signature-256": signature,
+          },
+        });
+
+        // Permission check should fail (returns false), so no session created
+        expect(mockFetch).not.toHaveBeenCalled();
+        expect(vi.mocked(sessionService.create)).not.toHaveBeenCalled();
+      });
+
+      it("rejects repository with query string injection (evil.com/foo?)", async () => {
+        const payload = makeIssuePayload("evil.com/foo?", "alice");
+        const payloadStr = JSON.stringify(payload);
+        const signature = signPayload(payloadStr, WEBHOOK_SECRET);
+
+        await app.inject({
+          method: "POST",
+          url: "/v1/webhooks/github",
+          payload,
+          headers: {
+            "x-github-event": "issues",
+            "x-hub-signature-256": signature,
+          },
+        });
+
+        expect(mockFetch).not.toHaveBeenCalled();
+        expect(vi.mocked(sessionService.create)).not.toHaveBeenCalled();
+      });
+
+      it("rejects username with path traversal (../evil)", async () => {
+        const payload = makeIssuePayload("org/repo", "../evil");
+        const payloadStr = JSON.stringify(payload);
+        const signature = signPayload(payloadStr, WEBHOOK_SECRET);
+
+        await app.inject({
+          method: "POST",
+          url: "/v1/webhooks/github",
+          payload,
+          headers: {
+            "x-github-event": "issues",
+            "x-hub-signature-256": signature,
+          },
+        });
+
+        expect(mockFetch).not.toHaveBeenCalled();
+        expect(vi.mocked(sessionService.create)).not.toHaveBeenCalled();
+      });
+
+      it("rejects repository with URL scheme injection", async () => {
+        const payload = makeIssuePayload("http://evil.com/x", "alice");
+        const payloadStr = JSON.stringify(payload);
+        const signature = signPayload(payloadStr, WEBHOOK_SECRET);
+
+        await app.inject({
+          method: "POST",
+          url: "/v1/webhooks/github",
+          payload,
+          headers: {
+            "x-github-event": "issues",
+            "x-hub-signature-256": signature,
+          },
+        });
+
+        expect(mockFetch).not.toHaveBeenCalled();
+        expect(vi.mocked(sessionService.create)).not.toHaveBeenCalled();
+      });
+
+      it("rejects username with encoded characters (%2F)", async () => {
+        const payload = makeIssuePayload("org/repo", "alice%2F..%2Fevil");
+        const payloadStr = JSON.stringify(payload);
+        const signature = signPayload(payloadStr, WEBHOOK_SECRET);
+
+        await app.inject({
+          method: "POST",
+          url: "/v1/webhooks/github",
+          payload,
+          headers: {
+            "x-github-event": "issues",
+            "x-hub-signature-256": signature,
+          },
+        });
+
+        expect(mockFetch).not.toHaveBeenCalled();
+        expect(vi.mocked(sessionService.create)).not.toHaveBeenCalled();
+      });
+
+      it("allows valid repository and username with hyphens and dots", async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ permission: "write" }),
+        } as Response);
+
+        const payload = makeIssuePayload("my-org.corp/my-repo.js", "alice-bob.dev");
+        const payloadStr = JSON.stringify(payload);
+        const signature = signPayload(payloadStr, WEBHOOK_SECRET);
+
+        await app.inject({
+          method: "POST",
+          url: "/v1/webhooks/github",
+          payload,
+          headers: {
+            "x-github-event": "issues",
+            "x-hub-signature-256": signature,
+          },
+        });
+
+        // Valid inputs should reach the GitHub API
+        expect(mockFetch).toHaveBeenCalledWith(
+          "https://api.github.com/repos/my-org.corp/my-repo.js/collaborators/alice-bob.dev/permission",
+          expect.objectContaining({
+            headers: expect.objectContaining({
+              Authorization: expect.stringContaining("Bearer"),
+            }),
+          })
+        );
+      });
+    });
+
     describe("PR comment event", () => {
       const commentPayload = {
         action: "created",

--- a/services/agent/src/routes/webhooks.ts
+++ b/services/agent/src/routes/webhooks.ts
@@ -93,7 +93,7 @@ function verifySignature(
 // ── Constants ────────────────────────────────────────────────────────
 
 const GITHUB_REPO_RE = /^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/;
-const GITHUB_USERNAME_RE = /^[a-zA-Z0-9-]+$/;
+const GITHUB_USERNAME_RE = /^[a-zA-Z0-9_.-]+$/;
 
 const AGENT_LABEL = "agent";
 const AGENT_COMMAND_PATTERN = /^\/agent\s+(.+)/i;


### PR DESCRIPTION
## Summary
- Broadens `GITHUB_USERNAME_RE` to allow underscores and dots (`^[a-zA-Z0-9_.-]+$`), matching the existing `GITHUB_REPO_RE` pattern
- Adds 6 SSRF-focused tests: path traversal (`../../evil.com`, `../evil`), query-string injection (`evil.com/foo?`), URL scheme injection (`http://evil.com/x`), percent-encoded characters (`%2F`), and a positive case for valid hyphen/dot inputs
- Existing regex guard in `checkCollaboratorPermission()` blocks all SSRF vectors before the `fetch()` URL is constructed

## Test plan
- [x] All 6 new SSRF tests pass
- [x] All 75 existing agent service tests pass (10 test files)
- [ ] CI green on PR

Closes #965