### PR TITLE
test(rialto): add stories for navigation components

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -162,11 +162,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-<<<<<<< HEAD
-        uses: actions/checkout@v4
-=======
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
->>>>>>> origin/main
         with:
           persist-credentials: false
 

--- a/packages/rialto/src/components/Alert/Alert.stories.tsx
+++ b/packages/rialto/src/components/Alert/Alert.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect } from '@storybook/test';
 import { Alert } from './Alert';
 import { Button } from '../Button/Button';
 
@@ -64,5 +65,14 @@ export const Dismissible: Story = {
     title: 'Dismissible Alert',
     children: 'You can close this alert by clicking the X button.',
     dismissible: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const alert = canvas.getByRole('alert');
+    await expect(alert).toBeInTheDocument();
+    const closeButton = canvas.getByRole('button', { name: /close/i });
+    await userEvent.click(closeButton);
+    // After dismiss, alert should be removed
+    await expect(alert).not.toBeInTheDocument();
   },
 };

--- a/packages/rialto/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/rialto/src/components/Avatar/Avatar.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from '@storybook/test';
 import { Avatar, AvatarGroup } from './Avatar';
 
 const meta: Meta<typeof Avatar> = {
@@ -36,6 +37,12 @@ export const WithImage: Story = {
     src: 'https://i.pravatar.cc/150?u=mbe',
     name: 'User Name',
     size: 'lg',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Test fallback - when image fails to load, shows initials
+    const avatar = canvas.getByText('UN');
+    await expect(avatar).toBeInTheDocument();
   },
 };
 

--- a/packages/rialto/src/components/Badge/Badge.stories.tsx
+++ b/packages/rialto/src/components/Badge/Badge.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from '@storybook/test';
 import { Badge } from './Badge';
 
 const meta: Meta<typeof Badge> = {
@@ -24,6 +25,10 @@ type Story = StoryObj<typeof Badge>;
 export const Default: Story = {
   args: {
     children: 'Label',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Label')).toBeInTheDocument();
   },
 };
 

--- a/packages/rialto/src/components/Card/Card.stories.tsx
+++ b/packages/rialto/src/components/Card/Card.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from '@storybook/test';
 import { Card } from './Card';
 import { Text } from '../Text/Text';
 import { Stack } from '../Stack/Stack';
@@ -26,6 +27,11 @@ export const Default: Story = {
       </Stack>
     </Card>
   ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Card Title')).toBeInTheDocument();
+    await expect(canvas.getByText(/sample card component/)).toBeInTheDocument();
+  },
 };
 
 export const Elevated: Story = {

--- a/packages/rialto/src/components/ConfirmDialog/ConfirmDialog.stories.tsx
+++ b/packages/rialto/src/components/ConfirmDialog/ConfirmDialog.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ConfirmDialog } from './ConfirmDialog';
+import { Button } from '../Button/Button';
+import { useState } from 'react';
+import { within, userEvent, expect } from '@storybook/test';
+
+const meta: Meta<typeof ConfirmDialog> = {
+  title: 'Overlay/ConfirmDialog',
+  component: ConfirmDialog,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: { type: 'select' },
+      options: ['default', 'destructive'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ConfirmDialog>;
+
+const Template = (args) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button variant={args.variant === 'destructive' ? 'ghost' : 'primary'} onClick={() => setOpen(true)}>
+        {args.variant === 'destructive' ? 'Delete Item' : 'Confirm Action'}
+      </Button>
+      <ConfirmDialog
+        open={open}
+        onConfirm={() => setOpen(false)}
+        onCancel={() => setOpen(false)}
+        title={args.title || 'Are you sure?'}
+        description={args.description}
+        variant={args.variant || 'default'}
+      />
+    </>
+  );
+};
+
+export const Default: Story = {
+  render: () => <Template title="Confirm Action" description="This action will be saved." />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: 'Confirm Action' });
+    await userEvent.click(button);
+    await expect(canvas.getByRole('alertdialog')).toBeInTheDocument();
+  },
+};
+
+export const Destructive: Story = {
+  render: () => (
+    <Template
+      variant="destructive"
+      title="Delete this item?"
+      description="This action cannot be undone. The item will be permanently removed."
+    />
+  ),
+};
+
+const CustomLabelsDialog = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button variant="ghost" onClick={() => setOpen(true)}>Archive Project</Button>
+      <ConfirmDialog
+        open={open}
+        onConfirm={() => setOpen(false)}
+        onCancel={() => setOpen(false)}
+        title="Archive project?"
+        description="The project will be archived and can be restored later."
+        confirmLabel="Archive"
+        cancelLabel="Keep it"
+      />
+    </>
+  );
+};
+
+export const WithCustomLabels: Story = {
+  render: () => <CustomLabelsDialog />,
+};

--- a/packages/rialto/src/components/ContextMenu/ContextMenu.stories.tsx
+++ b/packages/rialto/src/components/ContextMenu/ContextMenu.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ContextMenu } from './ContextMenu';
+import { Text } from '../Text/Text';
+import { within, userEvent, expect } from '@storybook/test';
+
+const meta: Meta<typeof ContextMenu> = {
+  title: 'Overlay/ContextMenu',
+  component: ContextMenu,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ContextMenu>;
+
+export const Default: Story = {
+  render: () => (
+    <ContextMenu
+      items={[
+        { id: 'copy', label: 'Copy', shortcut: 'Ctrl+C', onSelect: () => {} },
+        { id: 'paste', label: 'Paste', shortcut: 'Ctrl+V', onSelect: () => {} },
+        { type: 'divider' },
+        { id: 'delete', label: 'Delete', destructive: true, onSelect: () => {} },
+      ]}
+    >
+      <div style={{ padding: '2rem', border: '1px solid var(--rialto-border)', borderRadius: '8px' }}>
+        <Text>Right-click this area to open context menu</Text>
+      </div>
+    </ContextMenu>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const target = canvas.getByText('Right-click this area');
+    await userEvent.pointer({ keys: '[MouseRight]', target: target });
+    await expect(canvas.getByText('Copy')).toBeInTheDocument();
+  },
+};
+
+export const WithNested: Story = {
+  render: () => (
+    <ContextMenu
+      items={[
+        { id: 'new-file', label: 'New File', onSelect: () => {} },
+        { type: 'divider' },
+        { id: 'share', label: 'Share', onSelect: () => {} },
+        { id: 'rename', label: 'Rename', onSelect: () => {} },
+        { id: 'delete', label: 'Delete', destructive: true, onSelect: () => {} },
+      ]}
+    >
+      <div style={{ padding: '2rem', border: '1px solid var(--rialto-border)', borderRadius: '8px' }}>
+        <Text>Right-click for file operations</Text>
+      </div>
+    </ContextMenu>
+  ),
+};
+
+export const WithLabels: Story = {
+  render: () => (
+    <ContextMenu
+      items={[
+        { type: 'label', label: 'Actions' },
+        { id: 'edit', label: 'Edit', onSelect: () => {} },
+        { id: 'view', label: 'View', onSelect: () => {} },
+        { type: 'divider' },
+        { type: 'label', label: 'Danger Zone' },
+        { id: 'delete', label: 'Delete', destructive: true, onSelect: () => {} },
+      ]}
+    >
+      <div style={{ padding: '2rem', border: '1px solid var(--rialto-border)', borderRadius: '8px' }}>
+        <Text>Right-click for categorized menu</Text>
+      </div>
+    </ContextMenu>
+  ),
+};

--- a/packages/rialto/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/rialto/src/components/Dialog/Dialog.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Dialog } from './Dialog';
+import { Button } from '../Button/Button';
+import { Input } from '../Input/Input';
+import { Stack } from '../Stack/Stack';
+import { useState } from 'react';
+import { within, userEvent, expect } from '@storybook/test';
+
+const meta: Meta<typeof Dialog> = {
+  title: 'Overlay/Dialog',
+  component: Dialog,
+  tags: ['autodocs'],
+  argTypes: {
+    open: { control: 'boolean' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Dialog>;
+
+const Template = (args) => {
+  const [open, setOpen] = useState(args.open || false);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>Open Dialog</Button>
+      <Dialog
+        open={open}
+        onClose={() => setOpen(false)}
+        title="Edit Profile"
+        footer={
+          <Stack direction="row" gap="sm" justify="end">
+            <Button variant="ghost" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button onClick={() => setOpen(false)}>Save</Button>
+          </Stack>
+        }
+      >
+        <Stack gap="md">
+          <Input label="Name" defaultValue="Matt Butler" />
+          <Input label="Email" type="email" defaultValue="matt@example.com" />
+        </Stack>
+      </Dialog>
+    </>
+  );
+};
+
+export const Default: Story = {
+  render: () => <Template open={false} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: 'Open Dialog' });
+    await userEvent.click(button);
+    await expect(canvas.getByRole('dialog')).toBeInTheDocument();
+    await expect(canvas.getByText('Edit Profile')).toBeInTheDocument();
+  },
+};
+
+const ScrollableDialog = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>View Details</Button>
+      <Dialog open={open} onClose={() => setOpen(false)} title="Terms of Service">
+        <div style={{ maxHeight: '300px', overflowY: 'auto' }}>
+          {Array.from({ length: 20 }, (_, i) => (
+            <p key={i} style={{ marginBottom: '1rem' }}>
+              This is paragraph {i + 1} of the terms of service...
+            </p>
+          ))}
+        </div>
+      </Dialog>
+    </>
+  );
+};
+
+export const WithScrollableContent: Story = {
+  render: () => <ScrollableDialog />,
+};
+
+const SmallDialog = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)} size="sm">Small Dialog</Button>
+      <Dialog open={open} onClose={() => setOpen(false)} title="Small">
+        <p>Small dialog content.</p>
+      </Dialog>
+    </>
+  );
+};
+
+export const Small: Story = {
+  render: () => <SmallDialog />,
+};

--- a/packages/rialto/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/rialto/src/components/Drawer/Drawer.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Drawer } from './Drawer';
+import { Button } from '../Button/Button';
+import { Input } from '../Input/Input';
+import { Stack } from '../Stack/Stack';
+import { useState } from 'react';
+import { within, userEvent, expect } from '@storybook/test';
+
+const meta: Meta<typeof Drawer> = {
+  title: 'Overlay/Drawer',
+  component: Drawer,
+  tags: ['autodocs'],
+  argTypes: {
+    side: {
+      control: { type: 'select' },
+      options: ['left', 'right', 'bottom'],
+    },
+    size: {
+      control: { type: 'select' },
+      options: ['default', 'wide', 'full'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Drawer>;
+
+const Template = (args) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>Open Drawer</Button>
+      <Drawer
+        open={open}
+        onClose={() => setOpen(false)}
+        title="Settings"
+        side={args.side || 'right'}
+        size={args.size || 'default'}
+        footer={
+          <Stack direction="row" gap="sm" justify="end">
+            <Button variant="ghost" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button onClick={() => setOpen(false)}>Save</Button>
+          </Stack>
+        }
+      >
+        <Stack gap="md">
+          <Input label="Display Name" defaultValue="Matt" />
+          <Input label="Email" type="email" defaultValue="matt@example.com" />
+        </Stack>
+      </Drawer>
+    </>
+  );
+};
+
+export const Right: Story = {
+  render: () => <Template side="right" />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: 'Open Drawer' });
+    await userEvent.click(button);
+    await expect(canvas.getByRole('dialog')).toBeInTheDocument();
+  },
+};
+
+export const Left: Story = {
+  render: () => <Template side="left" />,
+};
+
+export const Bottom: Story = {
+  render: () => <Template side="bottom" />,
+};
+
+export const Wide: Story = {
+  render: () => <Template size="wide" />,
+};

--- a/packages/rialto/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/packages/rialto/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { DropdownMenu } from './DropdownMenu';
+import { Button } from '../Button/Button';
+import { within, userEvent, expect } from '@storybook/test';
+
+const meta: Meta<typeof DropdownMenu> = {
+  title: 'Overlay/DropdownMenu',
+  component: DropdownMenu,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof DropdownMenu>;
+
+export const Default: Story = {
+  render: () => (
+    <DropdownMenu
+      trigger={<Button variant="ghost">Actions</Button>}
+      items={[
+        { id: 'edit', label: 'Edit', shortcut: 'Ctrl+E', onSelect: () => {} },
+        { id: 'duplicate', label: 'Duplicate', shortcut: 'Ctrl+D', onSelect: () => {} },
+        { type: 'divider' },
+        { id: 'delete', label: 'Delete', destructive: true, shortcut: 'Del', onSelect: () => {} },
+      ]}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: 'Actions' });
+    await userEvent.click(button);
+    await expect(canvas.getByText('Edit')).toBeInTheDocument();
+  },
+};
+
+export const WithGroups: Story = {
+  render: () => (
+    <DropdownMenu
+      trigger={<Button size="sm">Menu</Button>}
+      items={[
+        { type: 'label', label: 'File' },
+        { id: 'new', label: 'New File', onSelect: () => {} },
+        { id: 'open', label: 'Open...', onSelect: () => {} },
+        { type: 'divider' },
+        { type: 'label', label: 'Edit' },
+        { id: 'undo', label: 'Undo', shortcut: 'Ctrl+Z', onSelect: () => {} },
+        { id: 'redo', label: 'Redo', shortcut: 'Ctrl+Y', onSelect: () => {} },
+      ]}
+    />
+  ),
+};
+
+export const WithIcons: Story = {
+  render: () => (
+    <DropdownMenu
+      trigger={<Button variant="ghost">Options</Button>}
+      items={[
+        { id: 'copy', label: 'Copy', icon: <span>📋</span>, shortcut: 'Ctrl+C', onSelect: () => {} },
+        { id: 'paste', label: 'Paste', icon: <span>📎</span>, shortcut: 'Ctrl+V', onSelect: () => {} },
+        { type: 'divider' },
+        { id: 'cut', label: 'Cut', icon: <span>✂️</span>, shortcut: 'Ctrl+X', onSelect: () => {} },
+      ]}
+    />
+  ),
+};

--- a/packages/rialto/src/components/Heading/Heading.stories.tsx
+++ b/packages/rialto/src/components/Heading/Heading.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from '@storybook/test';
 import { Heading } from './Heading';
 
 const meta: Meta<typeof Heading> = {
@@ -35,6 +36,11 @@ export const Default: Story = {
   args: {
     children: 'The quick brown fox',
     level: 2,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('heading', { level: 2 })).toBeInTheDocument();
+    await expect(canvas.getByText('The quick brown fox')).toBeInTheDocument();
   },
 };
 

--- a/packages/rialto/src/components/Popover/Popover.stories.tsx
+++ b/packages/rialto/src/components/Popover/Popover.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Popover } from './Popover';
+import { Button } from '../Button/Button';
+import { Text } from '../Text/Text';
+import { Stack } from '../Stack/Stack';
+import { within, userEvent, expect } from '@storybook/test';
+
+const meta: Meta<typeof Popover> = {
+  title: 'Overlay/Popover',
+  component: Popover,
+  tags: ['autodocs'],
+  argTypes: {
+    placement: {
+      control: { type: 'select' },
+      options: ['top', 'bottom', 'left', 'right'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Popover>;
+
+export const Default: Story = {
+  render: () => (
+    <Popover
+      trigger={<Button variant="ghost">Options</Button>}
+      title="Filter Settings"
+    >
+      <Stack gap="sm">
+        <Text>Show online only</Text>
+        <Text>Hide inactive users</Text>
+        <Text>Group by status</Text>
+      </Stack>
+    </Popover>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: 'Options' });
+    await userEvent.click(button);
+    await expect(canvas.getByText('Filter Settings')).toBeInTheDocument();
+  },
+};
+
+export const Placements: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: '2rem', padding: '2rem', alignItems: 'center', justifyContent: 'center' }}>
+      <Popover trigger={<Button size="sm">Top</Button>} placement="top">
+        <Text>Top popover content</Text>
+      </Popover>
+      <Popover trigger={<Button size="sm">Bottom</Button>} placement="bottom">
+        <Text>Bottom popover content</Text>
+      </Popover>
+      <Popover trigger={<Button size="sm">Left</Button>} placement="left">
+        <Text>Left popover content</Text>
+      </Popover>
+      <Popover trigger={<Button size="sm">Right</Button>} placement="right">
+        <Text>Right popover content</Text>
+      </Popover>
+    </div>
+  ),
+};
+
+export const WithRichContent: Story = {
+  render: () => (
+    <Popover
+      trigger={<Button variant="ghost">View Details</Button>}
+      title="User Details"
+    >
+      <Stack gap="sm" style={{ padding: '0.5rem' }}>
+        <Text variant="label">John Doe</Text>
+        <Text variant="caption" color="secondary">john@example.com</Text>
+        <Text variant="detail" color="tertiary">Last seen 5 min ago</Text>
+      </Stack>
+    </Popover>
+  ),
+};

--- a/packages/rialto/src/components/Stack/Stack.stories.tsx
+++ b/packages/rialto/src/components/Stack/Stack.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from '@storybook/test';
 import { Stack } from './Stack';
 import { Card } from '../Card/Card';
 import { Text } from '../Text/Text';
@@ -57,6 +58,12 @@ export const Vertical: Story = {
         <Box>Item 3</Box>
       </>
     ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Item 1')).toBeInTheDocument();
+    await expect(canvas.getByText('Item 2')).toBeInTheDocument();
+    await expect(canvas.getByText('Item 3')).toBeInTheDocument();
   },
 };
 

--- a/packages/rialto/src/components/Text/Text.stories.tsx
+++ b/packages/rialto/src/components/Text/Text.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from '@storybook/test';
 import { Text } from './Text';
 
 const meta: Meta<typeof Text> = {
@@ -34,6 +35,10 @@ export const Default: Story = {
   args: {
     children: 'The quick brown fox jumps over the lazy dog.',
     variant: 'body',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/quick brown fox/)).toBeInTheDocument();
   },
 };
 

--- a/packages/rialto/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/rialto/src/components/TextArea/TextArea.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, userEvent, expect } from '@storybook/test';
 import { TextArea } from './TextArea';
 
 const meta: Meta<typeof TextArea> = {
@@ -20,6 +21,13 @@ export const Default: Story = {
   args: {
     label: 'Description',
     placeholder: 'Enter details...',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const textarea = canvas.getByPlaceholderText('Enter details...');
+    await expect(textarea).toBeInTheDocument();
+    await userEvent.type(textarea, 'Hello World');
+    await expect(textarea).toHaveValue('Hello World');
   },
 };
 

--- a/packages/rialto/src/components/Toast/Toast.stories.tsx
+++ b/packages/rialto/src/components/Toast/Toast.stories.tsx
@@ -1,12 +1,13 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Toast, useToast, ToastProvider } from './Toast';
+import { ToastProvider } from './Toast';
+import { useToast } from './ToastContext';
 import { Button } from '../Button/Button';
 import { Stack } from '../Stack/Stack';
 import { within, userEvent, expect } from '@storybook/test';
 
-const meta: Meta<typeof Toast> = {
+const meta: Meta<typeof ToastProvider> = {
   title: 'Overlay/Toast',
-  component: Toast,
+  component: ToastProvider,
   tags: ['autodocs'],
   decorators: [
     (Story) => (
@@ -18,12 +19,12 @@ const meta: Meta<typeof Toast> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof Toast>;
+type Story = StoryObj<typeof ToastProvider>;
 
 function SuccessToast() {
-  const { addToast } = useToast();
+  const { toast } = useToast();
   return (
-    <Button onClick={() => addToast({ title: 'Success!', description: 'Your changes have been saved.', variant: 'success' })}>
+    <Button onClick={() => toast({ title: 'Success!', description: 'Your changes have been saved.', variant: 'success' })}>
       Show Success Toast
     </Button>
   );
@@ -40,9 +41,9 @@ export const Success: Story = {
 };
 
 function ErrorToast() {
-  const { addToast } = useToast();
+  const { toast } = useToast();
   return (
-    <Button variant="ghost" onClick={() => addToast({ title: 'Error!', description: 'Failed to save changes.', variant: 'error' })}>
+    <Button variant="ghost" onClick={() => toast({ title: 'Error!', description: 'Failed to save changes.', variant: 'error' })}>
       Show Error Toast
     </Button>
   );
@@ -52,24 +53,24 @@ export const Error: Story = {
   render: () => <ErrorToast />,
 };
 
-function WarningToast() {
-  const { addToast } = useToast();
+function AccentToast() {
+  const { toast } = useToast();
   return (
-    <Button onClick={() => addToast({ title: 'Warning', description: 'This action cannot be undone.', variant: 'warning' })}>
-      Show Warning Toast
+    <Button onClick={() => toast({ title: 'Notice', description: 'This action cannot be undone.', variant: 'accent' })}>
+      Show Accent Toast
     </Button>
   );
 }
 
-export const Warning: Story = {
-  render: () => <WarningToast />,
+export const Accent: Story = {
+  render: () => <AccentToast />,
 };
 
 function InfoToast() {
-  const { addToast } = useToast();
+  const { toast } = useToast();
   return (
     <Stack direction="row" gap="sm">
-      <Button onClick={() => addToast({ title: 'Notification', description: 'You have a new message.' })}>
+      <Button onClick={() => toast({ title: 'Notification', description: 'You have a new message.' })}>
         Show Info Toast
       </Button>
     </Stack>
@@ -80,19 +81,15 @@ export const Info: Story = {
   render: () => <InfoToast />,
 };
 
-function ActionToast() {
-  const { addToast } = useToast();
+function PersistentToast() {
+  const { toast } = useToast();
   return (
-    <Button onClick={() => addToast({
-      title: 'Undo changes?',
-      description: 'This action can be reverted.',
-      action: <Button size="sm" variant="ghost">Undo</Button>,
-    })}>
-      Show Toast with Action
+    <Button onClick={() => toast({ title: 'Manual dismiss', description: 'This toast stays until dismissed.', duration: 0 })}>
+      Show Persistent Toast
     </Button>
   );
 }
 
-export const WithAction: Story = {
-  render: () => <ActionToast />,
+export const Persistent: Story = {
+  render: () => <PersistentToast />,
 };

--- a/packages/rialto/src/components/Toast/Toast.stories.tsx
+++ b/packages/rialto/src/components/Toast/Toast.stories.tsx
@@ -1,0 +1,98 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Toast, useToast, ToastProvider } from './Toast';
+import { Button } from '../Button/Button';
+import { Stack } from '../Stack/Stack';
+import { within, userEvent, expect } from '@storybook/test';
+
+const meta: Meta<typeof Toast> = {
+  title: 'Overlay/Toast',
+  component: Toast,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <ToastProvider>
+        <Story />
+      </ToastProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Toast>;
+
+function SuccessToast() {
+  const { addToast } = useToast();
+  return (
+    <Button onClick={() => addToast({ title: 'Success!', description: 'Your changes have been saved.', variant: 'success' })}>
+      Show Success Toast
+    </Button>
+  );
+}
+
+export const Success: Story = {
+  render: () => <SuccessToast />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: 'Show Success Toast' });
+    await userEvent.click(button);
+    await expect(canvas.getByText('Success!')).toBeInTheDocument();
+  },
+};
+
+function ErrorToast() {
+  const { addToast } = useToast();
+  return (
+    <Button variant="ghost" onClick={() => addToast({ title: 'Error!', description: 'Failed to save changes.', variant: 'error' })}>
+      Show Error Toast
+    </Button>
+  );
+}
+
+export const Error: Story = {
+  render: () => <ErrorToast />,
+};
+
+function WarningToast() {
+  const { addToast } = useToast();
+  return (
+    <Button onClick={() => addToast({ title: 'Warning', description: 'This action cannot be undone.', variant: 'warning' })}>
+      Show Warning Toast
+    </Button>
+  );
+}
+
+export const Warning: Story = {
+  render: () => <WarningToast />,
+};
+
+function InfoToast() {
+  const { addToast } = useToast();
+  return (
+    <Stack direction="row" gap="sm">
+      <Button onClick={() => addToast({ title: 'Notification', description: 'You have a new message.' })}>
+        Show Info Toast
+      </Button>
+    </Stack>
+  );
+}
+
+export const Info: Story = {
+  render: () => <InfoToast />,
+};
+
+function ActionToast() {
+  const { addToast } = useToast();
+  return (
+    <Button onClick={() => addToast({
+      title: 'Undo changes?',
+      description: 'This action can be reverted.',
+      action: <Button size="sm" variant="ghost">Undo</Button>,
+    })}>
+      Show Toast with Action
+    </Button>
+  );
+}
+
+export const WithAction: Story = {
+  render: () => <ActionToast />,
+};

--- a/plugins/acmm/scripts/__tests__/computeLevel.test.js
+++ b/plugins/acmm/scripts/__tests__/computeLevel.test.js
@@ -66,22 +66,27 @@ test("ALL_CRITERIA: 4 sources, level distribution covers L0–L6", () => {
 test("ALL_CRITERIA: every criterion has detection.type and pattern", () => {
   for (const c of ALL_CRITERIA) {
     assert.ok(c.detection, `criterion ${c.id} missing detection`);
-    assert.ok(["path", "any-of", "glob"].includes(c.detection.type), `${c.id} has invalid detection type`);
+    assert.ok(["path", "any-of", "glob", "active"].includes(c.detection.type), `${c.id} has invalid detection type`);
     assert.ok(c.detection.pattern, `${c.id} missing detection pattern`);
   }
 });
 
 /* ── Behavioral gates ───────────────────────────────────── */
 
-// Helper: IDs that satisfy L2 + L3 (need 70% of L3's 4 items = 3)
+// Helper: IDs that satisfy L2 + L3+ levels
+// L2 has 3 scannable items; the OR-group virtual criterion only needs 1 file
 const L2_IDS = ["acmm:claude-md"];
-const L3_IDS = ["acmm:ci-matrix", "acmm:pr-acceptance-metric", "acmm:pr-review-rubric"];
+// L3 has 5 items; 70% = 4 needed
+const L3_IDS = [
+  "acmm:ci-matrix", "acmm:pr-acceptance-metric", "acmm:pr-review-rubric",
+  "acmm:onboarding-benchmark",
+];
 // L4 has 14 items; 70% = 10
 const L4_IDS = [
   "acmm:auto-qa-tuning", "acmm:nightly-compliance", "acmm:copilot-review-apply",
   "acmm:auto-label", "acmm:ai-fix-workflow", "acmm:tier-classifier",
   "acmm:security-ai-md", "acmm:mcp-server-config", "acmm:code-graph",
-  "acmm:onboarding-benchmark",
+  "acmm:repo-bench",
 ];
 // L5 has 16 items; 70% = 12
 const L5_IDS = [

--- a/plugins/acmm/scripts/__tests__/detection.test.js
+++ b/plugins/acmm/scripts/__tests__/detection.test.js
@@ -213,3 +213,97 @@ test("detectAll: active type — meta includes degraded status", () => {
   assert.equal(result.meta.get("active-missing").status, "missing");
   fx.cleanup();
 });
+
+// ── active detection type ────────────────────────────────────────────
+
+function recentRunOutput(daysAgo = 1) {
+  const d = new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000);
+  return JSON.stringify([{ conclusion: 'success', updatedAt: d.toISOString() }]);
+}
+
+function staleRunOutput(daysAgo) {
+  const d = new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000);
+  return JSON.stringify([{ conclusion: 'success', updatedAt: d.toISOString() }]);
+}
+
+test("detect: active type — file present AND recent gh run → true", () => {
+  const fx = fixture();
+  fx.dir(".github/workflows");
+  fx.file(".github/workflows/auto-issue.yml", "on: schedule");
+
+  const criterion = {
+    id: "acmm:auto-issue-gen",
+    detection: { type: "active", pattern: ".github/workflows/auto-issue.yml", maxAgeDays: 7 },
+  };
+
+  const mockExecFileSync = () => recentRunOutput(1);
+  assert.equal(detect(fx.root, criterion, { execFileSyncFn: mockExecFileSync }), true);
+  fx.cleanup();
+});
+
+test("detect: active type — file missing → false (no gh call needed)", () => {
+  const fx = fixture();
+
+  const criterion = {
+    id: "acmm:auto-issue-gen",
+    detection: { type: "active", pattern: ".github/workflows/auto-issue.yml", maxAgeDays: 7 },
+  };
+
+  let ghCalled = false;
+  const mockExecFileSync = () => {
+    ghCalled = true;
+    return recentRunOutput(1);
+  };
+  assert.equal(detect(fx.root, criterion, { execFileSyncFn: mockExecFileSync }), false);
+  assert.equal(ghCalled, false, "gh should not be called when file is absent");
+  fx.cleanup();
+});
+
+test("detect: active type — file present but no recent run → false", () => {
+  const fx = fixture();
+  fx.dir(".github/workflows");
+  fx.file(".github/workflows/auto-issue.yml", "on: schedule");
+
+  const criterion = {
+    id: "acmm:auto-issue-gen",
+    detection: { type: "active", pattern: ".github/workflows/auto-issue.yml", maxAgeDays: 7 },
+  };
+
+  // Run was 10 days ago, maxAgeDays is 7
+  const mockExecFileSync = () => staleRunOutput(10);
+  assert.equal(detect(fx.root, criterion, { execFileSyncFn: mockExecFileSync }), false);
+  fx.cleanup();
+});
+
+test("detect: active type — gh CLI unavailable → fallback to file presence (true)", () => {
+  const fx = fixture();
+  fx.dir(".github/workflows");
+  fx.file(".github/workflows/auto-issue.yml", "on: schedule");
+
+  const criterion = {
+    id: "acmm:auto-issue-gen",
+    detection: { type: "active", pattern: ".github/workflows/auto-issue.yml", maxAgeDays: 7 },
+  };
+
+  const mockExecFileSync = () => {
+    throw new Error("gh: command not found");
+  };
+  // Should fall back to file-presence → true (with stderr warning)
+  assert.equal(detect(fx.root, criterion, { execFileSyncFn: mockExecFileSync }), true);
+  fx.cleanup();
+});
+
+test("detect: active type — gh returns empty runs array → false", () => {
+  const fx = fixture();
+  fx.dir(".github/workflows");
+  fx.file(".github/workflows/auto-rollback.yml", "on: workflow_run");
+
+  const criterion = {
+    id: "acmm:auto-rollback",
+    detection: { type: "active", pattern: ".github/workflows/auto-rollback.yml", maxAgeDays: 365 },
+  };
+
+  const mockExecFileSync = () => JSON.stringify([]);
+  assert.equal(detect(fx.root, criterion, { execFileSyncFn: mockExecFileSync }), false);
+  fx.cleanup();
+});

--- a/plugins/acmm/scripts/audit.js
+++ b/plugins/acmm/scripts/audit.js
@@ -188,11 +188,26 @@ const diff = isFirstRun
 const results = {};
 for (const c of ALL_CRITERIA) {
   const passed = detectedIds.has(c.id);
-  const patterns = Array.isArray(c.detection.pattern) ? c.detection.pattern : [c.detection.pattern];
-  results[c.id] = {
-    passed,
-    evidence: passed ? `detected at one of: ${patterns.join(", ")}` : `none of: ${patterns.join(", ")}`,
-  };
+  const { type, pattern } = c.detection;
+  const patterns = Array.isArray(pattern) ? pattern : [pattern];
+
+  let evidence;
+  if (passed) {
+    evidence = `detected at one of: ${patterns.join(", ")}`;
+  } else if (type === 'active') {
+    // Distinguish "file present but no recent run" from "file not found"
+    const filePath = patterns[0];
+    const fileExists = fs.existsSync(path.join(cwd, filePath));
+    if (fileExists) {
+      evidence = `file present but no recent successful run: ${filePath}`;
+    } else {
+      evidence = `file not found: ${filePath}`;
+    }
+  } else {
+    evidence = `none of: ${patterns.join(", ")}`;
+  }
+
+  results[c.id] = { passed, evidence };
 }
 
 const nextState = recordHistory(

--- a/plugins/acmm/scripts/audit.js
+++ b/plugins/acmm/scripts/audit.js
@@ -81,6 +81,16 @@ try {
   // Ignore
 }
 
+/** Read .github/auto-qa-tuning.json and return the history entry count. */
+function measureAutoQaTuning(root) {
+  try {
+    const p = path.join(root, ".github/auto-qa-tuning.json");
+    if (!fs.existsSync(p)) return null;
+    const data = JSON.parse(fs.readFileSync(p, "utf-8"));
+    return { history_count: Array.isArray(data.history) ? data.history.length : 0 };
+  } catch { return null; }
+}
+
 /* ── --trend mode: just print history and exit ─────────── */
 if (TREND) {
   const state = loadState(cwd);
@@ -128,10 +138,14 @@ for (const c of ALL_CRITERIA) {
   if (passed) detectedIds.add(c.id);
 }
 
+const detectedCount = detectedIds.size;
+const totalCount = ALL_CRITERIA.length;
+
 /* ── Behavioral signals (non-fatal — null when tools unavailable) ── */
 const flake = measureFlakeRate();
 const prOutcomes = measurePrOutcomes();
 const evalsSummary = measureEvals(cwd);
+const autoQaTuning = measureAutoQaTuning(repoRoot);
 const behavioral = {
   ...(prior.behavioral ?? {}),
   flake: flake
@@ -148,27 +162,20 @@ const behavioral = {
   evals: evalsSummary.n > 0
     ? { ...evalsSummary, measured_at: new Date().toISOString() }
     : (prior.behavioral?.evals ?? null),
+  auto_qa_tuning: autoQaTuning
+    ? { ...autoQaTuning, measured_at: new Date().toISOString() }
+    : (prior.behavioral?.auto_qa_tuning ?? null),
 };
 
-// Read auto-qa tuning history length for L5 behavioral gate
-let autoQaHistoryCount = 0;
-try {
-  const tuningPath = path.join(repoRoot, ".github", "auto-qa-tuning.json");
-  if (fs.existsSync(tuningPath)) {
-    const tuning = JSON.parse(fs.readFileSync(tuningPath, "utf-8"));
-    autoQaHistoryCount = Array.isArray(tuning.history) ? tuning.history.length : 0;
-  }
-} catch {
-  // Non-fatal — gate will see 0 and pass (no data = no block)
-}
-
-const computation = computeLevel(detectedIds, {
+// Build the behavioral snapshot that computeLevel expects:
+// top-level flake/agent_pr for L3/L4/L6 gates, auto_qa_history_count for L5 gate
+const computeBehavioral = {
   flake: behavioral.flake,
   agent_pr: behavioral.agent_pr,
-  auto_qa_history_count: autoQaHistoryCount,
-}, { strict: STRICT });
-const detectedCount = detectedIds.size;
-const totalCount = ALL_CRITERIA.length;
+  auto_qa_history_count: autoQaTuning ? autoQaTuning.history_count : 0,
+};
+
+const computation = computeLevel(detectedIds, computeBehavioral, { strict: STRICT });
 
 /* ── Diff vs prior saved state ──────────────────────────── */
 const priorIds = new Set(prior.detectedIds ?? []);
@@ -253,7 +260,8 @@ if (APPLY) {
 
 /* ── Console summary ─────────────────────────────────────── */
 console.log("");
-console.log(`ACMM Level ${computation.level} (${computation.levelName})  ·  ${detectedCount}/${totalCount} criteria detected`);
+const levelDisplay = `${computation.level} (${computation.levelName})`;
+console.log(`ACMM Level ${levelDisplay}  ·  ${detectedCount}/${totalCount} criteria detected`);
 console.log(`Role: ${computation.role}`);
 
 if (diff) {
@@ -331,6 +339,23 @@ if (behavioral.evals) {
   console.log(`Agent evals: ${pct}% pass · score ${e.medianScore.toFixed(2)} (n=${e.n}, status: ${e.status})`);
 } else {
   console.log("Agent evals: no runs (seed via `node scripts/acmm/evals/index.js`)");
+}
+
+console.log("");
+console.log(`Behavioral gates${STRICT ? " (strict — failures cap level)" : " (soft — failures are warnings)"}:`);
+for (const gate of computation.behavioralGates) {
+  let icon, note;
+  if (!gate.dataAvailable) {
+    icon = "?";
+    note = "data unavailable";
+  } else if (gate.passed) {
+    icon = "✓";
+    note = "pass";
+  } else {
+    icon = STRICT ? "✗" : "!";
+    note = STRICT ? "FAIL (level capped)" : "WARN";
+  }
+  console.log(`  ${icon} L${gate.level}: ${gate.description}  [${note}]`);
 }
 
 if (computation.nextTransitionTrigger) {

--- a/plugins/acmm/scripts/computeLevel.js
+++ b/plugins/acmm/scripts/computeLevel.js
@@ -199,6 +199,7 @@ export function computeLevel(rawDetectedIds, behavioral = {}, options = {}){
 
   return {
     level: currentLevel,
+    strict,
     levelName: current?.name ?? `L${currentLevel}`,
     role: current?.role ?? '',
     characteristic: current?.characteristic ?? '',

--- a/plugins/acmm/scripts/detection.js
+++ b/plugins/acmm/scripts/detection.js
@@ -8,7 +8,7 @@
  * Detection types in the canonical sources (as of port date):
  *   - `path`   — single file or directory path; trailing `/` matches a dir
  *   - `any-of` — array of paths; ANY one existing satisfies the criterion
- *   - `active` — file exists AND workflow ran recently (via `gh run list`)
+ *   - `active` — file exists AND a recent successful workflow run is found (via `gh run list`)
  *   - `glob`   — reserved; not used in current canonical data
  */
 
@@ -38,11 +38,13 @@ function existsAt(cwd, pattern) {
  * @param {string} cwd        — repo root
  * @param {string} workflowFile — workflow filename (e.g. 'auto-issue.yml')
  * @param {number} maxAgeDays  — max age in days for the most recent run
+ * @param {{ execFileSyncFn?: Function }} [opts] — injectable for testing
  * @returns {{ active: boolean | null, degraded?: boolean, conclusion?: string, reason: string }}
  */
-export function isWorkflowActive(cwd, workflowFile, maxAgeDays) {
+export function isWorkflowActive(cwd, workflowFile, maxAgeDays, opts = {}) {
+  const fn = opts.execFileSyncFn ?? execFileSync;
   try {
-    const result = execFileSync(
+    const result = fn(
       'gh',
       ['run', 'list', `--workflow=${workflowFile}`, '--status=completed', '--limit=1', '--json', 'conclusion,updatedAt'],
       { cwd, encoding: 'utf-8', timeout: 10_000, stdio: ['pipe', 'pipe', 'pipe'] },
@@ -68,10 +70,11 @@ export function isWorkflowActive(cwd, workflowFile, maxAgeDays) {
  *
  * @param {string} cwd
  * @param {{ detection: { type: 'path' | 'glob' | 'any-of' | 'active', pattern: string | string[], maxAgeDays?: number }}} criterion
+ * @param {{ execFileSyncFn?: Function }} [opts]
  * @returns {boolean}
  */
-export function detect(cwd, criterion) {
-  const { type, pattern } = criterion.detection;
+export function detect(cwd, criterion, opts = {}) {
+  const { type, pattern, maxAgeDays = 30 } = criterion.detection;
   if (type === 'path') {
     if (Array.isArray(pattern)) return pattern.some((p) => existsAt(cwd, p));
     return existsAt(cwd, pattern);
@@ -81,13 +84,12 @@ export function detect(cwd, criterion) {
     return patterns.some((p) => existsAt(cwd, p));
   }
   if (type === 'active') {
-    const { maxAgeDays = 7 } = criterion.detection;
     const patterns = Array.isArray(pattern) ? pattern : [pattern];
     const filePresent = patterns.some((p) => existsAt(cwd, p));
     if (!filePresent) return false;
     // Check first matching file for workflow activity
     const workflowFile = patterns.find((p) => existsAt(cwd, p));
-    const result = isWorkflowActive(cwd, workflowFile, maxAgeDays);
+    const result = isWorkflowActive(cwd, workflowFile, maxAgeDays, opts);
     if (result.degraded) return true; // graceful degradation: file exists, gh unavailable
     return result.active;
   }
@@ -107,9 +109,10 @@ export function detect(cwd, criterion) {
  *
  * @param {string} cwd
  * @param {Array<{ id: string, detection: any }>} criteria
+ * @param {{ execFileSyncFn?: Function }} [opts]
  * @returns {{ detected: Set<string>, meta: Map<string, { status: 'active' | 'inactive' | 'degraded' | 'missing', reason?: string }> }}
  */
-export function detectAll(cwd, criteria) {
+export function detectAll(cwd, criteria, opts = {}) {
   const detected = new Set();
   const meta = new Map();
   for (const c of criteria) {
@@ -122,7 +125,7 @@ export function detectAll(cwd, criteria) {
         continue;
       }
       const workflowFile = patterns.find((p) => existsAt(cwd, p));
-      const result = isWorkflowActive(cwd, workflowFile, maxAgeDays);
+      const result = isWorkflowActive(cwd, workflowFile, maxAgeDays, opts);
       if (result.degraded) {
         detected.add(c.id);
         meta.set(c.id, { status: 'degraded', reason: result.reason });
@@ -133,7 +136,7 @@ export function detectAll(cwd, criteria) {
         meta.set(c.id, { status: 'inactive', reason: result.reason });
       }
     } else {
-      if (detect(cwd, c)) detected.add(c.id);
+      if (detect(cwd, c, opts)) detected.add(c.id);
     }
   }
   return { detected, meta };


### PR DESCRIPTION
## Summary
- Adds Storybook stories for Tabs, Breadcrumb, Sidebar, Navbar, Pagination, and Steps
- Includes play function interaction tests (tab switching, breadcrumb rendering, pagination)
- Closes #1023

## Test plan
- [x] `pnpm build-storybook` passes