### PR TITLE
fix(gen): document missing env vars in .env.example

### DIFF
--- a/apps/gen/.env.example
+++ b/apps/gen/.env.example
@@ -2,3 +2,18 @@ VITE_AUTH_AUTHORITY=https://your-tenant.us.auth0.com
 VITE_AUTH_CLIENT_ID=your_client_id
 VITE_AUTH_AUDIENCE=https://api.mattbutlerengineering.com
 VITE_AUTH_REDIRECT_URI=http://localhost:3005/gen/callback
+
+# Sentry error reporting (browser)
+VITE_SENTRY_DSN=
+
+# Sentry source-map upload (build time — set in CI secrets, not committed)
+SENTRY_AUTH_TOKEN=
+SENTRY_ORG=
+SENTRY_PROJECT=
+
+# E2E auth (Playwright — ROPC flow, test environment only)
+E2E_AUTH0_DOMAIN=dev-xxx.us.auth0.com
+E2E_AUTH0_CLIENT_ID=
+E2E_AUTH0_AUDIENCE=https://api.mattbutlerengineering.com
+E2E_AUTH_EMAIL=
+E2E_AUTH_PASSWORD=


### PR DESCRIPTION
## Summary

- `check-env-sync` was failing because `apps/gen/.env.example` was missing 9 env vars that the code references
- Adds Sentry build-time vars (`SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`), browser DSN (`VITE_SENTRY_DSN`), and Playwright ROPC E2E vars (`E2E_AUTH0_DOMAIN`, `E2E_AUTH0_CLIENT_ID`, `E2E_AUTH0_AUDIENCE`, `E2E_AUTH_EMAIL`, `E2E_AUTH_PASSWORD`) with placeholder values and brief comments
- The nightly compliance scan gates on `check-env-sync` passing; this fix removes the drift that caused issue #1109

## Test plan

- [ ] `node scripts/check-env-sync.js` passes (verified locally — all packages ✅)
- [ ] Nightly compliance scan passes on next run

Closes #1109

https://claude.ai/code/session_018QGjbVJoEnY7dp1EafXXCr

---
_Generated by [Claude Code](https://claude.ai/code/session_018QGjbVJoEnY7dp1EafXXCr)_