### PR TITLE
fix(edge-router): bundle worker dependencies before Pulumi upload to resolve 403

### DIFF
--- a/.github/workflows/pulumi-up.yml
+++ b/.github/workflows/pulumi-up.yml
@@ -57,6 +57,14 @@ jobs:
           VITE_AUTH_REDIRECT_URI: https://mattbutlerengineering.com/gen/callback
           VITE_API_URL: https://mattbutlerengineering.com
 
+      - name: Bundle edge router worker
+        run: |
+          mkdir -p infrastructure/worker/dist
+          npx esbuild infrastructure/worker/edge-router.js \
+            --bundle \
+            --format=esm \
+            --outfile=infrastructure/worker/dist/edge-router.js
+
       - name: Pulumi Cancel (Clear stale locks)
         run: |
           cd infrastructure/pulumi

--- a/infrastructure/pulumi/index.ts
+++ b/infrastructure/pulumi/index.ts
@@ -270,10 +270,15 @@ const healthKv = new cloudflare.WorkersKvNamespace("mattbutlerengineering-health
 // are all managed as Pulumi WorkersScript resources. Service Bindings
 // call app Workers in-process, bypassing the CDN entirely.
 
+// edge-router.js imports circuit-breaker.js, rate-limiter.js, and dep-graph.json.
+// The Cloudflare Workers API rejects a worker whose modules are missing at
+// initialization — which surfaces as HTTP 403 for every route the worker covers.
+// The wrangler.toml `bundle` step (added to pulumi-up.yml) inlines all imports
+// into a single ESM file before Pulumi reads it.
 const workerScript = new cloudflare.WorkersScript("mattbutlerengineering-edge-router", {
   accountId: cloudflareAccountId,
   scriptName: "mattbutlerengineering-edge-router",
-  content: readFileSync("../worker/edge-router.js", "utf-8"),
+  content: readFileSync("../worker/dist/edge-router.js", "utf-8"),
   mainModule: "edge-router.js",
   compatibilityDate: "2026-03-25",
   bindings: [

--- a/infrastructure/worker/edge-router.js
+++ b/infrastructure/worker/edge-router.js
@@ -1132,7 +1132,7 @@ export default {
         const canaryUrl = new URL(strippedCanaryPath + url.search, canaryOrigin);
         const canaryRequest = new Request(canaryUrl, request);
         const canaryResponse = await canaryBinding.fetch(canaryRequest);
-        return addHeaders(canaryResponse, url.pathname);
+        return addHeaders(canaryResponse, url.pathname, nonce);
       }
 
       // Unknown /canary/* path — 404


### PR DESCRIPTION
## Summary

- The edge router Cloudflare Worker was uploaded as `edge-router.js` alone, but it imports `circuit-breaker.js`, `rate-limiter.js`, and `dep-graph.json` as local ES modules — Cloudflare fails initialization when these are absent, returning HTTP 403 for all routes (`mattbutlerengineering.com`, `/rialto/`)
- Add an esbuild bundle step to `pulumi-up.yml` that inlines all imports into a single ESM file (`infrastructure/worker/dist/edge-router.js`) before Pulumi uploads it
- Update `infrastructure/pulumi/index.ts` to read the bundled output path
- Fix a missing nonce argument in the canary route's `addHeaders` call (was passing `undefined`, leaving a literal `"undefined"` string as the CSP nonce)

## Test plan

- [ ] Verify CI passes
- [ ] After merge and Pulumi deploy, confirm `curl -A "Mozilla/5.0" https://mattbutlerengineering.com/` returns 200
- [ ] Confirm `curl -A "Mozilla/5.0" https://mattbutlerengineering.com/rialto` returns 200

Closes #1065

https://claude.ai/code/session_016s1zmyCGrQxuPgydAUEuqg

---
_Generated by [Claude Code](https://claude.ai/code/session_016s1zmyCGrQxuPgydAUEuqg)_