### PR TITLE
fix(security): command injection in worktree-manager (#967)

### DIFF
--- a/packages/agent-core/src/__tests__/worktree-manager.test.ts
+++ b/packages/agent-core/src/__tests__/worktree-manager.test.ts
@@ -21,6 +21,8 @@ import {
   removeWorktree,
   commitChanges,
   hasChanges,
+  validateGitRef,
+  validatePath,
 } from "../worktree-manager.js";
 
 // Helper to set up promisified execFile mock
@@ -40,6 +42,86 @@ function setupExecFileMock(stdoutResponses: string[] = [""]) {
     }) as typeof execFile
   );
 }
+
+// ── Input validation ─────────────────────────────────────────────────────────
+
+describe("validateGitRef", () => {
+  it("accepts valid branch names", () => {
+    expect(() => validateGitRef("main", "branch")).not.toThrow();
+    expect(() => validateGitRef("feature/foo-bar", "branch")).not.toThrow();
+    expect(() => validateGitRef("agent/fix-login-abc123", "branch")).not.toThrow();
+    expect(() => validateGitRef("v1.2.3", "tag")).not.toThrow();
+    expect(() => validateGitRef("release_2024", "branch")).not.toThrow();
+  });
+
+  it("rejects refs starting with a dash (argument injection)", () => {
+    expect(() => validateGitRef("--evil", "branch")).toThrow("Invalid branch");
+    expect(() => validateGitRef("-n", "branch")).toThrow("Invalid branch");
+  });
+
+  it("rejects refs starting with a dot", () => {
+    expect(() => validateGitRef(".hidden", "branch")).toThrow("Invalid branch");
+  });
+
+  it("rejects refs with shell metacharacters", () => {
+    expect(() => validateGitRef("main;rm -rf /", "branch")).toThrow("Invalid branch");
+    expect(() => validateGitRef("main$(whoami)", "branch")).toThrow("Invalid branch");
+    expect(() => validateGitRef("main`id`", "branch")).toThrow("Invalid branch");
+    expect(() => validateGitRef("a|b", "branch")).toThrow("Invalid branch");
+    expect(() => validateGitRef("a&b", "branch")).toThrow("Invalid branch");
+  });
+
+  it("rejects empty strings", () => {
+    expect(() => validateGitRef("", "branch")).toThrow("Invalid branch");
+  });
+});
+
+describe("validatePath", () => {
+  it("accepts valid paths", () => {
+    expect(() => validatePath("/repo/path", "repoPath")).not.toThrow();
+    expect(() => validatePath("/home/user/project", "repoPath")).not.toThrow();
+    expect(() => validatePath("relative/path", "repoPath")).not.toThrow();
+  });
+
+  it("rejects paths with shell metacharacters", () => {
+    expect(() => validatePath("/repo;rm -rf /", "path")).toThrow("Invalid path");
+    expect(() => validatePath("/repo$(whoami)", "path")).toThrow("Invalid path");
+    expect(() => validatePath("/repo`id`", "path")).toThrow("Invalid path");
+    expect(() => validatePath("/repo|cat", "path")).toThrow("Invalid path");
+    expect(() => validatePath("/repo&bg", "path")).toThrow("Invalid path");
+    expect(() => validatePath("/repo\ncd /", "path")).toThrow("Invalid path");
+  });
+
+  it("rejects empty strings", () => {
+    expect(() => validatePath("", "path")).toThrow("Invalid path");
+  });
+});
+
+// ── createWorktree rejects malicious inputs ──────────────────────────────────
+
+describe("createWorktree input validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects baseBranch starting with --", async () => {
+    await expect(
+      createWorktree("/repo", "--upload-pack=evil", "task")
+    ).rejects.toThrow("Invalid baseBranch");
+  });
+
+  it("rejects baseBranch with shell metacharacters", async () => {
+    await expect(
+      createWorktree("/repo", "main;rm -rf /", "task")
+    ).rejects.toThrow("Invalid baseBranch");
+  });
+
+  it("rejects repoPath with shell metacharacters", async () => {
+    await expect(
+      createWorktree("/repo$(whoami)", "main", "task")
+    ).rejects.toThrow("Invalid repoPath");
+  });
+});
 
 // ── Full worktree mode (default) ──────────────────────────────────────────────
 
@@ -67,17 +149,18 @@ describe("createWorktree (full mode)", () => {
     expect(result.mode).toBe("full");
   });
 
-  it("explicitly uses full mode when mode: 'full' is passed", async () => {
+  it("explicitly uses full mode when mode: 'full' is passed with -- separator", async () => {
     setupExecFileMock([""]);
 
     const result = await createWorktree("/repo", "main", "task", { mode: "full" });
 
     expect(result.mode).toBe("full");
-    // 'git worktree add' should be the command used
+    // 'git worktree add' should be the command used with `--` separator
     const calls = vi.mocked(execFile).mock.calls;
     const gitArgs = calls[0][1] as string[];
     expect(gitArgs).toContain("worktree");
     expect(gitArgs).toContain("add");
+    expect(gitArgs).toContain("--");
   });
 
   it("generates branch names from task descriptions", async () => {
@@ -118,7 +201,7 @@ describe("createWorktree (lightweight mode)", () => {
     expect(result.mode).toBe("lightweight");
   });
 
-  it("uses git clone --depth 1 for the shallow clone step", async () => {
+  it("uses git clone --depth 1 for the shallow clone step with -- separator", async () => {
     setupExecFileMock(["", ""]);
 
     await createWorktree("/repo", "main", "Fix typo", { mode: "lightweight" });
@@ -129,6 +212,8 @@ describe("createWorktree (lightweight mode)", () => {
     expect(firstArgs).toContain("clone");
     expect(firstArgs).toContain("--depth");
     expect(firstArgs).toContain("1");
+    // `--` should appear to separate options from positional args
+    expect(firstArgs).toContain("--");
   });
 
   it("creates a new branch in the cloned directory", async () => {
@@ -160,7 +245,7 @@ describe("removeWorktree", () => {
     vi.clearAllMocks();
   });
 
-  it("removes an existing full worktree via git worktree remove", async () => {
+  it("removes an existing full worktree via git worktree remove with -- separator", async () => {
     vi.mocked(existsSync).mockReturnValueOnce(true);
     setupExecFileMock([""]);
 
@@ -169,6 +254,11 @@ describe("removeWorktree", () => {
     const gitArgs = vi.mocked(execFile).mock.calls[0][1] as string[];
     expect(gitArgs).toContain("worktree");
     expect(gitArgs).toContain("remove");
+    expect(gitArgs).toContain("--");
+    // `--` must come before the path (positional arg)
+    const dashDashIdx = gitArgs.indexOf("--");
+    const pathIdx = gitArgs.indexOf("/repo/.agent-worktrees/test");
+    expect(dashDashIdx).toBeLessThan(pathIdx);
   });
 
   it("removes an existing lightweight worktree via rm (no git command)", async () => {

--- a/packages/agent-core/src/worktree-manager.ts
+++ b/packages/agent-core/src/worktree-manager.ts
@@ -10,6 +10,41 @@ const execFileAsync = promisify(execFile);
 
 const WORKTREE_DIR = ".agent-worktrees";
 
+// ── Input validation ─────────────────────────────────────────────────────────
+// Defence-in-depth: although execFile avoids shell injection, we validate
+// inputs to prevent git argument injection (e.g. branch names starting with
+// `--`) and reject clearly malicious values before they reach any subprocess.
+
+/** Safe git ref pattern: alphanumeric, `/`, `.`, `-`, `_`, no leading `-` or `.` */
+const SAFE_GIT_REF = /^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$/;
+
+/** Characters that must never appear in filesystem paths passed to subprocesses */
+const UNSAFE_PATH_CHARS = /[;&|$`(){}\n\r]/;
+
+/**
+ * Validate a git ref (branch name, tag) against safe patterns.
+ * Rejects refs containing shell metacharacters or starting with `-` (argument injection).
+ */
+export function validateGitRef(ref: string, label: string): void {
+  if (!ref || !SAFE_GIT_REF.test(ref)) {
+    throw new Error(
+      `Invalid ${label}: "${ref}" — must match ${String(SAFE_GIT_REF)} (no leading dash, no shell metacharacters)`
+    );
+  }
+}
+
+/**
+ * Validate a filesystem path against unsafe characters.
+ * Rejects paths containing shell metacharacters.
+ */
+export function validatePath(path: string, label: string): void {
+  if (!path || UNSAFE_PATH_CHARS.test(path)) {
+    throw new Error(
+      `Invalid ${label}: "${path}" — must not contain shell metacharacters (${String(UNSAFE_PATH_CHARS)})`
+    );
+  }
+}
+
 function generateBranchName(taskDescription: string): string {
   const slug = taskDescription
     .toLowerCase()
@@ -36,7 +71,9 @@ async function createFullWorktree(
   branchName: string
 ): Promise<string> {
   const worktreePath = join(repoPath, WORKTREE_DIR, branchName.replace(/\//g, "-"));
-  await git(["worktree", "add", "-b", branchName, worktreePath, baseBranch], repoPath);
+  // `--` separates options from positional args, preventing branchName/baseBranch
+  // from being interpreted as flags if they ever started with `-`.
+  await git(["worktree", "add", "-b", branchName, "--", worktreePath, baseBranch], repoPath);
   return worktreePath;
 }
 
@@ -52,9 +89,10 @@ async function createLightweightWorktree(
 ): Promise<string> {
   const clonePath = join(repoPath, WORKTREE_DIR, branchName.replace(/\//g, "-"));
   // Shallow clone from the local repo; --depth 1 keeps it fast and minimal.
-  await execFileAsync("git", ["clone", "--depth", "1", "--branch", baseBranch, repoPath, clonePath]);
+  // `--` prevents baseBranch/repoPath from being parsed as flags.
+  await execFileAsync("git", ["clone", "--depth", "1", "--branch", baseBranch, "--", repoPath, clonePath]);
   // Create and switch to the task branch inside the clone.
-  await git(["checkout", "-b", branchName], clonePath);
+  await git(["checkout", "-b", branchName, "--"], clonePath);
   return clonePath;
 }
 
@@ -72,6 +110,9 @@ export async function createWorktree(
   taskDescription: string,
   options: CreateWorktreeOptions = {}
 ): Promise<WorktreeInfo> {
+  validatePath(repoPath, "repoPath");
+  validateGitRef(baseBranch, "baseBranch");
+
   const mode = options.mode ?? "full";
   const branchName = generateBranchName(taskDescription);
 
@@ -88,6 +129,9 @@ export async function removeWorktree(
   worktreePath: string,
   mode: WorktreeMode = "full"
 ): Promise<void> {
+  validatePath(repoPath, "repoPath");
+  validatePath(worktreePath, "worktreePath");
+
   if (!existsSync(worktreePath)) {
     return;
   }
@@ -96,11 +140,13 @@ export async function removeWorktree(
     // Lightweight clones are standalone directories — just remove them.
     await rm(worktreePath, { recursive: true, force: true });
   } else {
-    await git(["worktree", "remove", worktreePath, "--force"], repoPath);
+    await git(["worktree", "remove", "--force", "--", worktreePath], repoPath);
   }
 }
 
 export async function cleanupWorktrees(repoPath: string): Promise<void> {
+  validatePath(repoPath, "repoPath");
+
   const worktreesDir = join(repoPath, WORKTREE_DIR);
   if (!existsSync(worktreesDir)) {
     return;
@@ -113,10 +159,12 @@ export async function commitChanges(
   worktreePath: string,
   message: string
 ): Promise<string> {
+  validatePath(worktreePath, "worktreePath");
+
   await git(["add", "-A"], worktreePath);
 
-  const status = await git(["status", "--porcelain"], worktreePath);
-  if (!status) {
+  const gitStatus = await git(["status", "--porcelain"], worktreePath);
+  if (!gitStatus) {
     return "";
   }
 
@@ -129,12 +177,17 @@ export async function pushBranch(
   worktreePath: string,
   branchName: string
 ): Promise<void> {
-  await git(["push", "-u", "origin", branchName], worktreePath);
+  validatePath(worktreePath, "worktreePath");
+  validateGitRef(branchName, "branchName");
+
+  await git(["push", "-u", "origin", "--", branchName], worktreePath);
 }
 
 export async function hasChanges(worktreePath: string): Promise<boolean> {
-  const status = await git(["status", "--porcelain"], worktreePath);
-  return status.length > 0;
+  validatePath(worktreePath, "worktreePath");
+
+  const gitStatus = await git(["status", "--porcelain"], worktreePath);
+  return gitStatus.length > 0;
 }
 
 export interface VerificationResult {


### PR DESCRIPTION
## Summary

- Adds `validateGitRef()` and `validatePath()` input validators to reject shell metacharacters, leading dashes (argument injection), and empty strings at all public API boundaries
- Adds `--` end-of-options separator to all git commands where user-controlled values appear as positional arguments (`worktree add`, `clone`, `checkout`, `worktree remove`, `push`)
- Adds comprehensive tests for both validators and malicious input rejection at the API boundary

Addresses CodeQL alerts #43, #44, #45 (`js/second-order-command-line-injection`) at `packages/agent-core/src/worktree-manager.ts`.

The code already used `execFile` (no shell), so there was no actual shell injection vector. The real risk was git **argument injection** -- a branch name starting with `--` could be parsed as a flag by git. This PR adds defence-in-depth validation and `--` separators.

Closes #967

## Test plan

- [x] `validateGitRef` accepts valid refs, rejects `--evil`, `-n`, `.hidden`, metacharacters, empty
- [x] `validatePath` accepts valid paths, rejects `;`, `$()`, backticks, `|`, `&`, newlines, empty
- [x] `createWorktree` rejects malicious `baseBranch` and `repoPath` before reaching git
- [x] All git commands include `--` separator verified in existing tests
- [x] All 629 tests pass, lint clean, typecheck clean