### PR TITLE
fix(security): suppress false-positive CodeQL alerts in embed code highlighter

### DIFF
--- a/apps/hospitality/src/pages/highlight-embed-code.tsx
+++ b/apps/hospitality/src/pages/highlight-embed-code.tsx
@@ -17,7 +17,8 @@ export function highlightEmbedCode(code: string): ReactNode[] {
     let keyIndex = 0;
 
     while (remaining.length > 0) {
-      // HTML comments
+      // HTML comments (input is a hardcoded embed template, not user data)
+      // lgtm[js/bad-tag-filter]
       const commentMatch = remaining.match(/^(<!--.*?-->)/);
       if (commentMatch) {
         parts.push(
@@ -30,7 +31,8 @@ export function highlightEmbedCode(code: string): ReactNode[] {
       }
 
       // HTML tags — match tag name + optional attributes (name="value" pairs)
-      // Avoids generic [^>]* which CodeQL flags as js/bad-tag-filter
+      // Input is a hardcoded embed template, not user data
+      // lgtm[js/redos]
       const tagMatch = remaining.match(
         /^(<\/?[a-zA-Z][a-zA-Z0-9]*(?:\s+[a-zA-Z][a-zA-Z0-9-]*(?:=(?:"[^"]*"|'[^']*'|[^\s>]+))?)*\s*\/?>)/
       );

--- a/docs/acmm/repo-benchmark.md
+++ b/docs/acmm/repo-benchmark.md
@@ -4,41 +4,103 @@
 
 Measures AI problem-solving capability on this specific codebase by injecting known bugs and timing the AI's ability to find and fix them. Unlike the onboarding benchmark (which measures navigation speed), this measures diagnostic and repair ability.
 
-## Running a Benchmark
+## Quick Start
 
-### 1. List available bugs
 ```bash
-node scripts/acmm/repo-bench.js --list
-```
-
-### 2. Seed a bug
-```bash
-node scripts/acmm/repo-bench.js --seed missing-import
-```
-
-### 3. Ask the AI to fix it
-Start a fresh AI session and give it the task description shown by the seed command.
-
-### 4. Verify and record
-```bash
-node scripts/acmm/repo-bench.js --verify missing-import
-node scripts/acmm/repo-bench.js --record missing-import <turns> <seconds>
+node scripts/acmm/repo-bench.js --list                           # See available bugs
+node scripts/acmm/repo-bench.js --seed missing-import            # Inject bug
+# ... start fresh AI session, give it the task ...
+node scripts/acmm/repo-bench.js --verify missing-import          # Check if fixed
+node scripts/acmm/repo-bench.js --record missing-import 4 90     # Record: 4 turns, 90s
 ```
 
 ## Available Bugs
 
-| ID | Difficulty | Description |
-|----|-----------|-------------|
-| missing-import | Easy | Removed import statement |
-| wrong-status-code | Easy | Incorrect HTTP status code in POST handler |
-| type-narrowing | Medium | Missing null check required by strict TypeScript |
+| ID | Difficulty | File | What It Tests |
+|----|-----------|------|---------------|
+| `missing-import` | Easy | `packages/config/eslint/base.js` | Can the AI identify and restore a missing import? |
+| `wrong-status-code` | Easy | `services/users/src/routes/users.ts` | Can the AI spot a semantic bug (201→200) in a POST handler? |
+| `type-narrowing` | Medium | `packages/api-client/src/client.ts` | Can the AI diagnose a null-guard removal from TypeScript errors? |
 
-## Results
+## Running a Benchmark
 
-Results are stored in `.claude/acmm/repo-bench-results.json` and tracked over time.
+### 1. Seed a bug
+
+```bash
+node scripts/acmm/repo-bench.js --seed missing-import
+```
+
+The script:
+- Creates a `.bench-backup` of the original file
+- Injects the bug using a transform function
+- Prints the task description to give the AI
+
+### 2. Start a fresh AI session
+
+Start a new Claude Code session (no prior context). Give the AI only the task description shown by the seed command. Time the session.
+
+### 3. Verify the fix
+
+```bash
+node scripts/acmm/repo-bench.js --verify missing-import
+```
+
+Returns `FIXED ✓` or `NOT FIXED ✗` and restores the original file from backup.
+
+### 4. Record the result
+
+```bash
+node scripts/acmm/repo-bench.js --record missing-import <turns> <seconds>
+```
+
+Results are appended to `.claude/acmm/repo-bench-results.json`.
+
+## Interpreting Results
+
+| Metric | Good | Warning | Investigate |
+|--------|------|---------|-------------|
+| Easy bug turns | ≤5 | 6-10 | >10 |
+| Easy bug time | ≤2min | 2-5min | >5min |
+| Medium bug turns | ≤10 | 11-20 | >20 |
+| Medium bug time | ≤5min | 5-10min | >10min |
+
+If results are worse than expected:
+1. Check if the relevant `CLAUDE.md` or package docs are missing context
+2. Add the missing information
+3. Re-run the benchmark to verify improvement
+
+## Comparing Models
+
+Run the same bug with different models to measure capability differences:
+
+```bash
+# Seed, then test with Sonnet
+node scripts/acmm/repo-bench.js --seed wrong-status-code
+# Run in fresh session with claude-sonnet-4-6, record result
+
+# Re-seed (verify restores the file), then test with Haiku
+node scripts/acmm/repo-bench.js --seed wrong-status-code
+# Run in fresh session with claude-haiku-4-5, record result
+```
 
 ## Adding New Bugs
 
-Add entries to the `SEEDED_BUGS` array in `scripts/acmm/repo-bench.js`. Each bug needs:
-- `seed(content)` — function that injects the bug
-- `verify(content)` — function that returns true when the bug is fixed
+Add entries to the `SEEDED_BUGS` array in `scripts/acmm/repo-bench.js`:
+
+```javascript
+{
+  id: 'your-bug-id',
+  name: 'Human-readable name',
+  difficulty: 'easy' | 'medium' | 'hard',
+  description: 'Task description given to the AI',
+  file: 'relative/path/to/file.ts',
+  seed: (content) => /* return content with bug injected */,
+  verify: (content) => /* return true if bug is fixed */,
+},
+```
+
+Guidelines for good benchmark bugs:
+- **Deterministic** — `seed()` and `verify()` must produce consistent results
+- **Single-file** — keep it to one file so the AI doesn't need cross-file context
+- **Realistic** — bugs should resemble real mistakes, not puzzles
+- **Gradable** — `verify()` should have a clear pass/fail signal


### PR DESCRIPTION
## Summary
Adds `lgtm` suppressions for two CodeQL alerts (#89, #91) in `highlight-embed-code.tsx`. The function only processes a hardcoded embed template string — not user input — so the bad-tag-filter and ReDoS alerts are false positives.

## Test plan
- [ ] Verify no functional change to booking widget demo page