### PR TITLE
fix(rialto-web): allow component description text to wrap fully

### DIFF
--- a/apps/rialto-web/src/pages/components/ComponentPageLayout.module.css
+++ b/apps/rialto-web/src/pages/components/ComponentPageLayout.module.css
@@ -1,9 +1,12 @@
 /* ── Component page layout ───────────────────────────────────────── */
 
 .page {
+  width: 100%;
   max-width: 900px;
   margin-inline: auto;
   padding: var(--rialto-space-xl);
+  min-width: 0;
+  overflow-wrap: break-word;
 }
 
 .header {
@@ -11,6 +14,8 @@
   flex-direction: column;
   gap: var(--rialto-space-xs);
   margin-block-end: var(--rialto-space-lg);
+  min-width: 0;
+  overflow-wrap: break-word;
 }
 
 .content {
@@ -23,6 +28,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--rialto-space-md);
+  min-width: 0;
 }
 
 .sectionTitle {
@@ -36,6 +42,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--rialto-space-md);
+  min-width: 0;
 }
 
 /* ── Demo row (horizontal group of examples) ──────────────────────── */


### PR DESCRIPTION
## Summary

- Fixes text truncation on component showcase pages (e.g. InputGroup) where long description text was clipped by ancestor `overflow: hidden` constraints in the nested flex layout
- Adds `min-width: 0` to `.page`, `.header`, `.section`, and `.sectionContent` containers in `ComponentPageLayout.module.css` so flex items can shrink below their content width
- Adds `overflow-wrap: break-word` to `.page` and `.header` to ensure long text wraps instead of overflowing
- Adds `width: 100%` to `.page` to explicitly fill the available content area

Closes #1018

## Test plan

- [ ] Visit the InputGroup showcase page and verify the full description text is visible without truncation
- [ ] Check other component pages with long descriptions (Button, Select, CheckboxRadio, MasterOverride) to confirm text wraps properly
- [ ] Verify no horizontal scrollbar is introduced on any component page
- [ ] Test at mobile viewport widths to ensure description still wraps correctly
- [ ] Run `pnpm --dir apps/rialto-web build` (verified passing)
- [ ] Run `pnpm --dir apps/rialto-web typecheck` (verified passing)
- [ ] Run `pnpm --dir apps/rialto-web lint` (verified: 0 errors, only pre-existing warnings)