### PR TITLE
fix(ci): update backup-verify workflow to use Prisma 7

### DIFF
--- a/.github/workflows/backup-verify.yml
+++ b/.github/workflows/backup-verify.yml
@@ -40,14 +40,17 @@ jobs:
           PGUSER: verify
           PGPASSWORD: verify_test_only
           PGDATABASE: verify_restore
+          NODE_PATH: /usr/local/lib/node_modules
         run: |
-          npm install -g prisma@6
+          npm install -g prisma@7
 
           for SERVICE in users reservations agent; do
-            SCHEMA_PATH="services/$SERVICE/prisma/schema.prisma"
-            if [ -f "$SCHEMA_PATH" ]; then
-              DATABASE_URL="postgresql://verify:verify_test_only@localhost:5432/verify_restore" \
-                prisma db push --schema "$SCHEMA_PATH" --skip-generate --accept-data-loss 2>&1 || {
+            if [ -f "services/$SERVICE/prisma.config.ts" ]; then
+              (
+                cd "services/$SERVICE"
+                DATABASE_URL="postgresql://verify:verify_test_only@localhost:5432/verify_restore" \
+                  prisma db push --skip-generate --accept-data-loss 2>&1
+              ) || {
                 echo "::error::Schema push failed for $SERVICE"
                 exit 1
               }


### PR DESCRIPTION
## Summary

Closes #1043

The `backup-verify` workflow was installing `prisma@6` but all services have migrated to Prisma 7. Prisma 7 schemas no longer embed `url` in the `datasource` block (connection URL moves to `prisma.config.ts`) — Prisma 6 rejects these schemas with P1012, causing the weekly verification to fail.

- Upgrade `npm install -g prisma@6` → `prisma@7`
- Add `NODE_PATH=/usr/local/lib/node_modules` so globally-installed Prisma can resolve `prisma/config` (per known gotcha for global Prisma 7 installs)
- `cd` into each service directory so Prisma auto-discovers `prisma.config.ts` instead of using `--schema` flag
- Check for `prisma.config.ts` existence rather than `schema.prisma` as the gate condition

## Test plan

- [ ] Re-run `backup-verify` workflow via workflow_dispatch and confirm all 3 service schemas push successfully
- [ ] Confirm table count check ≥ 3 still passes

https://claude.ai/code/session_01SvsRo3BhmRkGM9Lz4tNx2x

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvsRo3BhmRkGM9Lz4tNx2x)_