### PR TITLE
test(rialto-web): add E2E interaction, navigation, theme, search, and a11y tests

### DIFF
--- a/apps/rialto-web/e2e/a11y-pages.spec.ts
+++ b/apps/rialto-web/e2e/a11y-pages.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+const PAGES_TO_AUDIT = [
+  { name: "Button", path: "/components/button" },
+  { name: "Input", path: "/components/input" },
+  { name: "Toggle", path: "/components/toggle" },
+  { name: "Select", path: "/components/select" },
+  { name: "Tabs", path: "/components/tabs" },
+  { name: "Dialog", path: "/components/dialog" },
+  { name: "Badge", path: "/components/badge" },
+];
+
+for (const { name, path } of PAGES_TO_AUDIT) {
+  test(`a11y: ${name} page has no critical violations`, async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.goto(path);
+    await page.waitForLoadState("networkidle");
+
+    const results = await new AxeBuilder({ page })
+      .disableRules(["color-contrast"])
+      .analyze();
+
+    const critical = results.violations.filter(
+      (v) => v.impact === "critical" || v.impact === "serious"
+    );
+
+    expect(
+      critical,
+      `${name} page has ${critical.length} critical/serious a11y violations:\n${critical.map((v) => `  - ${v.id}: ${v.description} (${v.nodes.length} instances)`).join("\n")}`
+    ).toHaveLength(0);
+  });
+}

--- a/apps/rialto-web/e2e/interaction.spec.ts
+++ b/apps/rialto-web/e2e/interaction.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+});
+
+test("Button page — clicking a button triggers visual feedback", async ({ page }) => {
+  await page.goto("/components/button");
+  await page.waitForLoadState("networkidle");
+
+  const button = page.getByRole("button", { name: /primary/i }).first();
+  await expect(button).toBeVisible();
+  await button.click();
+});
+
+test("Input page — typing in an input updates the value", async ({ page }) => {
+  await page.goto("/components/input");
+  await page.waitForLoadState("networkidle");
+
+  const input = page.getByRole("textbox").first();
+  await expect(input).toBeVisible();
+  await input.fill("Hello Rialto");
+  await expect(input).toHaveValue("Hello Rialto");
+});
+
+test("Toggle page — clicking a toggle switches state", async ({ page }) => {
+  await page.goto("/components/toggle");
+  await page.waitForLoadState("networkidle");
+
+  const toggle = page.getByRole("switch").first();
+  await expect(toggle).toBeVisible();
+  const wasChecked = await toggle.isChecked();
+  await toggle.click();
+  const isNowChecked = await toggle.isChecked();
+  expect(isNowChecked).toBe(!wasChecked);
+});
+
+test("Select page — opening a select shows options", async ({ page }) => {
+  await page.goto("/components/select");
+  await page.waitForLoadState("networkidle");
+
+  const trigger = page.getByRole("combobox").first();
+  await expect(trigger).toBeVisible();
+  await trigger.click();
+  const listbox = page.getByRole("listbox");
+  await expect(listbox).toBeVisible();
+});
+
+test("Checkbox page — checking a checkbox toggles its state", async ({ page }) => {
+  await page.goto("/components/checkbox-radio");
+  await page.waitForLoadState("networkidle");
+
+  const checkbox = page.getByRole("checkbox").first();
+  await expect(checkbox).toBeVisible();
+  const wasChecked = await checkbox.isChecked();
+  await checkbox.click();
+  const isNowChecked = await checkbox.isChecked();
+  expect(isNowChecked).toBe(!wasChecked);
+});

--- a/apps/rialto-web/e2e/navigation.spec.ts
+++ b/apps/rialto-web/e2e/navigation.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.goto("/");
+  await page.waitForLoadState("networkidle");
+});
+
+test("sidebar shows category sections", async ({ page }) => {
+  const sidebar = page.locator("nav");
+  await expect(sidebar.getByText("Forms")).toBeVisible();
+  await expect(sidebar.getByText("Navigation")).toBeVisible();
+  await expect(sidebar.getByText("Feedback")).toBeVisible();
+});
+
+test("clicking a component link navigates to its page", async ({ page }) => {
+  await page.getByRole("link", { name: "Button" }).first().click();
+  await expect(page).toHaveURL(/\/components\/button/);
+  await expect(page.getByRole("heading", { name: /button/i }).first()).toBeVisible();
+});
+
+test("navigating between categories works", async ({ page }) => {
+  await page.getByRole("link", { name: "Input" }).first().click();
+  await expect(page).toHaveURL(/\/components\/input/);
+
+  await page.getByRole("link", { name: "Toggle" }).first().click();
+  await expect(page).toHaveURL(/\/components\/toggle/);
+});
+
+test("sidebar highlights the active component", async ({ page }) => {
+  await page.getByRole("link", { name: "Button" }).first().click();
+  const activeLink = page.getByRole("link", { name: "Button" }).first();
+  await expect(activeLink).toHaveAttribute("aria-current", "page");
+});
+
+test("overview page loads from root", async ({ page }) => {
+  const heading = page.getByRole("heading").first();
+  await expect(heading).toBeVisible();
+});

--- a/apps/rialto-web/e2e/search.spec.ts
+++ b/apps/rialto-web/e2e/search.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.goto("/");
+  await page.waitForLoadState("networkidle");
+});
+
+test("search input exists in sidebar", async ({ page }) => {
+  const search = page.getByPlaceholder(/search|filter/i);
+  await expect(search).toBeVisible();
+});
+
+test("typing in search filters sidebar links", async ({ page }) => {
+  const search = page.getByPlaceholder(/search|filter/i);
+  const nav = page.locator("nav");
+
+  const linksBefore = await nav.getByRole("link").count();
+  expect(linksBefore).toBeGreaterThan(5);
+
+  await search.fill("button");
+  await page.waitForTimeout(300);
+
+  const linksAfter = await nav.getByRole("link").count();
+  expect(linksAfter).toBeLessThan(linksBefore);
+  await expect(nav.getByRole("link", { name: /button/i })).toBeVisible();
+});
+
+test("clearing search restores all links", async ({ page }) => {
+  const search = page.getByPlaceholder(/search|filter/i);
+  const nav = page.locator("nav");
+
+  const initialCount = await nav.getByRole("link").count();
+
+  await search.fill("button");
+  await page.waitForTimeout(300);
+  await search.clear();
+  await page.waitForTimeout(300);
+
+  const restoredCount = await nav.getByRole("link").count();
+  expect(restoredCount).toBe(initialCount);
+});

--- a/apps/rialto-web/e2e/theme.spec.ts
+++ b/apps/rialto-web/e2e/theme.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.goto("/");
+  await page.waitForLoadState("networkidle");
+});
+
+test("theme toggle button exists", async ({ page }) => {
+  const toggle = page.getByRole("button", { name: /theme/i });
+  await expect(toggle).toBeVisible();
+});
+
+test("clicking theme toggle changes the data-theme attribute", async ({ page }) => {
+  const html = page.locator("html");
+  const initialTheme = await html.getAttribute("data-theme");
+
+  const toggle = page.getByRole("button", { name: /theme/i });
+  await toggle.click();
+
+  const newTheme = await html.getAttribute("data-theme");
+  expect(newTheme).not.toBe(initialTheme);
+});
+
+test("theme persists after navigation", async ({ page }) => {
+  const html = page.locator("html");
+
+  const toggle = page.getByRole("button", { name: /theme/i });
+  await toggle.click();
+  const themeAfterToggle = await html.getAttribute("data-theme");
+
+  await page.getByRole("link", { name: "Button" }).first().click();
+  await page.waitForLoadState("networkidle");
+
+  const themeAfterNav = await html.getAttribute("data-theme");
+  expect(themeAfterNav).toBe(themeAfterToggle);
+});


### PR DESCRIPTION
## Summary
- Adds 5 Playwright spec files covering interaction, navigation, theme, search, and a11y
- 7 component pages scanned with axe-core for critical/serious violations
- 5 component types exercised: Button, Input, Toggle, Select, Checkbox
- Theme toggle, search filtering, and navigation all tested end-to-end
- Closes #1012

## Test plan
- [x] `pnpm build` passes
- [ ] `npx playwright test` against local dev server