### PR TITLE
fix(security): suppress false-positive rate-limiting alerts (#969)

### DIFF
--- a/services/agent/src/routes/health.ts
+++ b/services/agent/src/routes/health.ts
@@ -134,6 +134,7 @@ export const healthRoutes: FastifyPluginAsync = async (fastify: FastifyInstance)
   };
 
   // /health — used by DO App Platform internal health checks (direct container access)
+  // lgtm[js/missing-rate-limiting] — rate limiting is applied globally via @fastify/rate-limit in app.ts
   fastify.get<{ Reply: HealthResponse }>(
     "/health",
     { schema: { ...healthSchema, operationId: "getAgentHealth" } },
@@ -142,6 +143,7 @@ export const healthRoutes: FastifyPluginAsync = async (fastify: FastifyInstance)
 
   // /api/gen/health — public path via DO ingress (preservePathPrefix: true, prefix "/api/gen")
   // Required for synthetic monitoring hitting api.mattbutlerengineering.com/api/gen/health
+  // lgtm[js/missing-rate-limiting] — rate limiting is applied globally via @fastify/rate-limit in app.ts
   fastify.get<{ Reply: HealthResponse }>(
     "/api/gen/health",
     { schema: { ...healthSchema, operationId: "getAgentHealthApiGen" } },

--- a/services/agent/src/routes/remediation.ts
+++ b/services/agent/src/routes/remediation.ts
@@ -55,6 +55,7 @@ export const remediationRoutes: FastifyPluginAsync = async (fastify) => {
     return Readable.from(rawBody);
   });
 
+  // lgtm[js/missing-rate-limiting] — rate limiting is applied globally via @fastify/rate-limit in app.ts
   fastify.post<{
     Body: unknown;
     Reply: { sessionId: string } | ApiError;

--- a/services/agent/src/routes/webhooks.ts
+++ b/services/agent/src/routes/webhooks.ts
@@ -162,6 +162,7 @@ export const webhookRoutes: FastifyPluginAsync = async (fastify) => {
   });
 
   // POST /v1/webhooks/github — Handle GitHub webhook events
+  // lgtm[js/missing-rate-limiting] — rate limiting is applied globally via @fastify/rate-limit in app.ts
   fastify.post<{
     Body: unknown;
     Reply: { received: true } | ApiError;

--- a/services/reservations/src/routes/health.ts
+++ b/services/reservations/src/routes/health.ts
@@ -163,13 +163,16 @@ const healthHandler: HealthRouteHandler = async (request) => {
 
 export const healthRoutes: FastifyPluginAsync = async (fastify) => {
   // /health — used by DO App Platform internal health checks (direct container access)
+  // lgtm[js/missing-rate-limiting] — rate limiting is applied globally via @fastify/rate-limit in app.ts
   fastify.get("/health", { schema: { ...healthSchema, operationId: "getHealth" } }, healthHandler);
 
   // /api/health — public path via DO ingress (preservePathPrefix: true, prefix "/api")
   // Required for post-deploy verification workflow hitting api.mattbutlerengineering.com/api/health
+  // lgtm[js/missing-rate-limiting] — rate limiting is applied globally via @fastify/rate-limit in app.ts
   fastify.get("/api/health", { schema: { ...healthSchema, operationId: "getHealthApi" } }, healthHandler);
 
   // /api/v1/reservations/health — public path via DO ingress (preservePathPrefix: true, prefix "/api/v1/reservations")
   // Must be registered here (not in reservationRoutes) to avoid falling through to /:id param route
+  // lgtm[js/missing-rate-limiting] — rate limiting is applied globally via @fastify/rate-limit in app.ts
   fastify.get("/api/v1/reservations/health", { schema: { ...healthSchema, operationId: "getHealthApiReservations" } }, healthHandler);
 };

--- a/services/users/src/routes/health.ts
+++ b/services/users/src/routes/health.ts
@@ -172,8 +172,10 @@ export const healthRoutes: FastifyPluginAsync = async (fastify: FastifyInstance)
   };
 
   // /health — used by DO App Platform internal health checks (direct container access)
+  // lgtm[js/missing-rate-limiting] — rate limiting is applied globally via @fastify/rate-limit in app.ts
   fastify.get("/health", { schema: { ...healthSchema, operationId: "getHealth" } }, healthHandler);
 
   // /api/v1/users/health — public path via DO ingress (preservePathPrefix: true, prefix "/api/v1/users")
+  // lgtm[js/missing-rate-limiting] — rate limiting is applied globally via @fastify/rate-limit in app.ts
   fastify.get("/api/v1/users/health", { schema: { ...healthSchema, operationId: "getHealthApiUsers" } }, healthHandler);
 };


### PR DESCRIPTION
## Summary

- Added `lgtm[js/missing-rate-limiting]` suppression comments to 9 route handlers flagged by CodeQL across 3 services (agent, reservations, users)
- These are false positives: all services register `@fastify/rate-limit` globally in their `app.ts`, but CodeQL cannot trace the plugin registration across file boundaries
- No runtime behavior changes -- comments only

## Files changed

| Service | File | Routes suppressed |
|---------|------|-------------------|
| agent | `src/routes/health.ts` | `/health`, `/api/gen/health` |
| agent | `src/routes/remediation.ts` | `/remediation` |
| agent | `src/routes/webhooks.ts` | `/github` |
| reservations | `src/routes/health.ts` | `/health`, `/api/health`, `/api/v1/reservations/health` |
| users | `src/routes/health.ts` | `/health`, `/api/v1/users/health` |

## Verification

Each service's `app.ts` confirms global rate-limit registration:
```typescript
await fastify.register(rateLimit, {
  max: 100,
  timeWindow: "1 minute",
  ...
});
```

## Test plan

- [x] Verify suppression comments are syntactically correct
- [x] Confirm `@fastify/rate-limit` is registered globally in all 3 service `app.ts` files
- [x] Run typecheck on affected services (users passes; agent/reservations have pre-existing baseline failures unrelated to this change)
- [ ] Verify CodeQL alerts are suppressed on next scan

Closes #969