### PR TITLE
feat(acmm): add auto-qa tuning workflow

### DIFF
--- a/.github/workflows/auto-qa-tune.yml
+++ b/.github/workflows/auto-qa-tune.yml
@@ -1,0 +1,41 @@
+name: Auto-QA Threshold Tuner
+
+on:
+  schedule:
+    # Monday 9am UTC
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  tune:
+    name: Tune QA Thresholds
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Run auto-qa-tune
+        run: node scripts/auto-qa-tune.mjs
+
+      - name: Commit updated thresholds (if changed)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet .github/auto-qa-tuning.json; then
+            echo "No threshold changes — nothing to commit."
+          else
+            git add .github/auto-qa-tuning.json
+            git commit -m "chore(acmm): auto-tune QA thresholds [skip ci]"
+            git push
+          fi

--- a/scripts/__tests__/auto-qa-tune.test.mjs
+++ b/scripts/__tests__/auto-qa-tune.test.mjs
@@ -1,0 +1,198 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeAcceptanceRates,
+  tiersBelowFloor,
+  adjustThresholds,
+} from '../auto-qa-tune.mjs';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const ENTRY_NO_CATEGORIES = {
+  date: '2026-05-02',
+  window_days: 30,
+  total_ai_prs: 40,
+  merged: 40,
+  rejected: 0,
+  acceptance_rate: 1,
+};
+
+const ENTRY_WITH_CATEGORIES = {
+  date: '2026-05-02',
+  window_days: 30,
+  total_ai_prs: 20,
+  acceptance_rate: 0.75,
+  by_category: {
+    'tier:trivial': { total: 10, merged: 9 },   // 0.90 — above 0.85 floor
+    'tier:standard': { total: 10, merged: 7 },  // 0.70 — below 0.85 floor
+  },
+};
+
+const SEED_TUNING = {
+  version: 1,
+  lastTunedAt: '2026-04-25',
+  thresholds: {
+    acceptanceRateFloor: 0.85,
+    maxBudgetUSD: 1.5,
+    maxRetries: 2,
+    stuckTurnsThreshold: 8,
+  },
+  rules: {
+    'tier:trivial': {
+      maxBudgetUSDOverride: 0.5,
+    },
+    'tier:critical': {
+      requireSpecialistReview: true,
+    },
+  },
+  history: [
+    {
+      date: '2026-04-25',
+      trigger: 'seed',
+      note: 'Initial values.',
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// computeAcceptanceRates
+// ---------------------------------------------------------------------------
+
+describe('computeAcceptanceRates', () => {
+  it('returns overall rate from top-level field when no by_category', () => {
+    const { overall, byCategory } = computeAcceptanceRates(ENTRY_NO_CATEGORIES);
+    expect(overall).toBe(1);
+    expect(byCategory).toEqual({});
+  });
+
+  it('computes per-category rates correctly', () => {
+    const { overall, byCategory } = computeAcceptanceRates(ENTRY_WITH_CATEGORIES);
+    expect(overall).toBe(0.75);
+    expect(byCategory['tier:trivial']).toBeCloseTo(0.9);
+    expect(byCategory['tier:standard']).toBeCloseTo(0.7);
+  });
+
+  it('skips categories with zero total to avoid division by zero', () => {
+    const entry = {
+      acceptance_rate: 0.8,
+      by_category: {
+        'tier:empty': { total: 0, merged: 0 },
+      },
+    };
+    const { byCategory } = computeAcceptanceRates(entry);
+    expect(byCategory['tier:empty']).toBeUndefined();
+  });
+
+  it('defaults overall to 1 when acceptance_rate field is absent', () => {
+    const { overall } = computeAcceptanceRates({});
+    expect(overall).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tiersBelowFloor
+// ---------------------------------------------------------------------------
+
+describe('tiersBelowFloor', () => {
+  it('returns tiers whose rate is strictly below the floor', () => {
+    const rates = {
+      'tier:trivial': 0.9,
+      'tier:standard': 0.7,
+      'tier:critical': 0.85,
+    };
+    const below = tiersBelowFloor(rates, 0.85);
+    expect(below).toContain('tier:standard');
+    expect(below).not.toContain('tier:trivial');
+    // tier:critical is exactly at the floor — not below
+    expect(below).not.toContain('tier:critical');
+  });
+
+  it('returns empty array when all tiers are at or above floor', () => {
+    const rates = { 'tier:trivial': 0.95, 'tier:critical': 0.88 };
+    expect(tiersBelowFloor(rates, 0.85)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// adjustThresholds — no changes needed
+// ---------------------------------------------------------------------------
+
+describe('adjustThresholds — no tiers below floor', () => {
+  it('does not mutate the input object', () => {
+    const original = JSON.parse(JSON.stringify(SEED_TUNING));
+    adjustThresholds(SEED_TUNING, [], '2026-05-02');
+    expect(SEED_TUNING).toEqual(original);
+  });
+
+  it('appends a history entry explaining no change was needed', () => {
+    const result = adjustThresholds(SEED_TUNING, [], '2026-05-02');
+    const last = result.history[result.history.length - 1];
+    expect(last.trigger).toBe('auto-tune');
+    expect(last.note).toMatch(/above acceptance floor/i);
+  });
+
+  it('updates lastTunedAt', () => {
+    const result = adjustThresholds(SEED_TUNING, [], '2026-05-02');
+    expect(result.lastTunedAt).toBe('2026-05-02');
+  });
+
+  it('preserves all other thresholds unchanged', () => {
+    const result = adjustThresholds(SEED_TUNING, [], '2026-05-02');
+    expect(result.thresholds).toEqual(SEED_TUNING.thresholds);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// adjustThresholds — tiers below floor
+// ---------------------------------------------------------------------------
+
+describe('adjustThresholds — tiers below floor', () => {
+  it('halves maxBudgetUSDOverride for the failing tier', () => {
+    const result = adjustThresholds(SEED_TUNING, ['tier:trivial'], '2026-05-02');
+    expect(result.rules['tier:trivial'].maxBudgetUSDOverride).toBeCloseTo(0.25);
+  });
+
+  it('falls back to global maxBudgetUSD when tier has no override', () => {
+    const result = adjustThresholds(SEED_TUNING, ['tier:critical'], '2026-05-02');
+    // tier:critical had no maxBudgetUSDOverride → falls back to 1.5 → halved to 0.75
+    expect(result.rules['tier:critical'].maxBudgetUSDOverride).toBeCloseTo(0.75);
+  });
+
+  it('preserves existing tier properties not related to budget', () => {
+    const result = adjustThresholds(SEED_TUNING, ['tier:critical'], '2026-05-02');
+    expect(result.rules['tier:critical'].requireSpecialistReview).toBe(true);
+  });
+
+  it('does not modify tiers that are above the floor', () => {
+    const result = adjustThresholds(SEED_TUNING, ['tier:trivial'], '2026-05-02');
+    // tier:critical should remain untouched
+    expect(result.rules['tier:critical']).toEqual(SEED_TUNING.rules['tier:critical']);
+  });
+
+  it('includes a human-readable rationale in the history entry', () => {
+    const result = adjustThresholds(SEED_TUNING, ['tier:trivial'], '2026-05-02');
+    const last = result.history[result.history.length - 1];
+    expect(last.trigger).toBe('auto-tune');
+    expect(last.note).toMatch(/tier:trivial/);
+    expect(last.note).toMatch(/0\.5/);   // previous value
+    expect(last.note).toMatch(/0\.25/);  // new value
+  });
+
+  it('history note names both previous and new value for each changed tier', () => {
+    const result = adjustThresholds(
+      SEED_TUNING,
+      ['tier:trivial', 'tier:critical'],
+      '2026-05-03',
+    );
+    const last = result.history[result.history.length - 1];
+    expect(last.note).toMatch(/tier:trivial/);
+    expect(last.note).toMatch(/tier:critical/);
+  });
+
+  it('does not mutate the input rules object', () => {
+    const originalRules = JSON.parse(JSON.stringify(SEED_TUNING.rules));
+    adjustThresholds(SEED_TUNING, ['tier:trivial'], '2026-05-02');
+    expect(SEED_TUNING.rules).toEqual(originalRules);
+  });
+});

--- a/scripts/auto-qa-tune.mjs
+++ b/scripts/auto-qa-tune.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+
+/**
+ * Auto-QA threshold tuner for the agent QA loop.
+ *
+ * Reads docs/metrics/pr-acceptance.json, computes per-category acceptance
+ * rates, and adjusts maxBudgetUSD overrides in .github/auto-qa-tuning.json
+ * when a category falls below acceptanceRateFloor.
+ *
+ * Usage:
+ *   node scripts/auto-qa-tune.mjs
+ *   node scripts/auto-qa-tune.mjs --dry-run
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const cwd = process.cwd();
+const METRICS_PATH = join(cwd, 'docs/metrics/pr-acceptance.json');
+const TUNING_PATH = join(cwd, '.github/auto-qa-tuning.json');
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes('--dry-run');
+
+// ---------------------------------------------------------------------------
+// I/O helpers
+// ---------------------------------------------------------------------------
+
+/** @returns {unknown} */
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, 'utf-8'));
+}
+
+/** @param {string} filePath @param {unknown} data */
+function writeJson(filePath, data) {
+  writeFileSync(filePath, JSON.stringify(data, null, 2) + '\n', 'utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance-rate computation
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute acceptance rate for a single metrics entry.
+ * Falls back to the top-level `acceptance_rate` when no per-category data exists.
+ *
+ * @param {object} entry - one entry from pr-acceptance.json
+ * @returns {{ overall: number, byCategory: Record<string, number> }}
+ */
+export function computeAcceptanceRates(entry) {
+  const overall = typeof entry.acceptance_rate === 'number' ? entry.acceptance_rate : 1;
+
+  const byCategory = {};
+
+  if (entry.by_category && typeof entry.by_category === 'object') {
+    for (const [category, stats] of Object.entries(entry.by_category)) {
+      if (
+        stats &&
+        typeof stats === 'object' &&
+        typeof stats.merged === 'number' &&
+        typeof stats.total === 'number' &&
+        stats.total > 0
+      ) {
+        byCategory[category] = stats.merged / stats.total;
+      }
+    }
+  }
+
+  return { overall, byCategory };
+}
+
+/**
+ * Determine which rule tiers are below the floor.
+ *
+ * @param {Record<string, number>} byCategory
+ * @param {number} floor
+ * @returns {string[]} tier keys (e.g. "tier:trivial")
+ */
+export function tiersBelowFloor(byCategory, floor) {
+  return Object.entries(byCategory)
+    .filter(([, rate]) => rate < floor)
+    .map(([cat]) => cat);
+}
+
+// ---------------------------------------------------------------------------
+// Threshold adjustment
+// ---------------------------------------------------------------------------
+
+/**
+ * Halve the maxBudgetUSD / maxBudgetUSDOverride for every tier that is below
+ * the acceptance floor.  Returns an immutable copy with adjusted rules and a
+ * new history entry.
+ *
+ * @param {object} tuning      - current auto-qa-tuning.json contents
+ * @param {string[]} belowTiers - tier keys that need tightening
+ * @param {string} today       - ISO date string (YYYY-MM-DD)
+ * @returns {object}           - new tuning object (never mutates input)
+ */
+export function adjustThresholds(tuning, belowTiers, today) {
+  if (belowTiers.length === 0) {
+    const historyEntry = {
+      date: today,
+      trigger: 'auto-tune',
+      note: 'All categories at or above acceptance floor. No threshold changes needed.',
+    };
+    return {
+      ...tuning,
+      lastTunedAt: today,
+      history: [...tuning.history, historyEntry],
+    };
+  }
+
+  const updatedRules = { ...tuning.rules };
+  const changes = [];
+
+  for (const tier of belowTiers) {
+    const existing = updatedRules[tier] ?? {};
+    const key = 'maxBudgetUSDOverride';
+    const prev = typeof existing[key] === 'number' ? existing[key] : tuning.thresholds.maxBudgetUSD;
+    const next = +(prev / 2).toFixed(2);
+
+    updatedRules[tier] = {
+      ...existing,
+      [key]: next,
+      [`${key}.$comment`]:
+        `Auto-tuned on ${today}: acceptance rate fell below floor — halved from ${prev} to ${next}.`,
+    };
+
+    changes.push(`${tier}: maxBudgetUSDOverride ${prev} → ${next}`);
+  }
+
+  const historyEntry = {
+    date: today,
+    trigger: 'auto-tune',
+    note: `Tightened budgets for under-performing tiers. ${changes.join('; ')}.`,
+  };
+
+  return {
+    ...tuning,
+    lastTunedAt: today,
+    rules: updatedRules,
+    history: [...tuning.history, historyEntry],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function isoDate(d = new Date()) {
+  return d.toISOString().slice(0, 10);
+}
+
+export async function run() {
+  const metricsRaw = readJson(METRICS_PATH);
+  const tuning = readJson(TUNING_PATH);
+
+  const metrics = Array.isArray(metricsRaw) ? metricsRaw : [metricsRaw];
+  const latest = metrics[metrics.length - 1];
+
+  const { overall, byCategory } = computeAcceptanceRates(latest);
+  const floor = tuning.thresholds.acceptanceRateFloor;
+  const today = isoDate();
+
+  // Seed categories from rules if byCategory is empty (no per-category data yet)
+  const effectiveByCategory =
+    Object.keys(byCategory).length > 0
+      ? byCategory
+      : Object.fromEntries(Object.keys(tuning.rules).map(tier => [tier, overall]));
+
+  const below = tiersBelowFloor(effectiveByCategory, floor);
+
+  const updated = adjustThresholds(tuning, below, today);
+
+  if (DRY_RUN) {
+    process.stdout.write(JSON.stringify(updated, null, 2) + '\n');
+    return updated;
+  }
+
+  writeJson(TUNING_PATH, updated);
+
+  const lastEntry = updated.history[updated.history.length - 1];
+  process.stdout.write(`[auto-qa-tune] ${lastEntry.note}\n`);
+
+  return updated;
+}
+
+// Run when invoked directly (not imported by tests)
+if (import.meta.url === `file://${process.argv[1]}`) {
+  run().catch(err => {
+    process.stderr.write(`[auto-qa-tune] Error: ${err.message}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/vitest.config.mjs
+++ b/scripts/vitest.config.mjs
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: false,
+    environment: 'node',
+    include: ['scripts/__tests__/**/*.test.mjs'],
+  },
+});


### PR DESCRIPTION
## Summary

Closes #991

- Adds `scripts/auto-qa-tune.mjs` — reads `docs/metrics/pr-acceptance.json`, computes per-category acceptance rates, halves `maxBudgetUSDOverride` for tiers below the 85% floor
- Every tuning event appends a `history` entry with human-readable rationale (L4 requirement: no auto-tuning without explanation)
- `.github/workflows/auto-qa-tune.yml` runs weekly (Monday 9am) or on manual dispatch
- 17 vitest tests covering acceptance rate computation, threshold adjustment, immutability, and history entries

## Test plan

- [x] 17/17 tests pass (`npx vitest run --config scripts/vitest.config.mjs`)
- [x] `node scripts/auto-qa-tune.mjs --dry-run` produces valid output
- [ ] Verify workflow runs on next Monday schedule