### PR TITLE
feat(acmm): add auto-qa tuning script (#991)

### DIFF
--- a/.github/auto-qa-tuning.json
+++ b/.github/auto-qa-tuning.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/specs/auto-qa-tuning",
-  "$comment": "Self-tuning thresholds for the agent QA loop. These thresholds are consumed by agent dispatch (mbe agent run) and reviewer agents. A future auto-qa.yml workflow will read this file and write back adjusted thresholds based on observed PR-acceptance metrics from docs/metrics/pr-acceptance.json. See docs/review-criteria.md for the rubric the QA loop applies.",
+  "$comment": "Self-tuning thresholds for the agent QA loop. These thresholds are consumed by agent dispatch (mbe agent run) and reviewer agents. Run `node plugins/acmm/scripts/auto-qa-tune.js` to read PR-acceptance metrics from docs/metrics/pr-acceptance.json and write back adjusted thresholds. See docs/review-criteria.md for the rubric the QA loop applies.",
   "version": 1,
   "lastTunedAt": "2026-04-25",
   "thresholds": {

--- a/plugins/acmm/scripts/__tests__/auto-qa-tune.test.js
+++ b/plugins/acmm/scripts/__tests__/auto-qa-tune.test.js
@@ -1,0 +1,144 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  latestSnapshot,
+  computeAdjustments,
+  buildHistoryEntry,
+} from "../auto-qa-tune.js";
+
+// ---------------------------------------------------------------------------
+// latestSnapshot
+// ---------------------------------------------------------------------------
+
+test("latestSnapshot: returns null for empty array", () => {
+  assert.equal(latestSnapshot([]), null);
+});
+
+test("latestSnapshot: returns null for non-array", () => {
+  assert.equal(latestSnapshot(null), null);
+  assert.equal(latestSnapshot(undefined), null);
+});
+
+test("latestSnapshot: returns most recent by date", () => {
+  const snapshots = [
+    { date: "2026-04-01", total_ai_prs: 10 },
+    { date: "2026-05-01", total_ai_prs: 20 },
+    { date: "2026-03-15", total_ai_prs: 5 },
+  ];
+  const result = latestSnapshot(snapshots);
+  assert.equal(result.date, "2026-05-01");
+  assert.equal(result.total_ai_prs, 20);
+});
+
+test("latestSnapshot: single entry returns that entry", () => {
+  const snapshots = [{ date: "2026-04-25", total_ai_prs: 7 }];
+  assert.equal(latestSnapshot(snapshots).date, "2026-04-25");
+});
+
+// ---------------------------------------------------------------------------
+// computeAdjustments — insufficient data
+// ---------------------------------------------------------------------------
+
+test("computeAdjustments: insufficient data (< 5 PRs) skips adjustments", () => {
+  const snapshot = { total_ai_prs: 3, merged: 2, rejected: 1, acceptance_rate: 0.67 };
+  const thresholds = { acceptanceRateFloor: 0.85, maxBudgetUSD: 1.5 };
+  const result = computeAdjustments(snapshot, thresholds);
+
+  assert.equal(result.thresholds.maxBudgetUSD, 1.5, "Budget should not change");
+  assert.equal(result.adjustments.length, 1);
+  assert.ok(result.adjustments[0].includes("Insufficient data"));
+});
+
+// ---------------------------------------------------------------------------
+// computeAdjustments — acceptance rate below floor
+// ---------------------------------------------------------------------------
+
+test("computeAdjustments: rate below floor reduces budget by 25%", () => {
+  const snapshot = { total_ai_prs: 20, merged: 15, rejected: 5, acceptance_rate: 0.75 };
+  const thresholds = { acceptanceRateFloor: 0.85, maxBudgetUSD: 1.5 };
+  const result = computeAdjustments(snapshot, thresholds);
+
+  assert.equal(result.thresholds.maxBudgetUSD, 1.13, "1.5 * 0.75 = 1.125 rounded to 1.13");
+  assert.ok(result.adjustments[0].includes("below the 85% floor"));
+  assert.ok(result.adjustments[0].includes("Budget reduced"));
+});
+
+test("computeAdjustments: budget never goes below $0.25 floor", () => {
+  const snapshot = { total_ai_prs: 10, merged: 3, rejected: 7, acceptance_rate: 0.3 };
+  const thresholds = { acceptanceRateFloor: 0.85, maxBudgetUSD: 0.3 };
+  const result = computeAdjustments(snapshot, thresholds);
+
+  assert.equal(result.thresholds.maxBudgetUSD, 0.25, "Floor is $0.25");
+});
+
+// ---------------------------------------------------------------------------
+// computeAdjustments — acceptance rate meets floor
+// ---------------------------------------------------------------------------
+
+test("computeAdjustments: rate at floor produces no changes", () => {
+  const snapshot = { total_ai_prs: 40, merged: 34, rejected: 6, acceptance_rate: 0.85 };
+  const thresholds = { acceptanceRateFloor: 0.85, maxBudgetUSD: 1.5 };
+  const result = computeAdjustments(snapshot, thresholds);
+
+  assert.equal(result.thresholds.maxBudgetUSD, 1.5, "Budget unchanged");
+  assert.ok(result.adjustments[0].includes("No adjustments needed"));
+});
+
+test("computeAdjustments: rate above floor produces no changes", () => {
+  const snapshot = { total_ai_prs: 40, merged: 40, rejected: 0, acceptance_rate: 1.0 };
+  const thresholds = { acceptanceRateFloor: 0.85, maxBudgetUSD: 1.5 };
+  const result = computeAdjustments(snapshot, thresholds);
+
+  assert.equal(result.thresholds.maxBudgetUSD, 1.5, "Budget unchanged");
+  assert.ok(result.adjustments[0].includes("No adjustments needed"));
+});
+
+// ---------------------------------------------------------------------------
+// computeAdjustments — immutability
+// ---------------------------------------------------------------------------
+
+test("computeAdjustments: does not mutate input thresholds", () => {
+  const snapshot = { total_ai_prs: 20, merged: 10, rejected: 10, acceptance_rate: 0.5 };
+  const thresholds = { acceptanceRateFloor: 0.85, maxBudgetUSD: 1.5 };
+  computeAdjustments(snapshot, thresholds);
+
+  assert.equal(thresholds.maxBudgetUSD, 1.5, "Original should be untouched");
+});
+
+// ---------------------------------------------------------------------------
+// buildHistoryEntry
+// ---------------------------------------------------------------------------
+
+test("buildHistoryEntry: adjustment present flags as tuned", () => {
+  const entry = buildHistoryEntry({
+    adjustments: ["Budget reduced from $1.50 to $1.13 because rate was low."],
+    date: "2026-05-02",
+    snapshotDate: "2026-05-01",
+  });
+
+  assert.equal(entry.date, "2026-05-02");
+  assert.equal(entry.trigger, "auto-qa-tune");
+  assert.equal(entry.snapshotDate, "2026-05-01");
+  assert.ok(entry.note.includes("Tuned thresholds"));
+});
+
+test("buildHistoryEntry: no adjustments flags as reviewed-only", () => {
+  const entry = buildHistoryEntry({
+    adjustments: ["Acceptance rate 100% meets or exceeds the 85% floor. No adjustments needed."],
+    date: "2026-05-02",
+    snapshotDate: "2026-05-01",
+  });
+
+  assert.ok(entry.note.includes("All metrics within acceptable ranges"));
+});
+
+test("buildHistoryEntry: insufficient data flags as reviewed-only", () => {
+  const entry = buildHistoryEntry({
+    adjustments: ["Insufficient data: only 2 AI PRs in window (need >= 5). No adjustments made."],
+    date: "2026-05-02",
+    snapshotDate: "2026-05-01",
+  });
+
+  assert.ok(entry.note.includes("All metrics within acceptable ranges"));
+});

--- a/plugins/acmm/scripts/auto-qa-tune.js
+++ b/plugins/acmm/scripts/auto-qa-tune.js
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+
+/**
+ * Auto-QA threshold tuner — closes the L3-to-L4 adaptive loop.
+ *
+ * Reads PR acceptance snapshots from docs/metrics/pr-acceptance.json and
+ * adjusts thresholds in .github/auto-qa-tuning.json. Each tuning event
+ * appends a history entry explaining *why* the adjustment was made, not
+ * just what changed.
+ *
+ * Usage:
+ *   node plugins/acmm/scripts/auto-qa-tune.js            # apply tuning
+ *   node plugins/acmm/scripts/auto-qa-tune.js --dry-run   # preview only
+ *
+ * Design constraints:
+ *   - Budget can only be *lowered* (never raised) by the tuner. Raising
+ *     the budget requires a human decision.
+ *   - Minimum budget floor is $0.25 to prevent the tuner from starving
+ *     agents entirely.
+ *   - If the most recent snapshot has no data (total_ai_prs === 0), the
+ *     tuner skips with a "no signal" history entry.
+ *   - Requires at least 5 total PRs in the most recent snapshot before
+ *     acting on acceptance rate — small samples produce noisy rates.
+ */
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const BUDGET_FLOOR = 0.25;
+const BUDGET_REDUCTION_FACTOR = 0.75;
+const MIN_SAMPLE_SIZE = 5;
+
+// ---------------------------------------------------------------------------
+// Pure functions (exported for testing)
+// ---------------------------------------------------------------------------
+
+/**
+ * Pick the most recent snapshot from the pr-acceptance array.
+ * Returns null if the array is empty or has no valid entries.
+ *
+ * @param {Array<{date: string}>} snapshots
+ * @returns {{date: string, window_days: number, total_ai_prs: number, merged: number, rejected: number, acceptance_rate: number} | null}
+ */
+export function latestSnapshot(snapshots) {
+  if (!Array.isArray(snapshots) || snapshots.length === 0) return null;
+  const sorted = [...snapshots].sort(
+    (a, b) => Date.parse(b.date) - Date.parse(a.date),
+  );
+  return sorted[0] ?? null;
+}
+
+/**
+ * Compute threshold adjustments from a single PR-acceptance snapshot.
+ *
+ * Returns an object with the (potentially unchanged) thresholds and an
+ * array of human-readable adjustment rationale strings.
+ *
+ * @param {{total_ai_prs: number, merged: number, rejected: number, acceptance_rate: number}} snapshot
+ * @param {{acceptanceRateFloor: number, maxBudgetUSD: number}} thresholds
+ * @returns {{thresholds: {acceptanceRateFloor: number, maxBudgetUSD: number}, adjustments: string[]}}
+ */
+export function computeAdjustments(snapshot, thresholds) {
+  const adjustments = [];
+  const next = { ...thresholds };
+
+  // Gate: insufficient data
+  if (snapshot.total_ai_prs < MIN_SAMPLE_SIZE) {
+    adjustments.push(
+      `Insufficient data: only ${snapshot.total_ai_prs} AI PRs in window (need >= ${MIN_SAMPLE_SIZE}). No adjustments made.`,
+    );
+    return { thresholds: next, adjustments };
+  }
+
+  const rate = snapshot.acceptance_rate;
+  const floor = thresholds.acceptanceRateFloor;
+
+  if (rate < floor) {
+    const oldBudget = next.maxBudgetUSD;
+    const newBudget = Math.max(
+      BUDGET_FLOOR,
+      +(oldBudget * BUDGET_REDUCTION_FACTOR).toFixed(2),
+    );
+    next.maxBudgetUSD = newBudget;
+
+    const pct = (rate * 100).toFixed(0);
+    const floorPct = (floor * 100).toFixed(0);
+    adjustments.push(
+      `Acceptance rate ${pct}% is below the ${floorPct}% floor ` +
+        `(${snapshot.merged} merged, ${snapshot.rejected} rejected out of ${snapshot.total_ai_prs} PRs). ` +
+        `Budget reduced from $${oldBudget.toFixed(2)} to $${newBudget.toFixed(2)} ` +
+        `to tighten quality gate — agents that cost more should produce higher-quality PRs.`,
+    );
+  }
+
+  if (adjustments.length === 0) {
+    const pct = (rate * 100).toFixed(0);
+    const floorPct = (floor * 100).toFixed(0);
+    adjustments.push(
+      `Acceptance rate ${pct}% meets or exceeds the ${floorPct}% floor ` +
+        `(${snapshot.merged} merged, ${snapshot.rejected} rejected). No adjustments needed.`,
+    );
+  }
+
+  return { thresholds: next, adjustments };
+}
+
+/**
+ * Build a complete history entry for this tuning run.
+ *
+ * @param {{adjustments: string[], date: string, snapshotDate: string}} params
+ * @returns {{date: string, trigger: string, snapshotDate: string, adjustments: string[], note: string}}
+ */
+export function buildHistoryEntry({ adjustments, date, snapshotDate }) {
+  const changed = adjustments.some(
+    (a) => !a.includes("No adjustments") && !a.includes("Insufficient data"),
+  );
+  return {
+    date,
+    trigger: "auto-qa-tune",
+    snapshotDate,
+    adjustments,
+    note: changed
+      ? `Tuned thresholds based on PR acceptance data from ${snapshotDate}. ${adjustments.length} finding(s).`
+      : `Reviewed PR acceptance data from ${snapshotDate}. All metrics within acceptable ranges.`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// IO (side-effectful main — not exported for tests)
+// ---------------------------------------------------------------------------
+
+function main() {
+  const DRY_RUN = process.argv.includes("--dry-run");
+  const cwd = process.cwd();
+  const configPath = resolve(cwd, ".github/auto-qa-tuning.json");
+  const metricsPath = resolve(cwd, "docs/metrics/pr-acceptance.json");
+
+  // --- Read config ---
+  if (!existsSync(configPath)) {
+    console.error(`Config not found: ${configPath}`);
+    process.exit(1);
+  }
+  const config = JSON.parse(readFileSync(configPath, "utf-8"));
+
+  // --- Read metrics ---
+  if (!existsSync(metricsPath)) {
+    console.log("No PR acceptance metrics found at", metricsPath, "— skipping.");
+    process.exit(0);
+  }
+  const snapshots = JSON.parse(readFileSync(metricsPath, "utf-8"));
+  const snapshot = latestSnapshot(snapshots);
+
+  if (!snapshot) {
+    console.log("PR acceptance metrics file is empty. Skipping tuning.");
+    process.exit(0);
+  }
+
+  // --- Compute ---
+  const today = new Date().toISOString().split("T")[0];
+  const { thresholds: adjusted, adjustments } = computeAdjustments(
+    snapshot,
+    config.thresholds,
+  );
+
+  const historyEntry = buildHistoryEntry({
+    adjustments,
+    date: today,
+    snapshotDate: snapshot.date,
+  });
+
+  // --- Apply ---
+  const updatedConfig = {
+    ...config,
+    lastTunedAt: today,
+    thresholds: { ...config.thresholds, ...adjusted },
+    history: [...config.history, historyEntry],
+  };
+
+  if (DRY_RUN) {
+    console.log("DRY RUN — would write this history entry:");
+    console.log(JSON.stringify(historyEntry, null, 2));
+    if (adjusted.maxBudgetUSD !== config.thresholds.maxBudgetUSD) {
+      console.log(
+        `\nBudget would change: $${config.thresholds.maxBudgetUSD} -> $${adjusted.maxBudgetUSD}`,
+      );
+    }
+    process.exit(0);
+  }
+
+  writeFileSync(configPath, JSON.stringify(updatedConfig, null, 2) + "\n");
+  console.log(
+    `Auto-QA tuning complete. ${adjustments.length} finding(s). History entry added.`,
+  );
+  for (const a of adjustments) {
+    console.log(`  - ${a}`);
+  }
+}
+
+// Only run main() when executed directly, not when imported by tests.
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+if (process.argv[1] === __filename) {
+  main();
+}


### PR DESCRIPTION
## Summary
- Adds `plugins/acmm/scripts/auto-qa-tune.js` — a Node.js script that reads PR acceptance metrics and adjusts `.github/auto-qa-tuning.json` thresholds, closing the L3-to-L4 adaptive loop
- Budget can only be *lowered* (never raised) by the tuner, with a $0.25 floor; requires >= 5 PRs before acting to avoid noisy small samples
- Each tuning event appends a history entry with human-readable rationale explaining *why* the adjustment was made
- Supports `--dry-run` for previewing changes without writing
- 13 unit tests covering all branches (insufficient data, below floor, at floor, above floor, budget floor, immutability, history entry construction)
- Updated `$comment` in `auto-qa-tuning.json` to reference the actual script instead of "a future workflow"

Closes #991

## Test plan
- [x] `node --test plugins/acmm/scripts/__tests__/auto-qa-tune.test.js` — 13/13 pass
- [x] `node plugins/acmm/scripts/auto-qa-tune.js --dry-run` — outputs correct history entry without modifying config
- [ ] Run without `--dry-run` to verify it writes back to `auto-qa-tuning.json` with a new history entry
- [ ] Test with a modified `pr-acceptance.json` where `acceptance_rate < 0.85` to verify budget reduction logic