### PR TITLE
feat(acmm): detect existing semantic code intelligence tools

### DIFF
--- a/plugins/acmm/scripts/__tests__/detection.test.js
+++ b/plugins/acmm/scripts/__tests__/detection.test.js
@@ -108,7 +108,29 @@ test("detect: code-graph — llms.txt present", () => {
   fx.file("llms.txt", "# index");
   const c = {
     id: "acmm:code-graph",
-    detection: { type: "any-of", pattern: [".vscode/settings.json", "tags", "TAGS", ".ctags", ".tree-sitter/", "llms.txt", "llms-full.txt"] },
+    detection: { type: "any-of", pattern: [".vscode/settings.json", "tags", "TAGS", ".ctags", ".tree-sitter/", "llms.txt", "llms-full.txt", "tsconfig.json", ".clangd", "pyrightconfig.json", ".claude/plugins/"] },
+  };
+  assert.equal(detect(fx.root, c), true);
+  fx.cleanup();
+});
+
+test("detect: code-graph — tsconfig.json present (TypeScript LSP)", () => {
+  const fx = fixture();
+  fx.file("tsconfig.json", '{"compilerOptions":{}}');
+  const c = {
+    id: "acmm:code-graph",
+    detection: { type: "any-of", pattern: [".vscode/settings.json", "tags", "TAGS", ".ctags", ".tree-sitter/", "llms.txt", "llms-full.txt", "tsconfig.json", ".clangd", "pyrightconfig.json", ".claude/plugins/"] },
+  };
+  assert.equal(detect(fx.root, c), true);
+  fx.cleanup();
+});
+
+test("detect: code-graph — .claude/plugins/ directory present (tree-sitter via plugin)", () => {
+  const fx = fixture();
+  fx.dir(".claude/plugins");
+  const c = {
+    id: "acmm:code-graph",
+    detection: { type: "any-of", pattern: [".vscode/settings.json", "tags", "TAGS", ".ctags", ".tree-sitter/", "llms.txt", "llms-full.txt", "tsconfig.json", ".clangd", "pyrightconfig.json", ".claude/plugins/"] },
   };
   assert.equal(detect(fx.root, c), true);
   fx.cleanup();
@@ -118,7 +140,7 @@ test("detect: code-graph — no code intelligence files present", () => {
   const fx = fixture();
   const c = {
     id: "acmm:code-graph",
-    detection: { type: "any-of", pattern: [".vscode/settings.json", "tags", "TAGS", ".ctags", ".tree-sitter/", "llms.txt", "llms-full.txt"] },
+    detection: { type: "any-of", pattern: [".vscode/settings.json", "tags", "TAGS", ".ctags", ".tree-sitter/", "llms.txt", "llms-full.txt", "tsconfig.json", ".clangd", "pyrightconfig.json", ".claude/plugins/"] },
   };
   assert.equal(detect(fx.root, c), false);
   fx.cleanup();

--- a/plugins/acmm/scripts/sources/acmm.js
+++ b/plugins/acmm/scripts/sources/acmm.js
@@ -685,7 +685,7 @@ const CRITERIA= [
     description: 'LSP, AST, or code graph tooling that helps AI navigate the codebase.',
     rationale: 'L4 signal: the AI can navigate complex type hierarchies and dependency graphs efficiently, not just read file text.',
     details: 'Code intelligence tools (LSP configs, tags files, tree-sitter grammars, or code graph generators) help the AI understand codebase structure beyond raw text. This enables faster navigation, better refactoring, and more accurate changes.',
-    detection: { type: 'any-of', pattern: ['.vscode/settings.json', 'tags', 'TAGS', '.ctags', '.tree-sitter/', 'llms.txt', 'llms-full.txt'] },
+    detection: { type: 'any-of', pattern: ['.vscode/settings.json', 'tags', 'TAGS', '.ctags', '.tree-sitter/', 'llms.txt', 'llms-full.txt', 'tsconfig.json', '.clangd', 'pyrightconfig.json', '.claude/plugins/'] },
   },
 
   {


### PR DESCRIPTION
## Summary

- Expands `acmm:code-graph` detection patterns to recognize LSP configs (`tsconfig.json`, `.clangd`, `pyrightconfig.json`) and Claude Code plugin directories (`.claude/plugins/`) as valid code intelligence signals
- Adds two new test cases covering `tsconfig.json` and `.claude/plugins/` detection
- Updates existing test patterns to match the expanded criterion

## Context

Issue #1075 identified `acmm:code-graph` as a gap. The repo already has semantic code intelligence via `claude-mem`'s tree-sitter-based `smart-explore`/`smart-outline` tools (installed as a plugin) and `llms.txt` files. The detection logic just didn't recognize all the signals. This PR broadens the pattern list so the criterion correctly detects existing tooling.

Closes #1075

## Test plan

- [x] All 24 detection tests pass (`node --test plugins/acmm/scripts/__tests__/detection.test.js`)
- [x] New tests verify `tsconfig.json` and `.claude/plugins/` directory detection
- [x] Negative test confirms no false positives when none of the patterns exist