### PR TITLE
test(rialto): add stories for feedback components

### DIFF
--- a/packages/rialto/src/components/Banner/Banner.stories.tsx
+++ b/packages/rialto/src/components/Banner/Banner.stories.tsx
@@ -1,0 +1,94 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn, expect, userEvent, within } from 'storybook/test';
+import { Banner } from './Banner';
+import { Button } from '../Button/Button';
+
+const meta: Meta<typeof Banner> = {
+  title: 'Feedback/Banner',
+  component: Banner,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: { type: 'select' },
+      options: ['info', 'warning', 'error', 'accent'],
+    },
+    dismissible: { control: 'boolean' },
+  },
+  args: {
+    onDismiss: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Banner>;
+
+export const Default: Story = {
+  args: {
+    variant: 'info',
+    children: 'A new version of Rialto is available. Check the changelog for details.',
+  },
+};
+
+export const Warning: Story = {
+  args: {
+    variant: 'warning',
+    children: 'Your session will expire in 5 minutes. Save your work to avoid losing changes.',
+  },
+};
+
+export const Error: Story = {
+  args: {
+    variant: 'error',
+    children: 'We could not sync your reservation data. Please refresh the page.',
+  },
+};
+
+export const Accent: Story = {
+  args: {
+    variant: 'accent',
+    children: 'New feature: AI-powered reservation suggestions are now available.',
+    action: <Button size="sm" variant="ghost">Try it</Button>,
+  },
+};
+
+export const WithAction: Story = {
+  args: {
+    variant: 'info',
+    children: 'A new version of the app is available.',
+    action: <Button size="sm">Update now</Button>,
+  },
+};
+
+export const Dismissible: Story = {
+  args: {
+    variant: 'info',
+    children: 'This banner can be dismissed by clicking the X button.',
+    dismissible: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const banner = canvas.getByRole('status');
+    await expect(banner).toBeInTheDocument();
+    const dismissButton = canvas.getByRole('button', { name: /dismiss/i });
+    await expect(dismissButton).toBeInTheDocument();
+    await userEvent.click(dismissButton);
+    await expect(canvas.queryByRole('status')).not.toBeInTheDocument();
+  },
+};
+
+export const DismissibleWarning: Story = {
+  args: {
+    variant: 'warning',
+    children: 'Scheduled maintenance at 11 PM tonight. Service may be briefly unavailable.',
+    dismissible: true,
+  },
+};
+
+export const DismissibleWithAction: Story = {
+  args: {
+    variant: 'info',
+    children: 'Updates are ready to install.',
+    action: <Button size="sm">Install</Button>,
+    dismissible: true,
+  },
+};

--- a/packages/rialto/src/components/EmptyState/EmptyState.stories.tsx
+++ b/packages/rialto/src/components/EmptyState/EmptyState.stories.tsx
@@ -1,0 +1,123 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, userEvent, within } from 'storybook/test';
+import { EmptyState } from './EmptyState';
+import { Button } from '../Button/Button';
+
+const SearchIcon = (
+  <svg
+    viewBox="0 0 40 40"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <circle cx="18" cy="18" r="10" />
+    <path d="M26 26L36 36" />
+  </svg>
+);
+
+const InboxIcon = (
+  <svg
+    viewBox="0 0 40 40"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <rect x="4" y="10" width="32" height="22" rx="2" />
+    <path d="M4 22h8l4 6 4-6h16" />
+  </svg>
+);
+
+const meta: Meta<typeof EmptyState> = {
+  title: 'Feedback/EmptyState',
+  component: EmptyState,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: { type: 'select' },
+      options: ['flat', 'elevated'],
+    },
+    size: {
+      control: { type: 'radio' },
+      options: ['sm', 'md'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof EmptyState>;
+
+export const Default: Story = {
+  args: {
+    heading: 'No items yet',
+    description: 'Get started by creating your first item.',
+    action: <Button>Create item</Button>,
+  },
+};
+
+export const NoResults: Story = {
+  args: {
+    icon: SearchIcon,
+    heading: 'No results found',
+    description: 'Try adjusting your search terms or clearing your filters.',
+    action: (
+      <div style={{ display: 'flex', gap: '0.5rem' }}>
+        <Button variant="secondary">Clear filters</Button>
+        <Button variant="ghost">Browse all</Button>
+      </div>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const heading = canvas.getByText('No results found');
+    await expect(heading).toBeInTheDocument();
+    const buttons = canvas.getAllByRole('button');
+    await expect(buttons).toHaveLength(2);
+    await userEvent.click(buttons[0]);
+  },
+};
+
+export const EmptyInbox: Story = {
+  args: {
+    icon: InboxIcon,
+    heading: 'Your inbox is empty',
+    description: "When guests send messages, they'll appear here.",
+  },
+};
+
+export const DefaultIcon: Story = {
+  args: {
+    heading: 'No reservations',
+    description: 'Upcoming reservations will appear here once bookings are made.',
+  },
+};
+
+export const Elevated: Story = {
+  args: {
+    variant: 'elevated',
+    heading: 'Nothing here yet',
+    description: 'Start by adding your first record.',
+    action: <Button>Add record</Button>,
+  },
+};
+
+export const Small: Story = {
+  args: {
+    size: 'sm',
+    heading: 'No items',
+    description: 'Add an item to get started.',
+    action: <Button size="sm">Add</Button>,
+  },
+};
+
+export const NoAction: Story = {
+  args: {
+    heading: 'All caught up',
+    description: 'There are no pending notifications at this time.',
+  },
+};

--- a/packages/rialto/src/components/HoverCard/HoverCard.stories.tsx
+++ b/packages/rialto/src/components/HoverCard/HoverCard.stories.tsx
@@ -1,0 +1,141 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, userEvent, within } from 'storybook/test';
+import { HoverCard } from './HoverCard';
+
+const ProfilePreview = () => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', minWidth: '200px' }}>
+    <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+      <div
+        style={{
+          width: 40,
+          height: 40,
+          borderRadius: '50%',
+          background: 'var(--rialto-accent)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: 'var(--rialto-surface)',
+          fontWeight: 500,
+          fontSize: '1rem',
+        }}
+      >
+        MB
+      </div>
+      <div>
+        <div style={{ fontWeight: 500, fontSize: 'var(--rialto-text-sm)' }}>Matt Butler</div>
+        <div style={{ fontSize: 'var(--rialto-text-xs)', color: 'var(--rialto-text-secondary)' }}>
+          @mattbutler
+        </div>
+      </div>
+    </div>
+    <p style={{ fontSize: 'var(--rialto-text-xs)', color: 'var(--rialto-text-secondary)', margin: 0 }}>
+      Building AI-native software tools. Creator of Rialto design system.
+    </p>
+    <div style={{ display: 'flex', gap: '1rem', fontSize: 'var(--rialto-text-xs)' }}>
+      <span><strong>42</strong> Following</span>
+      <span><strong>1.2k</strong> Followers</span>
+    </div>
+  </div>
+);
+
+const ReservationPreview = () => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', minWidth: '220px' }}>
+    <div style={{ fontWeight: 500, fontSize: 'var(--rialto-text-sm)' }}>The Bistro — Table 4</div>
+    <div style={{ fontSize: 'var(--rialto-text-xs)', color: 'var(--rialto-text-secondary)' }}>
+      Friday, May 9 &middot; 7:00 PM &middot; 4 guests
+    </div>
+    <div
+      style={{
+        padding: '0.25rem 0.5rem',
+        borderRadius: 'var(--rialto-radius-sharp)',
+        background: 'var(--rialto-success-muted)',
+        color: 'var(--rialto-success)',
+        fontSize: 'var(--rialto-text-xs)',
+        width: 'fit-content',
+      }}
+    >
+      Confirmed
+    </div>
+  </div>
+);
+
+const meta: Meta<typeof HoverCard> = {
+  title: 'Feedback/HoverCard',
+  component: HoverCard,
+  tags: ['autodocs'],
+  argTypes: {
+    placement: {
+      control: { type: 'select' },
+      options: ['top', 'bottom'],
+    },
+    openDelay: { control: { type: 'number' } },
+    closeDelay: { control: { type: 'number' } },
+  },
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof HoverCard>;
+
+export const Default: Story = {
+  args: {
+    content: <ProfilePreview />,
+    openDelay: 0,
+    placement: 'bottom',
+    children: (
+      <a href="/preview" style={{ color: 'var(--rialto-accent)', textDecoration: 'underline' }}>
+        @mattbutler
+      </a>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('link');
+    await expect(trigger).toBeInTheDocument();
+    await userEvent.hover(trigger);
+    const card = await canvas.findByRole('dialog');
+    await expect(card).toBeInTheDocument();
+    await userEvent.unhover(trigger);
+  },
+};
+
+export const PlacementTop: Story = {
+  args: {
+    content: <ProfilePreview />,
+    placement: 'top',
+    openDelay: 0,
+    children: (
+      <a href="/preview" style={{ color: 'var(--rialto-accent)', textDecoration: 'underline' }}>
+        Hover (top)
+      </a>
+    ),
+  },
+};
+
+export const PlacementBottom: Story = {
+  args: {
+    content: <ReservationPreview />,
+    placement: 'bottom',
+    openDelay: 0,
+    children: (
+      <a href="/preview" style={{ color: 'var(--rialto-accent)', textDecoration: 'underline' }}>
+        Table reservation
+      </a>
+    ),
+  },
+};
+
+export const WithCustomDelays: Story = {
+  args: {
+    content: <ProfilePreview />,
+    openDelay: 600,
+    closeDelay: 400,
+    children: (
+      <a href="/preview" style={{ color: 'var(--rialto-accent)', textDecoration: 'underline' }}>
+        Slow open, slow close
+      </a>
+    ),
+  },
+};

--- a/packages/rialto/src/components/Meter/Meter.stories.tsx
+++ b/packages/rialto/src/components/Meter/Meter.stories.tsx
@@ -1,0 +1,129 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+import { Meter } from './Meter';
+
+const meta: Meta<typeof Meter> = {
+  title: 'Feedback/Meter',
+  component: Meter,
+  tags: ['autodocs'],
+  argTypes: {
+    value: {
+      control: { type: 'range', min: 0, max: 100, step: 1 },
+    },
+    variant: {
+      control: { type: 'select' },
+      options: ['default', 'accent', 'success', 'error'],
+    },
+    size: {
+      control: { type: 'radio' },
+      options: ['sm', 'md'],
+    },
+    showValue: { control: 'boolean' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Meter>;
+
+export const Default: Story = {
+  args: {
+    value: 72,
+    label: 'Fuel Load',
+    showValue: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const meter = canvas.getByRole('meter');
+    await expect(meter).toBeInTheDocument();
+    await expect(meter).toHaveAttribute('aria-valuenow', '72');
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    value: 0,
+    label: 'Battery',
+    showValue: true,
+  },
+};
+
+export const HalfFull: Story = {
+  args: {
+    value: 50,
+    label: 'Storage used',
+    showValue: true,
+  },
+};
+
+export const Full: Story = {
+  args: {
+    value: 100,
+    label: 'Capacity',
+    showValue: true,
+  },
+};
+
+export const VariantAccent: Story = {
+  args: {
+    value: 68,
+    label: 'Revenue target',
+    variant: 'accent',
+    showValue: true,
+  },
+};
+
+export const VariantSuccess: Story = {
+  args: {
+    value: 85,
+    label: 'Occupancy rate',
+    variant: 'success',
+    showValue: true,
+  },
+};
+
+export const VariantError: Story = {
+  args: {
+    value: 92,
+    label: 'Disk usage',
+    variant: 'error',
+    showValue: true,
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', width: '300px' }}>
+      <Meter value={60} label="Default" variant="default" showValue />
+      <Meter value={60} label="Accent" variant="accent" showValue />
+      <Meter value={60} label="Success" variant="success" showValue />
+      <Meter value={60} label="Error" variant="error" showValue />
+    </div>
+  ),
+};
+
+export const SmallSize: Story = {
+  args: {
+    value: 45,
+    label: 'Network load',
+    size: 'sm',
+    showValue: true,
+  },
+};
+
+export const CustomRange: Story = {
+  args: {
+    value: 37,
+    min: 0,
+    max: 50,
+    label: 'Temperature (°C)',
+    variant: 'error',
+    showValue: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const meter = canvas.getByRole('meter');
+    await expect(meter).toHaveAttribute('aria-valuenow', '37');
+    await expect(meter).toHaveAttribute('aria-valuemin', '0');
+    await expect(meter).toHaveAttribute('aria-valuemax', '50');
+  },
+};

--- a/packages/rialto/src/components/Progress/Progress.stories.tsx
+++ b/packages/rialto/src/components/Progress/Progress.stories.tsx
@@ -1,0 +1,115 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+import { Progress, Spinner } from './Progress';
+
+const meta: Meta<typeof Progress> = {
+  title: 'Feedback/Progress',
+  component: Progress,
+  tags: ['autodocs'],
+  argTypes: {
+    value: {
+      control: { type: 'range', min: 0, max: 100, step: 1 },
+    },
+    size: {
+      control: { type: 'select' },
+      options: ['sm', 'md', 'lg'],
+    },
+    showValue: { control: 'boolean' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Progress>;
+
+export const Default: Story = {
+  args: {
+    value: 65,
+    label: 'Uploading files',
+    showValue: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const progressbar = canvas.getByRole('progressbar');
+    await expect(progressbar).toBeInTheDocument();
+    await expect(progressbar).toHaveAttribute('aria-valuenow', '65');
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    value: 0,
+    label: 'Starting upload',
+    showValue: true,
+  },
+};
+
+export const HalfComplete: Story = {
+  args: {
+    value: 50,
+    label: 'Processing',
+    showValue: true,
+  },
+};
+
+export const Complete: Story = {
+  args: {
+    value: 100,
+    label: 'Upload complete',
+    showValue: true,
+  },
+};
+
+export const Indeterminate: Story = {
+  args: {
+    label: 'Loading...',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const progressbar = canvas.getByRole('progressbar');
+    await expect(progressbar).toBeInTheDocument();
+    await expect(progressbar).not.toHaveAttribute('aria-valuenow');
+  },
+};
+
+export const SmallSize: Story = {
+  args: {
+    value: 40,
+    size: 'sm',
+    label: 'Syncing',
+  },
+};
+
+export const LargeSize: Story = {
+  args: {
+    value: 75,
+    size: 'lg',
+    label: 'Importing data',
+    showValue: true,
+  },
+};
+
+export const NoLabel: Story = {
+  args: {
+    value: 30,
+    'aria-label': 'File upload progress',
+  },
+};
+
+// Spinner stories — Spinner is co-located in Progress.tsx
+export const SpinnerDefault: Story = {
+  render: () => <Spinner />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const spinner = canvas.getByRole('status');
+    await expect(spinner).toBeInTheDocument();
+    await expect(spinner).toHaveAttribute('aria-label', 'Loading');
+  },
+};
+
+export const SpinnerSmall: Story = {
+  render: () => <Spinner size="sm" label="Loading items" />,
+};
+
+export const SpinnerLarge: Story = {
+  render: () => <Spinner size="lg" label="Processing reservation" />,
+};

--- a/packages/rialto/src/components/Skeleton/Skeleton.stories.tsx
+++ b/packages/rialto/src/components/Skeleton/Skeleton.stories.tsx
@@ -1,0 +1,114 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+import { Skeleton, SkeletonGroup } from './Skeleton';
+
+const meta: Meta<typeof Skeleton> = {
+  title: 'Feedback/Skeleton',
+  component: Skeleton,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: { type: 'select' },
+      options: ['text', 'heading', 'circle', 'rect', 'card'],
+    },
+    lines: { control: { type: 'number', min: 1, max: 10 } },
+    width: { control: 'text' },
+    height: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Skeleton>;
+
+export const Default: Story = {
+  args: {
+    variant: 'rect',
+    width: 200,
+    height: 20,
+  },
+  play: async ({ canvasElement }) => {
+    // Skeleton uses aria-hidden so we query the DOM directly
+    const skeleton = canvasElement.querySelector('[aria-hidden="true"]');
+    await expect(skeleton).not.toBeNull();
+  },
+};
+
+export const TextLines: Story = {
+  args: {
+    variant: 'text',
+    lines: 3,
+    width: '100%',
+  },
+};
+
+export const HeadingLines: Story = {
+  args: {
+    variant: 'heading',
+    lines: 2,
+    width: '80%',
+  },
+};
+
+export const Circle: Story = {
+  args: {
+    variant: 'circle',
+    width: 48,
+  },
+};
+
+export const Card: Story = {
+  args: {
+    variant: 'card',
+    width: 300,
+    height: 180,
+  },
+};
+
+export const ProfileCard: Story = {
+  render: () => (
+    <SkeletonGroup>
+      <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'flex-start', width: 280 }}>
+        <Skeleton variant="circle" width={40} />
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+          <Skeleton variant="heading" width="60%" />
+          <Skeleton variant="text" lines={2} width="100%" />
+        </div>
+      </div>
+    </SkeletonGroup>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const group = canvas.getByRole('status');
+    await expect(group).toBeInTheDocument();
+    await expect(group).toHaveAttribute('aria-busy', 'true');
+  },
+};
+
+export const ArticleLayout: Story = {
+  render: () => (
+    <SkeletonGroup>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', width: 400 }}>
+        <Skeleton variant="card" width="100%" height={200} />
+        <Skeleton variant="heading" width="70%" />
+        <Skeleton variant="text" lines={4} width="100%" />
+      </div>
+    </SkeletonGroup>
+  ),
+};
+
+export const TableRows: Story = {
+  render: () => (
+    <SkeletonGroup>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem', width: 500 }}>
+        {[1, 2, 3, 4].map((i) => (
+          <div key={i} style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
+            <Skeleton variant="circle" width={32} />
+            <Skeleton variant="text" width="40%" />
+            <Skeleton variant="text" width="30%" />
+            <Skeleton variant="rect" width={60} height={22} />
+          </div>
+        ))}
+      </div>
+    </SkeletonGroup>
+  ),
+};

--- a/packages/rialto/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/rialto/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,0 +1,94 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, userEvent, within } from 'storybook/test';
+import { Tooltip } from './Tooltip';
+import { Button } from '../Button/Button';
+
+const meta: Meta<typeof Tooltip> = {
+  title: 'Feedback/Tooltip',
+  component: Tooltip,
+  tags: ['autodocs'],
+  argTypes: {
+    placement: {
+      control: { type: 'select' },
+      options: ['top', 'bottom', 'left', 'right'],
+    },
+    delay: { control: { type: 'number' } },
+    showOnFocus: { control: 'boolean' },
+  },
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Tooltip>;
+
+export const Default: Story = {
+  args: {
+    content: 'Copy to clipboard',
+    delay: 0,
+    children: <Button>Hover me</Button>,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button');
+    await expect(trigger).toBeInTheDocument();
+    await userEvent.hover(trigger);
+    const tooltip = await canvas.findByRole('tooltip');
+    await expect(tooltip).toBeInTheDocument();
+    await userEvent.unhover(trigger);
+  },
+};
+
+export const PlacementTop: Story = {
+  args: {
+    content: 'Appears above',
+    placement: 'top',
+    delay: 0,
+    children: <Button>Top</Button>,
+  },
+};
+
+export const PlacementBottom: Story = {
+  args: {
+    content: 'Appears below',
+    placement: 'bottom',
+    delay: 0,
+    children: <Button>Bottom</Button>,
+  },
+};
+
+export const PlacementLeft: Story = {
+  args: {
+    content: 'Appears to the left',
+    placement: 'left',
+    delay: 0,
+    children: <Button>Left</Button>,
+  },
+};
+
+export const PlacementRight: Story = {
+  args: {
+    content: 'Appears to the right',
+    placement: 'right',
+    delay: 0,
+    children: <Button>Right</Button>,
+  },
+};
+
+export const WithDelay: Story = {
+  args: {
+    content: 'Appears after 600ms',
+    delay: 600,
+    children: <Button>Delayed tooltip</Button>,
+  },
+};
+
+export const FocusOnly: Story = {
+  args: {
+    content: 'Keyboard accessible tooltip',
+    delay: 0,
+    showOnFocus: true,
+    children: <Button>Focus me (Tab)</Button>,
+  },
+};


### PR DESCRIPTION
## Summary

- Adds Storybook stories for 7 feedback components: Tooltip, HoverCard, Banner, EmptyState, Progress (including Spinner), Meter, and Skeleton
- Each story file includes a `Default` story, variant stories (e.g., severity levels for Banner, 0/50/100% for Progress, all fill variants for Meter), and `play` function interaction tests for interactive components
- Uses `storybook/test` for imports (not `@storybook/test`)

Closes #1026

## Test plan

- [ ] `pnpm --dir packages/rialto build-storybook` passes cleanly (verified locally)
- [ ] Tooltip: hover triggers tooltip, Escape key closes it
- [ ] HoverCard: hover opens panel, focus events trigger it
- [ ] Banner: dismissible variant removes banner on click
- [ ] EmptyState: Default story renders heading + CTA button
- [ ] Progress: `aria-valuenow` reflects value; indeterminate has no `aria-valuenow`
- [ ] Meter: `aria-valuenow/min/max` attributes are correct; all 4 fill variants render
- [ ] Skeleton: `aria-hidden` element present; SkeletonGroup has `role="status"` + `aria-busy="true"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)