### PR TITLE
fix(rialto): add dark mode theme toggle to Storybook preview

### DIFF
--- a/packages/rialto/.storybook/preview.tsx
+++ b/packages/rialto/.storybook/preview.tsx
@@ -1,9 +1,31 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import type { Preview } from '@storybook/react';
 import { RialtoProvider } from '../src/providers/RialtoProvider';
 import '../src/styles-entry.css';
 
+const BACKGROUNDS = {
+  light: '#f8f6f3',
+  dark: '#1a1918',
+  system: '#f8f6f3',
+};
+
 const preview: Preview = {
+  globalTypes: {
+    theme: {
+      description: 'RialtoProvider theme',
+      defaultValue: 'light',
+      toolbar: {
+        title: 'Theme',
+        icon: 'circlehollow',
+        items: [
+          { value: 'light', icon: 'sun', title: 'Light' },
+          { value: 'dark', icon: 'moon', title: 'Dark' },
+          { value: 'system', icon: 'mirror', title: 'System' },
+        ],
+        dynamicTitle: true,
+      },
+    },
+  },
   parameters: {
     controls: {
       matchers: {
@@ -14,8 +36,8 @@ const preview: Preview = {
     backgrounds: {
       default: 'light',
       values: [
-        { name: 'light', value: '#f8f6f3' },
-        { name: 'dark', value: '#1a1918' },
+        { name: 'light', value: BACKGROUNDS.light },
+        { name: 'dark', value: BACKGROUNDS.dark },
       ],
     },
     a11y: {
@@ -28,26 +50,25 @@ const preview: Preview = {
   },
   decorators: [
     (Story, context) => {
-      const [theme, setTheme] = useState<'light' | 'dark'>('light');
+      const selectedTheme = (context.globals.theme ?? 'light') as 'light' | 'dark' | 'system';
 
-      useEffect(() => {
-        const selected = context.globals.backgrounds?.value || '#f8f6f3';
-        setTheme(selected === '#1a1918' ? 'dark' : 'light');
-      }, [context.globals.backgrounds?.value]);
+      // Resolve which background name to activate based on the theme toggle.
+      // 'system' falls back to 'light' canvas since we can't know the OS preference at build time.
+      const backgroundName = selectedTheme === 'dark' ? 'dark' : 'light';
+
+      // Override the active background to stay in sync with the theme toggle.
+      context.parameters.backgrounds = {
+        ...context.parameters.backgrounds,
+        default: backgroundName,
+      };
 
       return (
-        <RialtoProvider theme={theme}>
+        <RialtoProvider theme={selectedTheme}>
           <Story />
         </RialtoProvider>
       );
     },
   ],
-  globalTypes: {
-    backgrounds: {
-      description: 'Global background color',
-      defaultValue: { value: '#f8f6f3', name: 'light' },
-    },
-  },
 };
 
 export default preview;


### PR DESCRIPTION
## Summary

- Adds a first-class **Theme** toolbar toggle (Light / Dark / System) to the Storybook toolbar via `globalTypes.theme`
- Decorator now reads `context.globals.theme` directly and passes it to `<RialtoProvider theme={...}>` — no more indirect hex-color inference
- Background canvas syncs automatically with the toolbar selection (dark theme → dark canvas, light/system → light canvas)
- Removes the `useEffect`/`useState` indirection that was delaying theme application by a render cycle

## Test plan

- [ ] Open Storybook (`pnpm storybook` from repo root or `packages/rialto`)
- [ ] Verify a **Theme** toolbar item appears with Sun/Moon/Mirror icons
- [ ] Toggle to **Dark** — confirm components render with dark tokens AND canvas turns dark (`#1a1918`)
- [ ] Toggle to **Light** — confirm components render with light tokens AND canvas turns light (`#f8f6f3`)
- [ ] Toggle to **System** — confirm components follow OS color scheme preference
- [ ] Verify the old background switcher (canvas color picker) still works independently

Closes #1034