### PR TITLE
feat: add Sentry → GitHub issue pipeline with /sentry-triage skill

### DIFF
--- a/.claude/skills/learning-loop/SKILL.md
+++ b/.claude/skills/learning-loop/SKILL.md
@@ -22,6 +22,14 @@ Read the output. The script queries 7 sensors (ACMM, PR metrics, agent cost, CI 
 
 If the script exits with code 1, regressions were detected. Note them for Step 3.
 
+### Step 1b: Sentry Triage
+
+If the Sentry MCP is available, run production error triage:
+
+Invoke `/sentry-triage` to query Sentry for new/regressed production errors and create GitHub issues for any that pass the severity/frequency/deduplication filters.
+
+This step is optional — if Sentry is not authenticated or unavailable, skip with a note in the summary.
+
 ### Step 2: Verify Past Fixes
 
 Run fix verification on recently-closed issues:

--- a/.claude/skills/sentry-triage/SKILL.md
+++ b/.claude/skills/sentry-triage/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: sentry-triage
+description: Query Sentry for production errors, filter by severity/frequency, deduplicate against existing GitHub issues, and create actionable issues for the ship-loop. Invoke with /sentry-triage.
+user-invocable: true
+---
+
+# Sentry Triage
+
+Automated production error to GitHub issue pipeline. Queries Sentry MCP for actionable errors and creates deduplicated issues for the ship-loop.
+
+## Prerequisites
+
+The Sentry plugin must be authenticated. If you get auth errors, run the Sentry authenticate flow first.
+
+## Workflow
+
+### Step 1: Query Sentry for Recent Issues
+
+Use the Sentry MCP tools to fetch recent issues. The tools are available as skills:
+
+```
+Use sentry:getIssues to fetch the most recent issues from Sentry.
+```
+
+If the Sentry MCP requires authentication, use the `sentry:seer` skill or the `mcp__plugin_sentry_sentry__authenticate` tool to authenticate first.
+
+Parse the response to extract:
+- Issue ID and URL
+- Title / error message
+- Level (error, fatal, warning)
+- Event count (frequency)
+- First seen / last seen dates
+- Affected user count
+- Stack trace (if available)
+- Tags (service, browser, OS, release)
+
+### Step 2: Filter Issues
+
+Apply these filters:
+1. **Recency**: Only issues with events in the last 7 days
+2. **Severity**: Only `error` or `fatal` level (skip `warning`, `info`)
+3. **Frequency**: Only issues with >5 occurrences in the window
+4. **Status**: Prioritize `new` and `regressed` over `ongoing`
+
+Sort by: frequency x severity (fatal = 2x weight) descending.
+
+### Step 3: Deduplicate Against GitHub Issues
+
+For each Sentry issue that passes filters:
+
+```bash
+# Search for existing GitHub issues mentioning this Sentry issue URL or ID
+gh issue list --state open --search "sentry <SENTRY_ISSUE_ID>" --json number,title,body --limit 5
+```
+
+Also search by error message title:
+```bash
+gh issue list --state open --search "<error_message_snippet>" --json number,title --limit 5
+```
+
+Skip any Sentry issue that already has a matching GitHub issue.
+
+### Step 4: Map to Service/Package
+
+Analyze the stack trace to determine which service/package is affected:
+
+- `services/users/` -> label `service:users`
+- `services/reservations/` -> label `service:reservations`
+- `services/agent/` -> label `service:agent`
+- `packages/` -> label with package name
+- `apps/` -> label with app name
+
+If the stack trace is unclear, use the Sentry tags (if they include a service name).
+
+### Step 5: Create GitHub Issues
+
+For the top 3 issues (max per run), create GitHub issues:
+
+```bash
+gh issue create \
+  --title "fix(<service>): <error_message_summary>" \
+  --label "ready,sentry,bug" \
+  --body "$(cat <<'EOF'
+## Sentry Production Error
+
+**Sentry Issue:** <SENTRY_URL>
+**Level:** <error|fatal>
+**Events:** <count> in last 7 days
+**Affected Users:** <count>
+**First Seen:** <date>
+**Status:** <new|regressed|ongoing>
+
+## Stack Trace Summary
+
+```
+<relevant stack trace lines, max 20 lines>
+```
+
+## Affected Area
+
+- **Service/Package:** <name>
+- **File:** <primary file from stack trace>
+- **Function:** <function name if available>
+
+## Suggested Fix Area
+
+<Brief analysis of what might be causing this based on the error message and stack trace>
+
+## Acceptance Criteria
+
+- [ ] Error rate for this issue drops by >50% after fix
+- [ ] Verified by learning-loop post-fix verification (48h after merge)
+
+_Detected by [sentry-triage](../.claude/skills/sentry-triage/SKILL.md)_
+EOF
+)"
+```
+
+### Step 6: Summary
+
+Print a summary:
+```
+Sentry Triage Complete
+  Queried: <N> issues from Sentry
+  Filtered: <N> passed severity/frequency filters
+  Deduplicated: <N> already have GitHub issues
+  Created: <N> new GitHub issues
+  Skipped: <N> (max 3 per run)
+```
+
+## Integration with Learning Loop
+
+The learning loop's Step 2 (Verify Past Fixes) handles post-fix verification for `sentry`-labeled issues. After a PR with `fixes #<issue>` merges, the verify-fixes script queries the originating sensor 48h later to check if the error rate dropped.
+
+To support this, the Sentry issue body includes the Sentry issue URL. The verification script can use `sentry:seer` to check if the error count has decreased since the fix was deployed.
+
+## Safety Rules
+
+- **Max 3 issues per run** -- prevents issue spam during incident cascades
+- **Never create duplicate issues** -- always deduplicate first
+- **Skip warning/info level** -- only actionable errors
+- **Frequency floor of 5** -- avoids one-off transient errors

--- a/.claude/skills/ship-loop/SKILL.md
+++ b/.claude/skills/ship-loop/SKILL.md
@@ -22,7 +22,8 @@ Autonomous continuous improvement loop with **parallel dispatch**. Runs discover
 │  ├── A1. System health check      ─┐                    │
 │  ├── A2. Dependabot alerts         ├── all in parallel  │
 │  ├── A2.5. Smoke audit (if merge)  │                    │
-│  └── A3. Check previous PRs/CI    ─┘                    │
+│  ├── A3. Check previous PRs/CI     │                    │
+│  └── A4. Sentry triage (if avail) ─┘                    │
 │            │                                            │
 │  Phase B: Dispatch (parallel batch)                     │
 │  ├── Agent 1: issue #59 ──┐                             │
@@ -164,7 +165,11 @@ gh issue close <linked-number> --comment "Merged via ship-loop. Deployed."
 
 **Why immediate merge for low-risk PRs?** Test/docs/deps/config changes cannot break the running application. Merging them right away frees up issue slots and keeps the backlog moving without wasting an entire loop iteration on a trivial wait.
 
-### A4. Gather & Claim Batch
+### A4. Sentry Triage (optional)
+
+If Sentry MCP is available, invoke `/sentry-triage` to check for new production errors. Issues created here enter the same queue as audit/CI findings.
+
+### A5. Gather & Claim Batch
 
 After all discovery steps complete, gather the full issue backlog:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ Automated system that audits the live site, finds and fixes issues, builds featu
 | `/ci-monitor` | Check CI health, auto-fix simple failures, escalate complex ones |
 | `/progress-tracker` | Metrics, self-tuning circuit breaker, trend analysis |
 | `/learning-loop` | Sensor-driven improvement: collect metrics → detect regressions → create issues → verify fixes → self-tune |
+| `/sentry-triage` | Query Sentry for production errors, filter by severity/frequency, deduplicate, create GitHub issues for ship-loop |
 | `/acmm-audit` | Score repo against canonical AI Codebase Maturity Model (6 levels, 100+ criteria from ACMM/Fullsend/AEF/Reflect), file next-level-gap issues, update README badge |
 
 ## mbe CLI Commands
@@ -71,6 +72,7 @@ mbe up                                           # Start dev servers
 | `tracking` | Parent issue tracking multi-part feature |
 | `meta-improvement` | Process improvement suggestion |
 | `acmm` | AI Codebase Maturity Model finding (created by `/acmm-audit --apply`) |
+| `sentry` | Production error triaged from Sentry |
 
 ### RemoteTriggers (scheduled background agents)
 


### PR DESCRIPTION
Closes #983

## Summary

- New `/sentry-triage` skill that queries Sentry MCP for production errors (error/fatal level, >5 occurrences, last 7 days), deduplicates against existing GitHub issues, maps stack traces to services/packages, and creates max 3 actionable issues per run with `ready,sentry,bug` labels
- Integrated into learning-loop as Step 1b (optional -- skips gracefully if Sentry MCP is unavailable)
- Added as Phase A4 in ship-loop parallel discovery alongside health checks, Dependabot, and smoke audit
- Created `sentry` GitHub label (red, D73A49) for tracking Sentry-originated issues
- Updated CLAUDE.md skills table and labels table

## Test plan

- [ ] Invoke `/sentry-triage` manually -- verify it queries Sentry, filters, deduplicates, and creates issues
- [ ] Invoke `/learning-loop` -- verify Step 1b runs when Sentry is available and skips cleanly when not
- [ ] Invoke `/ship-loop` -- verify A4 Sentry triage runs in parallel with other discovery steps
- [ ] Verify `sentry` label exists on the repo
- [ ] Verify created issues have correct format: Sentry link, stack trace summary, affected user count, suggested fix area
- [ ] Verify max 3 issues per run cap is respected
- [ ] Verify deduplication works (re-running does not create duplicate issues)