### PR TITLE
test(rialto): add stories for specialty components

### DIFF
--- a/packages/rialto/src/components/CommandPalette/CommandPalette.stories.tsx
+++ b/packages/rialto/src/components/CommandPalette/CommandPalette.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from '@storybook/test';
+import { CommandPalette } from './CommandPalette';
+
+const meta: Meta<typeof CommandPalette> = {
+  title: 'Specialty/CommandPalette',
+  component: CommandPalette,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof CommandPalette>;
+
+const sampleItems = [
+  { id: 'new-file', label: 'New File', group: 'Actions' },
+  { id: 'open-file', label: 'Open File', group: 'Actions' },
+  { id: 'save', label: 'Save', group: 'Actions' },
+  { id: 'settings', label: 'Settings', group: 'Navigation' },
+  { id: 'dashboard', label: 'Dashboard', group: 'Navigation' },
+];
+
+export const Open: Story = {
+  args: {
+    open: true,
+    onOpenChange: () => {},
+    items: sampleItems,
+    placeholder: 'Type a command...',
+    groups: ['Actions', 'Navigation'],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByPlaceholderText('Type a command...')).toBeInTheDocument();
+  },
+};
+
+export const Closed: Story = {
+  args: {
+    open: false,
+    onOpenChange: () => {},
+    items: sampleItems,
+  },
+};

--- a/packages/rialto/src/components/Footer/Footer.stories.tsx
+++ b/packages/rialto/src/components/Footer/Footer.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from '@storybook/test';
+import { Footer } from './Footer';
+
+const meta: Meta<typeof Footer> = {
+  title: 'Specialty/Footer',
+  component: Footer,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Footer>;
+
+export const Minimal: Story = {
+  args: {
+    variant: 'minimal',
+    children: <span>&copy; 2026 Acme Inc. All rights reserved.</span>,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/Acme Inc/)).toBeInTheDocument();
+  },
+};
+
+export const Rich: Story = {
+  args: {
+    variant: 'rich',
+    logo: <span style={{ fontWeight: 500, fontSize: '1.25rem' }}>Acme</span>,
+    columns: [
+      {
+        title: 'Product',
+        links: [
+          { label: 'Features', href: '#' },
+          { label: 'Pricing', href: '#' },
+        ],
+      },
+      {
+        title: 'Company',
+        links: [
+          { label: 'About', href: '#' },
+          { label: 'Careers', href: '#' },
+        ],
+      },
+    ],
+    copyright: '© 2026 Acme Inc.',
+  },
+};

--- a/packages/rialto/src/components/Hero/Hero.stories.tsx
+++ b/packages/rialto/src/components/Hero/Hero.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from '@storybook/test';
+import { Hero } from './Hero';
+import { Button } from '../Button/Button';
+
+const meta: Meta<typeof Hero> = {
+  title: 'Specialty/Hero',
+  component: Hero,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Hero>;
+
+export const Default: Story = {
+  args: {
+    title: 'Build something remarkable',
+    subtitle: 'A design system for teams that value precision and warmth.',
+    eyebrow: 'Introducing Rialto',
+    actions: (
+      <div style={{ display: 'flex', gap: '0.75rem' }}>
+        <Button variant="primary">Get started</Button>
+        <Button variant="secondary">Learn more</Button>
+      </div>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Build something remarkable')).toBeInTheDocument();
+  },
+};
+
+export const Simple: Story = {
+  args: {
+    title: 'Welcome back',
+    subtitle: 'Pick up where you left off.',
+  },
+};
+
+export const WithEyebrow: Story = {
+  args: {
+    eyebrow: 'New Release',
+    title: 'Version 2.0 is here',
+    subtitle: 'Faster, more accessible, and beautifully redesigned.',
+    actions: <Button variant="primary">Upgrade now</Button>,
+  },
+};

--- a/packages/rialto/src/components/ImageUpload/ImageUpload.stories.tsx
+++ b/packages/rialto/src/components/ImageUpload/ImageUpload.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from '@storybook/test';
+import { ImageUpload } from './ImageUpload';
+
+const meta: Meta<typeof ImageUpload> = {
+  title: 'Specialty/ImageUpload',
+  component: ImageUpload,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ImageUpload>;
+
+export const Default: Story = {
+  args: {
+    onChange: () => {},
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/drop/i)).toBeInTheDocument();
+  },
+};
+
+export const WithProgress: Story = {
+  args: {
+    onChange: () => {},
+    progress: 45,
+  },
+};
+
+export const WithExistingImage: Story = {
+  args: {
+    value: 'https://placehold.co/400x300/f8f6f3/1a1918?text=Preview',
+    onChange: () => {},
+  },
+};

--- a/packages/rialto/src/components/Kbd/Kbd.stories.tsx
+++ b/packages/rialto/src/components/Kbd/Kbd.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from '@storybook/test';
+import { Kbd } from './Kbd';
+
+const meta: Meta<typeof Kbd> = {
+  title: 'Specialty/Kbd',
+  component: Kbd,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Kbd>;
+
+export const Default: Story = {
+  args: { children: 'Ctrl' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Ctrl')).toBeInTheDocument();
+  },
+};
+
+export const KeyCombination: Story = {
+  render: () => (
+    <span style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+      <Kbd>Ctrl</Kbd> + <Kbd>K</Kbd>
+    </span>
+  ),
+};
+
+export const SingleKeys: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: '0.5rem' }}>
+      <Kbd>Enter</Kbd>
+      <Kbd>Esc</Kbd>
+      <Kbd>Tab</Kbd>
+      <Kbd>Space</Kbd>
+    </div>
+  ),
+};

--- a/packages/rialto/src/components/ScrollArea/ScrollArea.stories.tsx
+++ b/packages/rialto/src/components/ScrollArea/ScrollArea.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from '@storybook/test';
+import { ScrollArea } from './ScrollArea';
+
+const meta: Meta<typeof ScrollArea> = {
+  title: 'Specialty/ScrollArea',
+  component: ScrollArea,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ScrollArea>;
+
+export const Default: Story = {
+  args: {
+    maxHeight: 200,
+    children: (
+      <div>
+        {Array.from({ length: 20 }, (_, i) => (
+          <p key={i} style={{ margin: '0.5rem 0' }}>Scrollable item {i + 1}</p>
+        ))}
+      </div>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Scrollable item 1')).toBeInTheDocument();
+  },
+};
+
+export const Tall: Story = {
+  args: {
+    maxHeight: 400,
+    children: (
+      <div>
+        {Array.from({ length: 50 }, (_, i) => (
+          <p key={i} style={{ margin: '0.25rem 0' }}>Line {i + 1}</p>
+        ))}
+      </div>
+    ),
+  },
+};

--- a/packages/rialto/src/components/ThemeToggle/ThemeToggle.stories.tsx
+++ b/packages/rialto/src/components/ThemeToggle/ThemeToggle.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { within, expect } from '@storybook/test';
+import { ThemeToggle } from './ThemeToggle';
+
+const meta: Meta<typeof ThemeToggle> = {
+  title: 'Specialty/ThemeToggle',
+  component: ThemeToggle,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ThemeToggle>;
+
+export const Light: Story = {
+  args: {
+    theme: 'light',
+    onToggle: () => {},
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button')).toBeInTheDocument();
+  },
+};
+
+export const Dark: Story = {
+  args: {
+    theme: 'dark',
+    onToggle: () => {},
+  },
+};


### PR DESCRIPTION
## Summary
- Adds Storybook stories for Kbd, ThemeToggle, CommandPalette, ImageUpload, ScrollArea, Footer, and Hero
- Includes play function interaction tests and variant showcases
- Closes #1028

## Test plan
- [x] `pnpm build-storybook` passes