### PR TITLE
feat(services): add database connection pool monitoring to health checks

### DIFF
--- a/services/agent/src/routes/health.test.ts
+++ b/services/agent/src/routes/health.test.ts
@@ -9,6 +9,14 @@ vi.mock("../services/database.js", () => ({
   },
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
+  getPoolMetrics: vi.fn().mockReturnValue({
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
+  }),
 }));
 
 vi.mock("../services/health-checks.js", () => ({
@@ -67,7 +75,7 @@ vi.mock("@mbe/observability", async (importOriginal) => {
   };
 });
 
-import { prisma } from "../services/database.js";
+import { prisma, getPoolMetrics } from "../services/database.js";
 
 describe("Health Routes", () => {
   let app: FastifyInstance;
@@ -128,6 +136,48 @@ describe("Health Routes", () => {
       const body = JSON.parse(response.body);
       expect(body.status).toBe("degraded");
       expect(body.error_rates.degraded).toBe(true);
+    });
+
+    it("includes pool check in health response", async () => {
+      vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([{ "?column?": 1 }]);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/health",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.checks.pool).toBeDefined();
+      expect(body.checks.pool.status).toBe("ok");
+      expect(body.checks.pool.active).toBe(1);
+      expect(body.checks.pool.idle).toBe(4);
+      expect(body.checks.pool.busy).toBe(1);
+      expect(body.checks.pool.size).toBe(5);
+      expect(body.checks.pool.utilization).toBe(0.2);
+    });
+
+    it("returns degraded status when pool utilization is high", async () => {
+      vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([{ "?column?": 1 }]);
+      vi.mocked(getPoolMetrics).mockReturnValueOnce({
+        active: 5,
+        idle: 0,
+        busy: 5,
+        size: 5,
+        utilization: 1.0,
+        isDegraded: true,
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/health",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.status).toBe("degraded");
+      expect(body.checks.pool.status).toBe("degraded");
+      expect(body.checks.pool.message).toContain("Pool utilization high");
     });
   });
 });

--- a/services/agent/src/routes/health.ts
+++ b/services/agent/src/routes/health.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance, FastifyPluginAsync, FastifyRequest } from "fastify";
 import type { HealthResponse } from "@mbe/types";
 import type { RateLimitMonitor } from "@mbe/observability";
-import { prisma, getSlowQueryStats, getServiceStatus } from "../services/database.js";
+import { prisma, getSlowQueryStats, getServiceStatus, getPoolMetrics } from "../services/database.js";
 import { checkAuth0, checkLatencyAnomaly, recordDbLatency } from "../services/health-checks.js";
 
 export const healthRoutes: FastifyPluginAsync = async (fastify: FastifyInstance) => {
@@ -108,14 +108,30 @@ export const healthRoutes: FastifyPluginAsync = async (fastify: FastifyInstance)
       }),
     };
 
+    const poolMetrics = getPoolMetrics();
+    checks.pool = {
+      status: poolMetrics.isDegraded ? "degraded" : "ok",
+      ...(poolMetrics.isDegraded && {
+        message: `Pool utilization high: ${Math.round(poolMetrics.utilization * 100)}% (${poolMetrics.busy}/${poolMetrics.size} busy)`,
+      }),
+      ...{
+        active: poolMetrics.active,
+        idle: poolMetrics.idle,
+        busy: poolMetrics.busy,
+        size: poolMetrics.size,
+        utilization: poolMetrics.utilization,
+      },
+    };
+
     const errorRates = fastify.getErrorRates();
     const degradedEndpoints = errorRates.endpoints.filter((e) => e.rate > 0.1 && e.total >= 5);
-    
+
     const hasErrors =
       dbStatus === "error" ||
       slowQueryStatus === "degraded" ||
       auth0Result.status === "degraded" ||
       rateLimitSnapshot.isDegraded ||
+      poolMetrics.isDegraded ||
       errorRates.degraded;
 
     return {

--- a/services/agent/src/services/database.ts
+++ b/services/agent/src/services/database.ts
@@ -58,6 +58,31 @@ export function getPoolStats() {
   };
 }
 
+export interface PoolMetrics {
+  active: number;
+  idle: number;
+  busy: number;
+  size: number;
+  utilization: number;
+  isDegraded: boolean;
+}
+
+export function getPoolMetrics(): PoolMetrics {
+  const stats = getPoolStats();
+  const busy = stats.active;
+  const idle = stats.idle;
+  const utilization = CONNECTION_LIMIT > 0 ? busy / CONNECTION_LIMIT : 0;
+
+  return {
+    active: stats.total,
+    idle,
+    busy,
+    size: CONNECTION_LIMIT,
+    utilization,
+    isDegraded: utilization > POOL_UTILIZATION_THRESHOLD,
+  };
+}
+
 export function getServiceStatus(): "ok" | "degraded" {
   const stats = getSlowQueryStats();
   const poolStats = getPoolStats();

--- a/services/reservations/src/routes/health.test.ts
+++ b/services/reservations/src/routes/health.test.ts
@@ -78,6 +78,14 @@ vi.mock("../services/database.js", () => ({
   },
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
+  getPoolMetrics: vi.fn().mockReturnValue({
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
+  }),
 }));
 
 vi.mock("../services/health-checks.js", () => ({
@@ -127,7 +135,7 @@ vi.mock("@mbe/observability", async (importOriginal) => {
   };
 });
 
-import { prisma } from "../services/database.js";
+import { prisma, getPoolMetrics } from "../services/database.js";
 
 describe("Health Routes", () => {
   let app: FastifyInstance;
@@ -185,6 +193,48 @@ describe("Health Routes", () => {
       expect(response.statusCode).toBe(200);
       const body = JSON.parse(response.body);
       expect(body.status).toBe("degraded");
+    });
+
+    it("includes pool check in health response", async () => {
+      vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([{ "?column?": 1 }]);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/health",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.checks.pool).toBeDefined();
+      expect(body.checks.pool.status).toBe("ok");
+      expect(body.checks.pool.active).toBe(1);
+      expect(body.checks.pool.idle).toBe(4);
+      expect(body.checks.pool.busy).toBe(1);
+      expect(body.checks.pool.size).toBe(5);
+      expect(body.checks.pool.utilization).toBe(0.2);
+    });
+
+    it("returns degraded status when pool utilization is high", async () => {
+      vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([{ "?column?": 1 }]);
+      vi.mocked(getPoolMetrics).mockReturnValueOnce({
+        active: 5,
+        idle: 0,
+        busy: 5,
+        size: 5,
+        utilization: 1.0,
+        isDegraded: true,
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/health",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.status).toBe("degraded");
+      expect(body.checks.pool.status).toBe("degraded");
+      expect(body.checks.pool.message).toContain("Pool utilization high");
     });
   });
 });

--- a/services/reservations/src/routes/health.ts
+++ b/services/reservations/src/routes/health.ts
@@ -2,7 +2,7 @@ import type { FastifyPluginAsync, RouteHandlerMethod, RawServerDefault } from "f
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { HealthResponse } from "@mbe/types";
 import type { RateLimitMonitor } from "@mbe/observability";
-import { prisma, getSlowQueryStats, getServiceStatus } from "../services/database.js";
+import { prisma, getSlowQueryStats, getServiceStatus, getPoolMetrics } from "../services/database.js";
 import { checkAuth0, checkLatencyAnomaly, recordDbLatency } from "../services/health-checks.js";
 
 type HealthRouteHandler = RouteHandlerMethod<
@@ -137,6 +137,21 @@ const healthHandler: HealthRouteHandler = async (request) => {
     }),
   };
 
+  const poolMetrics = getPoolMetrics();
+  checks.pool = {
+    status: poolMetrics.isDegraded ? "degraded" : "ok",
+    ...(poolMetrics.isDegraded && {
+      message: `Pool utilization high: ${Math.round(poolMetrics.utilization * 100)}% (${poolMetrics.busy}/${poolMetrics.size} busy)`,
+    }),
+    ...{
+      active: poolMetrics.active,
+      idle: poolMetrics.idle,
+      busy: poolMetrics.busy,
+      size: poolMetrics.size,
+      utilization: poolMetrics.utilization,
+    },
+  };
+
   const errorRates = request.server.getErrorRates();
   const degradedEndpoints = errorRates.endpoints.filter((e) => e.rate > 0.1 && e.total >= 5);
   checks.error_rates = {
@@ -147,7 +162,7 @@ const healthHandler: HealthRouteHandler = async (request) => {
     }),
   };
 
-  const hasErrors = dbStatus === "error" || slowQueryStatus === "degraded" || auth0Result.status === "degraded" || rateLimitSnapshot.isDegraded || errorRates.degraded;
+  const hasErrors = dbStatus === "error" || slowQueryStatus === "degraded" || auth0Result.status === "degraded" || rateLimitSnapshot.isDegraded || poolMetrics.isDegraded || errorRates.degraded;
 
   return {
     status: hasErrors ? "degraded" : "ok",

--- a/services/reservations/src/services/database.ts
+++ b/services/reservations/src/services/database.ts
@@ -58,6 +58,31 @@ export function getPoolStats() {
   };
 }
 
+export interface PoolMetrics {
+  active: number;
+  idle: number;
+  busy: number;
+  size: number;
+  utilization: number;
+  isDegraded: boolean;
+}
+
+export function getPoolMetrics(): PoolMetrics {
+  const stats = getPoolStats();
+  const busy = stats.active;
+  const idle = stats.idle;
+  const utilization = CONNECTION_LIMIT > 0 ? busy / CONNECTION_LIMIT : 0;
+
+  return {
+    active: stats.total,
+    idle,
+    busy,
+    size: CONNECTION_LIMIT,
+    utilization,
+    isDegraded: utilization > POOL_UTILIZATION_THRESHOLD,
+  };
+}
+
 export function getServiceStatus(): "ok" | "degraded" {
   const stats = getSlowQueryStats();
   const poolStats = getPoolStats();

--- a/services/users/src/routes/health.test.ts
+++ b/services/users/src/routes/health.test.ts
@@ -9,6 +9,14 @@ vi.mock("../services/database.js", () => ({
   },
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
+  getPoolMetrics: vi.fn().mockReturnValue({
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
+  }),
 }));
 
 // Mock health checks
@@ -59,7 +67,7 @@ vi.mock("@mbe/observability", async (importOriginal) => {
   };
 });
 
-import { prisma } from "../services/database.js";
+import { prisma, getPoolMetrics } from "../services/database.js";
 
 describe("Health Routes", () => {
   let app: FastifyInstance;
@@ -117,6 +125,48 @@ describe("Health Routes", () => {
       expect(response.statusCode).toBe(200);
       const body = JSON.parse(response.body);
       expect(body.status).toBe("degraded");
+    });
+
+    it("includes pool check in health response", async () => {
+      vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([{ "?column?": 1 }]);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/health",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.checks.pool).toBeDefined();
+      expect(body.checks.pool.status).toBe("ok");
+      expect(body.checks.pool.active).toBe(1);
+      expect(body.checks.pool.idle).toBe(4);
+      expect(body.checks.pool.busy).toBe(1);
+      expect(body.checks.pool.size).toBe(5);
+      expect(body.checks.pool.utilization).toBe(0.2);
+    });
+
+    it("returns degraded status when pool utilization is high", async () => {
+      vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([{ "?column?": 1 }]);
+      vi.mocked(getPoolMetrics).mockReturnValueOnce({
+        active: 5,
+        idle: 0,
+        busy: 5,
+        size: 5,
+        utilization: 1.0,
+        isDegraded: true,
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/health",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.status).toBe("degraded");
+      expect(body.checks.pool.status).toBe("degraded");
+      expect(body.checks.pool.message).toContain("Pool utilization high");
     });
   });
 });

--- a/services/users/src/routes/health.ts
+++ b/services/users/src/routes/health.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance, FastifyPluginAsync, RouteHandlerMethod, RawServer
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { HealthResponse } from "@mbe/types";
 import type { RateLimitMonitor } from "@mbe/observability";
-import { prisma, getSlowQueryStats, getServiceStatus } from "../services/database.js";
+import { prisma, getSlowQueryStats, getServiceStatus, getPoolMetrics } from "../services/database.js";
 import { checkAuth0, checkLatencyAnomaly, recordDbLatency } from "../services/health-checks.js";
 
 type HealthRouteHandler = RouteHandlerMethod<
@@ -151,10 +151,25 @@ export const healthRoutes: FastifyPluginAsync = async (fastify: FastifyInstance)
       }),
     };
 
+    const poolMetrics = getPoolMetrics();
+    checks.pool = {
+      status: poolMetrics.isDegraded ? "degraded" : "ok",
+      ...(poolMetrics.isDegraded && {
+        message: `Pool utilization high: ${Math.round(poolMetrics.utilization * 100)}% (${poolMetrics.busy}/${poolMetrics.size} busy)`,
+      }),
+      ...{
+        active: poolMetrics.active,
+        idle: poolMetrics.idle,
+        busy: poolMetrics.busy,
+        size: poolMetrics.size,
+        utilization: poolMetrics.utilization,
+      },
+    };
+
     const errorRates = fastify.getErrorRates();
     const degradedEndpoints = errorRates.endpoints.filter((e) => e.rate > 0.1 && e.total >= 5);
 
-    const hasErrors = dbStatus === "error" || slowQueryStatus === "degraded" || auth0Result.status === "degraded" || rateLimitSnapshot.isDegraded || errorRates.degraded;
+    const hasErrors = dbStatus === "error" || slowQueryStatus === "degraded" || auth0Result.status === "degraded" || rateLimitSnapshot.isDegraded || poolMetrics.isDegraded || errorRates.degraded;
 
     return {
       status: hasErrors ? "degraded" : "ok",

--- a/services/users/src/routes/ready.test.ts
+++ b/services/users/src/routes/ready.test.ts
@@ -13,6 +13,14 @@ vi.mock("../services/database.js", () => ({
   },
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
+  getPoolMetrics: vi.fn().mockReturnValue({
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
+  }),
 }));
 
 vi.mock("../services/health-checks.js", () => ({

--- a/services/users/src/services/database.ts
+++ b/services/users/src/services/database.ts
@@ -60,6 +60,31 @@ export function getPoolStats() {
   };
 }
 
+export interface PoolMetrics {
+  active: number;
+  idle: number;
+  busy: number;
+  size: number;
+  utilization: number;
+  isDegraded: boolean;
+}
+
+export function getPoolMetrics(): PoolMetrics {
+  const stats = getPoolStats();
+  const busy = stats.active;
+  const idle = stats.idle;
+  const utilization = CONNECTION_LIMIT > 0 ? busy / CONNECTION_LIMIT : 0;
+
+  return {
+    active: stats.total,
+    idle,
+    busy,
+    size: CONNECTION_LIMIT,
+    utilization,
+    isDegraded: utilization > POOL_UTILIZATION_THRESHOLD,
+  };
+}
+
 export function getServiceStatus(): "ok" | "degraded" {
   const stats = getSlowQueryStats();
   const poolStats = getPoolStats();


### PR DESCRIPTION
## Summary

Closes #246

- Adds `getPoolMetrics()` to all 3 services' `database.ts` — reads `pg.Pool` internal counters (`totalCount`, `idleCount`, `waitingCount`) directly since services use `@prisma/adapter-pg`
- Adds `pool` check to health route responses alongside existing `database`, `slow_queries`, `auth0`, and `rate_limits` checks
- Service reports `degraded` when pool utilization exceeds 80% threshold
- Pool stats (active, idle, busy, size, utilization) visible in health response

## Acceptance Criteria

- [x] Pool metrics exposed in health check response
- [x] Service reports `degraded` when pool > 80%
- [x] Pool stats visible in `/health` response
- [x] Works for all 3 services (users, reservations, agent)

## Test plan

- [x] Users service: typecheck passes, all 47 tests pass (includes 2 new pool monitoring tests)
- [x] Agent service: 5/5 health tests pass (other failures are pre-existing `@mbe/agent-core` dist issue)
- [x] Reservations service: health tests pass (other failures are pre-existing `@mbe/feature-flags` dist issue)
- [x] Pre-commit hooks pass (eslint, check-adr, pack-changed)
- [ ] Verify pool stats appear in deployed health endpoint response