### PR TITLE
test(rialto): configure Storybook test runner with vitest

### DIFF
--- a/packages/rialto/vitest.config.storybook.ts
+++ b/packages/rialto/vitest.config.storybook.ts
@@ -1,21 +1,34 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { defineConfig } from 'vitest/config';
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
+import { playwright } from '@vitest/browser-playwright';
 
+const dirname =
+  typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
+
+// More info at: https://storybook.js.org/docs/writing-tests/integrations/vitest-addon
 export default defineConfig({
+  resolve: {
+    alias: {
+      // In Storybook 10, @storybook/test was folded into the storybook package
+      '@storybook/test': 'storybook/test',
+    },
+  },
   test: {
     projects: [
       {
+        extends: true,
         plugins: [
-          storybookTest({
-            configDir: '.storybook',
-          }),
+          storybookTest({ configDir: path.join(dirname, '.storybook') }),
         ],
         test: {
           name: 'storybook',
           browser: {
             enabled: true,
             headless: true,
-            provider: 'playwright',
+            provider: playwright({}),
             instances: [{ browser: 'chromium' }],
           },
         },


### PR DESCRIPTION
## Summary

- Fix `vitest.config.storybook.ts` to work with Vitest 4 and Storybook 10
- Use `playwright({})` factory call instead of the old string `'playwright'` provider (required by Vitest 4's new `BrowserProviderOption` API)
- Add `extends: true` to inherit project config, and ESM-safe `__dirname` fallback for `configDir`
- Add `@storybook/test → storybook/test` resolve alias — the package was folded into the main `storybook` package in Storybook 10; existing story files still import from the old `@storybook/test` path

Running `pnpm --dir packages/rialto test:storybook` now runs all 46 story tests across 11 story files and passes cleanly.

Closes #1030

## Test plan

- [x] `pnpm --dir packages/rialto test:storybook` passes (11 test files, 46 tests)
- [x] Failing stories produce clear error output (verified: vite import-analysis error with file/line reference is shown)
- [x] No changes to production source files — config-only change