### PR TITLE
fix(agent-core): add Zod validation for auto-QA tuning config

### DIFF
--- a/packages/agent-core/src/__tests__/qa-tuning-loader-io.test.ts
+++ b/packages/agent-core/src/__tests__/qa-tuning-loader-io.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+}));
+
+import { existsSync, readFileSync } from "node:fs";
+import { loadQaTuning } from "../qa-tuning-loader.js";
+
+const mockExistsSync = existsSync as ReturnType<typeof vi.fn>;
+const mockReadFileSync = readFileSync as ReturnType<typeof vi.fn>;
+
+describe("loadQaTuning", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  it("returns null when file does not exist", () => {
+    mockExistsSync.mockReturnValue(false);
+
+    const result = loadQaTuning("/fake/repo");
+
+    expect(result).toBeNull();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns thresholds for a valid config file", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({
+        version: 1,
+        lastTunedAt: "2026-05-01",
+        thresholds: {
+          acceptanceRateFloor: 0.85,
+          maxBudgetUSD: 1.5,
+          maxRetries: 2,
+          stuckTurnsThreshold: 8,
+          meanCloseHoursTarget: 24,
+          agentMergeShareTarget: 0.3,
+        },
+      }),
+    );
+
+    const result = loadQaTuning("/fake/repo");
+
+    expect(result).toEqual({
+      acceptanceRateFloor: 0.85,
+      maxBudgetUSD: 1.5,
+      maxRetries: 2,
+      stuckTurnsThreshold: 8,
+      meanCloseHoursTarget: 24,
+      agentMergeShareTarget: 0.3,
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns null and warns when config has wrong types", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({
+        version: "not-a-number",
+        lastTunedAt: 123,
+        thresholds: {
+          acceptanceRateFloor: "bad",
+          maxBudgetUSD: true,
+          maxRetries: null,
+          stuckTurnsThreshold: [],
+          meanCloseHoursTarget: {},
+          agentMergeShareTarget: "wrong",
+        },
+      }),
+    );
+
+    const result = loadQaTuning("/fake/repo");
+
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[qa-tuning] Config validation failed",
+      expect.objectContaining({
+        path: expect.stringContaining("auto-qa-tuning.json"),
+        issues: expect.arrayContaining([
+          expect.objectContaining({ message: expect.any(String) }),
+        ]),
+      }),
+    );
+  });
+
+  it("returns null and warns on unparseable JSON", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockImplementation(() => {
+      throw new SyntaxError("Unexpected token");
+    });
+
+    const result = loadQaTuning("/fake/repo");
+
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[qa-tuning] Failed to parse config JSON",
+      expect.objectContaining({
+        path: expect.stringContaining("auto-qa-tuning.json"),
+        error: expect.any(String),
+      }),
+    );
+  });
+
+  it("returns null and warns when a required threshold field is missing", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({
+        version: 1,
+        lastTunedAt: "2026-05-01",
+        thresholds: {
+          acceptanceRateFloor: 0.85,
+          maxBudgetUSD: 1.5,
+          // missing: maxRetries, stuckTurnsThreshold, meanCloseHoursTarget, agentMergeShareTarget
+        },
+      }),
+    );
+
+    const result = loadQaTuning("/fake/repo");
+
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[qa-tuning] Config validation failed",
+      expect.objectContaining({
+        issues: expect.arrayContaining([
+          expect.objectContaining({
+            path: expect.stringContaining("thresholds"),
+          }),
+        ]),
+      }),
+    );
+  });
+
+  it("returns thresholds from config with extra keys (rules, history, $comment)", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({
+        $schema: "https://json.schemastore.org/specs/auto-qa-tuning",
+        $comment: "Self-tuning thresholds",
+        version: 1,
+        lastTunedAt: "2026-04-25",
+        thresholds: {
+          acceptanceRateFloor: 0.85,
+          "acceptanceRateFloor.$comment": "Minimum acceptance rate",
+          maxBudgetUSD: 1.5,
+          maxRetries: 2,
+          stuckTurnsThreshold: 8,
+          meanCloseHoursTarget: 24,
+          agentMergeShareTarget: 0.3,
+        },
+        rules: { "tier:trivial": { maxBudgetUSDOverride: 0.5 } },
+        history: [{ date: "2026-04-25", trigger: "seed" }],
+      }),
+    );
+
+    const result = loadQaTuning("/fake/repo");
+
+    expect(result).toEqual({
+      acceptanceRateFloor: 0.85,
+      maxBudgetUSD: 1.5,
+      maxRetries: 2,
+      stuckTurnsThreshold: 8,
+      meanCloseHoursTarget: 24,
+      agentMergeShareTarget: 0.3,
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent-core/src/__tests__/qa-tuning-loader.test.ts
+++ b/packages/agent-core/src/__tests__/qa-tuning-loader.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { parseThresholds, applyTuningDefaults } from "../qa-tuning-loader.js";
+import {
+  parseThresholds,
+  applyTuningDefaults,
+  QaTuningConfigSchema,
+} from "../qa-tuning-loader.js";
 import type { QaTuningThresholds } from "../qa-tuning-loader.js";
 
 // ── parseThresholds ─────────────────────────────────────────────────
@@ -57,6 +61,7 @@ describe("parseThresholds", () => {
 
   it("ignores extra $comment fields", () => {
     const withComments = {
+      ...validConfig,
       thresholds: {
         ...validConfig.thresholds,
         "maxBudgetUSD.$comment": "some explanation",
@@ -144,3 +149,78 @@ describe("applyTuningDefaults", () => {
     expect(original.maxBudgetUsd).toBe(1.0);
   });
 });
+
+// ── QaTuningConfigSchema ───────────────────────────────────────────
+
+describe("QaTuningConfigSchema", () => {
+  const validRaw = {
+    version: 1,
+    lastTunedAt: "2026-05-01",
+    thresholds: {
+      acceptanceRateFloor: 0.85,
+      maxBudgetUSD: 1.5,
+      maxRetries: 2,
+      stuckTurnsThreshold: 8,
+      meanCloseHoursTarget: 24,
+      agentMergeShareTarget: 0.3,
+    },
+  };
+
+  it("accepts a valid config", () => {
+    const result = QaTuningConfigSchema.safeParse(validRaw);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts config with extra passthrough keys", () => {
+    const withExtras = {
+      ...validRaw,
+      $schema: "https://example.com",
+      $comment: "test",
+      rules: { "tier:trivial": { maxBudgetUSDOverride: 0.5 } },
+      history: [{ date: "2026-04-25", trigger: "seed" }],
+      thresholds: {
+        ...validRaw.thresholds,
+        "maxBudgetUSD.$comment": "explanation",
+      },
+    };
+    const result = QaTuningConfigSchema.safeParse(withExtras);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects config with wrong threshold type", () => {
+    const bad = {
+      ...validRaw,
+      thresholds: { ...validRaw.thresholds, maxBudgetUSD: "not-a-number" },
+    };
+    const result = QaTuningConfigSchema.safeParse(bad);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects config missing version", () => {
+    const { version: _, ...noVersion } = validRaw;
+    const result = QaTuningConfigSchema.safeParse(noVersion);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects config missing lastTunedAt", () => {
+    const { lastTunedAt: _, ...noDate } = validRaw;
+    const result = QaTuningConfigSchema.safeParse(noDate);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects config with missing threshold field", () => {
+    const { stuckTurnsThreshold: _, ...partial } = validRaw.thresholds;
+    const result = QaTuningConfigSchema.safeParse({
+      ...validRaw,
+      thresholds: partial,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-object input", () => {
+    expect(QaTuningConfigSchema.safeParse(null).success).toBe(false);
+    expect(QaTuningConfigSchema.safeParse("string").success).toBe(false);
+    expect(QaTuningConfigSchema.safeParse(42).success).toBe(false);
+  });
+});
+

--- a/packages/agent-core/src/qa-tuning-loader.ts
+++ b/packages/agent-core/src/qa-tuning-loader.ts
@@ -1,5 +1,6 @@
 import { readFileSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
+import { z } from "zod";
 
 // ── Types ───────────────────────────────────────────────────────────
 
@@ -18,6 +19,30 @@ export interface QaTuningConfig {
   readonly thresholds: QaTuningThresholds;
 }
 
+// ── Zod Schema ─────────────────────────────────────────────────────
+
+const QaTuningThresholdsSchema = z.object({
+  acceptanceRateFloor: z.number(),
+  maxBudgetUSD: z.number(),
+  maxRetries: z.number(),
+  stuckTurnsThreshold: z.number(),
+  meanCloseHoursTarget: z.number(),
+  agentMergeShareTarget: z.number(),
+});
+
+/**
+ * Full config schema — validates the top-level shape plus thresholds.
+ * Uses `.passthrough()` so extra keys (like `$comment` fields, `rules`,
+ * `history`) don't cause validation failures.
+ */
+export const QaTuningConfigSchema = z
+  .object({
+    version: z.number(),
+    lastTunedAt: z.string(),
+    thresholds: QaTuningThresholdsSchema.passthrough(),
+  })
+  .passthrough();
+
 // ── Constants ───────────────────────────────────────────────────────
 
 const CONFIG_FILENAME = ".github/auto-qa-tuning.json";
@@ -26,54 +51,26 @@ const CONFIG_FILENAME = ".github/auto-qa-tuning.json";
 
 /**
  * Extract only the threshold values we care about from a parsed config.
- * Returns null if the config shape is invalid.
+ * Validates `raw` against the Zod schema and returns null on failure.
  */
 export function parseThresholds(
   raw: unknown,
 ): QaTuningThresholds | null {
-  if (
-    typeof raw !== "object" ||
-    raw === null ||
-    !("thresholds" in raw)
-  ) {
+  const result = QaTuningConfigSchema.safeParse(raw);
+
+  if (!result.success) {
     return null;
   }
 
-  const config = raw as { thresholds: Record<string, unknown> };
-  const t = config.thresholds;
-
-  if (typeof t !== "object" || t === null) return null;
-
-  const maxBudgetUSD = typeof t.maxBudgetUSD === "number" ? t.maxBudgetUSD : null;
-  const stuckTurnsThreshold =
-    typeof t.stuckTurnsThreshold === "number" ? t.stuckTurnsThreshold : null;
-  const acceptanceRateFloor =
-    typeof t.acceptanceRateFloor === "number" ? t.acceptanceRateFloor : null;
-  const maxRetries =
-    typeof t.maxRetries === "number" ? t.maxRetries : null;
-  const meanCloseHoursTarget =
-    typeof t.meanCloseHoursTarget === "number" ? t.meanCloseHoursTarget : null;
-  const agentMergeShareTarget =
-    typeof t.agentMergeShareTarget === "number" ? t.agentMergeShareTarget : null;
-
-  if (
-    maxBudgetUSD === null ||
-    stuckTurnsThreshold === null ||
-    acceptanceRateFloor === null ||
-    maxRetries === null ||
-    meanCloseHoursTarget === null ||
-    agentMergeShareTarget === null
-  ) {
-    return null;
-  }
+  const { thresholds } = result.data;
 
   return {
-    acceptanceRateFloor,
-    maxBudgetUSD,
-    maxRetries,
-    stuckTurnsThreshold,
-    meanCloseHoursTarget,
-    agentMergeShareTarget,
+    acceptanceRateFloor: thresholds.acceptanceRateFloor,
+    maxBudgetUSD: thresholds.maxBudgetUSD,
+    maxRetries: thresholds.maxRetries,
+    stuckTurnsThreshold: thresholds.stuckTurnsThreshold,
+    meanCloseHoursTarget: thresholds.meanCloseHoursTarget,
+    agentMergeShareTarget: thresholds.agentMergeShareTarget,
   };
 }
 
@@ -128,8 +125,11 @@ export function applyTuningDefaults(
  *
  * Returns null when:
  *   - The file doesn't exist (first run, or running outside the repo)
- *   - The file is malformed
- *   - Any field is missing or has the wrong type
+ *   - The JSON is syntactically invalid
+ *   - Schema validation fails (missing/wrong-type fields)
+ *
+ * On validation failure a structured warning is logged so operators can
+ * diagnose bad config without the agent crashing.
  *
  * Callers should treat null as "use hard-coded defaults" — this function
  * never throws.
@@ -139,10 +139,38 @@ export function loadQaTuning(repoPath: string): QaTuningThresholds | null {
 
   if (!existsSync(configPath)) return null;
 
+  let raw: unknown;
   try {
-    const raw = JSON.parse(readFileSync(configPath, "utf-8"));
-    return parseThresholds(raw);
-  } catch {
+    raw = JSON.parse(readFileSync(configPath, "utf-8"));
+  } catch (err) {
+    console.warn("[qa-tuning] Failed to parse config JSON", {
+      path: configPath,
+      error: err instanceof Error ? err.message : String(err),
+    });
     return null;
   }
+
+  const result = QaTuningConfigSchema.safeParse(raw);
+
+  if (!result.success) {
+    console.warn("[qa-tuning] Config validation failed", {
+      path: configPath,
+      issues: result.error.issues.map((issue) => ({
+        path: issue.path.join("."),
+        message: issue.message,
+      })),
+    });
+    return null;
+  }
+
+  const { thresholds } = result.data;
+
+  return {
+    acceptanceRateFloor: thresholds.acceptanceRateFloor,
+    maxBudgetUSD: thresholds.maxBudgetUSD,
+    maxRetries: thresholds.maxRetries,
+    stuckTurnsThreshold: thresholds.stuckTurnsThreshold,
+    meanCloseHoursTarget: thresholds.meanCloseHoursTarget,
+    agentMergeShareTarget: thresholds.agentMergeShareTarget,
+  };
 }


### PR DESCRIPTION
## Summary

- Replace manual type-checking in `parseThresholds()` with a Zod schema (`QaTuningConfigSchema`) that validates `version`, `lastTunedAt`, and all six threshold fields
- On validation failure in `loadQaTuning()`, log a structured `console.warn` with file path and specific Zod issues instead of silently returning `null`
- Add `QaTuningConfigSchema` tests (valid config, passthrough keys, wrong types, missing fields, non-object input)
- Add `loadQaTuning` IO tests with mocked `node:fs` (valid file, wrong types with warning, missing file, unparseable JSON, missing threshold fields, extra keys)

## Test plan

- [x] All 662 existing tests pass (`pnpm --dir packages/agent-core test`)
- [x] Lint clean (`pnpm --dir packages/agent-core lint`)
- [ ] CI passes on PR

Closes #1101