### PR TITLE
test(gen): E2E coverage for playground, auth, and shared spec pages

### DIFF
--- a/apps/gen/e2e/a11y.test.ts
+++ b/apps/gen/e2e/a11y.test.ts
@@ -15,4 +15,19 @@ test.describe("Accessibility", () => {
 
     expect(violations).toHaveLength(0);
   });
+
+  test("shared spec error page has no critical violations", async ({ page }) => {
+    await page.goto("/s/invalid-id-for-a11y");
+    await expect(page.getByText("Spec not found")).toBeVisible({ timeout: 10_000 });
+
+    const accessibilityScanResults = await new AxeBuilder({ page })
+      .withTags(["wcag2aa"])
+      .analyze();
+
+    const violations = accessibilityScanResults.violations.filter(
+      (v) => v.impact === "critical" || v.impact === "serious"
+    );
+
+    expect(violations).toHaveLength(0);
+  });
 });

--- a/apps/gen/e2e/auth-helpers.ts
+++ b/apps/gen/e2e/auth-helpers.ts
@@ -1,0 +1,146 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Auth0 Resource Owner Password Grant configuration.
+ * All values come from environment variables — never hardcoded.
+ */
+interface Auth0Config {
+  domain: string;
+  clientId: string;
+  audience: string;
+  email: string;
+  password: string;
+}
+
+function getAuth0Config(): Auth0Config {
+  const domain = process.env.E2E_AUTH0_DOMAIN;
+  const clientId = process.env.E2E_AUTH0_CLIENT_ID;
+  const audience = process.env.E2E_AUTH0_AUDIENCE;
+  const email = process.env.E2E_AUTH_EMAIL;
+  const password = process.env.E2E_AUTH_PASSWORD;
+
+  if (!domain || !clientId || !audience || !email || !password) {
+    throw new Error(
+      "Missing required E2E auth env vars. Required:\n" +
+        "  E2E_AUTH0_DOMAIN      — Auth0 tenant domain (e.g. dev-xxx.us.auth0.com)\n" +
+        "  E2E_AUTH0_CLIENT_ID   — Auth0 app client ID (ROPC-enabled)\n" +
+        "  E2E_AUTH0_AUDIENCE    — API audience identifier\n" +
+        "  E2E_AUTH_EMAIL        — Test user email\n" +
+        "  E2E_AUTH_PASSWORD     — Test user password\n\n" +
+        "The Auth0 app must have the Password grant type enabled and the test user must not have MFA."
+    );
+  }
+
+  return { domain, clientId, audience, email, password };
+}
+
+/**
+ * Token response from Auth0's /oauth/token endpoint.
+ */
+interface TokenResponse {
+  access_token: string;
+  id_token: string;
+  token_type: string;
+  expires_in: number;
+}
+
+/**
+ * Fetches tokens from Auth0 using the Resource Owner Password Grant.
+ * This bypasses the browser login flow entirely — fast, reliable, CI-friendly.
+ */
+async function fetchAuth0Tokens(config: Auth0Config): Promise<TokenResponse> {
+  const response = await fetch(`https://${config.domain}/oauth/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      grant_type: "password",
+      username: config.email,
+      password: config.password,
+      audience: config.audience,
+      client_id: config.clientId,
+      scope: "openid profile email",
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `Auth0 token request failed (${response.status}): ${body}\n` +
+        "Verify: ROPC grant enabled, test user exists, no MFA, correct credentials."
+    );
+  }
+
+  return response.json() as Promise<TokenResponse>;
+}
+
+/**
+ * Decodes a JWT payload without verification (tokens come directly from Auth0).
+ */
+function decodeJwtPayload(token: string): Record<string, unknown> {
+  const base64 = token.split(".")[1];
+  const json = Buffer.from(base64, "base64url").toString("utf-8");
+  return JSON.parse(json) as Record<string, unknown>;
+}
+
+/**
+ * Builds the oidc-client-ts session storage object that react-oidc-context reads.
+ * The key format is: oidc.user:<authority>:<client_id>
+ */
+function buildOidcUserEntry(
+  config: Auth0Config,
+  tokens: TokenResponse
+): { key: string; value: string } {
+  const authority = `https://${config.domain}`;
+  const idClaims = decodeJwtPayload(tokens.id_token);
+
+  const oidcUser = {
+    access_token: tokens.access_token,
+    id_token: tokens.id_token,
+    token_type: tokens.token_type,
+    scope: "openid profile email",
+    expires_at: Math.floor(Date.now() / 1000) + tokens.expires_in,
+    profile: {
+      sub: idClaims.sub,
+      email: idClaims.email,
+      email_verified: idClaims.email_verified,
+      name: idClaims.name,
+      picture: idClaims.picture,
+      iss: idClaims.iss,
+      aud: idClaims.aud,
+      iat: idClaims.iat,
+      exp: idClaims.exp,
+    },
+  };
+
+  return {
+    key: `oidc.user:${authority}:${config.clientId}`,
+    value: JSON.stringify(oidcUser),
+  };
+}
+
+/**
+ * Injects authenticated session into the page's sessionStorage.
+ * After calling this, the react-oidc-context AuthProvider will see the user
+ * as authenticated without any browser-based login flow.
+ *
+ * Usage in Playwright setup:
+ *   await injectAuth0Session(page);
+ *   // page is now authenticated — navigate anywhere
+ */
+export async function injectAuth0Session(page: Page): Promise<void> {
+  const config = getAuth0Config();
+  const tokens = await fetchAuth0Tokens(config);
+  const entry = buildOidcUserEntry(config, tokens);
+
+  // Navigate to the app first so sessionStorage is on the correct origin
+  await page.goto("/");
+  await page.evaluate(
+    ({ key, value }) => {
+      sessionStorage.setItem(key, value);
+    },
+    entry
+  );
+
+  // Reload so AuthProvider picks up the injected session
+  await page.reload();
+}

--- a/apps/gen/e2e/auth.spec.ts
+++ b/apps/gen/e2e/auth.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Auth", () => {
+  test("unauthenticated user sees login prompt", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByText("Gen Playground")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
+  });
+
+  test("Sign In button is enabled", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByRole("button", { name: "Sign In" })).toBeEnabled();
+  });
+
+  test("callback route redirects to home", async ({ page }) => {
+    // Without a real OIDC state/code param, callback component redirects to /
+    await page.goto("/callback");
+    await expect(page).toHaveURL(/\/gen\/?(#.*)?$/);
+  });
+});

--- a/apps/gen/e2e/fixtures.ts
+++ b/apps/gen/e2e/fixtures.ts
@@ -1,0 +1,23 @@
+import { test as base } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { injectAuth0Session } from "./auth-helpers.js";
+
+/**
+ * Extended Playwright test with an `authPage` fixture.
+ * Injects Auth0 tokens via ROPC so every test starts fully authenticated.
+ *
+ * Usage:
+ *   import { test, expect } from "./fixtures.js";
+ *   test("some authenticated test", async ({ authPage }) => {
+ *     await authPage.goto("/");
+ *     ...
+ *   });
+ */
+export const test = base.extend<{ authPage: Page }>({
+  authPage: async ({ page }, use) => {
+    await injectAuth0Session(page);
+    await use(page);
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/apps/gen/e2e/playground.spec.ts
+++ b/apps/gen/e2e/playground.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from "./fixtures.js";
+import { AxeBuilder } from "@axe-core/playwright";
+
+test.describe("Playground", () => {
+  test("loads with prompt textarea", async ({ authPage }) => {
+    await authPage.goto("/");
+    await expect(
+      authPage.getByPlaceholder("Describe the UI you want to build...")
+    ).toBeVisible();
+  });
+
+  test("Generate button is visible", async ({ authPage }) => {
+    await authPage.goto("/");
+    await expect(authPage.getByRole("button", { name: "Generate" })).toBeVisible();
+  });
+
+  test("can type a prompt", async ({ authPage }) => {
+    await authPage.goto("/");
+    const textarea = authPage.getByPlaceholder("Describe the UI you want to build...");
+    await textarea.fill("a simple button");
+    await expect(textarea).toHaveValue("a simple button");
+    await expect(authPage.getByRole("button", { name: "Generate" })).toBeEnabled();
+  });
+
+  test("has no critical a11y violations", async ({ authPage }) => {
+    await authPage.goto("/");
+    // Wait for the playground to fully render
+    await expect(
+      authPage.getByPlaceholder("Describe the UI you want to build...")
+    ).toBeVisible();
+    const results = await new AxeBuilder({ page: authPage })
+      .withTags(["wcag2aa"])
+      .analyze();
+    const violations = results.violations.filter(
+      (v) => v.impact === "critical" || v.impact === "serious"
+    );
+    expect(violations).toHaveLength(0);
+  });
+});

--- a/apps/gen/e2e/shared-spec.spec.ts
+++ b/apps/gen/e2e/shared-spec.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "@playwright/test";
+import { AxeBuilder } from "@axe-core/playwright";
+
+test.describe("Shared Spec", () => {
+  test("shows not found state for unknown ID", async ({ page }) => {
+    await page.goto("/s/invalid-id-that-does-not-exist");
+    await expect(page.getByText("Spec not found")).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("shows Back to Gen Playground button in error state", async ({ page }) => {
+    await page.goto("/s/invalid-id-that-does-not-exist");
+    await expect(
+      page.getByRole("button", { name: "Back to Gen Playground" })
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("route is public — no Sign In prompt shown", async ({ page }) => {
+    await page.goto("/s/any-id");
+    // Shared spec bypasses auth gating; the login prompt must not appear
+    await expect(page.getByRole("button", { name: "Sign In" })).not.toBeVisible({
+      timeout: 5_000,
+    });
+  });
+
+  test("error page has no critical a11y violations", async ({ page }) => {
+    await page.goto("/s/invalid-id-for-a11y");
+    await expect(page.getByText("Spec not found")).toBeVisible({ timeout: 10_000 });
+    const results = await new AxeBuilder({ page })
+      .withTags(["wcag2aa"])
+      .analyze();
+    const violations = results.violations.filter(
+      (v) => v.impact === "critical" || v.impact === "serious"
+    );
+    expect(violations).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1011

Adds 5 new files to `apps/gen/e2e/` covering the 3 routes that were previously untested (only the homepage a11y test existed):

- **auth-helpers.ts** — Auth0 ROPC token injection helper (copy of hospitality pattern)
- **fixtures.ts** — `authPage` fixture that injects session before each test
- **auth.spec.ts** — unauthenticated users see the Gen Playground login prompt and Sign In button; callback route redirects to home
- **playground.spec.ts** — authenticated: prompt textarea visible, Generate button present, can fill input, a11y scan passes (wcag2aa)
- **shared-spec.spec.ts** — error state renders for unknown IDs, Back to Gen Playground button visible, route is public (no Sign In prompt), a11y scan passes
- **a11y.test.ts** — extended with shared spec error page a11y test

## Test plan

- [ ] `pnpm --dir apps/gen exec playwright test` passes with `E2E_AUTH*` env vars set
- [ ] Unauthenticated specs (auth.spec.ts, shared-spec.spec.ts) pass without env vars
- [ ] All 5 new files discovered by `playwright.config.ts` (`testDir: ./e2e`)
- [ ] No TypeScript errors in e2e files

https://claude.ai/code/session_01VEa95H5Lk7FqNe48KdvG2d

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEa95H5Lk7FqNe48KdvG2d)_