### PR TITLE
fix(api-client): surface actual error detail from failed stream responses

### DIFF
--- a/packages/api-client/src/streaming.ts
+++ b/packages/api-client/src/streaming.ts
@@ -44,7 +44,16 @@ export async function* streamNDJSON<T>(config: StreamConfig): AsyncGenerator<T> 
   });
 
   if (!response.ok) {
-    throw new Error(`Request failed: ${response.statusText}`);
+    let detail = response.statusText || `HTTP ${response.status}`;
+    try {
+      const body = await response.json();
+      detail = (body as Record<string, unknown>).detail as string
+        ?? (body as Record<string, unknown>).message as string
+        ?? detail;
+    } catch {
+      // Response body is not JSON — use status text
+    }
+    throw new Error(`Request failed: ${detail}`);
   }
 
   if (!response.body) {


### PR DESCRIPTION
## Summary
- HTTP/2 responses have empty `statusText`, so stream errors showed "Request failed: " with no useful info
- Now reads the response body for RFC 9457 `detail`/`message` fields before throwing
- This makes gen playground failures (auth errors, missing API keys, rate limits) visible to the user via the error toast

## Root cause for #1017
The submit handler IS wired correctly — `useGenStream` calls `streamNDJSON` which calls the `/api/gen/ui` endpoint with auth. The issue is that when the server returns an error (likely missing `AI_GATEWAY_API_KEY` on DO), the error message was empty due to HTTP/2 having no `statusText`. The error toast showed "Generation failed" with no detail.

Closes #1017

## Test plan
- [x] `pnpm typecheck` passes
- [ ] Verify error toast shows actual server error message when endpoint fails