### PR TITLE
feat(acmm): add adaptive cadence governor for RemoteTriggers

### DIFF
--- a/.claude/skills/issue-worker/SKILL.md
+++ b/.claude/skills/issue-worker/SKILL.md
@@ -10,6 +10,24 @@ Autonomous issue resolver. Picks up one ready issue, delegates implementation to
 
 ## Workflow
 
+### Step 0: Governor Check
+
+Before picking up work, check the adaptive cadence governor:
+
+```bash
+node plugins/acmm/scripts/cadence-governor.js
+```
+
+If the governor exits with code 1 (SKIP), exit cleanly: "Governor says SKIP (mode: \<MODE\>). No work this cycle."
+
+If the governor exits with code 0 (EXECUTE), proceed to Step 1.
+
+After completing work (Step 5a or 5b), mark that execution happened:
+
+```bash
+node plugins/acmm/scripts/cadence-governor.js --execute
+```
+
 ### Step 1: Find an Issue
 
 ```bash

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ apps/*/vite.config.d.ts
 .claude/settings.local.json
 .claude/improvement-loop/
 .claude/agent-spend.jsonl
+.claude/governor-state.json
 .claude/session-logs/*.json
 .claude/acmm/
 .claude/*.lock

--- a/plugins/acmm/scripts/__tests__/cadence-governor.test.js
+++ b/plugins/acmm/scripts/__tests__/cadence-governor.test.js
@@ -1,0 +1,219 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  determineMode,
+  shouldExecute,
+  loadState,
+  saveState,
+  buildNextState,
+} from "../cadence-governor.js";
+
+// ── determineMode ───────────────────────────────────────────────
+
+test("determineMode: >10 ready → SURGE", () => {
+  assert.equal(determineMode(11), "SURGE");
+  assert.equal(determineMode(50), "SURGE");
+});
+
+test("determineMode: 5-10 ready → BUSY", () => {
+  assert.equal(determineMode(5), "BUSY");
+  assert.equal(determineMode(10), "BUSY");
+});
+
+test("determineMode: 2-4 ready → QUIET", () => {
+  assert.equal(determineMode(2), "QUIET");
+  assert.equal(determineMode(4), "QUIET");
+});
+
+test("determineMode: 0-1 ready → IDLE", () => {
+  assert.equal(determineMode(0), "IDLE");
+  assert.equal(determineMode(1), "IDLE");
+});
+
+// ── shouldExecute ───────────────────────────────────────────────
+
+test("shouldExecute: SURGE always executes", () => {
+  const recent = new Date(Date.now() - 5 * 60 * 1000).toISOString(); // 5 min ago
+  assert.equal(shouldExecute("SURGE", recent), true);
+  assert.equal(shouldExecute("SURGE", null), true);
+});
+
+test("shouldExecute: BUSY always executes", () => {
+  const recent = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+  assert.equal(shouldExecute("BUSY", recent), true);
+  assert.equal(shouldExecute("BUSY", null), true);
+});
+
+test("shouldExecute: QUIET skips if last execution < 60 min ago", () => {
+  const now = Date.now();
+  const thirtyMinAgo = new Date(now - 30 * 60 * 1000).toISOString();
+  assert.equal(shouldExecute("QUIET", thirtyMinAgo, now), false);
+});
+
+test("shouldExecute: QUIET executes if last execution >= 60 min ago", () => {
+  const now = Date.now();
+  const ninetyMinAgo = new Date(now - 90 * 60 * 1000).toISOString();
+  assert.equal(shouldExecute("QUIET", ninetyMinAgo, now), true);
+});
+
+test("shouldExecute: QUIET executes if last execution exactly 60 min ago", () => {
+  const now = Date.now();
+  const sixtyMinAgo = new Date(now - 60 * 60 * 1000).toISOString();
+  assert.equal(shouldExecute("QUIET", sixtyMinAgo, now), true);
+});
+
+test("shouldExecute: IDLE never executes", () => {
+  assert.equal(shouldExecute("IDLE", null), false);
+  const recent = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+  assert.equal(shouldExecute("IDLE", recent), false);
+  const ancient = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+  assert.equal(shouldExecute("IDLE", ancient), false);
+});
+
+test("shouldExecute: null lastExecution → executes (for non-IDLE modes)", () => {
+  assert.equal(shouldExecute("SURGE", null), true);
+  assert.equal(shouldExecute("BUSY", null), true);
+  assert.equal(shouldExecute("QUIET", null), true);
+});
+
+test("shouldExecute: unknown mode → defaults to execute", () => {
+  assert.equal(shouldExecute("UNKNOWN", null), true);
+});
+
+// ── loadState / saveState ───────────────────────────────────────
+
+function tmpDir() {
+  const root = mkdtempSync(join(tmpdir(), "acmm-governor-"));
+  return {
+    root,
+    statePath: join(root, ".claude", "governor-state.json"),
+    cleanup() {
+      rmSync(root, { recursive: true, force: true });
+    },
+  };
+}
+
+test("loadState: missing file → default state", () => {
+  const fx = tmpDir();
+  const state = loadState(fx.statePath);
+  assert.equal(state.mode, null);
+  assert.equal(state.readyCount, 0);
+  assert.deepEqual(state.history, []);
+  assert.equal(state.shouldExecute, true);
+  fx.cleanup();
+});
+
+test("saveState: creates directories and writes valid JSON", () => {
+  const fx = tmpDir();
+  const state = { mode: "BUSY", readyCount: 7, history: [] };
+  saveState(state, fx.statePath);
+  const raw = readFileSync(fx.statePath, "utf-8");
+  const parsed = JSON.parse(raw);
+  assert.equal(parsed.mode, "BUSY");
+  assert.equal(parsed.readyCount, 7);
+  fx.cleanup();
+});
+
+test("loadState: round-trips with saveState", () => {
+  const fx = tmpDir();
+  const original = {
+    mode: "QUIET",
+    readyCount: 3,
+    lastCheck: "2026-05-02T17:00:00.000Z",
+    lastExecution: "2026-05-02T15:00:00.000Z",
+    shouldExecute: true,
+    history: [
+      {
+        date: "2026-05-02T17:00:00.000Z",
+        mode: "QUIET",
+        readyCount: 3,
+        executed: true,
+      },
+    ],
+  };
+  saveState(original, fx.statePath);
+  const loaded = loadState(fx.statePath);
+  assert.deepEqual(loaded, original);
+  fx.cleanup();
+});
+
+// ── buildNextState ──────────────────────────────────────────────
+
+test("buildNextState: computes mode and shouldExecute correctly", () => {
+  const now = Date.parse("2026-05-02T18:00:00.000Z");
+  const previousState = {
+    mode: null,
+    readyCount: 0,
+    lastCheck: null,
+    lastExecution: null,
+    shouldExecute: true,
+    history: [],
+  };
+
+  const result = buildNextState({ readyCount: 7, previousState, now });
+  assert.equal(result.mode, "BUSY");
+  assert.equal(result.shouldExecute, true);
+  assert.equal(result.readyCount, 7);
+  assert.equal(result.lastCheck, "2026-05-02T18:00:00.000Z");
+  assert.equal(result.lastExecution, null);
+  assert.equal(result.history.length, 1);
+  assert.equal(result.history[0].mode, "BUSY");
+  assert.equal(result.history[0].executed, true);
+});
+
+test("buildNextState: QUIET with recent execution → skip", () => {
+  const now = Date.parse("2026-05-02T18:00:00.000Z");
+  const previousState = {
+    mode: "QUIET",
+    readyCount: 3,
+    lastCheck: "2026-05-02T17:30:00.000Z",
+    lastExecution: "2026-05-02T17:30:00.000Z", // 30 min ago
+    shouldExecute: true,
+    history: [],
+  };
+
+  const result = buildNextState({ readyCount: 3, previousState, now });
+  assert.equal(result.mode, "QUIET");
+  assert.equal(result.shouldExecute, false);
+});
+
+test("buildNextState: caps history at MAX_HISTORY (100)", () => {
+  const now = Date.parse("2026-05-02T18:00:00.000Z");
+  const longHistory = Array.from({ length: 150 }, (_, i) => ({
+    date: new Date(now - (150 - i) * 60 * 1000).toISOString(),
+    mode: "BUSY",
+    readyCount: 7,
+    executed: true,
+  }));
+  const previousState = {
+    mode: "BUSY",
+    readyCount: 7,
+    lastCheck: null,
+    lastExecution: null,
+    shouldExecute: true,
+    history: longHistory,
+  };
+
+  const result = buildNextState({ readyCount: 7, previousState, now });
+  assert.equal(result.history.length, 100);
+});
+
+test("buildNextState: IDLE → skip even with no prior execution", () => {
+  const now = Date.parse("2026-05-02T18:00:00.000Z");
+  const previousState = {
+    mode: null,
+    readyCount: 0,
+    lastCheck: null,
+    lastExecution: null,
+    shouldExecute: true,
+    history: [],
+  };
+
+  const result = buildNextState({ readyCount: 0, previousState, now });
+  assert.equal(result.mode, "IDLE");
+  assert.equal(result.shouldExecute, false);
+});

--- a/plugins/acmm/scripts/cadence-governor.js
+++ b/plugins/acmm/scripts/cadence-governor.js
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+
+/**
+ * Adaptive cadence governor for RemoteTriggers.
+ *
+ * Checks workload (ready issue count) and decides whether the current
+ * trigger firing should execute or skip. Skills read the governor state
+ * to decide whether to proceed.
+ *
+ * Usage:
+ *   node plugins/acmm/scripts/cadence-governor.js          # check and update state
+ *   node plugins/acmm/scripts/cadence-governor.js --status  # print current mode
+ *   node plugins/acmm/scripts/cadence-governor.js --execute # mark that execution happened
+ */
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const DEFAULT_STATE_PATH = path.resolve(".claude/governor-state.json");
+const MAX_HISTORY = 100;
+
+/** @type {Record<string, {min: number, label: string, skipWindow: number}>} */
+const MODES = {
+  SURGE: { min: 11, label: "SURGE", skipWindow: 0 },
+  BUSY: { min: 5, label: "BUSY", skipWindow: 0 },
+  QUIET: { min: 2, label: "QUIET", skipWindow: 60 }, // skip if executed within 60 min
+  IDLE: { min: 0, label: "IDLE", skipWindow: Infinity }, // always skip
+};
+
+/**
+ * Determine the cadence mode from the ready issue count.
+ * @param {number} readyCount
+ * @returns {"SURGE" | "BUSY" | "QUIET" | "IDLE"}
+ */
+export function determineMode(readyCount) {
+  if (readyCount >= MODES.SURGE.min) return "SURGE";
+  if (readyCount >= MODES.BUSY.min) return "BUSY";
+  if (readyCount >= MODES.QUIET.min) return "QUIET";
+  return "IDLE";
+}
+
+/**
+ * Decide whether to execute based on mode and last execution time.
+ * @param {string} mode
+ * @param {string | null} lastExecution - ISO timestamp or null
+ * @param {number} [now] - current time in ms (for testing)
+ * @returns {boolean}
+ */
+export function shouldExecute(mode, lastExecution, now = Date.now()) {
+  const modeDef = MODES[mode];
+  if (!modeDef) return true;
+  if (modeDef.skipWindow === 0) return true;
+  if (modeDef.skipWindow === Infinity) return false;
+  if (!lastExecution) return true;
+
+  const elapsed = (now - new Date(lastExecution).getTime()) / (1000 * 60);
+  return elapsed >= modeDef.skipWindow;
+}
+
+/**
+ * Fetch the count of open issues labeled 'ready' via gh CLI.
+ * @returns {number | null} - null if gh is unavailable
+ */
+export function getReadyCount() {
+  try {
+    const result = execFileSync(
+      "gh",
+      [
+        "issue",
+        "list",
+        "--label",
+        "ready",
+        "--state",
+        "open",
+        "--json",
+        "number",
+        "--jq",
+        "length",
+      ],
+      { encoding: "utf-8", timeout: 15000, stdio: ["pipe", "pipe", "pipe"] },
+    );
+    return parseInt(result.trim(), 10) || 0;
+  } catch {
+    return null; // gh unavailable
+  }
+}
+
+/**
+ * Load governor state from disk.
+ * @param {string} statePath
+ * @returns {object}
+ */
+export function loadState(statePath = DEFAULT_STATE_PATH) {
+  try {
+    return JSON.parse(fs.readFileSync(statePath, "utf-8"));
+  } catch {
+    return {
+      mode: null,
+      readyCount: 0,
+      lastCheck: null,
+      lastExecution: null,
+      shouldExecute: true,
+      history: [],
+    };
+  }
+}
+
+/**
+ * Save governor state to disk.
+ * @param {object} state
+ * @param {string} statePath
+ */
+export function saveState(state, statePath = DEFAULT_STATE_PATH) {
+  fs.mkdirSync(path.dirname(statePath), { recursive: true });
+  fs.writeFileSync(statePath, JSON.stringify(state, null, 2) + "\n");
+}
+
+/**
+ * Build updated state from current inputs.
+ * @param {object} params
+ * @param {number} params.readyCount
+ * @param {object} params.previousState
+ * @param {number} [params.now] - current time in ms (for testing)
+ * @returns {object} new state
+ */
+export function buildNextState({ readyCount, previousState, now = Date.now() }) {
+  const mode = determineMode(readyCount);
+  const execute = shouldExecute(mode, previousState.lastExecution, now);
+  const timestamp = new Date(now).toISOString();
+
+  return {
+    mode,
+    readyCount,
+    lastCheck: timestamp,
+    lastExecution: previousState.lastExecution,
+    shouldExecute: execute,
+    history: [
+      ...previousState.history.slice(-(MAX_HISTORY - 1)),
+      { date: timestamp, mode, readyCount, executed: execute },
+    ],
+  };
+}
+
+/**
+ * CLI entry point. Only runs when this file is executed directly.
+ */
+function main() {
+  const args = new Set(process.argv.slice(2));
+  const statePath = DEFAULT_STATE_PATH;
+
+  if (args.has("--execute")) {
+    const state = loadState(statePath);
+    const updated = { ...state, lastExecution: new Date().toISOString() };
+    saveState(updated, statePath);
+    console.log(`Governor: marked execution at ${updated.lastExecution}`);
+    process.exit(0);
+  }
+
+  const readyCount = getReadyCount();
+  if (readyCount === null) {
+    console.log("Governor: gh CLI unavailable, defaulting to execute");
+    process.exit(0);
+  }
+
+  const previousState = loadState(statePath);
+  const newState = buildNextState({ readyCount, previousState });
+  saveState(newState, statePath);
+
+  const priorMode = previousState.mode;
+  const modeChanged = priorMode && priorMode !== newState.mode;
+
+  if (args.has("--status")) {
+    console.log(`Mode: ${newState.mode} (${readyCount} ready issues)`);
+    console.log(`Should execute: ${newState.shouldExecute}`);
+    if (modeChanged)
+      console.log(`Mode transition: ${priorMode} → ${newState.mode}`);
+    console.log(`Last execution: ${previousState.lastExecution || "never"}`);
+    process.exit(0);
+  }
+
+  // Default: print decision for consumption by calling skill
+  if (modeChanged) {
+    console.log(
+      `Governor: mode transition ${priorMode} → ${newState.mode} (${readyCount} ready)`,
+    );
+  }
+  console.log(
+    `Governor: ${newState.mode} mode, ${readyCount} ready → ${newState.shouldExecute ? "EXECUTE" : "SKIP"}`,
+  );
+
+  // Exit code: 0 = execute, 1 = skip
+  if (!newState.shouldExecute) process.exit(1);
+}
+
+// Run main() only when executed directly (not imported for testing)
+const isMain =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === path.resolve(new URL(import.meta.url).pathname);
+if (isMain) {
+  main();
+}


### PR DESCRIPTION
## Summary

- Adds `plugins/acmm/scripts/cadence-governor.js` — a lightweight guard that checks `ready` issue backlog and decides whether the current RemoteTrigger firing should execute or skip
- Modes: SURGE (>10 ready, always execute), BUSY (5-10, always execute), QUIET (2-4, skip if ran <60 min ago), IDLE (0-1, always skip)
- Updates issue-worker skill with a Step 0 governor check and post-execution marking
- State persisted to `.claude/governor-state.json` (gitignored) with rolling 100-entry history

Closes #995

## Test plan

- [x] 19 unit tests covering `determineMode`, `shouldExecute`, `loadState`/`saveState`, and `buildNextState` — all passing via `node --test`
- [x] Verified `--status` flag works end-to-end with live `gh issue list`
- [ ] Verify issue-worker respects governor skip in a RemoteTrigger cycle
- [ ] Verify `--execute` flag correctly updates `lastExecution` timestamp