### PR TITLE
fix(agent-core): surface cleanup errors instead of swallowing them

### DIFF
--- a/packages/agent-core/src/__tests__/session-runner.test.ts
+++ b/packages/agent-core/src/__tests__/session-runner.test.ts
@@ -341,6 +341,98 @@ describe("runSession", () => {
     expect(removeWorktree).not.toHaveBeenCalled();
   });
 
+  it("surfaces cleanup errors in cleanupErrors when removeWorktree fails", async () => {
+    const mockResult = createMockResultMessage();
+
+    vi.mocked(query).mockReturnValue(
+      mockQueryGenerator([mockResult]) as ReturnType<typeof query>
+    );
+    vi.mocked(hasChanges).mockResolvedValue(true);
+    vi.mocked(commitChanges).mockResolvedValue("abc123");
+    vi.mocked(pushBranch).mockResolvedValue(undefined);
+    vi.mocked(buildPrTitle).mockReturnValue("feat: test");
+    vi.mocked(buildPrBody).mockReturnValue("body");
+    vi.mocked(createPullRequest).mockResolvedValue({
+      url: "https://github.com/repo/pull/1",
+      number: 1,
+    });
+    vi.mocked(removeWorktree).mockRejectedValue(
+      new Error("fatal: worktree is locked")
+    );
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = await runSession(BASE_CONFIG);
+
+    // Session itself should still succeed
+    expect(result.status).toBe("succeeded");
+    expect(result.prUrl).toBe("https://github.com/repo/pull/1");
+
+    // Cleanup error should be surfaced
+    expect(result.cleanupErrors).toEqual(["fatal: worktree is locked"]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Worktree cleanup failed: fatal: worktree is locked"
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it("emits session:cleanup_warning event when removeWorktree fails", async () => {
+    const mockResult = createMockResultMessage();
+
+    vi.mocked(query).mockReturnValue(
+      mockQueryGenerator([mockResult]) as ReturnType<typeof query>
+    );
+    vi.mocked(hasChanges).mockResolvedValue(true);
+    vi.mocked(commitChanges).mockResolvedValue("abc123");
+    vi.mocked(pushBranch).mockResolvedValue(undefined);
+    vi.mocked(buildPrTitle).mockReturnValue("feat: test");
+    vi.mocked(buildPrBody).mockReturnValue("body");
+    vi.mocked(createPullRequest).mockResolvedValue({
+      url: "https://github.com/repo/pull/1",
+      number: 1,
+    });
+    vi.mocked(removeWorktree).mockRejectedValue(
+      new Error("fatal: worktree is locked")
+    );
+
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const events: SessionEvent[] = [];
+    await runSession(BASE_CONFIG, (event) => events.push(event));
+
+    const cleanupEvents = events.filter(
+      (e) => e.type === "session:cleanup_warning"
+    );
+    expect(cleanupEvents).toHaveLength(1);
+    expect(
+      (cleanupEvents[0].data as { message: string }).message
+    ).toContain("fatal: worktree is locked");
+
+    vi.restoreAllMocks();
+  });
+
+  it("omits cleanupErrors when removeWorktree succeeds", async () => {
+    const mockResult = createMockResultMessage();
+
+    vi.mocked(query).mockReturnValue(
+      mockQueryGenerator([mockResult]) as ReturnType<typeof query>
+    );
+    vi.mocked(hasChanges).mockResolvedValue(true);
+    vi.mocked(commitChanges).mockResolvedValue("abc123");
+    vi.mocked(pushBranch).mockResolvedValue(undefined);
+    vi.mocked(buildPrTitle).mockReturnValue("feat: test");
+    vi.mocked(buildPrBody).mockReturnValue("body");
+    vi.mocked(createPullRequest).mockResolvedValue({
+      url: "https://github.com/repo/pull/1",
+      number: 1,
+    });
+    vi.mocked(removeWorktree).mockResolvedValue(undefined);
+
+    const result = await runSession(BASE_CONFIG);
+
+    expect(result.status).toBe("succeeded");
+    expect(result.cleanupErrors).toBeUndefined();
+  });
+
   it("handles createWorktree failure gracefully", async () => {
     vi.mocked(createWorktree).mockRejectedValue(new Error("git worktree add failed"));
 

--- a/packages/agent-core/src/session-runner.ts
+++ b/packages/agent-core/src/session-runner.ts
@@ -158,6 +158,8 @@ export async function runSession(
       const abortController = new AbortController();
       let worktree: WorktreeInfo | undefined;
       let stuckReason: StuckPattern | null = null;
+      const cleanupErrors: string[] = [];
+      let pendingResult: SessionResult | undefined;
 
       // Cached git diff — computed once, reused across evaluation, static analysis,
       // security review, dep-bump check, and PR body generation.
@@ -784,29 +786,29 @@ export async function runSession(
             },
           });
 
-          return finalResult;
+          pendingResult = finalResult;
+        } else {
+          const failureCategoryNoResult = categorizeFailure(errors, stuckReason?.type);
+
+          rootSpan.setAttribute("session.status", "failed");
+          pendingResult = {
+            sessionId: "",
+            status: "failed",
+            branchName: worktree?.branchName ?? "",
+            prUrl,
+            costUsd: 0,
+            tokenUsage: { inputTokens: 0, outputTokens: 0 },
+            durationMs: 0,
+            numTurns: 0,
+            resultText: "",
+            errors,
+            stuckPattern: stuckReason?.type,
+            evaluation: evalSummary,
+            ...(failureCategoryNoResult ? { failureCategory: failureCategoryNoResult } : {}),
+            turnMetrics: collectedTurnMetrics,
+            toolCallMetrics: collectedToolCallMetrics,
+          };
         }
-
-        const failureCategoryNoResult = categorizeFailure(errors, stuckReason?.type);
-
-        rootSpan.setAttribute("session.status", "failed");
-        return {
-          sessionId: "",
-          status: "failed",
-          branchName: worktree?.branchName ?? "",
-          prUrl,
-          costUsd: 0,
-          tokenUsage: { inputTokens: 0, outputTokens: 0 },
-          durationMs: 0,
-          numTurns: 0,
-          resultText: "",
-          errors,
-          stuckPattern: stuckReason?.type,
-          evaluation: evalSummary,
-          ...(failureCategoryNoResult ? { failureCategory: failureCategoryNoResult } : {}),
-          turnMetrics: collectedTurnMetrics,
-          toolCallMetrics: collectedToolCallMetrics,
-        };
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
         emitEvent(onEvent, "session:error", { message: errorMessage });
@@ -849,7 +851,7 @@ export async function runSession(
         }
 
         rootSpan.setAttribute("session.status", "failed");
-        return {
+        pendingResult = {
           sessionId: "",
           status: "failed",
           branchName: worktree?.branchName ?? "",
@@ -868,12 +870,24 @@ export async function runSession(
         if (worktree && config.createPr) {
           try {
             await removeWorktree(config.repoPath, worktree.path);
-          } catch {
-            // Worktree cleanup is best-effort
+          } catch (cleanupErr) {
+            const cleanupMsg = cleanupErr instanceof Error
+              ? cleanupErr.message
+              : String(cleanupErr);
+            cleanupErrors.push(cleanupMsg);
+            console.warn(`Worktree cleanup failed: ${cleanupMsg}`);
+            emitEvent(onEvent, "session:cleanup_warning", {
+              message: `Worktree cleanup failed: ${cleanupMsg}`,
+            });
           }
         }
         rootSpan.end();
       }
+
+      // Attach any cleanup errors to the final result (immutable spread)
+      return cleanupErrors.length > 0
+        ? { ...pendingResult!, cleanupErrors }
+        : pendingResult!;
   }
       },
     );

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -124,6 +124,8 @@ export interface SessionResult {
   readonly numTurns: number;
   readonly resultText: string;
   readonly errors: readonly string[];
+  /** Non-fatal errors from post-session cleanup (e.g. worktree removal failures). */
+  readonly cleanupErrors?: readonly string[];
   readonly stuckPattern?: string;
   readonly failureCategory?: FailureCategory;
   readonly turnMetrics?: readonly TurnMetrics[];
@@ -151,7 +153,8 @@ export type SessionEventType =
   | "session:tool_result"
   | "session:turn_metrics"
   | "session:tool_latency"
-  | "session:heartbeat";
+  | "session:heartbeat"
+  | "session:cleanup_warning";
 
 // ── Heartbeat / liveness configuration ──────────────────────────────
 


### PR DESCRIPTION
## Summary

- Adds `cleanupErrors?: readonly string[]` field to `SessionResult` type to surface non-fatal cleanup failures
- Replaces the silent `.catch()` in the session runner's `finally` block with proper error capture: `console.warn`, `session:cleanup_warning` event emission, and inclusion in the returned result
- Cleanup failures remain non-blocking — the session outcome (succeeded/failed) is unaffected

Closes #1103

## Test plan

- [x] New test: `surfaces cleanup errors in cleanupErrors when removeWorktree fails` — verifies cleanup error appears in `result.cleanupErrors` and `console.warn` is called
- [x] New test: `emits session:cleanup_warning event when removeWorktree fails` — verifies event callback receives the warning
- [x] New test: `omits cleanupErrors when removeWorktree succeeds` — verifies no `cleanupErrors` field on clean cleanup
- [x] All 652 existing tests pass
- [x] Lint and typecheck pass