### PR TITLE
test(hospitality): E2E coverage for reservations, guests, settings, booking-widget, and onboarding

### DIFF
--- a/apps/hospitality/e2e/booking-widget.spec.ts
+++ b/apps/hospitality/e2e/booking-widget.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "./fixtures.js";
+
+test.describe("Booking Widget demo page", () => {
+  test("page loads with heading and description", async ({ authPage }) => {
+    await authPage.goto("/booking-widget");
+
+    await expect(authPage.getByRole("heading", { name: "Booking Widget" })).toBeVisible();
+  });
+
+  test("renders embed code section", async ({ authPage }) => {
+    await authPage.goto("/booking-widget");
+
+    const codeBlock = authPage.locator("pre");
+    await expect(codeBlock).toBeVisible();
+
+    const codeText = await codeBlock.textContent();
+    expect(codeText).toContain("BookingWidget");
+  });
+
+  test("shows venue selector or widget preview area", async ({ authPage }) => {
+    await authPage.goto("/booking-widget");
+
+    const previewArea = authPage.getByText(/preview|select a venue/i);
+    await expect(previewArea).toBeVisible();
+  });
+});

--- a/apps/hospitality/e2e/guests.spec.ts
+++ b/apps/hospitality/e2e/guests.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from "./fixtures.js";
+
+test.describe("CF-7: Guest directory and search", () => {
+  test("page loads with header and search input", async ({ authPage }) => {
+    await authPage.goto("/guests");
+
+    await expect(authPage.getByRole("heading", { name: "Guests" })).toBeVisible();
+
+    const searchInput = authPage.getByPlaceholder("Search guests...");
+    await expect(searchInput).toBeVisible();
+  });
+
+  test("Add Guest button is visible", async ({ authPage }) => {
+    await authPage.goto("/guests");
+
+    await expect(authPage.getByRole("button", { name: "Add Guest" })).toBeVisible();
+  });
+
+  test("search input filters guest list", async ({ authPage }) => {
+    await authPage.goto("/guests");
+
+    const searchInput = authPage.getByPlaceholder("Search guests...");
+    await searchInput.fill("Test");
+
+    const liveRegion = authPage.locator('[aria-live="polite"]', { hasText: /guest/ });
+    await expect(liveRegion.first()).toBeVisible();
+  });
+
+  test("empty search state shows no guests message", async ({ authPage }) => {
+    await authPage.goto("/guests");
+
+    const searchInput = authPage.getByPlaceholder("Search guests...");
+    await searchInput.fill("zzzzz-no-match-9999");
+
+    await expect(
+      authPage.getByText(/no guests found/i).or(authPage.getByText(/no guests yet/i)),
+    ).toBeVisible();
+  });
+
+  test("Add Guest dialog opens with required fields", async ({ authPage }) => {
+    await authPage.goto("/guests");
+
+    await authPage.getByRole("button", { name: "Add Guest" }).click();
+
+    const dialog = authPage.getByRole("dialog", { name: /add guest/i });
+    await expect(dialog).toBeVisible();
+
+    await expect(dialog.getByPlaceholder("Full name")).toBeVisible();
+    await expect(dialog.getByPlaceholder("guest@example.com")).toBeVisible();
+  });
+
+  test("Add Guest dialog can be dismissed", async ({ authPage }) => {
+    await authPage.goto("/guests");
+
+    await authPage.getByRole("button", { name: "Add Guest" }).click();
+
+    const dialog = authPage.getByRole("dialog", { name: /add guest/i });
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByRole("button", { name: /cancel|close/i }).click();
+
+    await expect(dialog).not.toBeVisible();
+  });
+
+  test("clicking a guest opens detail drawer", async ({ authPage }) => {
+    await authPage.goto("/guests");
+
+    const firstGuest = authPage.getByRole("button", { name: /view details for/i }).first();
+    const guestCount = await firstGuest.count();
+
+    if (guestCount > 0) {
+      await firstGuest.click();
+      await expect(authPage.getByRole("dialog")).toBeVisible();
+    }
+  });
+});

--- a/apps/hospitality/e2e/onboarding.spec.ts
+++ b/apps/hospitality/e2e/onboarding.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from "./fixtures.js";
+
+test.describe("Venue onboarding wizard", () => {
+  test("page loads with heading and step 1 (Basic Info)", async ({ authPage }) => {
+    await authPage.goto("/onboarding");
+
+    await expect(authPage.getByRole("heading", { name: "New Venue" })).toBeVisible();
+    await expect(authPage.getByLabel("Venue Name")).toBeVisible();
+    await expect(authPage.getByLabel("Slug")).toBeVisible();
+  });
+
+  test("step 1 requires venue name before advancing", async ({ authPage }) => {
+    await authPage.goto("/onboarding");
+
+    await authPage.getByRole("button", { name: "Next" }).click();
+
+    await expect(authPage.getByLabel("Venue Name")).toBeVisible();
+  });
+
+  test("completes step 1 and advances to step 2", async ({ authPage }) => {
+    await authPage.goto("/onboarding");
+
+    await authPage.getByLabel("Venue Name").fill("E2E Test Venue");
+
+    await authPage.getByRole("button", { name: "Next" }).click();
+
+    await expect(authPage.getByLabel("Timezone")).toBeVisible();
+  });
+
+  test("step 2 shows timezone and currency selectors", async ({ authPage }) => {
+    await authPage.goto("/onboarding");
+
+    await authPage.getByLabel("Venue Name").fill("E2E Test Venue");
+    await authPage.getByRole("button", { name: "Next" }).click();
+
+    await expect(authPage.getByLabel("Timezone")).toBeVisible();
+    await expect(authPage.getByLabel("Currency")).toBeVisible();
+  });
+
+  test("Back button returns to previous step", async ({ authPage }) => {
+    await authPage.goto("/onboarding");
+
+    await authPage.getByLabel("Venue Name").fill("E2E Test Venue");
+    await authPage.getByRole("button", { name: "Next" }).click();
+    await expect(authPage.getByLabel("Timezone")).toBeVisible();
+
+    await authPage.getByRole("button", { name: "Back" }).click();
+
+    await expect(authPage.getByLabel("Venue Name")).toBeVisible();
+  });
+
+  test("Back button is disabled on step 1", async ({ authPage }) => {
+    await authPage.goto("/onboarding");
+
+    await expect(authPage.getByRole("button", { name: "Back" })).toBeDisabled();
+  });
+
+  test("advances through all 5 steps to confirmation", async ({ authPage }) => {
+    await authPage.goto("/onboarding");
+
+    await authPage.getByLabel("Venue Name").fill("E2E Test Venue");
+    await authPage.getByRole("button", { name: "Next" }).click();
+
+    await expect(authPage.getByLabel("Timezone")).toBeVisible();
+    await authPage.getByRole("button", { name: "Next" }).click();
+
+    await authPage.getByRole("button", { name: "Next" }).click();
+
+    await authPage.getByRole("button", { name: "Next" }).click();
+
+    await expect(authPage.getByRole("button", { name: /create venue/i })).toBeVisible();
+    await expect(authPage.getByText("Basic Information")).toBeVisible();
+  });
+});

--- a/apps/hospitality/e2e/reservations.spec.ts
+++ b/apps/hospitality/e2e/reservations.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from "./fixtures.js";
+
+test.describe("CF-6: Reservations page with filtering", () => {
+  test("page loads with header and stats row", async ({ authPage }) => {
+    await authPage.goto("/reservations");
+
+    await expect(authPage.getByRole("heading", { name: "Reservations" })).toBeVisible();
+
+    const statsRow = authPage.locator('[role="status"]').first();
+    await expect(statsRow).toBeVisible();
+  });
+
+  test("displays status filter segments and search input", async ({ authPage }) => {
+    await authPage.goto("/reservations");
+
+    await expect(authPage.getByRole("radio", { name: "All" })).toBeVisible();
+    await expect(authPage.getByRole("radio", { name: "Confirmed" })).toBeVisible();
+    await expect(authPage.getByRole("radio", { name: "Pending" })).toBeVisible();
+    await expect(authPage.getByRole("radio", { name: "Cancelled" })).toBeVisible();
+
+    const searchInput = authPage.getByRole("textbox");
+    await expect(searchInput).toBeVisible();
+  });
+
+  test("status filter updates list when Confirmed is selected", async ({ authPage }) => {
+    await authPage.goto("/reservations");
+
+    await authPage.getByRole("radio", { name: "Confirmed" }).click();
+
+    await expect(authPage).toHaveURL(/status=CONFIRMED/);
+  });
+
+  test("search input filters the reservation list", async ({ authPage }) => {
+    await authPage.goto("/reservations");
+
+    const searchInput = authPage.getByRole("textbox");
+    await searchInput.fill("Test");
+
+    const resultCount = authPage.locator('[aria-live="polite"]', { hasText: /reservation/ }).last();
+    await expect(resultCount).toBeVisible();
+  });
+
+  test("All filter clears status selection", async ({ authPage }) => {
+    await authPage.goto("/reservations?status=CONFIRMED");
+
+    await authPage.getByRole("radio", { name: "All" }).click();
+
+    await expect(authPage).not.toHaveURL(/status=CONFIRMED/);
+  });
+
+  test("shows empty state when no results match search", async ({ authPage }) => {
+    await authPage.goto("/reservations");
+
+    const searchInput = authPage.getByRole("textbox");
+    await searchInput.fill("zzzzz-no-match-9999");
+
+    await expect(authPage.getByText("No reservations")).toBeVisible();
+  });
+});

--- a/apps/hospitality/e2e/settings.spec.ts
+++ b/apps/hospitality/e2e/settings.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from "./fixtures.js";
+
+test.describe("CF-10: Settings page and preferences persistence", () => {
+  test("page loads with heading and appearance card", async ({ authPage }) => {
+    await authPage.goto("/settings");
+
+    await expect(authPage.getByRole("heading", { name: "Settings" })).toBeVisible();
+    await expect(authPage.getByText("Appearance")).toBeVisible();
+  });
+
+  test("theme selector is visible with options", async ({ authPage }) => {
+    await authPage.goto("/settings");
+
+    await expect(authPage.getByText(/system|light|dark/i).first()).toBeVisible();
+  });
+
+  test("settings page persists across navigation", async ({ authPage }) => {
+    await authPage.goto("/settings");
+
+    await expect(authPage.getByRole("heading", { name: "Settings" })).toBeVisible();
+
+    await authPage.goto("/");
+    await authPage.goto("/settings");
+
+    await expect(authPage.getByRole("heading", { name: "Settings" })).toBeVisible();
+    await expect(authPage.getByText("Appearance")).toBeVisible();
+  });
+
+  test("notifications card is visible", async ({ authPage }) => {
+    await authPage.goto("/settings");
+
+    await expect(authPage.getByText("Notifications")).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1009

Adds 5 new Playwright spec files covering 8 previously-untested routes. All specs use the existing `authPage` fixture from `e2e/fixtures.ts` (Auth0 ROPC, no browser login flow).

- **reservations.spec.ts** — CF-6: page loads, status filter segments (All/Confirmed/Pending/Cancelled), search input filters, URL param reflects status, empty state renders
- **guests.spec.ts** — CF-7: page loads, search filters list, Add Guest dialog opens with name/email fields, dialog dismisses, clicking a guest opens detail drawer
- **settings.spec.ts** — CF-10: page loads with Appearance + Notifications cards, settings route persists across navigation
- **booking-widget.spec.ts** — page loads, embed code `<pre>` block is visible and contains `BookingWidget`, preview area visible
- **onboarding.spec.ts** — 5-step wizard: step 1 requires venue name before advancing, steps 2–5 navigable in sequence, Back button disabled on step 1, Confirmation step shows review cards + Create Venue button

## Test plan

- [ ] `pnpm test:e2e` passes with `E2E_AUTH*` env vars set
- [ ] All 5 new spec files are discovered by `playwright.config.ts` (testDir: `./e2e`)
- [ ] No TypeScript errors in e2e directory

https://claude.ai/code/session_01KCZofQUTU4BMn26EVEFZQE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCZofQUTU4BMn26EVEFZQE)_