### PR TITLE
feat(acmm): add per-issue retry tracking with agent-skip label

### DIFF
--- a/.claude/skills/issue-worker/SKILL.md
+++ b/.claude/skills/issue-worker/SKILL.md
@@ -13,10 +13,12 @@ Autonomous issue resolver. Picks up one ready issue, delegates implementation to
 ### Step 1: Find an Issue
 
 ```bash
-gh issue list --label "ready" --state open --limit 1 --sort created --json number,title,body,labels
+gh issue list --label "ready" --state open --limit 5 --sort created --json number,title,body,labels
 ```
 
-If no issues are returned, **exit cleanly** with a message: "No ready issues found. Nothing to do."
+Filter the results to exclude issues that also have the `agent-skip` label. Pick the first issue that passes all filters (no `agent-skip`, dependencies met, etc.).
+
+If no issues remain after filtering, **exit cleanly** with a message: "No ready issues found. Nothing to do."
 
 ### Step 1b: Check Dependencies
 
@@ -37,6 +39,32 @@ done
 ```
 
 If any dependency is still open, skip this issue and try the next oldest `ready` issue. This prevents out-of-order execution for issues created by `/decompose`.
+
+### Step 1c: Check Retry Count
+
+Before claiming, check how many times this issue has already failed:
+
+```bash
+# Count previous agent-failed attempt comments on this issue
+ATTEMPT_COUNT=$(gh issue view <NUMBER> --json comments --jq '[.comments[] | select(.body | test("agent-failed attempt"))] | length')
+
+# Read maxRetries from auto-qa-tuning.json
+MAX_RETRIES=$(node -e "console.log(JSON.parse(require('fs').readFileSync('.github/auto-qa-tuning.json','utf-8')).thresholds.maxRetries)")
+
+if [ "$ATTEMPT_COUNT" -ge "$MAX_RETRIES" ]; then
+  echo "Issue #<NUMBER> has failed $ATTEMPT_COUNT times (max: $MAX_RETRIES). Skipping."
+  gh issue edit <NUMBER> --add-label "agent-skip" --remove-label "ready"
+  gh issue comment <NUMBER> --body "**Auto-skipped** after $ATTEMPT_COUNT failed attempts (max retries: $MAX_RETRIES).
+
+This issue needs manual review or a different approach. To retry:
+\`\`\`bash
+gh issue edit <NUMBER> --add-label ready --remove-label agent-skip
+\`\`\`"
+  # Try the next ready issue instead, or exit if none remain
+fi
+```
+
+If the issue has reached `maxRetries`, skip it and move to the next candidate from the filtered list. If no candidates remain, exit cleanly.
 
 ### Step 2: Claim the Issue
 
@@ -100,16 +128,35 @@ Closes #<ISSUE_NUMBER>"
 
 ### Step 5b: On Failure (Agent Could Not Complete)
 
-```bash
-# Add agent-failed label, remove in-progress
-gh issue edit <NUMBER> --add-label "agent-failed" --remove-label "in-progress"
+First, determine the current attempt count:
 
-# Comment the failure details
-gh issue comment <NUMBER> --body "Automated agent was unable to resolve this issue.
+```bash
+# Count previous agent-failed attempt comments on this issue
+ATTEMPT_COUNT=$(gh issue view <NUMBER> --json comments --jq '[.comments[] | select(.body | test("agent-failed attempt"))] | length')
+
+# Read maxRetries from auto-qa-tuning.json
+MAX_RETRIES=$(node -e "console.log(JSON.parse(require('fs').readFileSync('.github/auto-qa-tuning.json','utf-8')).thresholds.maxRetries)")
+
+NEXT_ATTEMPT=$((ATTEMPT_COUNT + 1))
+```
+
+Then comment with attempt tracking and set labels based on whether max retries have been reached:
+
+```bash
+# Comment the failure details with attempt tracking
+gh issue comment <NUMBER> --body "**agent-failed attempt #$NEXT_ATTEMPT** — Automated agent was unable to resolve this issue.
 
 **Error**: <error summary>
 
-This issue may require manual intervention or a more detailed task description."
+Attempts so far: $NEXT_ATTEMPT/$MAX_RETRIES
+$(if [ "$NEXT_ATTEMPT" -ge "$MAX_RETRIES" ]; then echo 'This issue will be auto-skipped on next worker run.'; else echo 'Will retry on next worker cycle.'; fi)"
+
+# Set labels based on retry status
+if [ "$NEXT_ATTEMPT" -ge "$MAX_RETRIES" ]; then
+  gh issue edit <NUMBER> --add-label "agent-skip" --remove-label "in-progress"
+else
+  gh issue edit <NUMBER> --add-label "agent-failed" --add-label "ready" --remove-label "in-progress"
+fi
 ```
 
 ## Safety Rules
@@ -129,19 +176,30 @@ Issues with the `ci-fix` label should be treated with higher urgency — if both
 
 ```bash
 # Check for ci-fix issues first
-CI_ISSUE=$(gh issue list --label "ready" --label "ci-fix" --state open --limit 1 --sort created --json number -q '.[0].number')
+CI_ISSUE=$(gh issue list --label "ready" --label "ci-fix" --state open --limit 5 --sort created --json number,labels -q '[.[] | select(.labels | map(.name) | index("agent-skip") | not)] | .[0].number')
 
 if [ -n "$CI_ISSUE" ]; then
   # Work the CI fix issue
 else
-  # Fall back to any ready issue
-  gh issue list --label "ready" --state open --limit 1 --sort created --json number,title,body,labels
+  # Fall back to any ready issue (excluding agent-skip)
+  gh issue list --label "ready" --state open --limit 5 --sort created --json number,title,body,labels
+  # Filter out issues with agent-skip label from results
 fi
 ```
 
 ## Retry Policy
 
-If an issue has the `agent-failed` label AND the `ready` label (someone manually re-queued it), the worker will pick it up again. This allows manual retry by:
+Failed issues are automatically re-queued with both `agent-failed` and `ready` labels (unless max retries have been reached). The attempt count is tracked via comments matching the `agent-failed attempt` pattern.
+
+After `maxRetries` (from `.github/auto-qa-tuning.json`, currently 2) failed attempts, the issue is labeled `agent-skip` instead of being re-queued. This prevents infinite retry loops.
+
+To manually retry a skipped issue:
+
+```bash
+gh issue edit <NUMBER> --add-label "ready" --remove-label "agent-skip"
+```
+
+To manually retry a failed issue that has not been auto-skipped:
 
 ```bash
 gh issue edit <NUMBER> --add-label "ready" --remove-label "agent-failed"

--- a/.claude/skills/progress-tracker/SKILL.md
+++ b/.claude/skills/progress-tracker/SKILL.md
@@ -26,6 +26,7 @@ gh issue list --label "ready" --state open --json number,title
 gh issue list --label "in-progress" --state open --json number,title
 gh issue list --label "has-pr" --state open --json number,title
 gh issue list --label "agent-failed" --state open --json number,title
+gh issue list --label "agent-skip" --state open --json number,title,createdAt
 
 # PRs merged recently
 gh pr list --state merged --json number,title,mergedAt,headRefName --limit 50
@@ -65,6 +66,7 @@ Calculate these key indicators:
 | **Queue Depth** | Count of issues with `ready` label (target: < 5) |
 | **Stale Issues** | Issues with `ready` label open > 7 days |
 | **Blocked Issues** | Issues with `agent-failed` label not re-queued |
+| **Skipped Issues** | Issues with `agent-skip` label (exceeded max retries, need manual review) |
 | **Daily Agent Spend** | Sum of costUsd from .claude/agent-spend.jsonl for today (target: < $10) |
 | **7d Agent Spend** | Sum of costUsd from last 7 days of entries |
 | **Avg Cost/Issue** | 7d spend / issues closed in 7d |
@@ -106,6 +108,7 @@ Append a dated entry to `.claude/improvement-loop/log.md`:
 | CI Pass Rate | N% | >95% | ✅/⚠️/❌ |
 | Queue Depth | N | <5 | ✅/⚠️/❌ |
 | Stale Issues | N | 0 | ✅/⚠️/❌ |
+| Skipped Issues | N | 0 | ✅/⚠️/❌ |
 | Daily Agent Spend | $N.NN | <$10 | ✅/⚠️/❌ |
 | 7d Agent Spend | $N.NN | <$50 | ✅/⚠️/❌ |
 | Avg Cost/Issue | $N.NN | <$2 | ✅/⚠️/❌ |
@@ -115,7 +118,18 @@ Append a dated entry to `.claude/improvement-loop/log.md`:
 
 ### Recommendations
 - [Actionable suggestions]
+
+### Skipped Issues (agent-skip)
+[List any issues with the `agent-skip` label that need manual attention]
 ```
+
+Query skipped issues for the report:
+
+```bash
+gh issue list --label "agent-skip" --state open --json number,title,createdAt --jq '.[] | "  #\(.number) \(.title) (created: \(.createdAt | split("T")[0]))"'
+```
+
+If any `agent-skip` issues exist, include a summary line in the report: "N issues skipped after max retries -- need manual review"
 
 Create the file if it does not exist. Always **append** — never overwrite previous entries.
 
@@ -183,11 +197,11 @@ $(gh issue list --label agent-failed --state open --json number,title -q '.[] | 
 
 ### Auto-Retry Stale Failures
 
-If an issue has been `agent-failed` for 3+ days with no activity, re-queue it (the agent or skills may have improved):
+If an issue has been `agent-failed` for 3+ days with no activity, re-queue it (the agent or skills may have improved). Issues with the `agent-skip` label are excluded -- they have already exhausted their retry budget and need manual intervention:
 
 ```bash
-# Find stale agent-failed issues (created > 3 days ago)
-STALE=$(gh issue list --label "agent-failed" --state open --json number,createdAt -q '[.[] | select(.createdAt < (now - 259200 | todate))] | .[].number')
+# Find stale agent-failed issues (created > 3 days ago), excluding agent-skip
+STALE=$(gh issue list --label "agent-failed" --state open --json number,createdAt,labels -q '[.[] | select(.createdAt < (now - 259200 | todate)) | select(.labels | map(.name) | index("agent-skip") | not)] | .[].number')
 
 for NUM in $STALE; do
   gh issue edit $NUM --add-label "ready" --remove-label "agent-failed"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ mbe up                                           # Start dev servers
 | `in-progress` | Agent is working on it |
 | `has-pr` | PR created, awaiting merge/review |
 | `agent-failed` | Agent could not complete — needs manual review or retry |
+| `agent-skip` | Exhausted max retries — needs manual review or different approach |
 | `audit` | Found by site-audit |
 | `ci-fix` | CI failure needing fix |
 | `feature` | New feature (created by `/decompose`) |


### PR DESCRIPTION
## Summary

- Issue-worker now tracks agent failure attempts per issue via structured comment pattern matching (`agent-failed attempt #N`)
- After `maxRetries` (read from `.github/auto-qa-tuning.json`, currently 2) failed attempts, issues get labeled `agent-skip` instead of being re-queued
- `agent-skip` issues are excluded from issue-worker pickup and progress-tracker auto-retry
- Progress-tracker weekly report surfaces `agent-skip` issues needing manual attention
- Human can remove `agent-skip` and re-add `ready` to retry

## Test plan

- [ ] Verify issue-worker fetches 5 candidates and filters out `agent-skip` labeled issues
- [ ] Verify Step 1c correctly counts `agent-failed attempt` comments and reads `maxRetries`
- [ ] Verify Step 5b comments include attempt tracking format and applies correct labels
- [ ] Verify progress-tracker queries `agent-skip` issues and includes them in report
- [ ] Verify auto-retry stale failures excludes `agent-skip` issues
- [ ] Manual test: create a test issue, simulate 2 failures, confirm `agent-skip` is applied
- [ ] Manual test: remove `agent-skip`, add `ready`, confirm issue is picked up again

Closes #994