### PR TITLE
feat(acmm): add behavioral gates to computeLevel()

### DIFF
--- a/plugins/acmm/scripts/__tests__/computeLevel.test.js
+++ b/plugins/acmm/scripts/__tests__/computeLevel.test.js
@@ -1,7 +1,7 @@
-import { test } from "node:test";
+import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 
-import { computeLevel } from "../computeLevel.js";
+import { computeLevel, BEHAVIORAL_GATES } from "../computeLevel.js";
 import { ALL_CRITERIA, SOURCES } from "../sources/index.js";
 
 test("computeLevel: empty detection set → L1 (Assisted)", () => {
@@ -69,4 +69,185 @@ test("ALL_CRITERIA: every criterion has detection.type and pattern", () => {
     assert.ok(["path", "any-of", "glob"].includes(c.detection.type), `${c.id} has invalid detection type`);
     assert.ok(c.detection.pattern, `${c.id} missing detection pattern`);
   }
+});
+
+/* ── Behavioral gates ───────────────────────────────────── */
+
+// Helper: IDs that satisfy L2 + L3 (need 70% of L3's 4 items = 3)
+const L2_IDS = ["acmm:claude-md"];
+const L3_IDS = ["acmm:ci-matrix", "acmm:pr-acceptance-metric", "acmm:pr-review-rubric"];
+// L4 has 14 items; 70% = 10
+const L4_IDS = [
+  "acmm:auto-qa-tuning", "acmm:nightly-compliance", "acmm:copilot-review-apply",
+  "acmm:auto-label", "acmm:ai-fix-workflow", "acmm:tier-classifier",
+  "acmm:security-ai-md", "acmm:mcp-server-config", "acmm:code-graph",
+  "acmm:onboarding-benchmark",
+];
+// L5 has 16 items; 70% = 12
+const L5_IDS = [
+  "acmm:github-actions-ai", "acmm:auto-qa-self-tuning", "acmm:public-metrics",
+  "acmm:policy-as-code", "acmm:reflection-log", "acmm:audit-trail",
+  "acmm:self-correction-metric", "acmm:state-backup", "acmm:ai-health-dashboard",
+  "acmm:prompt-injection-sandbox", "acmm:agent-attestation", "acmm:ai-service-fallback",
+];
+// L6 has 8 items; 70% = 6
+const L6_IDS = [
+  "acmm:auto-issue-gen", "acmm:multi-agent-orchestration", "acmm:merge-queue",
+  "acmm:strategic-dashboard", "acmm:risk-assessment-config", "acmm:observability-runbook",
+];
+
+/** Builds a Set of all IDs up to and including the given level */
+function idsThrough(level) {
+  const all = [...L2_IDS];
+  if (level >= 3) all.push(...L3_IDS);
+  if (level >= 4) all.push(...L4_IDS);
+  if (level >= 5) all.push(...L5_IDS);
+  if (level >= 6) all.push(...L6_IDS);
+  return new Set(all);
+}
+
+describe("computeLevel with behavioral gates", () => {
+  test("backward compatible: no behavioral param returns behavioralGates array", () => {
+    const result = computeLevel(new Set(L2_IDS));
+    assert.ok(Array.isArray(result.behavioralGates), "behavioralGates should be an array");
+    assert.equal(result.behavioralGates.length, BEHAVIORAL_GATES.length);
+    assert.equal(result.level, 2);
+  });
+
+  test("backward compatible: empty behavioral param does not block advancement", () => {
+    const ids = idsThrough(3);
+    const result = computeLevel(ids, {});
+    assert.equal(result.level, 3, "should reach L3 with no behavioral data");
+    // Gates with no data should all pass
+    for (const g of result.behavioralGates) {
+      assert.equal(g.passed, true, `gate ${g.name} should pass when no data`);
+      assert.equal(g.dataAvailable, false, `gate ${g.name} should report no data`);
+    }
+  });
+
+  test("L3 blocked by high flake rate in strict mode", () => {
+    const ids = idsThrough(3);
+    const behavioral = { flake: { rate_30d: 0.25 } }; // 25% > 20% threshold
+    const result = computeLevel(ids, behavioral, { strict: true });
+    assert.equal(result.level, 2, "L3 should be blocked by high flake rate in strict mode");
+
+    const flakeGate = result.behavioralGates.find((g) => g.name === "ci-flake-rate");
+    assert.equal(flakeGate.passed, false);
+    assert.equal(flakeGate.value, 0.25);
+    assert.equal(flakeGate.strict, true);
+    assert.equal(flakeGate.dataAvailable, true);
+  });
+
+  test("L3 warning but not blocked by high flake rate in soft mode", () => {
+    const ids = idsThrough(3);
+    const behavioral = { flake: { rate_30d: 0.25 } }; // 25% > 20% threshold
+    const result = computeLevel(ids, behavioral, { strict: false });
+    assert.equal(result.level, 3, "L3 should NOT be blocked in soft mode");
+
+    const flakeGate = result.behavioralGates.find((g) => g.name === "ci-flake-rate");
+    assert.equal(flakeGate.passed, false, "gate should report failure");
+    assert.equal(flakeGate.strict, false);
+  });
+
+  test("L3 passes when flake rate is below threshold", () => {
+    const ids = idsThrough(3);
+    const behavioral = { flake: { rate_30d: 0.10 } }; // 10% < 20%
+    const result = computeLevel(ids, behavioral, { strict: true });
+    assert.equal(result.level, 3, "L3 should pass when flake rate is low");
+
+    const flakeGate = result.behavioralGates.find((g) => g.name === "ci-flake-rate");
+    assert.equal(flakeGate.passed, true);
+  });
+
+  test("L4 blocked by low PR acceptance rate in strict mode", () => {
+    const ids = idsThrough(4);
+    const behavioral = {
+      flake: { rate_30d: 0.05 },       // L3 gate passes
+      agent_pr: { acceptance_rate_30d: 0.40 }, // 40% < 50% threshold
+    };
+    const result = computeLevel(ids, behavioral, { strict: true });
+    assert.equal(result.level, 3, "L4 should be blocked by low PR acceptance");
+
+    const prGate = result.behavioralGates.find((g) => g.name === "agent-pr-acceptance");
+    assert.equal(prGate.passed, false);
+    assert.equal(prGate.value, 0.40);
+  });
+
+  test("L5 blocked by insufficient auto-qa history in strict mode", () => {
+    const ids = idsThrough(5);
+    const behavioral = {
+      flake: { rate_30d: 0.05 },
+      agent_pr: { acceptance_rate_30d: 0.80 },
+      auto_qa_history_count: 1, // must be > 1
+    };
+    const result = computeLevel(ids, behavioral, { strict: true });
+    assert.equal(result.level, 4, "L5 should be blocked by auto_qa_history_count <= 1");
+
+    const qaGate = result.behavioralGates.find((g) => g.name === "auto-qa-tuning-history");
+    assert.equal(qaGate.passed, false);
+    assert.equal(qaGate.value, 1);
+  });
+
+  test("L6 blocked by high revert rate in strict mode", () => {
+    const ids = idsThrough(6);
+    const behavioral = {
+      flake: { rate_30d: 0.05 },
+      agent_pr: { acceptance_rate_30d: 0.80, revert_rate_30d: 0.15 }, // 15% > 10%
+      auto_qa_history_count: 3,
+    };
+    const result = computeLevel(ids, behavioral, { strict: true });
+    assert.equal(result.level, 5, "L6 should be blocked by high revert rate");
+
+    const revertGate = result.behavioralGates.find((g) => g.name === "agent-pr-revert-rate");
+    assert.equal(revertGate.passed, false);
+    assert.equal(revertGate.value, 0.15);
+  });
+
+  test("all gates pass: full advancement to L6", () => {
+    const ids = idsThrough(6);
+    const behavioral = {
+      flake: { rate_30d: 0.05 },
+      agent_pr: { acceptance_rate_30d: 0.80, revert_rate_30d: 0.02 },
+      auto_qa_history_count: 5,
+    };
+    const result = computeLevel(ids, behavioral, { strict: true });
+    assert.equal(result.level, 6, "should reach L6 when all gates pass");
+
+    for (const g of result.behavioralGates) {
+      assert.equal(g.passed, true, `gate ${g.name} should pass`);
+    }
+  });
+
+  test("gate results include expected fields", () => {
+    const ids = idsThrough(3);
+    const behavioral = { flake: { rate_30d: 0.25 } };
+    const result = computeLevel(ids, behavioral, { strict: true });
+
+    const gate = result.behavioralGates[0];
+    assert.ok("level" in gate, "gate should have level");
+    assert.ok("name" in gate, "gate should have name");
+    assert.ok("passed" in gate, "gate should have passed");
+    assert.ok("value" in gate, "gate should have value");
+    assert.ok("threshold" in gate, "gate should have threshold");
+    assert.ok("strict" in gate, "gate should have strict");
+    assert.ok("direction" in gate, "gate should have direction");
+    assert.ok("dataAvailable" in gate, "gate should have dataAvailable");
+    assert.ok("description" in gate, "gate should have description");
+  });
+
+  test("soft mode: multiple failing gates produce warnings but allow advancement", () => {
+    const ids = idsThrough(4);
+    const behavioral = {
+      flake: { rate_30d: 0.25 },                // L3 gate fails
+      agent_pr: { acceptance_rate_30d: 0.30 },   // L4 gate fails
+    };
+    const result = computeLevel(ids, behavioral, { strict: false });
+    assert.equal(result.level, 4, "should still reach L4 in soft mode");
+
+    const failedGates = result.behavioralGates.filter((g) => !g.passed);
+    assert.equal(failedGates.length, 2, "two gates should fail");
+    for (const g of failedGates) {
+      assert.equal(g.strict, false, "failed gates should be marked as soft");
+    }
+  });
 });

--- a/plugins/acmm/scripts/audit.js
+++ b/plugins/acmm/scripts/audit.js
@@ -33,6 +33,7 @@ const args = new Set(process.argv.slice(2));
 const APPLY = args.has("--apply");
 const BADGE = args.has("--badge");
 const TREND = args.has("--trend");
+const STRICT = args.has("--strict");
 
 // --project <path> support
 let projectPath = process.cwd();
@@ -127,7 +128,45 @@ for (const c of ALL_CRITERIA) {
   if (passed) detectedIds.add(c.id);
 }
 
-const computation = computeLevel(detectedIds);
+/* ── Behavioral signals (non-fatal — null when tools unavailable) ── */
+const flake = measureFlakeRate();
+const prOutcomes = measurePrOutcomes();
+const evalsSummary = measureEvals(cwd);
+const behavioral = {
+  ...(prior.behavioral ?? {}),
+  flake: flake
+    ? {
+        rate_30d: flake.flake_rate_30d,
+        sample_size: flake.flake_sample_size,
+        flaky_shas: flake.flaky_shas,
+        measured_at: new Date().toISOString(),
+      }
+    : (prior.behavioral?.flake ?? null),
+  agent_pr: prOutcomes
+    ? { ...prOutcomes, measured_at: new Date().toISOString() }
+    : (prior.behavioral?.agent_pr ?? null),
+  evals: evalsSummary.n > 0
+    ? { ...evalsSummary, measured_at: new Date().toISOString() }
+    : (prior.behavioral?.evals ?? null),
+};
+
+// Read auto-qa tuning history length for L5 behavioral gate
+let autoQaHistoryCount = 0;
+try {
+  const tuningPath = path.join(repoRoot, ".github", "auto-qa-tuning.json");
+  if (fs.existsSync(tuningPath)) {
+    const tuning = JSON.parse(fs.readFileSync(tuningPath, "utf-8"));
+    autoQaHistoryCount = Array.isArray(tuning.history) ? tuning.history.length : 0;
+  }
+} catch {
+  // Non-fatal — gate will see 0 and pass (no data = no block)
+}
+
+const computation = computeLevel(detectedIds, {
+  flake: behavioral.flake,
+  agent_pr: behavioral.agent_pr,
+  auto_qa_history_count: autoQaHistoryCount,
+}, { strict: STRICT });
 const detectedCount = detectedIds.size;
 const totalCount = ALL_CRITERIA.length;
 
@@ -155,28 +194,6 @@ for (const c of ALL_CRITERIA) {
     evidence: passed ? `detected at one of: ${patterns.join(", ")}` : `none of: ${patterns.join(", ")}`,
   };
 }
-
-/* ── Behavioral signals (non-fatal — null when tools unavailable) ── */
-const flake = measureFlakeRate();
-const prOutcomes = measurePrOutcomes();
-const evalsSummary = measureEvals(cwd);
-const behavioral = {
-  ...(prior.behavioral ?? {}),
-  flake: flake
-    ? {
-        rate_30d: flake.flake_rate_30d,
-        sample_size: flake.flake_sample_size,
-        flaky_shas: flake.flaky_shas,
-        measured_at: new Date().toISOString(),
-      }
-    : (prior.behavioral?.flake ?? null),
-  agent_pr: prOutcomes
-    ? { ...prOutcomes, measured_at: new Date().toISOString() }
-    : (prior.behavioral?.agent_pr ?? null),
-  evals: evalsSummary.n > 0
-    ? { ...evalsSummary, measured_at: new Date().toISOString() }
-    : (prior.behavioral?.evals ?? null),
-};
 
 const nextState = recordHistory(
   {
@@ -254,6 +271,22 @@ console.log("");
 console.log(`Prerequisites (soft): ${computation.prerequisites.met}/${computation.prerequisites.total}`);
 console.log(`Cross-cutting learning: ${computation.crossCutting.learning.met}/${computation.crossCutting.learning.total}`);
 console.log(`Cross-cutting traceability: ${computation.crossCutting.traceability.met}/${computation.crossCutting.traceability.total}`);
+
+if (computation.behavioralGates.length > 0) {
+  console.log("");
+  console.log(`Behavioral gates (${STRICT ? "strict" : "soft"}):`);
+  for (const g of computation.behavioralGates) {
+    const icon = g.passed ? "✓" : STRICT ? "✗" : "⚠";
+    const val = g.dataAvailable
+      ? g.direction === "below"
+        ? `${(g.value * 100).toFixed(1)}% < ${(g.threshold * 100).toFixed(0)}%`
+        : typeof g.value === "number" && g.threshold < 1
+          ? `${(g.value * 100).toFixed(1)}% > ${(g.threshold * 100).toFixed(0)}%`
+          : `${g.value} > ${g.threshold}`
+      : "no data";
+    console.log(`  ${icon} L${g.level} ${g.name}: ${val}${!g.passed && !STRICT ? " (warning)" : ""}`);
+  }
+}
 
 if (behavioral.flake) {
   const pct = (behavioral.flake.rate_30d * 100).toFixed(1);

--- a/plugins/acmm/scripts/computeLevel.js
+++ b/plugins/acmm/scripts/computeLevel.js
@@ -8,6 +8,72 @@ const LEVEL_COMPLETION_THRESHOLD = 0.7
 /** Level 0 = prerequisites (soft indicator, not gating) */
 const PREREQUISITE_LEVEL = 0
 
+/**
+ * Behavioral gates — each ties a runtime signal to a level advancement check.
+ * When `strict` is true, a failing gate blocks level advancement (hard gate).
+ * When `strict` is false (default), a failing gate emits a warning but allows advancement (soft gate).
+ */
+const BEHAVIORAL_GATES = [
+  {
+    level: 3,
+    name: 'ci-flake-rate',
+    description: 'CI flake rate must be below 20%',
+    threshold: 0.20,
+    direction: 'below', // value must be below threshold to pass
+    extract: (b) => b?.flake?.rate_30d,
+  },
+  {
+    level: 4,
+    name: 'agent-pr-acceptance',
+    description: 'Agent PR acceptance rate must exceed 50%',
+    threshold: 0.50,
+    direction: 'above', // value must be above threshold to pass
+    extract: (b) => b?.agent_pr?.acceptance_rate_30d,
+  },
+  {
+    level: 5,
+    name: 'auto-qa-tuning-history',
+    description: 'Auto-QA tuning history must have more than 1 entry',
+    threshold: 1,
+    direction: 'above', // value must be above threshold to pass
+    extract: (b) => b?.auto_qa_history_count,
+  },
+  {
+    level: 6,
+    name: 'agent-pr-revert-rate',
+    description: 'Agent PR revert rate must be below 10%',
+    threshold: 0.10,
+    direction: 'below', // value must be below threshold to pass
+    extract: (b) => b?.agent_pr?.revert_rate_30d,
+  },
+]
+
+/**
+ * Evaluate a single behavioral gate against the provided behavioral data.
+ * Returns a gate result object with pass/fail status and metadata.
+ */
+function evaluateGate(gate, behavioral, strict) {
+  const value = gate.extract(behavioral)
+  const hasValue = value !== undefined && value !== null
+  // Gates with no data are treated as passed (data unavailable = no block)
+  const passed = !hasValue
+    ? true
+    : gate.direction === 'below'
+      ? value < gate.threshold
+      : value > gate.threshold
+  return {
+    level: gate.level,
+    name: gate.name,
+    description: gate.description,
+    passed,
+    value: hasValue ? value : null,
+    threshold: gate.threshold,
+    direction: gate.direction,
+    strict,
+    dataAvailable: hasValue,
+  }
+}
+
 /** Virtual criterion representing the OR group above (not in acmm.ts source). */
 const VIRTUAL_AGENT_INSTRUCTIONS= {
   id: 'acmm:agent-instructions',
@@ -60,7 +126,9 @@ function levelDef(n) {
   return ACMM_LEVELS.find((l) => l.n === n)
 }
 
-export function computeLevel(rawDetectedIds){
+export function computeLevel(rawDetectedIds, behavioral = {}, options = {}){
+  const strict = options.strict ?? false
+
   // Synthesise the virtual L2 OR-group criterion before the level walk.
   const detectedIds = new Set(rawDetectedIds)
   if ([...AGENT_INSTRUCTION_FILE_IDS].some((id) => detectedIds.has(id))) {
@@ -77,6 +145,16 @@ export function computeLevel(rawDetectedIds){
     detectedByLevel[n] = required.filter((c) => detectedIds.has(c.id)).length
   }
 
+  // Evaluate all behavioral gates up front
+  const behavioralGates = BEHAVIORAL_GATES.map((gate) =>
+    evaluateGate(gate, behavioral, strict),
+  )
+  // Index gate results by level for quick lookup
+  const gateByLevel = {}
+  for (const g of behavioralGates) {
+    gateByLevel[g.level] = g
+  }
+
   let currentLevel = MIN_LEVEL
   for (let n = MIN_LEVEL + 1; n <= MAX_LEVEL; n++) {
     const required = requiredByLevel[n]
@@ -86,6 +164,13 @@ export function computeLevel(rawDetectedIds){
     const threshold = n === 2 ? 1 / required : LEVEL_COMPLETION_THRESHOLD
     const ratio = detected / required
     if (ratio >= threshold) {
+      // Check behavioral gate for this level (if one exists)
+      const gate = gateByLevel[n]
+      if (gate && !gate.passed && strict) {
+        // Hard gate: block advancement
+        break
+      }
+      // Soft gate failure or no gate: advance
       currentLevel = n
     } else {
       break
@@ -136,6 +221,7 @@ export function computeLevel(rawDetectedIds){
         total: traceabilityCriteria.length,
       },
     },
+    behavioralGates,
   }
 }
 
@@ -153,4 +239,4 @@ export function getCriteriaByLevel() {
   return byLevel
 }
 
-export { LEVEL_COMPLETION_THRESHOLD, MIN_LEVEL, MAX_LEVEL, PREREQUISITE_LEVEL }
+export { BEHAVIORAL_GATES, LEVEL_COMPLETION_THRESHOLD, MIN_LEVEL, MAX_LEVEL, PREREQUISITE_LEVEL }


### PR DESCRIPTION
## Summary

Closes #990

- Add behavioral gates to `computeLevel()` that validate runtime signals (CI flake rate, PR acceptance rate, auto-QA tuning history, revert rate) at L3-L6
- Gates are soft by default (warnings in report) with `--strict` flag to make them hard (block level advancement)
- `audit.js` now passes collected behavioral data and auto-QA tuning history into level computation
- Return value includes `behavioralGates` array with pass/fail status, values, and thresholds for each gate

### Gate definitions

| Level | Gate | Threshold | Direction |
|-------|------|-----------|-----------|
| L3 | CI flake rate | < 20% | below |
| L4 | Agent PR acceptance | > 50% | above |
| L5 | Auto-QA tuning history | > 1 entry | above |
| L6 | Agent PR revert rate | < 10% | below |

## Test plan

- [x] All 6 existing tests pass unchanged (backward compatibility)
- [x] 11 new tests covering: strict mode blocking at each level, soft mode warnings, backward compat with no behavioral param, all-gates-pass full advancement, gate result field validation, multiple failing gates in soft mode
- [x] `node --test plugins/acmm/scripts/__tests__/computeLevel.test.js` passes 17/17