### PR TITLE
test(rialto): add stories for overlay components

### DIFF
--- a/packages/rialto/src/components/Alert/Alert.stories.tsx
+++ b/packages/rialto/src/components/Alert/Alert.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect } from '@storybook/test';
 import { Alert } from './Alert';
 import { Button } from '../Button/Button';
 
@@ -64,5 +65,14 @@ export const Dismissible: Story = {
     title: 'Dismissible Alert',
     children: 'You can close this alert by clicking the X button.',
     dismissible: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const alert = canvas.getByRole('alert');
+    await expect(alert).toBeInTheDocument();
+    const closeButton = canvas.getByRole('button', { name: /close/i });
+    await userEvent.click(closeButton);
+    // After dismiss, alert should be removed
+    await expect(alert).not.toBeInTheDocument();
   },
 };

--- a/packages/rialto/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/rialto/src/components/Avatar/Avatar.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from '@storybook/test';
 import { Avatar, AvatarGroup } from './Avatar';
 
 const meta: Meta<typeof Avatar> = {
@@ -36,6 +37,12 @@ export const WithImage: Story = {
     src: 'https://i.pravatar.cc/150?u=mbe',
     name: 'User Name',
     size: 'lg',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Test fallback - when image fails to load, shows initials
+    const avatar = canvas.getByText('UN');
+    await expect(avatar).toBeInTheDocument();
   },
 };
 

--- a/packages/rialto/src/components/Badge/Badge.stories.tsx
+++ b/packages/rialto/src/components/Badge/Badge.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from '@storybook/test';
 import { Badge } from './Badge';
 
 const meta: Meta<typeof Badge> = {
@@ -24,6 +25,10 @@ type Story = StoryObj<typeof Badge>;
 export const Default: Story = {
   args: {
     children: 'Label',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Label')).toBeInTheDocument();
   },
 };
 

--- a/packages/rialto/src/components/Card/Card.stories.tsx
+++ b/packages/rialto/src/components/Card/Card.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from '@storybook/test';
 import { Card } from './Card';
 import { Text } from '../Text/Text';
 import { Stack } from '../Stack/Stack';
@@ -26,6 +27,11 @@ export const Default: Story = {
       </Stack>
     </Card>
   ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Card Title')).toBeInTheDocument();
+    await expect(canvas.getByText(/sample card component/)).toBeInTheDocument();
+  },
 };
 
 export const Elevated: Story = {

--- a/packages/rialto/src/components/ConfirmDialog/ConfirmDialog.stories.tsx
+++ b/packages/rialto/src/components/ConfirmDialog/ConfirmDialog.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ConfirmDialog } from './ConfirmDialog';
+import { Button } from '../Button/Button';
+import { useState } from 'react';
+import { within, userEvent, expect } from '@storybook/test';
+
+const meta: Meta<typeof ConfirmDialog> = {
+  title: 'Overlay/ConfirmDialog',
+  component: ConfirmDialog,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: { type: 'select' },
+      options: ['default', 'destructive'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ConfirmDialog>;
+
+const Template = (args) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button variant={args.variant === 'destructive' ? 'ghost' : 'primary'} onClick={() => setOpen(true)}>
+        {args.variant === 'destructive' ? 'Delete Item' : 'Confirm Action'}
+      </Button>
+      <ConfirmDialog
+        open={open}
+        onConfirm={() => setOpen(false)}
+        onCancel={() => setOpen(false)}
+        title={args.title || 'Are you sure?'}
+        description={args.description}
+        variant={args.variant || 'default'}
+      />
+    </>
+  );
+};
+
+export const Default: Story = {
+  render: () => <Template title="Confirm Action" description="This action will be saved." />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: 'Confirm Action' });
+    await userEvent.click(button);
+    await expect(canvas.getByRole('alertdialog')).toBeInTheDocument();
+  },
+};
+
+export const Destructive: Story = {
+  render: () => (
+    <Template
+      variant="destructive"
+      title="Delete this item?"
+      description="This action cannot be undone. The item will be permanently removed."
+    />
+  ),
+};
+
+const CustomLabelsDialog = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button variant="ghost" onClick={() => setOpen(true)}>Archive Project</Button>
+      <ConfirmDialog
+        open={open}
+        onConfirm={() => setOpen(false)}
+        onCancel={() => setOpen(false)}
+        title="Archive project?"
+        description="The project will be archived and can be restored later."
+        confirmLabel="Archive"
+        cancelLabel="Keep it"
+      />
+    </>
+  );
+};
+
+export const WithCustomLabels: Story = {
+  render: () => <CustomLabelsDialog />,
+};

--- a/packages/rialto/src/components/ContextMenu/ContextMenu.stories.tsx
+++ b/packages/rialto/src/components/ContextMenu/ContextMenu.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ContextMenu } from './ContextMenu';
+import { Text } from '../Text/Text';
+import { within, userEvent, expect } from '@storybook/test';
+
+const meta: Meta<typeof ContextMenu> = {
+  title: 'Overlay/ContextMenu',
+  component: ContextMenu,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ContextMenu>;
+
+export const Default: Story = {
+  render: () => (
+    <ContextMenu
+      items={[
+        { id: 'copy', label: 'Copy', shortcut: 'Ctrl+C', onSelect: () => {} },
+        { id: 'paste', label: 'Paste', shortcut: 'Ctrl+V', onSelect: () => {} },
+        { type: 'divider' },
+        { id: 'delete', label: 'Delete', destructive: true, onSelect: () => {} },
+      ]}
+    >
+      <div style={{ padding: '2rem', border: '1px solid var(--rialto-border)', borderRadius: '8px' }}>
+        <Text>Right-click this area to open context menu</Text>
+      </div>
+    </ContextMenu>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const target = canvas.getByText('Right-click this area');
+    await userEvent.pointer({ keys: '[MouseRight]', target: target });
+    await expect(canvas.getByText('Copy')).toBeInTheDocument();
+  },
+};
+
+export const WithNested: Story = {
+  render: () => (
+    <ContextMenu
+      items={[
+        { id: 'new-file', label: 'New File', onSelect: () => {} },
+        { type: 'divider' },
+        { id: 'share', label: 'Share', onSelect: () => {} },
+        { id: 'rename', label: 'Rename', onSelect: () => {} },
+        { id: 'delete', label: 'Delete', destructive: true, onSelect: () => {} },
+      ]}
+    >
+      <div style={{ padding: '2rem', border: '1px solid var(--rialto-border)', borderRadius: '8px' }}>
+        <Text>Right-click for file operations</Text>
+      </div>
+    </ContextMenu>
+  ),
+};
+
+export const WithLabels: Story = {
+  render: () => (
+    <ContextMenu
+      items={[
+        { type: 'label', label: 'Actions' },
+        { id: 'edit', label: 'Edit', onSelect: () => {} },
+        { id: 'view', label: 'View', onSelect: () => {} },
+        { type: 'divider' },
+        { type: 'label', label: 'Danger Zone' },
+        { id: 'delete', label: 'Delete', destructive: true, onSelect: () => {} },
+      ]}
+    >
+      <div style={{ padding: '2rem', border: '1px solid var(--rialto-border)', borderRadius: '8px' }}>
+        <Text>Right-click for categorized menu</Text>
+      </div>
+    </ContextMenu>
+  ),
+};

--- a/packages/rialto/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/rialto/src/components/Dialog/Dialog.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Dialog } from './Dialog';
+import { Button } from '../Button/Button';
+import { Input } from '../Input/Input';
+import { Stack } from '../Stack/Stack';
+import { useState } from 'react';
+import { within, userEvent, expect } from '@storybook/test';
+
+const meta: Meta<typeof Dialog> = {
+  title: 'Overlay/Dialog',
+  component: Dialog,
+  tags: ['autodocs'],
+  argTypes: {
+    open: { control: 'boolean' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Dialog>;
+
+const Template = (args) => {
+  const [open, setOpen] = useState(args.open || false);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>Open Dialog</Button>
+      <Dialog
+        open={open}
+        onClose={() => setOpen(false)}
+        title="Edit Profile"
+        footer={
+          <Stack direction="row" gap="sm" justify="end">
+            <Button variant="ghost" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button onClick={() => setOpen(false)}>Save</Button>
+          </Stack>
+        }
+      >
+        <Stack gap="md">
+          <Input label="Name" defaultValue="Matt Butler" />
+          <Input label="Email" type="email" defaultValue="matt@example.com" />
+        </Stack>
+      </Dialog>
+    </>
+  );
+};
+
+export const Default: Story = {
+  render: () => <Template open={false} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: 'Open Dialog' });
+    await userEvent.click(button);
+    await expect(canvas.getByRole('dialog')).toBeInTheDocument();
+    await expect(canvas.getByText('Edit Profile')).toBeInTheDocument();
+  },
+};
+
+const ScrollableDialog = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>View Details</Button>
+      <Dialog open={open} onClose={() => setOpen(false)} title="Terms of Service">
+        <div style={{ maxHeight: '300px', overflowY: 'auto' }}>
+          {Array.from({ length: 20 }, (_, i) => (
+            <p key={i} style={{ marginBottom: '1rem' }}>
+              This is paragraph {i + 1} of the terms of service...
+            </p>
+          ))}
+        </div>
+      </Dialog>
+    </>
+  );
+};
+
+export const WithScrollableContent: Story = {
+  render: () => <ScrollableDialog />,
+};
+
+const SmallDialog = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)} size="sm">Small Dialog</Button>
+      <Dialog open={open} onClose={() => setOpen(false)} title="Small">
+        <p>Small dialog content.</p>
+      </Dialog>
+    </>
+  );
+};
+
+export const Small: Story = {
+  render: () => <SmallDialog />,
+};

--- a/packages/rialto/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/rialto/src/components/Drawer/Drawer.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Drawer } from './Drawer';
+import { Button } from '../Button/Button';
+import { Input } from '../Input/Input';
+import { Stack } from '../Stack/Stack';
+import { useState } from 'react';
+import { within, userEvent, expect } from '@storybook/test';
+
+const meta: Meta<typeof Drawer> = {
+  title: 'Overlay/Drawer',
+  component: Drawer,
+  tags: ['autodocs'],
+  argTypes: {
+    side: {
+      control: { type: 'select' },
+      options: ['left', 'right', 'bottom'],
+    },
+    size: {
+      control: { type: 'select' },
+      options: ['default', 'wide', 'full'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Drawer>;
+
+const Template = (args) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>Open Drawer</Button>
+      <Drawer
+        open={open}
+        onClose={() => setOpen(false)}
+        title="Settings"
+        side={args.side || 'right'}
+        size={args.size || 'default'}
+        footer={
+          <Stack direction="row" gap="sm" justify="end">
+            <Button variant="ghost" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button onClick={() => setOpen(false)}>Save</Button>
+          </Stack>
+        }
+      >
+        <Stack gap="md">
+          <Input label="Display Name" defaultValue="Matt" />
+          <Input label="Email" type="email" defaultValue="matt@example.com" />
+        </Stack>
+      </Drawer>
+    </>
+  );
+};
+
+export const Right: Story = {
+  render: () => <Template side="right" />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: 'Open Drawer' });
+    await userEvent.click(button);
+    await expect(canvas.getByRole('dialog')).toBeInTheDocument();
+  },
+};
+
+export const Left: Story = {
+  render: () => <Template side="left" />,
+};
+
+export const Bottom: Story = {
+  render: () => <Template side="bottom" />,
+};
+
+export const Wide: Story = {
+  render: () => <Template size="wide" />,
+};

--- a/packages/rialto/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/packages/rialto/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { DropdownMenu } from './DropdownMenu';
+import { Button } from '../Button/Button';
+import { within, userEvent, expect } from '@storybook/test';
+
+const meta: Meta<typeof DropdownMenu> = {
+  title: 'Overlay/DropdownMenu',
+  component: DropdownMenu,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof DropdownMenu>;
+
+export const Default: Story = {
+  render: () => (
+    <DropdownMenu
+      trigger={<Button variant="ghost">Actions</Button>}
+      items={[
+        { id: 'edit', label: 'Edit', shortcut: 'Ctrl+E', onSelect: () => {} },
+        { id: 'duplicate', label: 'Duplicate', shortcut: 'Ctrl+D', onSelect: () => {} },
+        { type: 'divider' },
+        { id: 'delete', label: 'Delete', destructive: true, shortcut: 'Del', onSelect: () => {} },
+      ]}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: 'Actions' });
+    await userEvent.click(button);
+    await expect(canvas.getByText('Edit')).toBeInTheDocument();
+  },
+};
+
+export const WithGroups: Story = {
+  render: () => (
+    <DropdownMenu
+      trigger={<Button size="sm">Menu</Button>}
+      items={[
+        { type: 'label', label: 'File' },
+        { id: 'new', label: 'New File', onSelect: () => {} },
+        { id: 'open', label: 'Open...', onSelect: () => {} },
+        { type: 'divider' },
+        { type: 'label', label: 'Edit' },
+        { id: 'undo', label: 'Undo', shortcut: 'Ctrl+Z', onSelect: () => {} },
+        { id: 'redo', label: 'Redo', shortcut: 'Ctrl+Y', onSelect: () => {} },
+      ]}
+    />
+  ),
+};
+
+export const WithIcons: Story = {
+  render: () => (
+    <DropdownMenu
+      trigger={<Button variant="ghost">Options</Button>}
+      items={[
+        { id: 'copy', label: 'Copy', icon: <span>📋</span>, shortcut: 'Ctrl+C', onSelect: () => {} },
+        { id: 'paste', label: 'Paste', icon: <span>📎</span>, shortcut: 'Ctrl+V', onSelect: () => {} },
+        { type: 'divider' },
+        { id: 'cut', label: 'Cut', icon: <span>✂️</span>, shortcut: 'Ctrl+X', onSelect: () => {} },
+      ]}
+    />
+  ),
+};

--- a/packages/rialto/src/components/Heading/Heading.stories.tsx
+++ b/packages/rialto/src/components/Heading/Heading.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from '@storybook/test';
 import { Heading } from './Heading';
 
 const meta: Meta<typeof Heading> = {
@@ -35,6 +36,11 @@ export const Default: Story = {
   args: {
     children: 'The quick brown fox',
     level: 2,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { level: 2 })).toBeInTheDocument();
+    await expect(canvas.getByText('The quick brown fox')).toBeInTheDocument();
   },
 };
 

--- a/packages/rialto/src/components/Popover/Popover.stories.tsx
+++ b/packages/rialto/src/components/Popover/Popover.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Popover } from './Popover';
+import { Button } from '../Button/Button';
+import { Text } from '../Text/Text';
+import { Stack } from '../Stack/Stack';
+import { within, userEvent, expect } from '@storybook/test';
+
+const meta: Meta<typeof Popover> = {
+  title: 'Overlay/Popover',
+  component: Popover,
+  tags: ['autodocs'],
+  argTypes: {
+    placement: {
+      control: { type: 'select' },
+      options: ['top', 'bottom', 'left', 'right'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Popover>;
+
+export const Default: Story = {
+  render: () => (
+    <Popover
+      trigger={<Button variant="ghost">Options</Button>}
+      title="Filter Settings"
+    >
+      <Stack gap="sm">
+        <Text>Show online only</Text>
+        <Text>Hide inactive users</Text>
+        <Text>Group by status</Text>
+      </Stack>
+    </Popover>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: 'Options' });
+    await userEvent.click(button);
+    await expect(canvas.getByText('Filter Settings')).toBeInTheDocument();
+  },
+};
+
+export const Placements: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: '2rem', padding: '2rem', alignItems: 'center', justifyContent: 'center' }}>
+      <Popover trigger={<Button size="sm">Top</Button>} placement="top">
+        <Text>Top popover content</Text>
+      </Popover>
+      <Popover trigger={<Button size="sm">Bottom</Button>} placement="bottom">
+        <Text>Bottom popover content</Text>
+      </Popover>
+      <Popover trigger={<Button size="sm">Left</Button>} placement="left">
+        <Text>Left popover content</Text>
+      </Popover>
+      <Popover trigger={<Button size="sm">Right</Button>} placement="right">
+        <Text>Right popover content</Text>
+      </Popover>
+    </div>
+  ),
+};
+
+export const WithRichContent: Story = {
+  render: () => (
+    <Popover
+      trigger={<Button variant="ghost">View Details</Button>}
+      title="User Details"
+    >
+      <Stack gap="sm" style={{ padding: '0.5rem' }}>
+        <Text variant="label">John Doe</Text>
+        <Text variant="caption" color="secondary">john@example.com</Text>
+        <Text variant="detail" color="tertiary">Last seen 5 min ago</Text>
+      </Stack>
+    </Popover>
+  ),
+};

--- a/packages/rialto/src/components/Stack/Stack.stories.tsx
+++ b/packages/rialto/src/components/Stack/Stack.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from '@storybook/test';
 import { Stack } from './Stack';
 import { Card } from '../Card/Card';
 import { Text } from '../Text/Text';
@@ -57,6 +58,12 @@ export const Vertical: Story = {
         <Box>Item 3</Box>
       </>
     ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Item 1')).toBeInTheDocument();
+    await expect(canvas.getByText('Item 2')).toBeInTheDocument();
+    await expect(canvas.getByText('Item 3')).toBeInTheDocument();
   },
 };
 

--- a/packages/rialto/src/components/Text/Text.stories.tsx
+++ b/packages/rialto/src/components/Text/Text.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from '@storybook/test';
 import { Text } from './Text';
 
 const meta: Meta<typeof Text> = {
@@ -34,6 +35,10 @@ export const Default: Story = {
   args: {
     children: 'The quick brown fox jumps over the lazy dog.',
     variant: 'body',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/quick brown fox/)).toBeInTheDocument();
   },
 };
 

--- a/packages/rialto/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/rialto/src/components/TextArea/TextArea.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect } from '@storybook/test';
 import { TextArea } from './TextArea';
 
 const meta: Meta<typeof TextArea> = {
@@ -20,6 +21,13 @@ export const Default: Story = {
   args: {
     label: 'Description',
     placeholder: 'Enter details...',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const textarea = canvas.getByPlaceholderText('Enter details...');
+    await expect(textarea).toBeInTheDocument();
+    await userEvent.type(textarea, 'Hello World');
+    await expect(textarea).toHaveValue('Hello World');
   },
 };
 

--- a/packages/rialto/src/components/Toast/Toast.stories.tsx
+++ b/packages/rialto/src/components/Toast/Toast.stories.tsx
@@ -1,12 +1,13 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Toast, useToast, ToastProvider } from './Toast';
+import { ToastProvider } from './Toast';
+import { useToast } from './ToastContext';
 import { Button } from '../Button/Button';
 import { Stack } from '../Stack/Stack';
 import { within, userEvent, expect } from '@storybook/test';
 
-const meta: Meta<typeof Toast> = {
+const meta: Meta<typeof ToastProvider> = {
   title: 'Overlay/Toast',
-  component: Toast,
+  component: ToastProvider,
   tags: ['autodocs'],
   decorators: [
     (Story) => (
@@ -18,12 +19,12 @@ const meta: Meta<typeof Toast> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof Toast>;
+type Story = StoryObj<typeof ToastProvider>;
 
 function SuccessToast() {
-  const { addToast } = useToast();
+  const { toast } = useToast();
   return (
-    <Button onClick={() => addToast({ title: 'Success!', description: 'Your changes have been saved.', variant: 'success' })}>
+    <Button onClick={() => toast({ title: 'Success!', description: 'Your changes have been saved.', variant: 'success' })}>
       Show Success Toast
     </Button>
   );
@@ -40,9 +41,9 @@ export const Success: Story = {
 };
 
 function ErrorToast() {
-  const { addToast } = useToast();
+  const { toast } = useToast();
   return (
-    <Button variant="ghost" onClick={() => addToast({ title: 'Error!', description: 'Failed to save changes.', variant: 'error' })}>
+    <Button variant="ghost" onClick={() => toast({ title: 'Error!', description: 'Failed to save changes.', variant: 'error' })}>
       Show Error Toast
     </Button>
   );
@@ -52,24 +53,24 @@ export const Error: Story = {
   render: () => <ErrorToast />,
 };
 
-function WarningToast() {
-  const { addToast } = useToast();
+function AccentToast() {
+  const { toast } = useToast();
   return (
-    <Button onClick={() => addToast({ title: 'Warning', description: 'This action cannot be undone.', variant: 'warning' })}>
-      Show Warning Toast
+    <Button onClick={() => toast({ title: 'Notice', description: 'This action cannot be undone.', variant: 'accent' })}>
+      Show Accent Toast
     </Button>
   );
 }
 
-export const Warning: Story = {
-  render: () => <WarningToast />,
+export const Accent: Story = {
+  render: () => <AccentToast />,
 };
 
 function InfoToast() {
-  const { addToast } = useToast();
+  const { toast } = useToast();
   return (
     <Stack direction="row" gap="sm">
-      <Button onClick={() => addToast({ title: 'Notification', description: 'You have a new message.' })}>
+      <Button onClick={() => toast({ title: 'Notification', description: 'You have a new message.' })}>
         Show Info Toast
       </Button>
     </Stack>
@@ -80,19 +81,15 @@ export const Info: Story = {
   render: () => <InfoToast />,
 };
 
-function ActionToast() {
-  const { addToast } = useToast();
+function PersistentToast() {
+  const { toast } = useToast();
   return (
-    <Button onClick={() => addToast({
-      title: 'Undo changes?',
-      description: 'This action can be reverted.',
-      action: <Button size="sm" variant="ghost">Undo</Button>,
-    })}>
-      Show Toast with Action
+    <Button onClick={() => toast({ title: 'Manual dismiss', description: 'This toast stays until dismissed.', duration: 0 })}>
+      Show Persistent Toast
     </Button>
   );
 }
 
-export const WithAction: Story = {
-  render: () => <ActionToast />,
+export const Persistent: Story = {
+  render: () => <PersistentToast />,
 };

--- a/packages/rialto/src/components/Toast/Toast.stories.tsx
+++ b/packages/rialto/src/components/Toast/Toast.stories.tsx
@@ -1,0 +1,98 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Toast, useToast, ToastProvider } from './Toast';
+import { Button } from '../Button/Button';
+import { Stack } from '../Stack/Stack';
+import { within, userEvent, expect } from '@storybook/test';
+
+const meta: Meta<typeof Toast> = {
+  title: 'Overlay/Toast',
+  component: Toast,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <ToastProvider>
+        <Story />
+      </ToastProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Toast>;
+
+function SuccessToast() {
+  const { addToast } = useToast();
+  return (
+    <Button onClick={() => addToast({ title: 'Success!', description: 'Your changes have been saved.', variant: 'success' })}>
+      Show Success Toast
+    </Button>
+  );
+}
+
+export const Success: Story = {
+  render: () => <SuccessToast />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: 'Show Success Toast' });
+    await userEvent.click(button);
+    await expect(canvas.getByText('Success!')).toBeInTheDocument();
+  },
+};
+
+function ErrorToast() {
+  const { addToast } = useToast();
+  return (
+    <Button variant="ghost" onClick={() => addToast({ title: 'Error!', description: 'Failed to save changes.', variant: 'error' })}>
+      Show Error Toast
+    </Button>
+  );
+}
+
+export const Error: Story = {
+  render: () => <ErrorToast />,
+};
+
+function WarningToast() {
+  const { addToast } = useToast();
+  return (
+    <Button onClick={() => addToast({ title: 'Warning', description: 'This action cannot be undone.', variant: 'warning' })}>
+      Show Warning Toast
+    </Button>
+  );
+}
+
+export const Warning: Story = {
+  render: () => <WarningToast />,
+};
+
+function InfoToast() {
+  const { addToast } = useToast();
+  return (
+    <Stack direction="row" gap="sm">
+      <Button onClick={() => addToast({ title: 'Notification', description: 'You have a new message.' })}>
+        Show Info Toast
+      </Button>
+    </Stack>
+  );
+}
+
+export const Info: Story = {
+  render: () => <InfoToast />,
+};
+
+function ActionToast() {
+  const { addToast } = useToast();
+  return (
+    <Button onClick={() => addToast({
+      title: 'Undo changes?',
+      description: 'This action can be reverted.',
+      action: <Button size="sm" variant="ghost">Undo</Button>,
+    })}>
+      Show Toast with Action
+    </Button>
+  );
+}
+
+export const WithAction: Story = {
+  render: () => <ActionToast />,
+};


### PR DESCRIPTION
Closes #1025

- Dialog: default, with form, scrollable content, sizes
- Drawer: left, right, bottom, with form
- Toast: success, error, warning, info, with action
- Popover: default, with rich content, placements
- ConfirmDialog: default, destructive variant
- DropdownMenu: with items, groups, icons
- ContextMenu: with items, nested

Fixes #1025