### PR TITLE
fix(rialto): add @storybook/test resolve alias to Storybook build config

### DIFF
--- a/packages/rialto/.storybook/main.ts
+++ b/packages/rialto/.storybook/main.ts
@@ -1,8 +1,8 @@
 import type { StorybookConfig } from '@storybook/react-vite';
 
 import { dirname } from "path"
-
 import { fileURLToPath } from "url"
+import type { InlineConfig } from 'vite';
 
 /**
 * This function is used to resolve the absolute path of a package.
@@ -23,6 +23,14 @@ const config: StorybookConfig = {
     getAbsolutePath('@storybook/addon-docs'),
     getAbsolutePath('@storybook/addon-onboarding')
   ],
-  "framework": getAbsolutePath('@storybook/react-vite')
+  "framework": getAbsolutePath('@storybook/react-vite'),
+  viteFinal(viteConfig: InlineConfig) {
+    viteConfig.resolve = viteConfig.resolve ?? {};
+    viteConfig.resolve.alias = {
+      ...(viteConfig.resolve.alias as Record<string, string>),
+      '@storybook/test': 'storybook/test',
+    };
+    return viteConfig;
+  },
 };
 export default config;


### PR DESCRIPTION
## Summary
- Storybook 10 folded `@storybook/test` into the main `storybook` package
- The vitest config already had this alias, but `storybook build` uses its own Vite config
- Adds `viteFinal` hook to `.storybook/main.ts` with the same resolve alias
- Unblocks PRs #1038, #1041, #1042 (rialto story PRs all failing on this)

## Test plan
- [x] `pnpm build-storybook` passes locally