### PR TITLE
feat(agent-core): add model routing decision to session telemetry

### DIFF
--- a/packages/agent-core/src/session-runner.ts
+++ b/packages/agent-core/src/session-runner.ts
@@ -94,6 +94,12 @@ export async function runSession(
           task: config.taskDescription,
           model: config.model,
           maxBudgetUsd: String(config.maxBudgetUsd),
+          ...(config.modelRoutingReason
+            ? { modelRoutingReason: config.modelRoutingReason }
+            : {}),
+          ...(config.modelRoutingTier
+            ? { modelRoutingTier: config.modelRoutingTier }
+            : {}),
         },
       },
       async (): Promise<SessionResult> => {
@@ -130,6 +136,12 @@ export async function runSession(
       "session.max_budget_usd": effectiveConfig.maxBudgetUsd,
       "session.base_branch": effectiveConfig.baseBranch,
       ...(tuning ? { "session.qa_tuning_applied": true } : {}),
+      ...(effectiveConfig.modelRoutingReason
+        ? { "session.model_routing_reason": effectiveConfig.modelRoutingReason }
+        : {}),
+      ...(effectiveConfig.modelRoutingTier
+        ? { "session.model_routing_tier": effectiveConfig.modelRoutingTier }
+        : {}),
     },
   });
 

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -80,6 +80,10 @@ export interface SessionConfig {
   readonly sourceFiles?: readonly string[];
   readonly feedbackLoop?: FeedbackLoopConfig;
   readonly stuckDetectorConfig?: Partial<StuckDetectorConfig>;
+  /** The reason string from model routing (e.g. "Feature label with simple scope") */
+  readonly modelRoutingReason?: string;
+  /** The selected model tier from routing (e.g. "haiku", "sonnet", "opus") */
+  readonly modelRoutingTier?: string;
 }
 
 export const DEFAULT_SESSION_CONFIG: Omit<SessionConfig, "taskDescription" | "repoPath"> = {


### PR DESCRIPTION
## Summary

- Adds `modelRoutingReason` and `modelRoutingTier` optional fields to `SessionConfig` so CLI callers can pass through the routing decision from `routeModelWithReason()`
- Attaches both values to the OTel root span (`session.model_routing_reason`, `session.model_routing_tier`) and Langfuse trace metadata
- No changes to routing logic itself — purely observability

Closes #1102

## Test plan

- [x] `pnpm --dir packages/agent-core test` — 649/649 passing
- [x] `pnpm --dir packages/agent-core lint` — clean
- [ ] Verify routing attributes appear in OTel traces when `modelRoutingReason`/`modelRoutingTier` are set on `SessionConfig`
- [ ] Verify no span attributes are added when fields are omitted (backward compatible)