### PR TITLE
fix(ci): add failure notification to auto-rollback workflow

### DIFF
--- a/.github/workflows/auto-rollback.yml
+++ b/.github/workflows/auto-rollback.yml
@@ -106,3 +106,43 @@ jobs:
           echo "Post-deploy failure was not from an agent commit — skipping auto-rollback"
           echo "Commit: ${COMMIT_SHA}"
           echo "Author: ${COMMIT_AUTHOR}"
+
+      - name: File issue on rollback failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          today=$(date -u +%Y-%m-%d)
+          title="[URGENT] Auto-rollback failed [${today}]"
+
+          # Dedup: skip if an open issue with the same title already exists.
+          existing=$(gh issue list --state open --label ci-fix --search "$title" --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            echo "Issue #$existing already open for today; skipping."
+            exit 0
+          fi
+
+          printf '%s\n' \
+            "## Auto-rollback workflow failed" \
+            "" \
+            "The auto-rollback workflow failed on ${today}." \
+            "This means a post-deploy regression was detected but the" \
+            "automatic revert could not be completed (merge conflict," \
+            "branch deletion failure, or other infrastructure issue)." \
+            "" \
+            "**Commit:** \`${HEAD_SHA}\`" \
+            "**Run:** ${RUN_URL}" \
+            "" \
+            "### Next steps" \
+            "1. Check the [workflow run](${RUN_URL}) for error details" \
+            "2. Manually revert the offending commit if needed" \
+            "3. The \`ci-fix\` label will trigger \`mbe-issue-worker\` to attempt an auto-fix" \
+            > /tmp/rollback-failure-body.md
+
+          gh issue create \
+            --title "$title" \
+            --body-file /tmp/rollback-failure-body.md \
+            --label ci-fix \
+            --label audit


### PR DESCRIPTION
## Summary
- Adds a `File issue on rollback failure` step (with `if: failure()`) to the auto-rollback workflow
- When the workflow itself fails (revert conflict, branch deletion, infra issue), it creates a GitHub issue titled `[URGENT] Auto-rollback failed [YYYY-MM-DD]` with `ci-fix` and `audit` labels
- Includes dedup check: skips issue creation if a same-day issue is already open
- Uses safe `env:` binding for all GitHub context values (no direct `${{ }}` interpolation in `run:` blocks)
- Follows the same pattern as `nightly-compliance.yml` failure notification (lines 154-189)

Closes #1092

## Test plan
- [ ] Verify YAML syntax is valid (workflow parses correctly on push)
- [ ] Trigger a rollback failure scenario to confirm issue creation
- [ ] Verify dedup logic prevents duplicate issues on same day