### PR TITLE
fix(security): anchor regex in dep-bump-merger to prevent ReDoS

### DIFF
--- a/packages/agent-core/src/dep-bump-merger.ts
+++ b/packages/agent-core/src/dep-bump-merger.ts
@@ -36,7 +36,7 @@ function extractChangedFiles(diff: string): readonly string[] {
   for (const line of diff.split("\n")) {
     if (!line.startsWith("diff --git ")) continue;
     // e.g. "diff --git a/some/path/package.json b/some/path/package.json"
-    const match = line.match(/diff --git a\/\S+ b\/(.+)$/);
+    const match = line.match(/^diff --git a\/\S+ b\/(\S+)$/);
     if (match) {
       files.push(match[1]);
     }


### PR DESCRIPTION
## Summary
Anchors the diff-line regex with `^` and replaces greedy `.+` capture with `\S+` to prevent polynomial backtracking (CodeQL #57).

One-line change: `/diff --git a\/\S+ b\/(.+)$/` → `/^diff --git a\/\S+ b\/(\S+)$/`

Closes #968