### PR TITLE
feat(acmm): add 'active' detection type for workflow verification

### DIFF
--- a/plugins/acmm/scripts/__tests__/detection.test.js
+++ b/plugins/acmm/scripts/__tests__/detection.test.js
@@ -1,10 +1,10 @@
-import { test } from "node:test";
+import { test, mock } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { detect, detectAll } from "../detection.js";
+import { detect, detectAll, isWorkflowActive } from "../detection.js";
 
 function fixture() {
   const root = mkdtempSync(join(tmpdir(), "acmm-detect-"));
@@ -124,7 +124,7 @@ test("detect: code-graph — no code intelligence files present", () => {
   fx.cleanup();
 });
 
-test("detectAll: returns set of detected ids only", () => {
+test("detectAll: returns detected set and meta map", () => {
   const fx = fixture();
   fx.file("README.md");
   fx.file("AGENTS.md");
@@ -134,6 +134,82 @@ test("detectAll: returns set of detected ids only", () => {
     { id: "c", detection: { type: "any-of", pattern: ["AGENTS.md", "x.md"] } },
   ];
   const result = detectAll(fx.root, criteria);
-  assert.deepEqual([...result].sort(), ["a", "c"]);
+  assert.deepEqual([...result.detected].sort(), ["a", "c"]);
+  // non-active criteria produce no meta entries
+  assert.equal(result.meta.size, 0);
+  fx.cleanup();
+});
+
+// ── active detection type tests ────────────────────────────
+
+test("isWorkflowActive: returns degraded when gh CLI is unavailable", () => {
+  // Use a temp dir that's not a git repo — gh will fail
+  const fx = fixture();
+  const result = isWorkflowActive(fx.root, "nonexistent.yml", 7);
+  assert.equal(result.active, null);
+  assert.equal(result.degraded, true);
+  assert.ok(result.reason.includes("gh CLI unavailable"));
+  fx.cleanup();
+});
+
+test("detect: active type — file missing → false", () => {
+  const fx = fixture();
+  const c = {
+    id: "x",
+    detection: { type: "active", pattern: "workflow.yml", maxAgeDays: 7 },
+  };
+  assert.equal(detect(fx.root, c), false);
+  fx.cleanup();
+});
+
+test("detect: active type — file exists, gh unavailable → true (degraded)", () => {
+  // In a temp dir that's not a git repo, gh will fail → graceful degradation
+  const fx = fixture();
+  fx.file("workflow.yml", "name: test");
+  const c = {
+    id: "x",
+    detection: { type: "active", pattern: "workflow.yml", maxAgeDays: 7 },
+  };
+  // gh will error in temp dir (not a repo) → degraded → returns true
+  assert.equal(detect(fx.root, c), true);
+  fx.cleanup();
+});
+
+test("detect: active type — gh unavailable, file missing → false", () => {
+  const fx = fixture();
+  const c = {
+    id: "x",
+    detection: { type: "active", pattern: "does-not-exist.yml", maxAgeDays: 7 },
+  };
+  assert.equal(detect(fx.root, c), false);
+  fx.cleanup();
+});
+
+test("detect: active type — array pattern, first file missing second exists, gh degraded → true", () => {
+  const fx = fixture();
+  fx.file("b.yml", "name: b");
+  const c = {
+    id: "x",
+    detection: { type: "active", pattern: ["a.yml", "b.yml"], maxAgeDays: 7 },
+  };
+  // b.yml exists, gh will degrade → true
+  assert.equal(detect(fx.root, c), true);
+  fx.cleanup();
+});
+
+test("detectAll: active type — meta includes degraded status", () => {
+  const fx = fixture();
+  fx.file("workflow.yml", "name: test");
+  const criteria = [
+    { id: "active-one", detection: { type: "active", pattern: "workflow.yml", maxAgeDays: 7 } },
+    { id: "active-missing", detection: { type: "active", pattern: "missing.yml", maxAgeDays: 7 } },
+  ];
+  const result = detectAll(fx.root, criteria);
+  // workflow.yml exists, gh fails → degraded → detected
+  assert.ok(result.detected.has("active-one"));
+  assert.ok(!result.detected.has("active-missing"));
+  // meta should have entries for both active criteria
+  assert.equal(result.meta.get("active-one").status, "degraded");
+  assert.equal(result.meta.get("active-missing").status, "missing");
   fx.cleanup();
 });

--- a/plugins/acmm/scripts/detection.js
+++ b/plugins/acmm/scripts/detection.js
@@ -8,9 +8,11 @@
  * Detection types in the canonical sources (as of port date):
  *   - `path`   — single file or directory path; trailing `/` matches a dir
  *   - `any-of` — array of paths; ANY one existing satisfies the criterion
+ *   - `active` — file exists AND workflow ran recently (via `gh run list`)
  *   - `glob`   — reserved; not used in current canonical data
  */
 
+import { execFileSync } from 'node:child_process';
 import { existsSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -30,10 +32,42 @@ function existsAt(cwd, pattern) {
 }
 
 /**
+ * Check whether a GitHub Actions workflow has run successfully within a
+ * time window, using the `gh` CLI.
+ *
+ * @param {string} cwd        — repo root
+ * @param {string} workflowFile — workflow filename (e.g. 'auto-issue.yml')
+ * @param {number} maxAgeDays  — max age in days for the most recent run
+ * @returns {{ active: boolean | null, degraded?: boolean, conclusion?: string, reason: string }}
+ */
+export function isWorkflowActive(cwd, workflowFile, maxAgeDays) {
+  try {
+    const result = execFileSync(
+      'gh',
+      ['run', 'list', `--workflow=${workflowFile}`, '--status=completed', '--limit=1', '--json', 'conclusion,updatedAt'],
+      { cwd, encoding: 'utf-8', timeout: 10_000, stdio: ['pipe', 'pipe', 'pipe'] },
+    );
+    const runs = JSON.parse(result);
+    if (runs.length === 0) {
+      return { active: false, reason: 'no completed runs' };
+    }
+    const lastRun = new Date(runs[0].updatedAt);
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - maxAgeDays);
+    if (lastRun < cutoff) {
+      return { active: false, reason: `last run ${runs[0].updatedAt} exceeds ${maxAgeDays}d window` };
+    }
+    return { active: true, conclusion: runs[0].conclusion, reason: 'recent run found' };
+  } catch {
+    return { active: null, degraded: true, reason: 'gh CLI unavailable or error' };
+  }
+}
+
+/**
  * Run detection for a single criterion.
  *
  * @param {string} cwd
- * @param {{ detection: { type: 'path' | 'glob' | 'any-of', pattern: string | string[] }}} criterion
+ * @param {{ detection: { type: 'path' | 'glob' | 'any-of' | 'active', pattern: string | string[], maxAgeDays?: number }}} criterion
  * @returns {boolean}
  */
 export function detect(cwd, criterion) {
@@ -46,6 +80,17 @@ export function detect(cwd, criterion) {
     const patterns = Array.isArray(pattern) ? pattern : [pattern];
     return patterns.some((p) => existsAt(cwd, p));
   }
+  if (type === 'active') {
+    const { maxAgeDays = 7 } = criterion.detection;
+    const patterns = Array.isArray(pattern) ? pattern : [pattern];
+    const filePresent = patterns.some((p) => existsAt(cwd, p));
+    if (!filePresent) return false;
+    // Check first matching file for workflow activity
+    const workflowFile = patterns.find((p) => existsAt(cwd, p));
+    const result = isWorkflowActive(cwd, workflowFile, maxAgeDays);
+    if (result.degraded) return true; // graceful degradation: file exists, gh unavailable
+    return result.active;
+  }
   if (type === 'glob') {
     throw new Error(`detection.type='glob' is not implemented (no canonical criterion uses it).`);
   }
@@ -55,14 +100,41 @@ export function detect(cwd, criterion) {
 /**
  * Run detection for all criteria.
  *
+ * Returns both a Set of detected IDs (backward-compatible) and a Map
+ * with per-criterion metadata for `active` detections, distinguishing
+ * "file exists and operating" from "file exists but inactive" and
+ * "file exists, gh degraded".
+ *
  * @param {string} cwd
  * @param {Array<{ id: string, detection: any }>} criteria
- * @returns {Set<string>} set of detected criterion IDs
+ * @returns {{ detected: Set<string>, meta: Map<string, { status: 'active' | 'inactive' | 'degraded' | 'missing', reason?: string }> }}
  */
 export function detectAll(cwd, criteria) {
   const detected = new Set();
+  const meta = new Map();
   for (const c of criteria) {
-    if (detect(cwd, c)) detected.add(c.id);
+    if (c.detection.type === 'active') {
+      const { maxAgeDays = 7 } = c.detection;
+      const patterns = Array.isArray(c.detection.pattern) ? c.detection.pattern : [c.detection.pattern];
+      const filePresent = patterns.some((p) => existsAt(cwd, p));
+      if (!filePresent) {
+        meta.set(c.id, { status: 'missing', reason: 'file not found' });
+        continue;
+      }
+      const workflowFile = patterns.find((p) => existsAt(cwd, p));
+      const result = isWorkflowActive(cwd, workflowFile, maxAgeDays);
+      if (result.degraded) {
+        detected.add(c.id);
+        meta.set(c.id, { status: 'degraded', reason: result.reason });
+      } else if (result.active) {
+        detected.add(c.id);
+        meta.set(c.id, { status: 'active', reason: result.reason });
+      } else {
+        meta.set(c.id, { status: 'inactive', reason: result.reason });
+      }
+    } else {
+      if (detect(cwd, c)) detected.add(c.id);
+    }
   }
-  return detected;
+  return { detected, meta };
 }

--- a/plugins/acmm/scripts/sources/acmm.js
+++ b/plugins/acmm/scripts/sources/acmm.js
@@ -916,7 +916,7 @@ const CRITERIA= [
     description: 'Workflow or cron that generates work items for the AI to pick up — the system identifies its own problems and creates tasks.',
     rationale: 'L6 self-direction: the codebase proposes its own next task.',
     details: 'Automated issue generation is a cron-triggered workflow that scans the codebase for TODOs, stale dependencies, failing tests, or coverage gaps and files GitHub issues for each finding. The codebase identifies its own work rather than waiting for humans to notice problems. An AI mission will add a workflow that scans for common improvement opportunities and creates prioritized issues automatically.',
-    detection: { type: 'any-of', pattern: ['.github/workflows/auto-issue.yml', '.github/workflows/issue-gen.yml', '.github/workflows/auto-generate-issues.yml'] },
+    detection: { type: 'active', pattern: ['.github/workflows/auto-issue.yml', '.github/workflows/issue-gen.yml', '.github/workflows/auto-generate-issues.yml'], maxAgeDays: 7 },
   },
   {
     id: 'acmm:multi-agent-orchestration',
@@ -972,7 +972,7 @@ const CRITERIA= [
     rationale: 'Closes the gap between deployment and development.',
     scannable: false,
     details: 'Error rates from production monitoring creating GitHub issues tagged production-regression, which trigger RCA workflows.',
-    detection: { type: 'any-of', pattern: ['.github/workflows/production-feedback.yml'] },
+    detection: { type: 'active', pattern: ['.github/workflows/production-feedback.yml'], maxAgeDays: 30 },
   },
   {
     id: 'acmm:observability-runbook',
@@ -1040,7 +1040,7 @@ const CRITERIA= [
     description: 'Automated detection and revert of regressions caused by AI-authored changes.',
     rationale: 'L6 signal: the system not only acts but also undoes mistakes without human initiation.',
     details: 'Auto-rollback completes the autonomous loop: the system detects regressions from its own PRs (via post-deploy checks) and creates revert PRs automatically. Without this, L6 autonomy is one-directional — the system can break things but not fix them.',
-    detection: { type: 'any-of', pattern: ['.github/workflows/auto-rollback.yml', 'docs/acmm/auto-rollback.md'] },
+    detection: { type: 'active', pattern: ['.github/workflows/auto-rollback.yml', 'docs/acmm/auto-rollback.md'], maxAgeDays: 365 },
   },
   {
     id: 'acmm:multi-repo-orchestration',


### PR DESCRIPTION
## Summary

Closes #992

- Add `active` detection type to the ACMM detection engine that verifies workflows have actually run recently via `gh run list`, not just that the workflow file exists
- `isWorkflowActive()` queries GitHub for the most recent completed run and checks against a configurable `maxAgeDays` window
- Graceful degradation: when `gh` CLI is unavailable or errors, falls back to file-presence only (with `degraded: true` metadata)
- `detectAll()` now returns `{ detected, meta }` with per-criterion status (`active` / `inactive` / `degraded` / `missing`)
- Updated 3 L6 criteria in `acmm.js` to use `active` detection:
  - `acmm:auto-issue-gen` — workflow ran in last 7 days
  - `acmm:auto-rollback` — workflow has triggered at least once (maxAgeDays: 365)
  - `acmm:production-feedback` — workflow ran in last 30 days

## Test plan

- [x] 17/17 tests pass (`node --test plugins/acmm/scripts/__tests__/detection.test.js`)
- [x] `isWorkflowActive` returns degraded when gh CLI unavailable
- [x] `detect` active type: file missing returns false
- [x] `detect` active type: file exists + gh unavailable returns true (degraded)
- [x] `detect` active type: gh unavailable + file missing returns false
- [x] `detect` active type: array pattern with partial match + degraded
- [x] `detectAll` active type: meta map correctly populated
- [x] Existing tests still pass (backward compat for path/any-of types)