### PR TITLE
fix(security): ReDoS and bad HTML filter (#968)

### DIFF
--- a/apps/hospitality/src/pages/BookingWidgetDemoPage.test.tsx
+++ b/apps/hospitality/src/pages/BookingWidgetDemoPage.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { highlightEmbedCode } from "./highlight-embed-code.js";
+
+describe("highlightEmbedCode", () => {
+  function renderHighlighted(code: string) {
+    const nodes = highlightEmbedCode(code);
+    const { container } = render(<pre><code>{nodes}</code></pre>);
+    return container;
+  }
+
+  it("highlights simple HTML tags", () => {
+    const container = renderHighlighted("<div></div>");
+    const tags = container.querySelectorAll(".syntaxTag");
+    expect(tags).toHaveLength(2);
+    expect(tags[0].textContent).toBe("<div>");
+    expect(tags[1].textContent).toBe("</div>");
+  });
+
+  it("highlights tags with attributes", () => {
+    const container = renderHighlighted('<div id="booking-widget"></div>');
+    const tags = container.querySelectorAll(".syntaxTag");
+    expect(tags).toHaveLength(2);
+    expect(tags[0].textContent).toBe('<div id="booking-widget">');
+  });
+
+  it("highlights self-closing tags", () => {
+    const container = renderHighlighted("<br/>");
+    const tags = container.querySelectorAll(".syntaxTag");
+    expect(tags).toHaveLength(1);
+    expect(tags[0].textContent).toBe("<br/>");
+  });
+
+  it("highlights HTML comments", () => {
+    const container = renderHighlighted("<!-- Add to your website -->");
+    const comments = container.querySelectorAll(".syntaxComment");
+    expect(comments).toHaveLength(1);
+    expect(comments[0].textContent).toBe("<!-- Add to your website -->");
+  });
+
+  it("highlights script tags with src attribute", () => {
+    const container = renderHighlighted(
+      '<script src="https://mattbutlerengineering.com/widget.js"></script>'
+    );
+    const tags = container.querySelectorAll(".syntaxTag");
+    expect(tags).toHaveLength(2);
+    expect(tags[0].textContent).toBe(
+      '<script src="https://mattbutlerengineering.com/widget.js">'
+    );
+    expect(tags[1].textContent).toBe("</script>");
+  });
+
+  it("highlights JS-style comments inside script blocks", () => {
+    const container = renderHighlighted("  // Optional customization");
+    const comments = container.querySelectorAll(".syntaxComment");
+    expect(comments).toHaveLength(1);
+    expect(comments[0].textContent).toBe("// Optional customization");
+  });
+
+  it("highlights quoted strings", () => {
+    const container = renderHighlighted("  container: '#booking-widget',");
+    const strings = container.querySelectorAll(".syntaxString");
+    expect(strings).toHaveLength(1);
+    expect(strings[0].textContent).toBe("'#booking-widget'");
+  });
+
+  it("does not hang on adversarial input with nested angle brackets", () => {
+    // Input that could cause issues with naive [^>]* patterns
+    const adversarial = '<img src=">" onerror="alert(1)">';
+    const start = performance.now();
+    renderHighlighted(adversarial);
+    const elapsed = performance.now() - start;
+    expect(elapsed).toBeLessThan(100);
+  });
+
+  it("handles multi-line embed code correctly", () => {
+    const code = `<!-- Widget -->
+<div id="app"></div>
+<script>
+  // init
+</script>`;
+    const container = renderHighlighted(code);
+    const tags = container.querySelectorAll(".syntaxTag");
+    const comments = container.querySelectorAll(".syntaxComment");
+    // <div id="app">, </div>, <script>, </script>
+    expect(tags).toHaveLength(4);
+    // <!-- Widget --> and // init
+    expect(comments).toHaveLength(2);
+  });
+});

--- a/apps/hospitality/src/pages/BookingWidgetDemoPage.tsx
+++ b/apps/hospitality/src/pages/BookingWidgetDemoPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback, type ReactNode } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import { useAuth } from "@mbe/auth/react";
 import { createApiClient } from "@mbe/api-client";
 import {
@@ -17,6 +17,7 @@ import {
 import type { Venue } from "@mbe/types";
 import { PageHeader } from "../components/PageHeader";
 import { BookingWidget } from "../components/booking-widget";
+import { highlightEmbedCode } from "./highlight-embed-code.js";
 import styles from "./BookingWidgetDemoPage.module.css";
 
 /* ── Constants ─────────────────────────────── */
@@ -84,78 +85,6 @@ const FEATURES: readonly Feature[] = [
     svgPath: "M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z",
   },
 ] as const;
-
-/* ── Syntax highlighting ───────────────────── */
-
-function highlightEmbedCode(code: string): ReactNode[] {
-  const lines = code.split("\n");
-  return lines.map((line, lineIndex) => {
-    const parts: ReactNode[] = [];
-    let remaining = line;
-    let keyIndex = 0;
-
-    while (remaining.length > 0) {
-      // HTML comments
-      const commentMatch = remaining.match(/^(<!--.*?-->)/);
-      if (commentMatch) {
-        parts.push(
-          <span key={keyIndex++} className={styles.syntaxComment}>
-            {commentMatch[1]}
-          </span>
-        );
-        remaining = remaining.slice(commentMatch[1].length);
-        continue;
-      }
-
-      // HTML tags
-      const tagMatch = remaining.match(/^(<\/?[a-zA-Z][a-zA-Z0-9]*[^>]*>)/);
-      if (tagMatch) {
-        parts.push(
-          <span key={keyIndex++} className={styles.syntaxTag}>
-            {tagMatch[1]}
-          </span>
-        );
-        remaining = remaining.slice(tagMatch[1].length);
-        continue;
-      }
-
-      // Strings (single or double quoted)
-      const stringMatch = remaining.match(/^('[^']*'|"[^"]*")/);
-      if (stringMatch) {
-        parts.push(
-          <span key={keyIndex++} className={styles.syntaxString}>
-            {stringMatch[1]}
-          </span>
-        );
-        remaining = remaining.slice(stringMatch[1].length);
-        continue;
-      }
-
-      // JS line comments
-      const jsCommentMatch = remaining.match(/^(\/\/.*)/);
-      if (jsCommentMatch) {
-        parts.push(
-          <span key={keyIndex++} className={styles.syntaxComment}>
-            {jsCommentMatch[1]}
-          </span>
-        );
-        remaining = "";
-        continue;
-      }
-
-      // Plain text (advance one character)
-      parts.push(<span key={keyIndex++}>{remaining[0]}</span>);
-      remaining = remaining.slice(1);
-    }
-
-    return (
-      <span key={lineIndex}>
-        {parts}
-        {lineIndex < lines.length - 1 ? "\n" : null}
-      </span>
-    );
-  });
-}
 
 /* ── Loading skeleton ──────────────────────── */
 

--- a/apps/hospitality/src/pages/highlight-embed-code.tsx
+++ b/apps/hospitality/src/pages/highlight-embed-code.tsx
@@ -1,0 +1,83 @@
+/* eslint-disable mbe-local/prefer-rialto-components -- raw <span> is correct for inline syntax tokens */
+import type { ReactNode } from "react";
+import styles from "./BookingWidgetDemoPage.module.css";
+
+/**
+ * Syntax-highlights embed code for display in a `<pre><code>` block.
+ *
+ * The regex for HTML tags explicitly matches tag-name + attribute pairs
+ * rather than using a generic `[^>]*` pattern, which avoids the CodeQL
+ * `js/bad-tag-filter` alert.
+ */
+export function highlightEmbedCode(code: string): ReactNode[] {
+  const lines = code.split("\n");
+  return lines.map((line, lineIndex) => {
+    const parts: ReactNode[] = [];
+    let remaining = line;
+    let keyIndex = 0;
+
+    while (remaining.length > 0) {
+      // HTML comments
+      const commentMatch = remaining.match(/^(<!--.*?-->)/);
+      if (commentMatch) {
+        parts.push(
+          <span key={keyIndex++} className={styles.syntaxComment}>
+            {commentMatch[1]}
+          </span>
+        );
+        remaining = remaining.slice(commentMatch[1].length);
+        continue;
+      }
+
+      // HTML tags — match tag name + optional attributes (name="value" pairs)
+      // Avoids generic [^>]* which CodeQL flags as js/bad-tag-filter
+      const tagMatch = remaining.match(
+        /^(<\/?[a-zA-Z][a-zA-Z0-9]*(?:\s+[a-zA-Z][a-zA-Z0-9-]*(?:=(?:"[^"]*"|'[^']*'|[^\s>]+))?)*\s*\/?>)/
+      );
+      if (tagMatch) {
+        parts.push(
+          <span key={keyIndex++} className={styles.syntaxTag}>
+            {tagMatch[1]}
+          </span>
+        );
+        remaining = remaining.slice(tagMatch[1].length);
+        continue;
+      }
+
+      // Strings (single or double quoted)
+      const stringMatch = remaining.match(/^('[^']*'|"[^"]*")/);
+      if (stringMatch) {
+        parts.push(
+          <span key={keyIndex++} className={styles.syntaxString}>
+            {stringMatch[1]}
+          </span>
+        );
+        remaining = remaining.slice(stringMatch[1].length);
+        continue;
+      }
+
+      // JS line comments
+      const jsCommentMatch = remaining.match(/^(\/\/.*)/);
+      if (jsCommentMatch) {
+        parts.push(
+          <span key={keyIndex++} className={styles.syntaxComment}>
+            {jsCommentMatch[1]}
+          </span>
+        );
+        remaining = "";
+        continue;
+      }
+
+      // Plain text (advance one character)
+      parts.push(<span key={keyIndex++}>{remaining[0]}</span>);
+      remaining = remaining.slice(1);
+    }
+
+    return (
+      <span key={lineIndex}>
+        {parts}
+        {lineIndex < lines.length - 1 ? "\n" : null}
+      </span>
+    );
+  });
+}

--- a/packages/agent-core/src/__tests__/dep-bump-merger.test.ts
+++ b/packages/agent-core/src/__tests__/dep-bump-merger.test.ts
@@ -222,6 +222,33 @@ index aaaaaaa..bbbbbbb 100644
       expect(result.isTrivial).toBe(false);
     });
 
+    it("handles adversarial diff header without polynomial backtracking (ReDoS)", () => {
+      // Craft a line that would cause catastrophic backtracking with a `.+`
+      // pattern: many `b/` sequences force exponential retries when the
+      // engine backtracks through `a/.+`.  With `\S+` the match is linear.
+      const adversarial =
+        "diff --git a/" +
+        "b/".repeat(50) +
+        "package.json b/package.json";
+      const diff = [
+        adversarial,
+        "index 1234567..abcdefg 100644",
+        "--- a/package.json",
+        "+++ b/package.json",
+        "@@ -3,3 +3,3 @@",
+        `-    "react": "18.2.0",`,
+        `+    "react": "18.3.0",`,
+      ].join("\n");
+
+      // Should complete in < 100ms (a ReDoS would hang for seconds/minutes)
+      const start = performance.now();
+      const result = isTrivialDepBump(diff);
+      const elapsed = performance.now() - start;
+
+      expect(elapsed).toBeLessThan(100);
+      expect(result.isTrivial).toBe(true);
+    });
+
     it("lockfile lines do NOT count toward the 20-line limit", () => {
       // Large lockfile diff but tiny package.json diff — should still be trivial
       const lockfileLines = Array.from(

--- a/packages/agent-core/src/dep-bump-merger.ts
+++ b/packages/agent-core/src/dep-bump-merger.ts
@@ -36,7 +36,7 @@ function extractChangedFiles(diff: string): readonly string[] {
   for (const line of diff.split("\n")) {
     if (!line.startsWith("diff --git ")) continue;
     // e.g. "diff --git a/some/path/package.json b/some/path/package.json"
-    const match = line.match(/diff --git a\/.+ b\/(.+)$/);
+    const match = line.match(/diff --git a\/\S+ b\/(.+)$/);
     if (match) {
       files.push(match[1]);
     }


### PR DESCRIPTION
## Summary

- **ReDoS fix** (`packages/agent-core/src/dep-bump-merger.ts`): Replaced `.+` with `\S+` in the git diff header regex to eliminate polynomial backtracking. The original pattern `a/.+ b/(.+)$` allowed the `.+` to greedily consume `b/` delimiters, causing exponential retries on adversarial input. `\S+` prevents this by not matching spaces, making the delimiter unambiguous.
- **Bad HTML filter fix** (`apps/hospitality/src/pages/BookingWidgetDemoPage.tsx`): Replaced the generic `[^>]*` tag-matching regex with an explicit attribute-pair pattern (`name="value"` sequences). The original `[^>]*` pattern is flagged by CodeQL as `js/bad-tag-filter` because it can be bypassed with crafted HTML like `<img src=">" onerror="alert(1)">`.
- Extracted `highlightEmbedCode` into its own module (`highlight-embed-code.tsx`) for testability and separation of concerns.

## Test plan

- [x] Added ReDoS timing test: verifies adversarial input with 50 repeated `b/` sequences completes in < 100ms
- [x] Added 9 unit tests for `highlightEmbedCode`: tag matching, attributes, self-closing tags, comments, strings, multi-line code, and adversarial input timing
- [x] All 14 existing `dep-bump-merger` tests continue to pass
- [x] `pnpm --dir packages/agent-core typecheck` passes
- [x] Pre-commit hooks (eslint, check-adr, pack-changed) pass

Closes #968