### PR TITLE
test(rialto): add stories for form components

### DIFF
--- a/packages/rialto/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/rialto/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Autocomplete } from './Autocomplete';
+
+const FRAMEWORK_OPTIONS = [
+  { value: 'react', label: 'React' },
+  { value: 'vue', label: 'Vue' },
+  { value: 'angular', label: 'Angular' },
+  { value: 'svelte', label: 'Svelte' },
+  { value: 'solid', label: 'SolidJS' },
+  { value: 'qwik', label: 'Qwik' },
+  { value: 'astro', label: 'Astro' },
+  { value: 'remix', label: 'Remix' },
+];
+
+const meta: Meta<typeof Autocomplete> = {
+  title: 'Forms/Autocomplete',
+  component: Autocomplete,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    onChange: { action: 'changed' },
+    onSelect: { action: 'selected' },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: '320px', minHeight: '280px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Autocomplete>;
+
+export const Default: Story = {
+  args: {
+    label: 'Framework',
+    placeholder: 'Search frameworks…',
+    options: FRAMEWORK_OPTIONS,
+  },
+};
+
+export const WithFiltering: Story = {
+  args: {
+    label: 'Framework',
+    placeholder: 'Type to filter…',
+    options: FRAMEWORK_OPTIONS,
+    hint: 'Type at least one character to see results.',
+  },
+};
+
+export const EmptyState: Story = {
+  args: {
+    label: 'Language',
+    placeholder: 'Search languages…',
+    options: [],
+    value: 'COBOL',
+    emptyText: 'No matching languages found.',
+  },
+};
+
+export const WithHint: Story = {
+  args: {
+    label: 'Tech stack',
+    placeholder: 'Search…',
+    options: FRAMEWORK_OPTIONS,
+    hint: 'Select the primary framework for your project.',
+    showOptional: true,
+  },
+};
+
+export const Required: Story = {
+  args: {
+    label: 'Framework',
+    placeholder: 'Select a framework…',
+    options: FRAMEWORK_OPTIONS,
+    required: true,
+  },
+};

--- a/packages/rialto/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/rialto/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { within, userEvent, expect } from '@storybook/test';
+import { within, expect } from '@storybook/test';
 import { Checkbox } from './Checkbox';
 
 const meta: Meta<typeof Checkbox> = {

--- a/packages/rialto/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/rialto/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect } from '@storybook/test';
+import { Checkbox } from './Checkbox';
+
+const meta: Meta<typeof Checkbox> = {
+  title: 'Forms/Checkbox',
+  component: Checkbox,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    onCheckedChange: { action: 'checkedChange' },
+    checked: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    indeterminate: { control: 'boolean' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Checkbox>;
+
+export const Unchecked: Story = {
+  args: {
+    label: 'Accept terms and conditions',
+    checked: false,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const checkbox = canvas.getByRole('checkbox');
+    await expect(checkbox).toBeInTheDocument();
+    await expect(checkbox).not.toBeChecked();
+  },
+};
+
+export const Checked: Story = {
+  args: {
+    label: 'Subscribe to newsletter',
+    checked: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const checkbox = canvas.getByRole('checkbox');
+    await expect(checkbox).toBeChecked();
+  },
+};
+
+export const Indeterminate: Story = {
+  args: {
+    label: 'Select all items',
+    indeterminate: true,
+    description: '3 of 7 items selected',
+  },
+};
+
+export const WithDescription: Story = {
+  args: {
+    label: 'Marketing emails',
+    checked: false,
+    description: 'Receive product updates and promotional offers.',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    label: 'Admin access',
+    checked: false,
+    disabled: true,
+    disabledReason: 'Contact your administrator to change this setting.',
+  },
+};
+
+export const DisabledChecked: Story = {
+  args: {
+    label: 'Required agreement',
+    checked: true,
+    disabled: true,
+  },
+};

--- a/packages/rialto/src/components/InputGroup/InputGroup.stories.tsx
+++ b/packages/rialto/src/components/InputGroup/InputGroup.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { InputGroup } from './InputGroup';
+import { Input } from '../Input/Input';
+import { Button } from '../Button/Button';
+import { Select } from '../Select/Select';
+
+const meta: Meta<typeof InputGroup> = {
+  title: 'Forms/InputGroup',
+  component: InputGroup,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof InputGroup>;
+
+export const InputWithButton: Story = {
+  render: () => (
+    <InputGroup style={{ width: '360px' }}>
+      <Input placeholder="Search…" style={{ flex: 1 }} />
+      <Button variant="primary">Search</Button>
+    </InputGroup>
+  ),
+};
+
+export const SelectWithInput: Story = {
+  render: () => (
+    <InputGroup style={{ width: '360px' }}>
+      <Select
+        options={[
+          { value: 'https', label: 'https://' },
+          { value: 'http', label: 'http://' },
+        ]}
+        value="https"
+        style={{ width: '120px' }}
+      />
+      <Input placeholder="example.com" style={{ flex: 1 }} />
+    </InputGroup>
+  ),
+};
+
+export const InputRange: Story = {
+  render: () => (
+    <InputGroup style={{ width: '320px' }}>
+      <Input placeholder="Min" style={{ flex: 1 }} type="number" />
+      <Input placeholder="Max" style={{ flex: 1 }} type="number" />
+    </InputGroup>
+  ),
+};
+
+export const InputWithGhostButton: Story = {
+  render: () => (
+    <InputGroup style={{ width: '360px' }}>
+      <Input placeholder="Enter coupon code" style={{ flex: 1 }} />
+      <Button variant="ghost">Apply</Button>
+    </InputGroup>
+  ),
+};

--- a/packages/rialto/src/components/NumberInput/NumberInput.stories.tsx
+++ b/packages/rialto/src/components/NumberInput/NumberInput.stories.tsx
@@ -1,0 +1,85 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { NumberInput } from './NumberInput';
+
+const meta: Meta<typeof NumberInput> = {
+  title: 'Forms/NumberInput',
+  component: NumberInput,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    onChange: { action: 'changed' },
+    disabled: { control: 'boolean' },
+    error: { control: 'boolean' },
+    size: {
+      control: 'select',
+      options: ['small', 'default', 'large'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof NumberInput>;
+
+export const Default: Story = {
+  args: {
+    label: 'Quantity',
+    value: 1,
+  },
+};
+
+export const WithMinMax: Story = {
+  args: {
+    label: 'Age',
+    value: 18,
+    min: 0,
+    max: 120,
+    hint: 'Must be between 0 and 120',
+  },
+};
+
+export const WithStep: Story = {
+  args: {
+    label: 'Price',
+    value: 9.99,
+    step: 0.5,
+    min: 0,
+    hint: 'Increments by $0.50',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    label: 'Max Seats',
+    value: 10,
+    disabled: true,
+    disabledReason: 'Seat count is fixed for your current plan.',
+  },
+};
+
+export const ErrorState: Story = {
+  args: {
+    label: 'Timeout (seconds)',
+    value: -1,
+    min: 1,
+    error: true,
+    hint: 'Value must be at least 1.',
+  },
+};
+
+export const SmallSize: Story = {
+  args: {
+    label: 'Count',
+    value: 3,
+    size: 'small',
+  },
+};
+
+export const LargeSize: Story = {
+  args: {
+    label: 'Budget',
+    value: 500,
+    size: 'large',
+  },
+};

--- a/packages/rialto/src/components/PinInput/PinInput.stories.tsx
+++ b/packages/rialto/src/components/PinInput/PinInput.stories.tsx
@@ -1,0 +1,94 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { PinInput } from './PinInput';
+
+const meta: Meta<typeof PinInput> = {
+  title: 'Forms/PinInput',
+  component: PinInput,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    onChange: { action: 'changed' },
+    onComplete: { action: 'completed' },
+    disabled: { control: 'boolean' },
+    error: { control: 'boolean' },
+    mask: { control: 'boolean' },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+    },
+    type: {
+      control: 'select',
+      options: ['numeric', 'alphanumeric'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof PinInput>;
+
+export const FourDigit: Story = {
+  args: {
+    label: 'PIN',
+    length: 4,
+    value: '',
+  },
+};
+
+export const SixDigit: Story = {
+  args: {
+    label: 'Verification code',
+    length: 6,
+    hint: 'Enter the 6-digit code from your authenticator app.',
+    value: '',
+  },
+};
+
+export const WithMask: Story = {
+  args: {
+    label: 'PIN',
+    length: 4,
+    mask: true,
+    hint: 'Your PIN is hidden for security.',
+    value: '',
+  },
+};
+
+export const Alphanumeric: Story = {
+  args: {
+    label: 'Access code',
+    length: 6,
+    type: 'alphanumeric',
+    hint: 'Letters and numbers accepted.',
+    value: '',
+  },
+};
+
+export const Prefilled: Story = {
+  args: {
+    label: 'Verification code',
+    length: 6,
+    value: '482',
+  },
+};
+
+export const ErrorState: Story = {
+  args: {
+    label: 'One-time code',
+    length: 6,
+    value: '000000',
+    error: true,
+    hint: 'Code is invalid or expired.',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    label: 'Recovery code',
+    length: 4,
+    value: '1234',
+    disabled: true,
+    disabledReason: 'Recovery codes cannot be edited here.',
+  },
+};

--- a/packages/rialto/src/components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/packages/rialto/src/components/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,0 +1,100 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { SegmentedControl } from './SegmentedControl';
+
+const meta: Meta<typeof SegmentedControl> = {
+  title: 'Forms/SegmentedControl',
+  component: SegmentedControl,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    onChange: { action: 'changed' },
+    size: {
+      control: 'select',
+      options: ['sm', 'md'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SegmentedControl>;
+
+export const TwoSegments: Story = {
+  args: {
+    segments: [
+      { id: 'list', label: 'List' },
+      { id: 'grid', label: 'Grid' },
+    ],
+    value: 'list',
+  },
+};
+
+export const ThreeSegments: Story = {
+  args: {
+    segments: [
+      { id: 'day', label: 'Day' },
+      { id: 'week', label: 'Week' },
+      { id: 'month', label: 'Month' },
+    ],
+    value: 'week',
+  },
+};
+
+export const FiveSegments: Story = {
+  args: {
+    segments: [
+      { id: '1h', label: '1H' },
+      { id: '1d', label: '1D' },
+      { id: '1w', label: '1W' },
+      { id: '1m', label: '1M' },
+      { id: '1y', label: '1Y' },
+    ],
+    value: '1d',
+  },
+};
+
+export const WithDisabledSegment: Story = {
+  args: {
+    segments: [
+      { id: 'light', label: 'Light' },
+      { id: 'dark', label: 'Dark' },
+      { id: 'system', label: 'System', disabled: true },
+    ],
+    value: 'light',
+  },
+};
+
+export const SmallSize: Story = {
+  args: {
+    segments: [
+      { id: 'asc', label: 'Asc' },
+      { id: 'desc', label: 'Desc' },
+    ],
+    value: 'asc',
+    size: 'sm',
+  },
+};
+
+export const Controlled: Story = {
+  render: () => {
+    const [view, setView] = useState('grid');
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '16px', alignItems: 'center' }}>
+        <SegmentedControl
+          segments={[
+            { id: 'list', label: 'List' },
+            { id: 'grid', label: 'Grid' },
+            { id: 'map', label: 'Map' },
+          ]}
+          value={view}
+          onChange={setView}
+        />
+        <span style={{ fontSize: '14px', color: 'var(--rialto-text-secondary)' }}>
+          Active view: <strong>{view}</strong>
+        </span>
+      </div>
+    );
+  },
+};

--- a/packages/rialto/src/components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/packages/rialto/src/components/SegmentedControl/SegmentedControl.stories.tsx
@@ -77,24 +77,26 @@ export const SmallSize: Story = {
   },
 };
 
+function ControlledDemo() {
+  const [view, setView] = useState('grid');
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '16px', alignItems: 'center' }}>
+      <SegmentedControl
+        segments={[
+          { id: 'list', label: 'List' },
+          { id: 'grid', label: 'Grid' },
+          { id: 'map', label: 'Map' },
+        ]}
+        value={view}
+        onChange={setView}
+      />
+      <span style={{ fontSize: '14px', color: 'var(--rialto-text-secondary)' }}>
+        Active view: <strong>{view}</strong>
+      </span>
+    </div>
+  );
+}
+
 export const Controlled: Story = {
-  render: () => {
-    const [view, setView] = useState('grid');
-    return (
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '16px', alignItems: 'center' }}>
-        <SegmentedControl
-          segments={[
-            { id: 'list', label: 'List' },
-            { id: 'grid', label: 'Grid' },
-            { id: 'map', label: 'Map' },
-          ]}
-          value={view}
-          onChange={setView}
-        />
-        <span style={{ fontSize: '14px', color: 'var(--rialto-text-secondary)' }}>
-          Active view: <strong>{view}</strong>
-        </span>
-      </div>
-    );
-  },
+  render: () => <ControlledDemo />,
 };

--- a/packages/rialto/src/components/Select/Select.stories.tsx
+++ b/packages/rialto/src/components/Select/Select.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Select } from './Select';
+
+const COUNTRY_OPTIONS = [
+  { value: 'us', label: 'United States' },
+  { value: 'ca', label: 'Canada' },
+  { value: 'gb', label: 'United Kingdom' },
+  { value: 'au', label: 'Australia' },
+  { value: 'de', label: 'Germany' },
+];
+
+const meta: Meta<typeof Select> = {
+  title: 'Forms/Select',
+  component: Select,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    onChange: { action: 'changed' },
+    disabled: { control: 'boolean' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Select>;
+
+export const Default: Story = {
+  args: {
+    label: 'Country',
+    placeholder: 'Select a country…',
+    options: COUNTRY_OPTIONS,
+  },
+};
+
+export const WithOptions: Story = {
+  args: {
+    label: 'Country',
+    options: COUNTRY_OPTIONS,
+    value: 'ca',
+  },
+};
+
+export const WithDisabledOption: Story = {
+  args: {
+    label: 'Plan',
+    options: [
+      { value: 'free', label: 'Free' },
+      { value: 'pro', label: 'Pro' },
+      { value: 'enterprise', label: 'Enterprise', disabled: true },
+    ],
+    value: 'free',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    label: 'Region',
+    options: COUNTRY_OPTIONS,
+    value: 'us',
+    disabled: true,
+    disabledReason: 'Region cannot be changed after account creation.',
+  },
+};
+
+export const ErrorState: Story = {
+  args: {
+    label: 'Category',
+    options: COUNTRY_OPTIONS,
+    placeholder: 'Select a category…',
+  },
+};

--- a/packages/rialto/src/components/Slider/Slider.stories.tsx
+++ b/packages/rialto/src/components/Slider/Slider.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Slider } from './Slider';
+
+const meta: Meta<typeof Slider> = {
+  title: 'Forms/Slider',
+  component: Slider,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    onChange: { action: 'changed' },
+    disabled: { control: 'boolean' },
+    showValue: { control: 'boolean' },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: '320px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Slider>;
+
+export const Default: Story = {
+  args: {
+    label: 'Volume',
+    defaultValue: 50,
+    showValue: true,
+  },
+};
+
+export const WithRange: Story = {
+  args: {
+    label: 'Brightness',
+    min: 10,
+    max: 200,
+    defaultValue: 100,
+    showValue: true,
+  },
+};
+
+export const WithStep: Story = {
+  args: {
+    label: 'Opacity',
+    min: 0,
+    max: 100,
+    step: 10,
+    defaultValue: 60,
+    showValue: true,
+    formatValue: (v) => `${v}%`,
+  },
+};
+
+export const WithCustomFormat: Story = {
+  args: {
+    label: 'Price limit',
+    min: 0,
+    max: 1000,
+    step: 50,
+    defaultValue: 400,
+    showValue: true,
+    formatValue: (v) => `$${v}`,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    label: 'CPU throttle',
+    value: 40,
+    disabled: true,
+    showValue: true,
+    disabledReason: 'CPU throttling is managed by your organization.',
+  },
+};


### PR DESCRIPTION
## Summary

Closes #1022

Adds Storybook stories for 8 form components with variant coverage:

- **Select** — Default, WithOptions, Disabled, ErrorState
- **NumberInput** — Default, WithMinMax, WithStep, Disabled, ErrorState
- **Checkbox** — Unchecked, Checked, Indeterminate, Disabled (with play functions)
- **Slider** — Default, WithRange, WithStep, Disabled
- **PinInput** — FourDigit, SixDigit, WithMask, Alphanumeric
- **Autocomplete** — Default, WithFiltering, EmptyState
- **InputGroup** — InputWithButton, SelectWithInput, InputRange
- **SegmentedControl** — TwoSegments, ThreeSegments, Controlled

## Test plan

- [x] `pnpm --dir packages/rialto typecheck` passes
- [x] ESLint passes (lint fixes applied in follow-up commit)
- [ ] Visual verification in Storybook