### PR TITLE
test(rialto): add stories for layout components

### DIFF
--- a/packages/rialto/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/rialto/src/components/Accordion/Accordion.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Accordion } from "./Accordion";
+
+const meta: Meta<typeof Accordion> = {
+  title: "Layout/Accordion",
+  component: Accordion,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof Accordion>;
+
+const sampleItems = [
+  {
+    id: "item-1",
+    title: "What is Rialto?",
+    content: "Rialto is a premium design system built with material honesty and precision surfaces.",
+  },
+  {
+    id: "item-2",
+    title: "How do I install it?",
+    content: "Run npm install @mattbutlerengineering/rialto in your project.",
+  },
+  {
+    id: "item-3",
+    title: "Is it accessible?",
+    content: "Yes. All components meet WCAG AA standards and support full keyboard navigation.",
+  },
+];
+
+export const SingleExpand: Story = {
+  args: {
+    items: sampleItems,
+    multiple: false,
+  },
+};
+
+export const MultipleExpand: Story = {
+  args: {
+    items: sampleItems,
+    multiple: true,
+  },
+};
+
+export const DefaultOpen: Story = {
+  args: {
+    items: sampleItems,
+    multiple: false,
+    defaultOpen: ["item-1"],
+  },
+};
+
+export const DefaultOpenMultiple: Story = {
+  args: {
+    items: sampleItems,
+    multiple: true,
+    defaultOpen: ["item-1", "item-3"],
+  },
+};
+
+export const WithDisabledItem: Story = {
+  args: {
+    items: [
+      ...sampleItems,
+      {
+        id: "item-4",
+        title: "This item is disabled",
+        content: "This content cannot be accessed.",
+        disabled: true,
+      },
+    ],
+    multiple: false,
+  },
+};

--- a/packages/rialto/src/components/AppBar/AppBar.stories.tsx
+++ b/packages/rialto/src/components/AppBar/AppBar.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { AppBar } from "./AppBar";
+
+const meta: Meta<typeof AppBar> = {
+  title: "Layout/AppBar",
+  component: AppBar,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof AppBar>;
+
+export const Default: Story = {
+  args: {
+    logo: "Acme",
+    glass: true,
+  },
+};
+
+export const WithActions: Story = {
+  args: {
+    logo: "Acme",
+    actions: "Login",
+    glass: true,
+  },
+};
+
+export const NoGlass: Story = {
+  args: {
+    logo: "Acme",
+    actions: "Login",
+    glass: false,
+  },
+};
+
+export const CustomHeight: Story = {
+  args: {
+    logo: "Acme",
+    actions: "Login",
+    glass: true,
+    height: "72px",
+  },
+};

--- a/packages/rialto/src/components/GlobalNav/GlobalNav.stories.tsx
+++ b/packages/rialto/src/components/GlobalNav/GlobalNav.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { GlobalNav } from "./GlobalNav";
+
+const meta: Meta<typeof GlobalNav> = {
+  title: "Layout/GlobalNav",
+  component: GlobalNav,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    currentApp: {
+      control: "select",
+      options: ["marketing", "hospitality", "rialto"],
+    },
+    theme: {
+      control: "select",
+      options: ["light", "dark"],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof GlobalNav>;
+
+export const Default: Story = {
+  args: {
+    currentApp: "marketing",
+  },
+};
+
+export const WithThemeToggle: Story = {
+  args: {
+    currentApp: "marketing",
+    theme: "light",
+    onThemeToggle: () => {},
+  },
+};
+
+export const HospitalityActive: Story = {
+  args: {
+    currentApp: "hospitality",
+    theme: "dark",
+    onThemeToggle: () => {},
+  },
+};
+
+export const RialtoActive: Story = {
+  args: {
+    currentApp: "rialto",
+    theme: "light",
+    onThemeToggle: () => {},
+  },
+};

--- a/packages/rialto/src/components/NavigationMenu/NavigationMenu.stories.tsx
+++ b/packages/rialto/src/components/NavigationMenu/NavigationMenu.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { NavigationMenu } from "./NavigationMenu";
+
+const meta: Meta<typeof NavigationMenu> = {
+  title: "Layout/NavigationMenu",
+  component: NavigationMenu,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof NavigationMenu>;
+
+export const Horizontal: Story = {
+  args: {
+    items: [
+      { label: "Home", href: "/" },
+      { label: "About", href: "/about" },
+      { label: "Blog", href: "/blog" },
+      { label: "Contact", href: "/contact" },
+    ],
+  },
+};
+
+export const WithDropdownItems: Story = {
+  args: {
+    items: [
+      { label: "Home", href: "/" },
+      {
+        label: "Products",
+        children: [
+          { label: "Widgets", href: "/products/widgets" },
+          { label: "Gadgets", href: "/products/gadgets" },
+          { label: "Gizmos", href: "/products/gizmos" },
+        ],
+      },
+      {
+        label: "Resources",
+        children: [
+          { label: "Documentation", href: "/docs" },
+          { label: "Blog", href: "/blog" },
+          { label: "Community", href: "/community" },
+        ],
+      },
+      { label: "Contact", href: "/contact" },
+    ],
+  },
+};
+
+export const MultipleDropdowns: Story = {
+  args: {
+    items: [
+      {
+        label: "Platform",
+        children: [
+          { label: "Overview", href: "/platform" },
+          { label: "Security", href: "/platform/security" },
+        ],
+      },
+      {
+        label: "Solutions",
+        children: [
+          { label: "Enterprise", href: "/solutions/enterprise" },
+          { label: "Startups", href: "/solutions/startups" },
+          { label: "Agencies", href: "/solutions/agencies" },
+        ],
+      },
+      {
+        label: "Developers",
+        children: [
+          { label: "API Reference", href: "/api" },
+          { label: "SDKs", href: "/sdks" },
+          { label: "Changelog", href: "/changelog" },
+        ],
+      },
+      { label: "Pricing", href: "/pricing" },
+    ],
+  },
+};

--- a/packages/rialto/src/components/PageHeader/PageHeader.stories.tsx
+++ b/packages/rialto/src/components/PageHeader/PageHeader.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { PageHeader } from "./PageHeader";
+
+const meta: Meta<typeof PageHeader> = {
+  title: "Layout/PageHeader",
+  component: PageHeader,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof PageHeader>;
+
+export const TitleOnly: Story = {
+  args: {
+    title: "Account Settings",
+  },
+};
+
+export const WithDescription: Story = {
+  args: {
+    title: "Account Settings",
+    children: "Manage your profile, notifications, and security preferences.",
+  },
+};
+
+export const WithBreadcrumb: Story = {
+  args: {
+    title: "Account Settings",
+    breadcrumbs: [
+      { label: "Home", href: "/" },
+      { label: "Dashboard", href: "/dashboard" },
+      { label: "Account Settings" },
+    ],
+  },
+};
+
+export const WithActions: Story = {
+  args: {
+    title: "Account Settings",
+    breadcrumbs: [
+      { label: "Home", href: "/" },
+      { label: "Account Settings" },
+    ],
+    actions: "Save Changes",
+  },
+};
+
+export const WithMeta: Story = {
+  args: {
+    title: "Reservations",
+    breadcrumbs: [
+      { label: "Home", href: "/" },
+      { label: "Reservations" },
+    ],
+    meta: "42 total",
+    actions: "New Reservation",
+  },
+};
+
+export const WithAll: Story = {
+  args: {
+    title: "Project Alpha",
+    breadcrumbs: [
+      { label: "Home", href: "/" },
+      { label: "Projects", href: "/projects" },
+      { label: "Project Alpha" },
+    ],
+    meta: "Active",
+    actions: "Edit Project",
+    children: "A strategic initiative to deliver the next-generation platform.",
+  },
+};


### PR DESCRIPTION
## Summary

Closes #1024

Adds Storybook stories for 5 layout components with key variant coverage:

- **Accordion** — SingleExpand, MultipleExpand, DefaultOpen, WithDisabledItem
- **NavigationMenu** — Horizontal, WithDropdownItems, MultipleDropdowns
- **GlobalNav** — Default, WithThemeToggle, HospitalityActive, RialtoActive
- **AppBar** — Default, WithActions, NoGlass, CustomHeight
- **PageHeader** — TitleOnly, WithDescription, WithBreadcrumb, WithActions, WithAll

## Test plan

- [x] `pnpm --dir packages/rialto typecheck` passes
- [x] ESLint passes on all 5 story files
- [ ] Visual verification in Storybook