### PR TITLE
fix(hospitality): prevent SSE connection accumulation and add 429 backoff

### DIFF
--- a/apps/hospitality/src/contexts/ReservationDataContext.tsx
+++ b/apps/hospitality/src/contexts/ReservationDataContext.tsx
@@ -8,8 +8,11 @@ import {
   type ReactNode,
 } from "react";
 import { useToast } from "@mattbutlerengineering/rialto";
-import type { Reservation } from "@mbe/types";
-import { useReservationEvents } from "../hooks/useReservationEvents.js";
+import type { Reservation, Table, ReservationHold } from "@mbe/types";
+import {
+  useReservationEvents,
+  type ReservationEvent,
+} from "../hooks/useReservationEvents.js";
 import { useVenue } from "./VenueContext.js";
 
 /* ── Toast rate limiter ────────────────────────── */
@@ -33,15 +36,27 @@ function canShowToast(limiter: ToastRateLimiter): {
   return { allowed: true, next: { timestamps: [...recent, now] } };
 }
 
+/* ── Event subscriber registry ────────────────── */
+
+type EventHandler = (event: ReservationEvent) => void;
+
 /* ── Context shape ─────────────────────────────── */
+
+/** Accepts a plain array or a functional updater, matching React's setState signature. */
+type TableSetter = Table[] | ((prev: Table[]) => Table[]);
 
 interface ReservationDataContextValue {
   readonly reservations: readonly Reservation[];
+  readonly tables: Table[];
   readonly isConnected: boolean;
+  readonly sseError: Error | null;
   readonly addReservation: (reservation: Reservation) => void;
   readonly updateReservation: (reservation: Reservation) => void;
   readonly removeReservation: (id: string) => void;
   readonly setReservations: (reservations: Reservation[]) => void;
+  readonly setTables: (next: TableSetter) => void;
+  /** Subscribe to raw SSE events. Returns an unsubscribe function. */
+  readonly subscribeToEvents: (handler: EventHandler) => () => void;
 }
 
 const ReservationDataContext =
@@ -59,7 +74,9 @@ export function ReservationDataProvider({
   const { selectedVenueId } = useVenue();
   const { toast } = useToast();
   const [reservations, setReservationsState] = useState<Reservation[]>([]);
+  const [tables, setTablesState] = useState<Table[]>([]);
   const toastLimiterRef = useRef<ToastRateLimiter>({ timestamps: [] });
+  const eventSubscribersRef = useRef<Set<EventHandler>>(new Set());
 
   const showRateLimitedToast = useCallback(
     (opts: Parameters<typeof toast>[0]) => {
@@ -96,11 +113,41 @@ export function ReservationDataProvider({
     setReservationsState(next);
   }, []);
 
-  /* ── SSE subscription ────────────────────────── */
+  const setTables = useCallback((next: TableSetter) => {
+    setTablesState(next);
+  }, []);
+
+  const subscribeToEvents = useCallback((handler: EventHandler) => {
+    eventSubscribersRef.current = new Set(eventSubscribersRef.current);
+    eventSubscribersRef.current.add(handler);
+    return () => {
+      eventSubscribersRef.current = new Set(eventSubscribersRef.current);
+      eventSubscribersRef.current.delete(handler);
+    };
+  }, []);
+
+  /** Broadcast a raw event to all page-level subscribers. */
+  const notifySubscribers = useCallback(
+    (type: ReservationEvent["type"], data: ReservationEvent["data"]) => {
+      const event: ReservationEvent = {
+        type,
+        venueId: selectedVenueId ?? "",
+        timestamp: new Date().toISOString(),
+        data,
+      };
+      for (const handler of eventSubscribersRef.current) {
+        handler(event);
+      }
+    },
+    [selectedVenueId]
+  );
+
+  /* ── SSE subscription (single connection for the entire app) ── */
 
   const handleCreated = useCallback(
     (reservation: Reservation) => {
       addReservation(reservation);
+      notifySubscribers("reservation:created", reservation);
       showRateLimitedToast({
         title: "New reservation",
         description: `${reservation.guestName ?? "Guest"} — ${new Date(reservation.startTime).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`,
@@ -108,53 +155,99 @@ export function ReservationDataProvider({
         duration: 5000,
       });
     },
-    [addReservation, showRateLimitedToast]
+    [addReservation, notifySubscribers, showRateLimitedToast]
   );
 
   const handleUpdated = useCallback(
     (reservation: Reservation) => {
       updateReservation(reservation);
+      notifySubscribers("reservation:updated", reservation);
     },
-    [updateReservation]
+    [updateReservation, notifySubscribers]
   );
 
   const handleCancelled = useCallback(
     (reservation: Reservation) => {
       updateReservation(reservation);
+      notifySubscribers("reservation:cancelled", reservation);
       showRateLimitedToast({
         title: "Reservation cancelled",
-        description: `${reservation.guestName ?? "Guest"}'s reservation was cancelled`,
+        description: `${reservation.guestName ?? "Guest"}’s reservation was cancelled`,
         variant: "error",
         duration: 5000,
       });
     },
-    [updateReservation, showRateLimitedToast]
+    [updateReservation, notifySubscribers, showRateLimitedToast]
   );
 
-  const { isConnected } = useReservationEvents({
+  const handleHoldCreated = useCallback(
+    (hold: ReservationHold) => {
+      notifySubscribers("hold:created", hold);
+    },
+    [notifySubscribers]
+  );
+
+  const handleHoldReleased = useCallback(
+    (hold: ReservationHold) => {
+      notifySubscribers("hold:released", hold);
+    },
+    [notifySubscribers]
+  );
+
+  const handleHoldConfirmed = useCallback(
+    (reservation: Reservation) => {
+      addReservation(reservation);
+      notifySubscribers("hold:confirmed", reservation);
+    },
+    [addReservation, notifySubscribers]
+  );
+
+  const handleTableUpdated = useCallback(
+    (table: Table) => {
+      setTablesState((prev) =>
+        prev.map((t) => (t.id === table.id ? table : t))
+      );
+      notifySubscribers("table:updated", table);
+    },
+    [notifySubscribers]
+  );
+
+  const { isConnected, error: sseError } = useReservationEvents({
     venueId: selectedVenueId ?? undefined,
     enabled: !!selectedVenueId,
     onReservationCreated: handleCreated,
     onReservationUpdated: handleUpdated,
     onReservationCancelled: handleCancelled,
+    onHoldCreated: handleHoldCreated,
+    onHoldReleased: handleHoldReleased,
+    onHoldConfirmed: handleHoldConfirmed,
+    onTableUpdated: handleTableUpdated,
   });
 
   const value = useMemo<ReservationDataContextValue>(
     () => ({
       reservations,
+      tables,
       isConnected,
+      sseError,
       addReservation,
       updateReservation,
       removeReservation,
       setReservations,
+      setTables,
+      subscribeToEvents,
     }),
     [
       reservations,
+      tables,
       isConnected,
+      sseError,
       addReservation,
       updateReservation,
       removeReservation,
       setReservations,
+      setTables,
+      subscribeToEvents,
     ]
   );
 

--- a/apps/hospitality/src/hooks/useReservationEvents.test.ts
+++ b/apps/hospitality/src/hooks/useReservationEvents.test.ts
@@ -278,6 +278,55 @@ describe("useReservationEvents", () => {
     expect(MockEventSource.instances.length).toBe(initialCount + 2);
   });
 
+  it("closes EventSource on error before scheduling reconnect", () => {
+    renderHook(() => useReservationEvents({ venueId: "v1" }));
+
+    const es = latestEventSource();
+    expect(es.readyState).not.toBe(2);
+
+    act(() => {
+      es.simulateError();
+    });
+
+    // The onerror handler should close the EventSource immediately
+    // to prevent the browser's built-in auto-reconnect from firing
+    expect(es.readyState).toBe(2);
+  });
+
+  it("applies longer cooldown after many consecutive failures", () => {
+    renderHook(() => useReservationEvents({ venueId: "v1" }));
+
+    // Simulate 8 consecutive errors to trigger rate-limit cooldown
+    for (let i = 0; i < 8; i++) {
+      act(() => {
+        latestEventSource().simulateError();
+      });
+      // Advance past the normal exponential backoff
+      act(() => {
+        vi.advanceTimersByTime(30_001);
+      });
+    }
+
+    const countBefore = MockEventSource.instances.length;
+
+    // 9th error should use 60s cooldown instead of 30s max
+    act(() => {
+      latestEventSource().simulateError();
+    });
+
+    // At 30s, should NOT have reconnected (would have if using normal backoff)
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+    });
+    expect(MockEventSource.instances.length).toBe(countBefore);
+
+    // At 60s, should reconnect
+    act(() => {
+      vi.advanceTimersByTime(30_001);
+    });
+    expect(MockEventSource.instances.length).toBe(countBefore + 1);
+  });
+
   it("cleans up EventSource on unmount", () => {
     const { unmount } = renderHook(() =>
       useReservationEvents({ venueId: "v1" })

--- a/apps/hospitality/src/hooks/useReservationEvents.ts
+++ b/apps/hospitality/src/hooks/useReservationEvents.ts
@@ -36,6 +36,16 @@ export interface UseReservationEventsResult {
   reconnect: () => void;
 }
 
+/**
+ * Initial backoff delay in ms. Doubles on each consecutive failure up to MAX_BACKOFF_MS.
+ * After MAX_BACKOFF_ATTEMPTS consecutive failures (likely 429 rate-limiting),
+ * a longer cooldown is applied to avoid hammering the server.
+ */
+const INITIAL_BACKOFF_MS = 1_000;
+const MAX_BACKOFF_MS = 30_000;
+const RATE_LIMIT_COOLDOWN_MS = 60_000;
+const MAX_BACKOFF_ATTEMPTS = 8;
+
 export function useReservationEvents(
   options: UseReservationEventsOptions = {}
 ): UseReservationEventsResult {
@@ -86,8 +96,12 @@ export function useReservationEvents(
   });
 
   const connect = useCallback(() => {
+    // Always close existing connection first to prevent duplicates.
+    // EventSource's built-in auto-reconnect fires immediately after onerror,
+    // so we must close() before opening a new one.
     if (eventSourceRef.current) {
       eventSourceRef.current.close();
+      eventSourceRef.current = null;
     }
 
     const baseUrl = import.meta.env.VITE_API_URL ?? "";
@@ -106,14 +120,25 @@ export function useReservationEvents(
     };
 
     eventSource.onerror = () => {
+      // Close the EventSource immediately to prevent the browser's built-in
+      // auto-reconnect from racing with our manual backoff reconnect.
+      // Without this, both fire and you get 2x connections on every error.
+      eventSource.close();
+      eventSourceRef.current = null;
+
       setIsConnected(false);
       const err = new Error("SSE connection error");
       setError(err);
       callbacksRef.current.onError?.(err);
 
-      // Exponential backoff reconnection
-      const delay = Math.min(1000 * Math.pow(2, reconnectAttempts.current), 30000);
-      reconnectAttempts.current += 1;
+      // After many consecutive failures, apply a longer cooldown.
+      // This is the likely 429 scenario — the server has rate-limited us.
+      const attempts = reconnectAttempts.current;
+      const delay =
+        attempts >= MAX_BACKOFF_ATTEMPTS
+          ? RATE_LIMIT_COOLDOWN_MS
+          : Math.min(INITIAL_BACKOFF_MS * Math.pow(2, attempts), MAX_BACKOFF_MS);
+      reconnectAttempts.current = attempts + 1;
 
       reconnectTimeoutRef.current = setTimeout(() => {
         connectRef.current?.();

--- a/apps/hospitality/src/pages/HomePage.tsx
+++ b/apps/hospitality/src/pages/HomePage.tsx
@@ -1,16 +1,13 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "@mbe/auth/react";
 import { Stat, Button, Skeleton } from "@mattbutlerengineering/rialto";
 import { PageHeader } from "../components/PageHeader";
 import { ErrorRetryBanner } from "../components/ErrorRetryBanner";
 import { ReservationList, ActivityFeed } from "../components/dashboard";
-import { useVenue } from "../contexts/VenueContext.js";
+import { useReservationData } from "../contexts/ReservationDataContext.js";
 import { useDashboardStats } from "../hooks/useDashboardStats";
-import {
-  useReservationEvents,
-  type ReservationEvent,
-} from "../hooks/useReservationEvents";
+import type { ReservationEvent } from "../hooks/useReservationEvents";
 import styles from "./HomePage.module.css";
 
 const MAX_FEED_ITEMS = 5;
@@ -28,7 +25,7 @@ function StatsLoading() {
 export function HomePage() {
   const { user } = useAuth();
   const navigate = useNavigate();
-  const { selectedVenueId } = useVenue();
+  const { isConnected, subscribeToEvents } = useReservationData();
   const { reservations, stats, isLoading, error, refetch } = useDashboardStats();
   const [feedEvents, setFeedEvents] = useState<readonly ReservationEvent[]>([]);
 
@@ -36,37 +33,10 @@ export function HomePage() {
     setFeedEvents((prev) => [event, ...prev].slice(0, MAX_FEED_ITEMS));
   }, []);
 
-  const { isConnected } = useReservationEvents({
-    venueId: selectedVenueId ?? undefined,
-    onReservationCreated: (data) =>
-      handleEvent({
-        type: "reservation:created",
-        venueId: "",
-        timestamp: new Date().toISOString(),
-        data,
-      }),
-    onReservationUpdated: (data) =>
-      handleEvent({
-        type: "reservation:updated",
-        venueId: "",
-        timestamp: new Date().toISOString(),
-        data,
-      }),
-    onReservationCancelled: (data) =>
-      handleEvent({
-        type: "reservation:cancelled",
-        venueId: "",
-        timestamp: new Date().toISOString(),
-        data,
-      }),
-    onTableUpdated: (data) =>
-      handleEvent({
-        type: "table:updated",
-        venueId: "",
-        timestamp: new Date().toISOString(),
-        data,
-      }),
-  });
+  // Subscribe to SSE events via the shared context (no extra EventSource connection)
+  useEffect(() => {
+    return subscribeToEvents(handleEvent);
+  }, [subscribeToEvents, handleEvent]);
 
   return (
     <div>

--- a/apps/hospitality/src/pages/TimelinePage.tsx
+++ b/apps/hospitality/src/pages/TimelinePage.tsx
@@ -3,12 +3,11 @@ import { useSearchParams } from "react-router-dom";
 import { useAuth } from "@mbe/auth/react";
 import { createApiClient } from "@mbe/api-client";
 import { Drawer, Button, Stack, Text, Card } from "@mattbutlerengineering/rialto";
-import type { Reservation, Table, TableStatus, UpdateReservationRequest } from "@mbe/types";
+import type { Reservation, TableStatus, UpdateReservationRequest } from "@mbe/types";
 import { TimelineGrid } from "../components/timeline";
 import { CancelReservationDialog } from "../components/timeline/CancelReservationDialog";
 import { EditReservationDrawer } from "../components/timeline/EditReservationDrawer";
 import { WalkInDialog } from "../components/timeline/WalkInDialog";
-import { useReservationEvents } from "../hooks/useReservationEvents";
 import { useVenue } from "../contexts/VenueContext.js";
 import { useReservationData } from "../contexts/ReservationDataContext.js";
 import { PageHeader } from "../components/PageHeader";
@@ -167,13 +166,14 @@ export function TimelinePage() {
   const { selectedVenueId } = useVenue();
   const {
     reservations: sharedReservations,
+    tables,
     isConnected,
     setReservations: setSharedReservations,
+    setTables,
     addReservation,
     updateReservation,
   } = useReservationData();
 
-  const [tables, setTables] = useState<Table[]>([]);
   const [searchParams, setSearchParams] = useSearchParams();
   const todayStr = useMemo(() => new Date().toLocaleDateString("en-CA"), []);
   const selectedDate = searchParams.get("date") ?? todayStr;
@@ -195,22 +195,8 @@ export function TimelinePage() {
     [accessToken]
   );
 
-  // SSE for table updates and hold confirmations (reservation events handled by context)
-  useReservationEvents({
-    venueId: selectedVenueId ?? undefined,
-    enabled: !!selectedVenueId,
-    onHoldConfirmed: useCallback(
-      (reservation: Reservation) => {
-        if (reservation.date === selectedDate) {
-          addReservation(reservation);
-        }
-      },
-      [selectedDate, addReservation]
-    ),
-    onTableUpdated: useCallback((table: Table) => {
-      setTables((prev) => prev.map((t) => (t.id === table.id ? table : t)));
-    }, []),
-  });
+  // Table updates and hold confirmations are now handled by the shared
+  // ReservationDataContext — no separate useReservationEvents needed.
 
   // Filter shared reservations to the selected date
   const reservations = useMemo(

--- a/services/reservations/src/services/sse-connection-manager.test.ts
+++ b/services/reservations/src/services/sse-connection-manager.test.ts
@@ -144,10 +144,10 @@ describe("SseConnectionManager", () => {
     });
 
     it("merges partial overrides with defaults", () => {
-      const manager = new SseConnectionManager({ maxConnectionsPerIp: 10 });
+      const manager = new SseConnectionManager({ maxConnectionsPerIp: 20 });
       const config = manager.getConfig();
 
-      expect(config.maxConnectionsPerIp).toBe(10);
+      expect(config.maxConnectionsPerIp).toBe(20);
       expect(config.connectionTimeoutMs).toBe(DEFAULT_SSE_CONFIG.connectionTimeoutMs);
     });
   });

--- a/services/reservations/src/services/sse-connection-manager.ts
+++ b/services/reservations/src/services/sse-connection-manager.ts
@@ -23,7 +23,7 @@ export interface SseConnectionConfig {
 
 /** Default configuration values. */
 export const DEFAULT_SSE_CONFIG: SseConnectionConfig = Object.freeze({
-  maxConnectionsPerIp: 5,
+  maxConnectionsPerIp: 10,
   connectionTimeoutMs: 30 * 60 * 1000, // 30 minutes
   maxEventBufferSize: 100,
   heartbeatIntervalMs: 30_000, // 30 seconds


### PR DESCRIPTION
## Summary

Fixes #1036 — SSE connection limit hit (429 Too Many Connections on `/api/v1/events/stream`).

Three root causes identified and fixed:

- **Browser auto-reconnect doubling connections**: EventSource's built-in auto-reconnect fires immediately after `onerror`, racing with our manual exponential backoff. Fix: `close()` the EventSource in `onerror` before scheduling our own retry.
- **Duplicate connections from multiple components**: `HomePage`, `TimelinePage`, and `ReservationDataContext` each independently called `useReservationEvents`, opening up to 3 SSE connections per tab. Fix: consolidate to a single connection in `ReservationDataContext`, with a `subscribeToEvents` API for pages that need raw event access.
- **No extended backoff for persistent 429s**: After 8+ consecutive failures (the rate-limiting scenario), the client now applies a 60-second cooldown instead of the normal 30-second max backoff.

Server-side `maxConnectionsPerIp` raised from 5 to 10 as a safety net.

### Files changed

| File | Change |
|------|--------|
| `apps/hospitality/src/hooks/useReservationEvents.ts` | Close EventSource in onerror; add rate-limit cooldown after 8 failures |
| `apps/hospitality/src/contexts/ReservationDataContext.tsx` | Single SSE connection for the app; handle all event types; expose `subscribeToEvents`, `tables`, `setTables` |
| `apps/hospitality/src/pages/HomePage.tsx` | Remove direct `useReservationEvents`; use context's `subscribeToEvents` |
| `apps/hospitality/src/pages/TimelinePage.tsx` | Remove direct `useReservationEvents`; use context's shared tables/events |
| `services/reservations/src/services/sse-connection-manager.ts` | Raise default `maxConnectionsPerIp` from 5 to 10 |
| `apps/hospitality/src/hooks/useReservationEvents.test.ts` | Add tests for close-on-error and rate-limit cooldown behavior |
| `services/reservations/src/services/sse-connection-manager.test.ts` | Update test for new default limit |

## Test plan

- [x] `useReservationEvents` tests pass (11/11) including 2 new tests
- [x] SSE connection manager tests pass (14/14)
- [x] Hospitality app builds successfully
- [x] No new TypeScript errors introduced (pre-existing rialto resolution errors remain)
- [ ] Manual: verify single SSE connection per tab in browser DevTools Network tab
- [ ] Manual: verify 429 triggers 60s cooldown after 8 consecutive failures