### PR TITLE
feat: add PWA support to marketing and rialto-web apps

### DIFF
--- a/apps/marketing/public/pwa-192x192.svg
+++ b/apps/marketing/public/pwa-192x192.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
+    <rect width="192" height="192" rx="36" fill="#2563eb"/>
+    <text x="96" y="138.24" font-family="system-ui, sans-serif" font-size="120" font-weight="bold" fill="white" text-anchor="middle">D</text>
+  </svg>

--- a/apps/marketing/public/pwa-512x512.svg
+++ b/apps/marketing/public/pwa-512x512.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+    <rect width="512" height="512" rx="96" fill="#2563eb"/>
+    <text x="256" y="368.64" font-family="system-ui, sans-serif" font-size="320" font-weight="bold" fill="white" text-anchor="middle">D</text>
+  </svg>

--- a/apps/marketing/vite.config.ts
+++ b/apps/marketing/vite.config.ts
@@ -8,7 +8,9 @@ export default defineConfig({
   plugins: [
     react(),
     VitePWA({
+      injectRegister: "script-defer",
       registerType: "autoUpdate",
+      scope: "/",
       includeAssets: ["favicon.svg", "apple-touch-icon.png", "robots.txt"],
       manifest: {
         name: "Matt Butler Engineering",
@@ -17,16 +19,61 @@ export default defineConfig({
         theme_color: "#ffffff",
         background_color: "#ffffff",
         display: "standalone",
+        scope: "/",
+        start_url: "/",
         icons: [
           {
-            src: "favicon.svg",
-            sizes: "any",
+            src: "pwa-192x192.svg",
+            sizes: "192x192",
             type: "image/svg+xml",
           },
           {
-            src: "apple-touch-icon.png",
-            sizes: "180x180",
-            type: "image/png",
+            src: "pwa-512x512.svg",
+            sizes: "512x512",
+            type: "image/svg+xml",
+          },
+          {
+            src: "pwa-512x512.svg",
+            sizes: "512x512",
+            type: "image/svg+xml",
+            purpose: "any maskable",
+          },
+        ],
+      },
+      workbox: {
+        // Precache assets only — NOT html. JS/CSS have content hashes so
+        // stale cache is harmless; HTML must always come from the network
+        // to avoid serving old bundles after a deploy.
+        globPatterns: ["**/*.{js,css,ico,png,svg,woff,woff2}"],
+        navigateFallback: null,
+        runtimeCaching: [
+          {
+            urlPattern: /^https:\/\/fonts\.googleapis\.com\/.*/i,
+            handler: "CacheFirst",
+            options: {
+              cacheName: "google-fonts-cache",
+              expiration: {
+                maxEntries: 10,
+                maxAgeSeconds: 60 * 60 * 24 * 365, // 1 year
+              },
+              cacheableResponse: {
+                statuses: [0, 200],
+              },
+            },
+          },
+          {
+            urlPattern: /^https:\/\/fonts\.gstatic\.com\/.*/i,
+            handler: "CacheFirst",
+            options: {
+              cacheName: "gstatic-fonts-cache",
+              expiration: {
+                maxEntries: 10,
+                maxAgeSeconds: 60 * 60 * 24 * 365, // 1 year
+              },
+              cacheableResponse: {
+                statuses: [0, 200],
+              },
+            },
           },
         ],
       },

--- a/apps/rialto-web/package.json
+++ b/apps/rialto-web/package.json
@@ -44,7 +44,8 @@
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "catalog:",
     "typescript": "catalog:",
-    "vite": "catalog:"
+    "vite": "catalog:",
+    "vite-plugin-pwa": "^1.2.0"
   },
   "license": "MIT",
   "acmm": {

--- a/apps/rialto-web/public/pwa-192x192.svg
+++ b/apps/rialto-web/public/pwa-192x192.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
+    <rect width="192" height="192" rx="36" fill="#2563eb"/>
+    <text x="96" y="138.24" font-family="system-ui, sans-serif" font-size="120" font-weight="bold" fill="white" text-anchor="middle">D</text>
+  </svg>

--- a/apps/rialto-web/public/pwa-512x512.svg
+++ b/apps/rialto-web/public/pwa-512x512.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+    <rect width="512" height="512" rx="96" fill="#2563eb"/>
+    <text x="256" y="368.64" font-family="system-ui, sans-serif" font-size="320" font-weight="bold" fill="white" text-anchor="middle">D</text>
+  </svg>

--- a/apps/rialto-web/vite.config.ts
+++ b/apps/rialto-web/vite.config.ts
@@ -1,11 +1,83 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { VitePWA } from "vite-plugin-pwa";
 import { sentryVitePlugin } from "@sentry/vite-plugin";
 
 export default defineConfig({
   base: "/rialto/",
   plugins: [
     react(),
+    VitePWA({
+      injectRegister: "script-defer",
+      registerType: "autoUpdate",
+      scope: "/rialto/",
+      includeAssets: ["favicon.svg", "apple-touch-icon.png", "robots.txt"],
+      manifest: {
+        name: "Rialto Design System",
+        short_name: "Rialto",
+        description: "Rialto Design System — a precision-crafted React component library",
+        theme_color: "#f8f6f3",
+        background_color: "#f8f6f3",
+        display: "standalone",
+        scope: "/rialto/",
+        start_url: "/rialto/",
+        icons: [
+          {
+            src: "pwa-192x192.svg",
+            sizes: "192x192",
+            type: "image/svg+xml",
+          },
+          {
+            src: "pwa-512x512.svg",
+            sizes: "512x512",
+            type: "image/svg+xml",
+          },
+          {
+            src: "pwa-512x512.svg",
+            sizes: "512x512",
+            type: "image/svg+xml",
+            purpose: "any maskable",
+          },
+        ],
+      },
+      workbox: {
+        // Precache assets only — NOT html. JS/CSS have content hashes so
+        // stale cache is harmless; HTML must always come from the network
+        // to avoid serving old bundles after a deploy.
+        globPatterns: ["**/*.{js,css,ico,png,svg,woff,woff2}"],
+        navigateFallback: null,
+        runtimeCaching: [
+          {
+            urlPattern: /^https:\/\/fonts\.googleapis\.com\/.*/i,
+            handler: "CacheFirst",
+            options: {
+              cacheName: "google-fonts-cache",
+              expiration: {
+                maxEntries: 10,
+                maxAgeSeconds: 60 * 60 * 24 * 365, // 1 year
+              },
+              cacheableResponse: {
+                statuses: [0, 200],
+              },
+            },
+          },
+          {
+            urlPattern: /^https:\/\/fonts\.gstatic\.com\/.*/i,
+            handler: "CacheFirst",
+            options: {
+              cacheName: "gstatic-fonts-cache",
+              expiration: {
+                maxEntries: 10,
+                maxAgeSeconds: 60 * 60 * 24 * 365, // 1 year
+              },
+              cacheableResponse: {
+                statuses: [0, 200],
+              },
+            },
+          },
+        ],
+      },
+    }),
     sentryVitePlugin({
       org: process.env.SENTRY_ORG,
       project: process.env.SENTRY_PROJECT,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -381,6 +381,9 @@ importers:
       vite:
         specifier: 'catalog:'
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      vite-plugin-pwa:
+        specifier: ^1.2.0
+        version: 1.2.0(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0)
 
   infrastructure/pulumi:
     dependencies:
@@ -8071,10 +8074,6 @@ packages:
   tinyexec@1.0.4:
     resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
     engines: {node: '>=18'}
-
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
 
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
@@ -16935,11 +16934,6 @@ snapshots:
 
   tinyexec@1.0.4: {}
 
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -17238,7 +17232,7 @@ snapshots:
     dependencies:
       debug: 4.4.3
       pretty-bytes: 6.1.1
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
       workbox-build: 7.4.0(@types/babel__core@7.20.5)
       workbox-window: 7.4.0


### PR DESCRIPTION
## Summary

- Adds full `vite-plugin-pwa` configuration to `apps/marketing` (scope `/`) replicating the hospitality app pattern
- Adds `vite-plugin-pwa` as a dev dependency and full PWA configuration to `apps/rialto-web` (scope `/rialto/`)
- Copies `pwa-192x192.svg` and `pwa-512x512.svg` icon files into both apps' `public/` directories
- Both apps generate a service worker (workbox `generateSW` mode), a `manifest.webmanifest`, font runtime caching, and `navigateFallback: null` to avoid stale HTML

Closes #328

## Test plan

- [x] `pnpm --dir apps/marketing typecheck` passes
- [x] `pnpm --dir apps/marketing build` passes — emits `dist/sw.js` and `dist/manifest.webmanifest`
- [x] `pnpm --dir apps/rialto-web typecheck` passes
- [x] `pnpm --dir apps/rialto-web build` passes — emits `dist/sw.js` and `dist/manifest.webmanifest`
- [ ] Lighthouse PWA audit on deployed marketing site scores installable
- [ ] Lighthouse PWA audit on deployed rialto-web site scores installable