### PR TITLE
test(rialto): enable automated axe-core a11y checks on all stories

### DIFF
--- a/packages/rialto/.storybook/preview.tsx
+++ b/packages/rialto/.storybook/preview.tsx
@@ -26,6 +26,11 @@ const preview: Preview = {
       },
     },
   },
+  // Enable automated axe-core a11y checks on every story (not manual-only).
+  // color-contrast is disabled here because it is covered by token-contrast.test.ts.
+  initialGlobals: {
+    a11y: { manual: false },
+  },
   parameters: {
     controls: {
       matchers: {
@@ -41,9 +46,12 @@ const preview: Preview = {
       ],
     },
     a11y: {
+      // Violations will cause test failures when running via vitest storybook runner.
+      test: 'error',
       config: {
         rules: [
-          { id: 'color-contrast', enabled: true },
+          // color-contrast is tested separately in token-contrast.test.ts
+          { id: 'color-contrast', enabled: false },
         ],
       },
     },


### PR DESCRIPTION
## Summary

- Adds `initialGlobals: { a11y: { manual: false } }` to `.storybook/preview.tsx` so axe-core runs automatically on every story during the vitest storybook test runner (instead of requiring manual invocation in the Storybook UI)
- Sets `parameters.a11y.test: 'error'` so any axe violations fail the test run
- Disables the `color-contrast` axe rule globally since it is already covered by `token-contrast.test.ts`

The `@storybook/addon-a11y` addon was already installed (v10.3.5) — this change activates automated checking via its `initialGlobals` and `parameters.a11y` API.

Closes #1031

## Test plan

- [ ] `pnpm --dir packages/rialto build-storybook` completes without errors
- [ ] `pnpm --dir packages/rialto test --project storybook` runs a11y checks on each story
- [ ] A11y violations (other than color-contrast) cause test failures
- [ ] Storybook UI still loads correctly with the a11y panel showing automated results

🤖 Generated with [Claude Code](https://claude.com/claude-code)