### PR TITLE
fix: remove stale Cloudflare Web Analytics CSP entries

### DIFF
--- a/infrastructure/worker/edge-router.js
+++ b/infrastructure/worker/edge-router.js
@@ -60,11 +60,11 @@ function buildSecurityHeaders(nonce) {
     "Permissions-Policy": "camera=(), microphone=(), geolocation=(), payment=()",
     "Content-Security-Policy": [
       "default-src 'self'",
-      `script-src 'nonce-${nonce}' 'self' https://static.cloudflareinsights.com`,
+      `script-src 'nonce-${nonce}' 'self'`,
       "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
       "img-src 'self' data: https:",
       "font-src 'self' https://fonts.gstatic.com",
-      "connect-src 'self' https://dev-ytbgmz5ls3wh4xdx.us.auth0.com https://api.mattbutlerengineering.com https://cloudflareinsights.com",
+      "connect-src 'self' https://dev-ytbgmz5ls3wh4xdx.us.auth0.com https://api.mattbutlerengineering.com",
       "frame-ancestors 'none'",
       "base-uri 'self'",
       "form-action 'self'",


### PR DESCRIPTION
## Summary

Closes #1013

Removes `https://static.cloudflareinsights.com` from `script-src` and `https://cloudflareinsights.com` from `connect-src` in the edge router CSP. Web Analytics is not enabled for this zone, so the beacon script fails with `ERR_CONNECTION_REFUSED` on every page load.

## Test plan

- [x] CSP no longer references cloudflareinsights domains
- [ ] Deploy edge router and verify no console errors on mattbutlerengineering.com