### PR TITLE
test(rialto): add stories for data display components

### DIFF
--- a/packages/rialto/src/components/DataList/DataList.stories.tsx
+++ b/packages/rialto/src/components/DataList/DataList.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+import { DataList } from './DataList';
+
+const carSpecs = [
+  { label: 'Team', value: 'Red Bull Racing' },
+  { label: 'Engine', value: 'Honda RBPT' },
+  { label: 'Chassis', value: 'RB19' },
+  { label: 'Weight', value: '798 kg' },
+  { label: 'Power Unit', value: '1,000+ hp' },
+];
+
+const meta: Meta<typeof DataList> = {
+  title: 'Data Display/DataList',
+  component: DataList,
+  tags: ['autodocs'],
+  argTypes: {
+    orientation: {
+      control: { type: 'radio' },
+      options: ['horizontal', 'vertical'],
+    },
+    striped: { control: 'boolean' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof DataList>;
+
+export const Default: Story = {
+  args: {
+    items: carSpecs,
+    orientation: 'horizontal',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const teamLabel = canvas.getByText('Team');
+    await expect(teamLabel).toBeInTheDocument();
+    const teamValue = canvas.getByText('Red Bull Racing');
+    await expect(teamValue).toBeInTheDocument();
+  },
+};
+
+export const Vertical: Story = {
+  args: {
+    items: carSpecs,
+    orientation: 'vertical',
+  },
+};
+
+export const Striped: Story = {
+  args: {
+    items: carSpecs,
+    orientation: 'horizontal',
+    striped: true,
+  },
+};
+
+export const StripedVertical: Story = {
+  args: {
+    items: carSpecs,
+    orientation: 'vertical',
+    striped: true,
+  },
+};
+
+export const WithReactNodes: Story = {
+  args: {
+    items: [
+      { label: 'Status', value: <span style={{ color: 'green' }}>Active</span> },
+      { label: 'Driver', value: <strong>Max Verstappen</strong> },
+      { label: 'Lap Time', value: '1:25.410' },
+      { label: 'Sector 1', value: '28.241' },
+      { label: 'Sector 2', value: '32.618' },
+    ],
+    orientation: 'horizontal',
+  },
+};

--- a/packages/rialto/src/components/Divider/Divider.stories.tsx
+++ b/packages/rialto/src/components/Divider/Divider.stories.tsx
@@ -1,0 +1,100 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+import { Divider } from './Divider';
+
+const meta: Meta<typeof Divider> = {
+  title: 'Data Display/Divider',
+  component: Divider,
+  tags: ['autodocs'],
+  argTypes: {
+    orientation: {
+      control: { type: 'radio' },
+      options: ['horizontal', 'vertical'],
+    },
+    spacing: {
+      control: { type: 'radio' },
+      options: ['compact', 'default', 'spacious'],
+    },
+    accent: { control: 'boolean' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Divider>;
+
+export const Default: Story = {
+  args: {
+    orientation: 'horizontal',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const divider = canvas.getByRole('separator');
+    await expect(divider).toBeInTheDocument();
+    await expect(divider).toHaveAttribute('aria-orientation', 'horizontal');
+  },
+};
+
+export const WithLabel: Story = {
+  args: {
+    label: 'Or',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const label = canvas.getByText('Or');
+    await expect(label).toBeInTheDocument();
+  },
+};
+
+export const Accent: Story = {
+  args: {
+    accent: true,
+  },
+};
+
+export const AccentWithLabel: Story = {
+  args: {
+    label: 'Section Break',
+    accent: true,
+  },
+};
+
+export const Compact: Story = {
+  args: {
+    spacing: 'compact',
+  },
+};
+
+export const Spacious: Story = {
+  args: {
+    spacing: 'spacious',
+  },
+};
+
+export const Vertical: Story = {
+  render: () => (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', height: '60px' }}>
+      <span>Left Content</span>
+      <Divider orientation="vertical" />
+      <span>Right Content</span>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const divider = canvas.getByRole('separator');
+    await expect(divider).toHaveAttribute('aria-orientation', 'vertical');
+  },
+};
+
+export const InContext: Story = {
+  render: () => (
+    <div style={{ width: '300px' }}>
+      <p style={{ margin: '0 0 0.5rem' }}>Qualifying Results</p>
+      <Divider />
+      <p style={{ margin: '0.5rem 0' }}>P1: Max Verstappen — 1:25.410</p>
+      <Divider label="Gap" />
+      <p style={{ margin: '0.5rem 0' }}>P2: Charles Leclerc — 1:25.732</p>
+      <Divider accent />
+      <p style={{ margin: '0.5rem 0 0' }}>P3: Lewis Hamilton — 1:25.987</p>
+    </div>
+  ),
+};

--- a/packages/rialto/src/components/Stat/Stat.stories.tsx
+++ b/packages/rialto/src/components/Stat/Stat.stories.tsx
@@ -1,0 +1,106 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+import { Stat } from './Stat';
+
+const meta: Meta<typeof Stat> = {
+  title: 'Data Display/Stat',
+  component: Stat,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    trend: {
+      control: { type: 'radio' },
+      options: ['up', 'down', 'neutral'],
+    },
+    size: {
+      control: { type: 'radio' },
+      options: ['sm', 'md', 'lg'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Stat>;
+
+export const Default: Story = {
+  args: {
+    label: 'Lap Time',
+    value: '1:25.410',
+    delta: '-0.342s',
+    trend: 'down',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const stat = canvas.getByRole('group', { name: 'Lap Time' });
+    await expect(stat).toBeInTheDocument();
+    const value = canvas.getByText('1:25.410');
+    await expect(value).toBeInTheDocument();
+  },
+};
+
+export const TrendUp: Story = {
+  args: {
+    label: 'Championship Points',
+    value: '575',
+    delta: '+42',
+    trend: 'up',
+  },
+};
+
+export const TrendDown: Story = {
+  args: {
+    label: 'Pit Stop Time',
+    value: '2.4s',
+    delta: '-0.3s',
+    trend: 'down',
+  },
+};
+
+export const Neutral: Story = {
+  args: {
+    label: 'Grid Position',
+    value: 'P1',
+    delta: 'No change',
+    trend: 'neutral',
+  },
+};
+
+export const NoDelta: Story = {
+  args: {
+    label: 'Total Races',
+    value: '22',
+  },
+};
+
+export const Small: Story = {
+  args: {
+    label: 'Top Speed',
+    value: '372 km/h',
+    delta: '+5 km/h',
+    trend: 'up',
+    size: 'sm',
+  },
+};
+
+export const Large: Story = {
+  args: {
+    label: 'Season Wins',
+    value: '19',
+    delta: '+3',
+    trend: 'up',
+    size: 'lg',
+  },
+};
+
+export const Dashboard: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: '1.5rem', flexWrap: 'wrap' }}>
+      <Stat label="Race Position" value="P1" delta="+2" trend="up" />
+      <Stat label="Lap Time" value="1:25.410" delta="-0.342s" trend="down" />
+      <Stat label="Tire Age" value="18 laps" trend="neutral" />
+      <Stat label="Gap to Leader" value="+3.2s" delta="+0.4s" trend="up" />
+    </div>
+  ),
+};

--- a/packages/rialto/src/components/Table/Table.stories.tsx
+++ b/packages/rialto/src/components/Table/Table.stories.tsx
@@ -1,0 +1,111 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn, expect, userEvent, within } from 'storybook/test';
+import { Table } from './Table';
+
+interface Driver {
+  name: string;
+  team: string;
+  points: number;
+  wins: number;
+}
+
+const drivers: Driver[] = [
+  { name: 'Max Verstappen', team: 'Red Bull Racing', points: 575, wins: 19 },
+  { name: 'Sergio Perez', team: 'Red Bull Racing', points: 285, wins: 2 },
+  { name: 'Lewis Hamilton', team: 'Mercedes', points: 234, wins: 0 },
+  { name: 'Carlos Sainz', team: 'Ferrari', points: 200, wins: 1 },
+  { name: 'Fernando Alonso', team: 'Aston Martin', points: 206, wins: 0 },
+];
+
+const columns = [
+  { key: 'name', header: 'Driver', sortable: true },
+  { key: 'team', header: 'Team', sortable: true },
+  { key: 'points', header: 'Points', sortable: true, align: 'right' as const },
+  { key: 'wins', header: 'Wins', sortable: true, align: 'right' as const },
+];
+
+const meta: Meta<typeof Table> = {
+  title: 'Data Display/Table',
+  component: Table,
+  tags: ['autodocs'],
+  args: {
+    onRowClick: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Table>;
+
+export const Default: Story = {
+  args: {
+    columns,
+    data: drivers,
+    rowKey: (row) => (row as Driver).name,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const pointsHeader = canvas.getByRole('columnheader', { name: /Points/i });
+    await expect(pointsHeader).toBeInTheDocument();
+    await userEvent.click(pointsHeader);
+    const firstCell = canvas.getAllByRole('cell')[2];
+    await expect(firstCell).toBeInTheDocument();
+  },
+};
+
+export const Striped: Story = {
+  args: {
+    columns,
+    data: drivers,
+    rowKey: (row) => (row as Driver).name,
+    striped: true,
+  },
+};
+
+export const Compact: Story = {
+  args: {
+    columns,
+    data: drivers,
+    rowKey: (row) => (row as Driver).name,
+    density: 'compact',
+  },
+};
+
+export const Spacious: Story = {
+  args: {
+    columns,
+    data: drivers,
+    rowKey: (row) => (row as Driver).name,
+    density: 'spacious',
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    columns,
+    data: [],
+    rowKey: (row) => (row as Driver).name,
+    emptyMessage: 'No drivers found for this season.',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const emptyCell = canvas.getByText('No drivers found for this season.');
+    await expect(emptyCell).toBeInTheDocument();
+  },
+};
+
+export const SortedByPoints: Story = {
+  args: {
+    columns,
+    data: drivers,
+    rowKey: (row) => (row as Driver).name,
+    striped: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const pointsHeader = canvas.getByRole('columnheader', { name: /Points/i });
+    await userEvent.click(pointsHeader);
+    await expect(pointsHeader).toHaveAttribute('aria-sort', 'ascending');
+    await userEvent.click(pointsHeader);
+    await expect(pointsHeader).toHaveAttribute('aria-sort', 'descending');
+  },
+};

--- a/packages/rialto/src/components/Tag/Tag.stories.tsx
+++ b/packages/rialto/src/components/Tag/Tag.stories.tsx
@@ -1,0 +1,132 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn, expect, userEvent, within } from 'storybook/test';
+import { Tag, AnimatedTag, TagGroup } from './Tag';
+
+const meta: Meta<typeof Tag> = {
+  title: 'Data Display/Tag',
+  component: Tag,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    variant: {
+      control: { type: 'select' },
+      options: ['default', 'accent', 'success', 'error'],
+    },
+    dismissible: { control: 'boolean' },
+    selected: { control: 'boolean' },
+  },
+  args: {
+    onClick: fn(),
+    onDismiss: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Tag>;
+
+export const Default: Story = {
+  args: {
+    children: 'Telemetry',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const tag = canvas.getByText('Telemetry');
+    await expect(tag).toBeInTheDocument();
+  },
+};
+
+export const Variants: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+      <Tag variant="default">Default</Tag>
+      <Tag variant="accent">Accent</Tag>
+      <Tag variant="success">Confirmed</Tag>
+      <Tag variant="error">Cancelled</Tag>
+    </div>
+  ),
+};
+
+function InteractiveTagGroup() {
+  const [selected, setSelected] = useState('all');
+  return (
+    <div style={{ display: 'flex', gap: '0.5rem' }}>
+      {(['all', 'dry', 'inter', 'wet'] as const).map((filter) => (
+        <Tag
+          key={filter}
+          onClick={() => setSelected(filter)}
+          selected={selected === filter}
+        >
+          {filter.charAt(0).toUpperCase() + filter.slice(1)}
+        </Tag>
+      ))}
+    </div>
+  );
+}
+
+export const Interactive: Story = {
+  render: () => <InteractiveTagGroup />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const dryTag = canvas.getByRole('button', { name: /Dry/i });
+    await expect(dryTag).toBeInTheDocument();
+    await userEvent.click(dryTag);
+  },
+};
+
+export const Dismissible: Story = {
+  args: {
+    children: 'Removable Tag',
+    dismissible: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const dismissBtn = canvas.getByRole('button', { name: /Remove Removable Tag/i });
+    await expect(dismissBtn).toBeInTheDocument();
+  },
+};
+
+export const Selected: Story = {
+  args: {
+    children: 'Active Filter',
+    selected: true,
+    onClick: fn(),
+  },
+};
+
+function AnimatedTagGroupDemo() {
+  const allTags = ['DRS', 'Safety Car', 'Pit Window', 'Weather', 'Tyre Deg'];
+  const [activeTags, setActiveTags] = useState(allTags);
+
+  const remove = (tag: string) => {
+    setActiveTags((prev) => prev.filter((t) => t !== tag));
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', width: '300px' }}>
+      <TagGroup>
+        {activeTags.map((tag) => (
+          <AnimatedTag key={tag} id={tag} dismissible onDismiss={() => remove(tag)}>
+            {tag}
+          </AnimatedTag>
+        ))}
+      </TagGroup>
+      {activeTags.length === 0 && (
+        <span style={{ fontSize: '0.875rem', opacity: 0.6 }}>All tags removed</span>
+      )}
+    </div>
+  );
+}
+
+export const AnimatedGroup: Story = {
+  render: () => <AnimatedTagGroupDemo />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const dismissBtn = canvas.getByRole('button', { name: /Remove DRS/i });
+    await expect(dismissBtn).toBeInTheDocument();
+    await userEvent.click(dismissBtn);
+    await expect(canvas.queryByText('DRS')).not.toBeInTheDocument();
+  },
+};

--- a/packages/rialto/src/components/TapeChart/TapeChart.stories.tsx
+++ b/packages/rialto/src/components/TapeChart/TapeChart.stories.tsx
@@ -1,0 +1,149 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn, expect, within } from 'storybook/test';
+import { TapeChart } from './TapeChart';
+import type { TapeChartRoom, TapeChartReservation } from './types';
+
+const rooms: TapeChartRoom[] = [
+  { id: 'r101', name: 'Room 101', category: 'Standard', capacity: 2 },
+  { id: 'r102', name: 'Room 102', category: 'Standard', capacity: 2 },
+  { id: 'r201', name: 'Room 201', category: 'Deluxe', capacity: 2 },
+  { id: 'r202', name: 'Room 202', category: 'Deluxe', capacity: 3 },
+  { id: 'r301', name: 'Suite 301', category: 'Suite', capacity: 4 },
+];
+
+const reservations: TapeChartReservation[] = [
+  {
+    id: 'res-1',
+    roomId: 'r101',
+    start: '2026-05-03',
+    end: '2026-05-07',
+    status: 'confirmed',
+    guestName: 'Max Verstappen',
+    partySize: 2,
+    ratePerNight: 18000,
+    currency: 'USD',
+  },
+  {
+    id: 'res-2',
+    roomId: 'r201',
+    start: '2026-05-05',
+    end: '2026-05-09',
+    status: 'checkedIn',
+    guestName: 'Lewis Hamilton',
+    partySize: 1,
+    ratePerNight: 25000,
+    currency: 'USD',
+  },
+  {
+    id: 'res-3',
+    roomId: 'r301',
+    start: '2026-05-04',
+    end: '2026-05-06',
+    status: 'tentative',
+    guestName: 'Carlos Sainz',
+    partySize: 4,
+    ratePerNight: 45000,
+    currency: 'USD',
+  },
+  {
+    id: 'res-4',
+    roomId: 'r102',
+    start: '2026-05-06',
+    end: '2026-05-10',
+    status: 'confirmed',
+    guestName: 'Fernando Alonso',
+    partySize: 2,
+    ratePerNight: 18000,
+    currency: 'USD',
+  },
+  {
+    id: 'res-5',
+    roomId: 'r202',
+    start: '2026-05-03',
+    end: '2026-05-05',
+    status: 'checkedOut',
+    guestName: 'Charles Leclerc',
+    partySize: 2,
+    ratePerNight: 25000,
+    currency: 'USD',
+  },
+];
+
+const meta: Meta<typeof TapeChart> = {
+  title: 'Data Display/TapeChart',
+  component: TapeChart,
+  tags: ['autodocs'],
+  argTypes: {
+    density: {
+      control: { type: 'radio' },
+      options: ['compact', 'comfortable'],
+    },
+    loading: { control: 'boolean' },
+  },
+  args: {
+    onReservationClick: fn(),
+  },
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof TapeChart>;
+
+export const Default: Story = {
+  args: {
+    rooms,
+    reservations,
+    startDate: '2026-05-03',
+    endDate: '2026-05-11',
+    currency: 'USD',
+    locale: 'en-US',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const region = canvas.getByRole('region');
+    await expect(region).toBeInTheDocument();
+  },
+};
+
+export const Compact: Story = {
+  args: {
+    rooms,
+    reservations,
+    startDate: '2026-05-03',
+    endDate: '2026-05-11',
+    currency: 'USD',
+    density: 'compact',
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    rooms,
+    reservations: [],
+    startDate: '2026-05-03',
+    endDate: '2026-05-11',
+    loading: true,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    rooms,
+    reservations: [],
+    startDate: '2026-05-03',
+    endDate: '2026-05-11',
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    rooms,
+    reservations: [],
+    startDate: '2026-05-03',
+    endDate: '2026-05-11',
+    error: new Error('Failed to load reservations. Please try again.'),
+    onRetry: fn(),
+  },
+};

--- a/packages/rialto/src/components/Timeline/Timeline.stories.tsx
+++ b/packages/rialto/src/components/Timeline/Timeline.stories.tsx
@@ -1,0 +1,119 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+import { Timeline } from './Timeline';
+
+const raceEvents = [
+  {
+    title: 'Lights Out',
+    description: 'Race start at Circuit de Monaco',
+    timestamp: '14:00',
+    status: 'completed' as const,
+  },
+  {
+    title: 'Safety Car Deployed',
+    description: 'Incident at Rascasse corner',
+    timestamp: '14:18',
+    status: 'completed' as const,
+  },
+  {
+    title: 'Pit Window Opens',
+    description: 'Optimal pit stop window begins on lap 24',
+    timestamp: '14:35',
+    status: 'active' as const,
+  },
+  {
+    title: 'Final Stint',
+    description: 'Push to the finish line',
+    timestamp: '15:00',
+    status: 'upcoming' as const,
+  },
+  {
+    title: 'Chequered Flag',
+    description: 'Race end after 78 laps',
+    timestamp: '15:42',
+    status: 'upcoming' as const,
+  },
+];
+
+const meta: Meta<typeof Timeline> = {
+  title: 'Data Display/Timeline',
+  component: Timeline,
+  tags: ['autodocs'],
+  argTypes: {
+    compact: { control: 'boolean' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Timeline>;
+
+export const Default: Story = {
+  args: {
+    events: raceEvents,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const timeline = canvas.getByRole('list', { name: 'Timeline' });
+    await expect(timeline).toBeInTheDocument();
+    const items = canvas.getAllByRole('listitem');
+    await expect(items).toHaveLength(raceEvents.length);
+  },
+};
+
+export const Compact: Story = {
+  args: {
+    events: raceEvents,
+    compact: true,
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    events: [
+      {
+        title: 'Qualifying Session',
+        timestamp: '10:00',
+        status: 'completed',
+      },
+      {
+        title: 'Grid Penalty Applied',
+        description: 'Engine component change — 5-place grid penalty',
+        timestamp: '11:30',
+        status: 'error',
+      },
+      {
+        title: 'Race Start',
+        description: 'Starting from P8 after penalty',
+        timestamp: '14:00',
+        status: 'upcoming',
+      },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const errorItem = canvas.getByText('Grid Penalty Applied');
+    await expect(errorItem).toBeInTheDocument();
+  },
+};
+
+export const AllCompleted: Story = {
+  args: {
+    events: [
+      { title: 'Practice 1', timestamp: 'Fri 14:00', status: 'completed' },
+      { title: 'Practice 2', timestamp: 'Fri 17:00', status: 'completed' },
+      { title: 'Practice 3', timestamp: 'Sat 12:00', status: 'completed' },
+      { title: 'Qualifying', timestamp: 'Sat 15:00', status: 'completed' },
+      { title: 'Race', timestamp: 'Sun 14:00', status: 'completed' },
+    ],
+  },
+};
+
+export const MinimalEvents: Story = {
+  args: {
+    events: [
+      { title: 'Check In', status: 'completed' },
+      { title: 'Room Assigned', status: 'active' },
+      { title: 'Check Out', status: 'upcoming' },
+    ],
+  },
+};

--- a/packages/rialto/src/components/Tree/Tree.stories.tsx
+++ b/packages/rialto/src/components/Tree/Tree.stories.tsx
@@ -1,0 +1,139 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn, expect, userEvent, within } from 'storybook/test';
+import { Tree } from './Tree';
+import type { TreeNode } from './Tree';
+
+const f1CarTree: TreeNode[] = [
+  {
+    id: 'powertrain',
+    label: 'Powertrain',
+    children: [
+      { id: 'ice', label: 'ICE' },
+      { id: 'mgu-k', label: 'MGU-K' },
+      { id: 'mgu-h', label: 'MGU-H' },
+      { id: 'energy-store', label: 'Energy Store' },
+    ],
+  },
+  {
+    id: 'chassis',
+    label: 'Chassis',
+    children: [
+      { id: 'floor', label: 'Floor' },
+      { id: 'diffuser', label: 'Diffuser' },
+      {
+        id: 'wings',
+        label: 'Wings',
+        children: [
+          { id: 'front-wing', label: 'Front Wing' },
+          { id: 'rear-wing', label: 'Rear Wing' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'suspension',
+    label: 'Suspension',
+    children: [
+      { id: 'push-rod', label: 'Push Rod (front)' },
+      { id: 'pull-rod', label: 'Pull Rod (rear)' },
+    ],
+  },
+  {
+    id: 'electronics',
+    label: 'Electronics',
+    children: [
+      { id: 'ecu', label: 'ECU', disabled: true },
+      { id: 'sensors', label: 'Sensors' },
+    ],
+  },
+];
+
+const meta: Meta<typeof Tree> = {
+  title: 'Data Display/Tree',
+  component: Tree,
+  tags: ['autodocs'],
+  args: {
+    onSelect: fn(),
+    onExpandedChange: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Tree>;
+
+export const Default: Story = {
+  args: {
+    data: f1CarTree,
+    defaultExpanded: ['powertrain'],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const tree = canvas.getByRole('tree');
+    await expect(tree).toBeInTheDocument();
+    const powertrainItem = canvas.getByRole('treeitem', { name: /Powertrain/i });
+    await expect(powertrainItem).toBeInTheDocument();
+    await expect(powertrainItem).toHaveAttribute('aria-expanded', 'true');
+  },
+};
+
+export const AllCollapsed: Story = {
+  args: {
+    data: f1CarTree,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const powertrainItem = canvas.getByRole('treeitem', { name: /Powertrain/i });
+    await expect(powertrainItem).toHaveAttribute('aria-expanded', 'false');
+  },
+};
+
+export const ExpandCollapse: Story = {
+  args: {
+    data: f1CarTree,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const chassisItem = canvas.getByRole('treeitem', { name: /Chassis/i });
+    await expect(chassisItem).toHaveAttribute('aria-expanded', 'false');
+    await userEvent.click(chassisItem);
+    await expect(chassisItem).toHaveAttribute('aria-expanded', 'true');
+    const floorItem = canvas.getByRole('treeitem', { name: /Floor/i });
+    await expect(floorItem).toBeInTheDocument();
+    await userEvent.click(chassisItem);
+    await expect(chassisItem).toHaveAttribute('aria-expanded', 'false');
+  },
+};
+
+export const WithSelection: Story = {
+  args: {
+    data: f1CarTree,
+    defaultExpanded: ['powertrain', 'chassis', 'wings'],
+    selectionMode: 'single',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const iceItem = canvas.getByRole('treeitem', { name: /^ICE$/i });
+    await userEvent.click(iceItem);
+    await expect(iceItem).toHaveAttribute('aria-selected', 'true');
+  },
+};
+
+export const NoSelection: Story = {
+  args: {
+    data: f1CarTree,
+    defaultExpanded: ['powertrain'],
+    selectionMode: 'none',
+  },
+};
+
+export const DeepNested: Story = {
+  args: {
+    data: f1CarTree,
+    defaultExpanded: ['chassis', 'wings'],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const frontWingItem = canvas.getByRole('treeitem', { name: /Front Wing/i });
+    await expect(frontWingItem).toBeInTheDocument();
+  },
+};


### PR DESCRIPTION
## Summary

- Adds Storybook `.stories.tsx` files for all 8 data display components: Table, DataList, Stat, Tag, Timeline, TapeChart, Tree, Divider
- Each story file includes a `Default` story with realistic sample data, variant stories covering component props, and `play` functions for interactive components
- Uses `storybook/test` (not `@storybook/test`) per the latest story convention
- Storybook build verified locally via `pnpm build-storybook`

## Components covered

| Component | Stories | Play functions |
|-----------|---------|----------------|
| Table | Default, Striped, Compact, Spacious, Empty, SortedByPoints | Column sort interaction |
| DataList | Default, Vertical, Striped, StripedVertical, WithReactNodes | Render assertion |
| Stat | Default, TrendUp, TrendDown, Neutral, NoDelta, Small, Large, Dashboard | Role/value assertion |
| Tag | Default, Variants, Interactive, Dismissible, Selected, AnimatedGroup | Click + dismiss interaction |
| Timeline | Default, Compact, WithError, AllCompleted, MinimalEvents | Role/count assertion |
| TapeChart | Default, Compact, Loading, Empty, WithError | Region assertion |
| Tree | Default, AllCollapsed, ExpandCollapse, WithSelection, NoSelection, DeepNested | Expand/collapse interaction |
| Divider | Default, WithLabel, Accent, AccentWithLabel, Compact, Spacious, Vertical, InContext | ARIA orientation check |

## Test plan

- [ ] `pnpm --dir packages/rialto build-storybook` passes (verified locally)
- [ ] All stories render without console errors in Storybook
- [ ] Play functions pass in Storybook test runner

Closes #1027

🤖 Generated with [Claude Code](https://claude.com/claude-code)