### PR TITLE
test(api-client): add unit tests for all 7 domain HTTP client modules

### DIFF
--- a/packages/api-client/llms-full.txt
+++ b/packages/api-client/llms-full.txt
@@ -269,7 +269,16 @@
       });
     
       if (!response.ok) {
-        throw new Error(`Request failed: ${response.statusText}`);
+        let detail = response.statusText || `HTTP ${response.status}`;
+        try {
+          const body = await response.json();
+          detail = (body as Record<string, unknown>).detail as string
+            ?? (body as Record<string, unknown>).message as string
+            ?? detail;
+        } catch {
+          // Response body is not JSON — use status text
+        }
+        throw new Error(`Request failed: ${detail}`);
       }
     
       if (!response.body) {
@@ -440,12 +449,14 @@
       getAccessToken?: () => string | null | Promise<string | null>;
       timeout?: number;
       maxRetries?: number;
+      onError?: (error: ApiClientError) => void;
     }) {
       const client = new ApiClient({
         baseUrl: config.baseUrl ?? "",
         getAccessToken: config.getAccessToken,
         timeout: config.timeout,
         maxRetries: config.maxRetries,
+        onError: config.onError,
       });
     
       return {
@@ -552,6 +563,7 @@
       getAccessToken?: () => string | null | Promise<string | null>;
       timeout?: number;
       maxRetries?: number;
+      onError?: (error: ApiClientError) => void;
     }
     export interface RequestOptions extends RequestInit {
       signal?: AbortSignal;

--- a/packages/api-client/llms.txt
+++ b/packages/api-client/llms.txt
@@ -65,7 +65,7 @@
         page?: number | undefined;
         limit?: number | undefined;
         date?: string | undefined;
-        status?: import("/Users/mbutler/github/mattbutlerengineering/fix-c...;
+        status?: import("/home/user/mattbutlerengineering/packages/types/s...;
         tableId?: string | undefined;
       }
     </item>
@@ -85,6 +85,7 @@
         getAccessToken?: () => string | null | Promise<string | null>;
         timeout?: number;
         maxRetries?: number;
+        onError?: (error: ApiClientError) => void;
       }) { /* ... */ }
     </item>
   </file>
@@ -122,6 +123,7 @@
         getAccessToken?: (() => string | Promise<string | null> | null) | undefined;
         timeout?: number | undefined;
         maxRetries?: number | undefined;
+        onError?: ((error: import("/home/user/mattbutlerengineering/package...;
       }
     </item>
     <item priority="low">

--- a/packages/api-client/src/availability.test.ts
+++ b/packages/api-client/src/availability.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ApiClient } from "./client.js";
+import { AvailabilityClient, HoldsClient } from "./availability.js";
+
+const mockFetch = vi.fn<typeof fetch>();
+vi.stubGlobal("fetch", mockFetch);
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeApiClient() {
+  return new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 0 });
+}
+
+const fakeTimeSlot = {
+  time: "19:00",
+  available: true,
+  tableIds: ["t1", "t2"],
+};
+
+const fakeDateAvailability = {
+  date: "2026-06-01",
+  available: true,
+  slotsCount: 5,
+};
+
+const fakeHold = {
+  id: "h1",
+  venueId: "v1",
+  tableId: "t1",
+  guestId: "g1",
+  date: "2026-06-01",
+  startTime: "19:00",
+  partySize: 2,
+  expiresAt: "2026-06-01T20:00:00Z",
+  status: "ACTIVE",
+};
+
+const fakeReservation = {
+  id: "r1",
+  venueId: "v1",
+  status: "CONFIRMED",
+};
+
+describe("AvailabilityClient", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  describe("getTimeSlots", () => {
+    it("requests /api/v1/availability/:venueId with required params", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: [fakeTimeSlot] }));
+
+      await new AvailabilityClient(makeApiClient()).getTimeSlots({
+        venueId: "v1",
+        date: "2026-06-01",
+        partySize: 2,
+      });
+
+      const [url] = mockFetch.mock.calls[0]!;
+      const parsed = new URL(url as string);
+      expect(parsed.pathname).toBe("/api/v1/availability/v1");
+      expect(parsed.searchParams.get("date")).toBe("2026-06-01");
+      expect(parsed.searchParams.get("partySize")).toBe("2");
+    });
+
+    it("includes optional duration when provided", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: [] }));
+
+      await new AvailabilityClient(makeApiClient()).getTimeSlots({
+        venueId: "v1",
+        date: "2026-06-01",
+        partySize: 2,
+        duration: 90,
+      });
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(new URL(url as string).searchParams.get("duration")).toBe("90");
+    });
+
+    it("omits duration when not provided", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: [] }));
+
+      await new AvailabilityClient(makeApiClient()).getTimeSlots({
+        venueId: "v1",
+        date: "2026-06-01",
+        partySize: 2,
+      });
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(new URL(url as string).searchParams.has("duration")).toBe(false);
+    });
+
+    it("returns the time slots array", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: [fakeTimeSlot] }));
+
+      const result = await new AvailabilityClient(makeApiClient()).getTimeSlots({
+        venueId: "v1",
+        date: "2026-06-01",
+        partySize: 2,
+      });
+      expect(result).toEqual([fakeTimeSlot]);
+    });
+  });
+
+  describe("getDates", () => {
+    it("requests /api/v1/availability/:venueId/dates with params", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: [fakeDateAvailability] }));
+
+      await new AvailabilityClient(makeApiClient()).getDates({
+        venueId: "v1",
+        startDate: "2026-06-01",
+        endDate: "2026-06-30",
+        partySize: 4,
+      });
+
+      const [url] = mockFetch.mock.calls[0]!;
+      const parsed = new URL(url as string);
+      expect(parsed.pathname).toBe("/api/v1/availability/v1/dates");
+      expect(parsed.searchParams.get("startDate")).toBe("2026-06-01");
+      expect(parsed.searchParams.get("endDate")).toBe("2026-06-30");
+      expect(parsed.searchParams.get("partySize")).toBe("4");
+    });
+
+    it("returns the date availability array", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: [fakeDateAvailability] }));
+
+      const result = await new AvailabilityClient(makeApiClient()).getDates({
+        venueId: "v1",
+        startDate: "2026-06-01",
+        endDate: "2026-06-30",
+        partySize: 4,
+      });
+      expect(result).toEqual([fakeDateAvailability]);
+    });
+  });
+});
+
+describe("HoldsClient", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  describe("setSessionId / getSessionId", () => {
+    it("stores and retrieves session ID", () => {
+      const holdsClient = new HoldsClient(makeApiClient());
+      expect(holdsClient.getSessionId()).toBeNull();
+
+      holdsClient.setSessionId("sess-123");
+      expect(holdsClient.getSessionId()).toBe("sess-123");
+    });
+  });
+
+  describe("create", () => {
+    it("sends POST /api/v1/holds with x-session-id header", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeHold }));
+
+      const holdsClient = new HoldsClient(makeApiClient());
+      holdsClient.setSessionId("sess-abc");
+
+      await holdsClient.create({
+        venueId: "v1",
+        tableId: "t1",
+        date: "2026-06-01",
+        startTime: "19:00",
+        partySize: 2,
+      });
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/holds");
+      expect(options?.method).toBe("POST");
+      expect((options?.headers as Record<string, string>)["x-session-id"]).toBe("sess-abc");
+    });
+
+    it("generates a sessionId if none is set", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeHold }));
+
+      const holdsClient = new HoldsClient(makeApiClient());
+      const result = await holdsClient.create({
+        venueId: "v1",
+        tableId: "t1",
+        date: "2026-06-01",
+        startTime: "19:00",
+        partySize: 2,
+      });
+
+      expect(result.sessionId).toBeTruthy();
+      expect(holdsClient.getSessionId()).toBe(result.sessionId);
+    });
+
+    it("returns hold and sessionId", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeHold }));
+
+      const holdsClient = new HoldsClient(makeApiClient());
+      holdsClient.setSessionId("sess-xyz");
+
+      const result = await holdsClient.create({
+        venueId: "v1",
+        tableId: "t1",
+        date: "2026-06-01",
+        startTime: "19:00",
+        partySize: 2,
+      });
+
+      expect(result.hold).toEqual(fakeHold);
+      expect(result.sessionId).toBe("sess-xyz");
+    });
+  });
+
+  describe("get", () => {
+    it("requests GET /api/v1/holds/:id and unwraps data", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeHold }));
+
+      const result = await new HoldsClient(makeApiClient()).get("h1");
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/holds/h1");
+      expect(result).toEqual(fakeHold);
+    });
+  });
+
+  describe("release", () => {
+    it("sends DELETE /api/v1/holds/:id with x-session-id header", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ success: true }));
+
+      const holdsClient = new HoldsClient(makeApiClient());
+      holdsClient.setSessionId("sess-abc");
+      await holdsClient.release("h1");
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/holds/h1");
+      expect(options?.method).toBe("DELETE");
+      expect((options?.headers as Record<string, string>)["x-session-id"]).toBe("sess-abc");
+    });
+
+    it("throws when no session ID is set", async () => {
+      const holdsClient = new HoldsClient(makeApiClient());
+
+      await expect(holdsClient.release("h1")).rejects.toThrow("Session ID required");
+    });
+  });
+
+  describe("confirm", () => {
+    it("sends POST /api/v1/holds/:id/confirm with x-session-id header", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeReservation }));
+
+      const holdsClient = new HoldsClient(makeApiClient());
+      holdsClient.setSessionId("sess-abc");
+
+      await holdsClient.confirm("h1", {
+        guestId: "g1",
+        notes: "Window seat please",
+      });
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/holds/h1/confirm");
+      expect(options?.method).toBe("POST");
+      expect((options?.headers as Record<string, string>)["x-session-id"]).toBe("sess-abc");
+    });
+
+    it("throws when no session ID is set", async () => {
+      const holdsClient = new HoldsClient(makeApiClient());
+
+      await expect(
+        holdsClient.confirm("h1", { guestId: "g1" })
+      ).rejects.toThrow("Session ID required");
+    });
+
+    it("returns the confirmed reservation", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeReservation }));
+
+      const holdsClient = new HoldsClient(makeApiClient());
+      holdsClient.setSessionId("sess-abc");
+
+      const result = await holdsClient.confirm("h1", { guestId: "g1" });
+      expect(result).toEqual(fakeReservation);
+    });
+  });
+
+  describe("error handling", () => {
+    it("propagates 404 errors on get", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ error: "Not Found", message: "Hold not found", statusCode: 404 }, 404)
+      );
+
+      await expect(new HoldsClient(makeApiClient()).get("bad")).rejects.toThrow();
+    });
+  });
+});

--- a/packages/api-client/src/floor-plans.test.ts
+++ b/packages/api-client/src/floor-plans.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ApiClient } from "./client.js";
+import { FloorPlansClient } from "./floor-plans.js";
+
+const mockFetch = vi.fn<typeof fetch>();
+vi.stubGlobal("fetch", mockFetch);
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeClient() {
+  const apiClient = new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 0 });
+  return new FloorPlansClient(apiClient);
+}
+
+const fakeFloorPlan = {
+  id: "fp1",
+  venueId: "v1",
+  name: "Main Floor",
+  isActive: true,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+const fakeTable = {
+  id: "t1",
+  venueId: "v1",
+  name: "Table 1",
+  minCapacity: 2,
+  maxCapacity: 4,
+  status: "AVAILABLE",
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+describe("FloorPlansClient", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  describe("list", () => {
+    it("requests /api/v1/floor-plans with no params by default", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ data: [fakeFloorPlan], total: 1, page: 1, limit: 10 })
+      );
+
+      await makeClient().list();
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/floor-plans");
+    });
+
+    it("appends venueId filter when provided", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ data: [], total: 0, page: 1, limit: 10 })
+      );
+
+      await makeClient().list({ venueId: "v1", page: 1, limit: 5 });
+
+      const [url] = mockFetch.mock.calls[0]!;
+      const parsed = new URL(url as string);
+      expect(parsed.searchParams.get("venueId")).toBe("v1");
+      expect(parsed.searchParams.get("page")).toBe("1");
+      expect(parsed.searchParams.get("limit")).toBe("5");
+    });
+  });
+
+  describe("getById / get", () => {
+    it("requests GET /api/v1/floor-plans/:id and unwraps data", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeFloorPlan }));
+
+      const result = await makeClient().getById("fp1");
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/floor-plans/fp1");
+      expect(result).toEqual(fakeFloorPlan);
+    });
+
+    it("get() is an alias for getById()", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeFloorPlan }));
+
+      const result = await makeClient().get("fp1");
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/floor-plans/fp1");
+      expect(result).toEqual(fakeFloorPlan);
+    });
+  });
+
+  describe("create", () => {
+    it("sends POST /api/v1/floor-plans with body", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeFloorPlan }));
+
+      await makeClient().create({ venueId: "v1", name: "Main Floor" });
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/floor-plans");
+      expect(options?.method).toBe("POST");
+      expect(JSON.parse(options?.body as string)).toMatchObject({ name: "Main Floor" });
+    });
+  });
+
+  describe("update", () => {
+    it("sends PATCH /api/v1/floor-plans/:id", async () => {
+      const updated = { ...fakeFloorPlan, name: "Updated Floor" };
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: updated }));
+
+      await makeClient().update("fp1", { name: "Updated Floor" });
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/floor-plans/fp1");
+      expect(options?.method).toBe("PATCH");
+    });
+  });
+
+  describe("delete", () => {
+    it("sends DELETE /api/v1/floor-plans/:id", async () => {
+      mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+      await makeClient().delete("fp1");
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/floor-plans/fp1");
+      expect(options?.method).toBe("DELETE");
+    });
+  });
+
+  describe("setActive / activate", () => {
+    it("sends POST /api/v1/floor-plans/:id/active", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeFloorPlan }));
+
+      await makeClient().setActive("fp1");
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/floor-plans/fp1/active");
+      expect(options?.method).toBe("POST");
+    });
+
+    it("activate() is an alias for setActive()", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeFloorPlan }));
+
+      await makeClient().activate("fp1");
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/floor-plans/fp1/active");
+    });
+  });
+
+  describe("bulkUpdatePositions", () => {
+    it("sends POST /api/v1/floor-plans/:id/bulk-update-positions with positions", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: [fakeTable] }));
+
+      const positions = [{ tableId: "t1", x: 10, y: 20 }];
+      const result = await makeClient().bulkUpdatePositions("fp1", positions);
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/floor-plans/fp1/bulk-update-positions");
+      expect(options?.method).toBe("POST");
+      expect(JSON.parse(options?.body as string)).toEqual(positions);
+      expect(result).toEqual([fakeTable]);
+    });
+  });
+
+  describe("clone", () => {
+    it("sends POST /api/v1/floor-plans/:id/clone", async () => {
+      const cloned = { ...fakeFloorPlan, id: "fp2" };
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: cloned }));
+
+      const result = await makeClient().clone("fp1");
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/floor-plans/fp1/clone");
+      expect(options?.method).toBe("POST");
+      expect(result).toEqual(cloned);
+    });
+  });
+
+  describe("error handling", () => {
+    it("propagates 404 errors", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse(
+          { error: "Not Found", message: "Floor plan not found", statusCode: 404 },
+          404
+        )
+      );
+
+      await expect(makeClient().get("bad")).rejects.toThrow();
+    });
+
+    it("propagates network errors", async () => {
+      mockFetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+
+      await expect(makeClient().list()).rejects.toThrow(TypeError);
+    });
+  });
+});

--- a/packages/api-client/src/guests.test.ts
+++ b/packages/api-client/src/guests.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ApiClient } from "./client.js";
+import { GuestsClient } from "./guests.js";
+
+const mockFetch = vi.fn<typeof fetch>();
+vi.stubGlobal("fetch", mockFetch);
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeClient() {
+  const apiClient = new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 0 });
+  return new GuestsClient(apiClient);
+}
+
+const fakeGuest = {
+  id: "g1",
+  venueId: "v1",
+  name: "Bob Smith",
+  email: "bob@example.com",
+  phone: "+15551234567",
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+describe("GuestsClient", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  describe("list", () => {
+    it("requests /api/v1/guests with venueId", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ data: [fakeGuest], total: 1, page: 1, limit: 10 })
+      );
+
+      await makeClient().list({ venueId: "v1" });
+
+      const [url] = mockFetch.mock.calls[0]!;
+      const parsed = new URL(url as string);
+      expect(parsed.pathname).toBe("/api/v1/guests");
+      expect(parsed.searchParams.get("venueId")).toBe("v1");
+    });
+
+    it("appends optional page and limit", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ data: [], total: 0, page: 2, limit: 5 })
+      );
+
+      await makeClient().list({ venueId: "v1", page: 2, limit: 5 });
+
+      const [url] = mockFetch.mock.calls[0]!;
+      const parsed = new URL(url as string);
+      expect(parsed.searchParams.get("page")).toBe("2");
+      expect(parsed.searchParams.get("limit")).toBe("5");
+    });
+
+    it("returns paginated response", async () => {
+      const body = { data: [fakeGuest], total: 1, page: 1, limit: 10 };
+      mockFetch.mockResolvedValueOnce(jsonResponse(body));
+
+      const result = await makeClient().list({ venueId: "v1" });
+      expect(result).toEqual(body);
+    });
+  });
+
+  describe("search", () => {
+    it("requests /api/v1/guests/search with venueId", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ data: [], total: 0, page: 1, limit: 10 })
+      );
+
+      await makeClient().search({ venueId: "v1", query: "Bob" });
+
+      const [url] = mockFetch.mock.calls[0]!;
+      const parsed = new URL(url as string);
+      expect(parsed.pathname).toBe("/api/v1/guests/search");
+      expect(parsed.searchParams.get("venueId")).toBe("v1");
+      expect(parsed.searchParams.get("query")).toBe("Bob");
+    });
+
+    it("includes hasNotVisitedInDays when provided", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ data: [], total: 0, page: 1, limit: 10 })
+      );
+
+      await makeClient().search({ venueId: "v1", hasNotVisitedInDays: 30 });
+
+      const [url] = mockFetch.mock.calls[0]!;
+      const parsed = new URL(url as string);
+      expect(parsed.searchParams.get("hasNotVisitedInDays")).toBe("30");
+    });
+  });
+
+  describe("getSegments", () => {
+    it("requests /api/v1/guests/segments with venueId", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: [] }));
+
+      await makeClient().getSegments("v1");
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/guests/segments?venueId=v1");
+    });
+
+    it("returns the segments array", async () => {
+      const segments = [{ id: "s1", name: "VIP", venueId: "v1" }];
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: segments }));
+
+      const result = await makeClient().getSegments("v1");
+      expect(result).toEqual(segments);
+    });
+  });
+
+  describe("get", () => {
+    it("requests GET /api/v1/guests/:id and unwraps data", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeGuest }));
+
+      const result = await makeClient().get("g1");
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/guests/g1");
+      expect(result).toEqual(fakeGuest);
+    });
+  });
+
+  describe("create", () => {
+    it("sends POST /api/v1/guests with body", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeGuest }));
+
+      await makeClient().create({ venueId: "v1", name: "Bob Smith", email: "bob@example.com" });
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/guests");
+      expect(options?.method).toBe("POST");
+      expect(JSON.parse(options?.body as string)).toMatchObject({ name: "Bob Smith" });
+    });
+  });
+
+  describe("findOrCreate", () => {
+    it("sends POST /api/v1/guests/find-or-create", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeGuest }));
+
+      await makeClient().findOrCreate({
+        venueId: "v1",
+        name: "Bob Smith",
+        email: "bob@example.com",
+      });
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/guests/find-or-create");
+      expect(options?.method).toBe("POST");
+    });
+  });
+
+  describe("update", () => {
+    it("sends PATCH /api/v1/guests/:id", async () => {
+      const updated = { ...fakeGuest, name: "Robert Smith" };
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: updated }));
+
+      await makeClient().update("g1", { name: "Robert Smith" });
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/guests/g1");
+      expect(options?.method).toBe("PATCH");
+    });
+  });
+
+  describe("delete", () => {
+    it("sends DELETE /api/v1/guests/:id", async () => {
+      mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+      await makeClient().delete("g1");
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/guests/g1");
+      expect(options?.method).toBe("DELETE");
+    });
+  });
+
+  describe("error handling", () => {
+    it("propagates 404 errors", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ error: "Not Found", message: "Guest not found", statusCode: 404 }, 404)
+      );
+
+      await expect(makeClient().get("bad")).rejects.toThrow();
+    });
+
+    it("propagates network errors", async () => {
+      mockFetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+
+      await expect(makeClient().list({ venueId: "v1" })).rejects.toThrow(TypeError);
+    });
+  });
+});

--- a/packages/api-client/src/reservations.test.ts
+++ b/packages/api-client/src/reservations.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ApiClient } from "./client.js";
+import { ReservationsClient } from "./reservations.js";
+
+const mockFetch = vi.fn<typeof fetch>();
+vi.stubGlobal("fetch", mockFetch);
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeClient() {
+  const apiClient = new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 0 });
+  return new ReservationsClient(apiClient);
+}
+
+const fakeReservation = {
+  id: "r1",
+  venueId: "v1",
+  guestId: "g1",
+  tableId: "t1",
+  partySize: 2,
+  status: "CONFIRMED",
+  date: "2026-06-01",
+  startTime: "19:00",
+  durationMinutes: 90,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+describe("ReservationsClient", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  describe("list", () => {
+    it("requests /api/v1/reservations with no params when called with defaults", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ data: [fakeReservation], total: 1, page: 1, limit: 10 })
+      );
+
+      await makeClient().list();
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/reservations");
+    });
+
+    it("appends filter query params", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ data: [], total: 0, page: 1, limit: 10 })
+      );
+
+      await makeClient().list({ venueId: "v1", date: "2026-06-01", status: "CONFIRMED" });
+
+      const [url] = mockFetch.mock.calls[0]!;
+      const parsed = new URL(url as string);
+      expect(parsed.searchParams.get("venueId")).toBe("v1");
+      expect(parsed.searchParams.get("date")).toBe("2026-06-01");
+      expect(parsed.searchParams.get("status")).toBe("CONFIRMED");
+    });
+
+    it("returns the paginated response directly", async () => {
+      const body = { data: [fakeReservation], total: 1, page: 1, limit: 10 };
+      mockFetch.mockResolvedValueOnce(jsonResponse(body));
+
+      const result = await makeClient().list();
+      expect(result).toEqual(body);
+    });
+  });
+
+  describe("me", () => {
+    it("requests /api/v1/reservations/me with pagination", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ data: [], total: 0, page: 1, limit: 10 })
+      );
+
+      await makeClient().me();
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/reservations/me?page=1&limit=10");
+    });
+
+    it("passes custom page and limit", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ data: [], total: 0, page: 3, limit: 5 })
+      );
+
+      await makeClient().me(3, 5);
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/reservations/me?page=3&limit=5");
+    });
+  });
+
+  describe("get", () => {
+    it("requests GET /api/v1/reservations/:id", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeReservation }));
+
+      await makeClient().get("r1");
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/reservations/r1");
+    });
+
+    it("unwraps data from ApiResponse", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeReservation }));
+
+      const result = await makeClient().get("r1");
+      expect(result).toEqual(fakeReservation);
+    });
+  });
+
+  describe("create", () => {
+    it("sends POST /api/v1/reservations with body", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeReservation }));
+
+      await makeClient().create({
+        venueId: "v1",
+        guestId: "g1",
+        tableId: "t1",
+        partySize: 2,
+        date: "2026-06-01",
+        startTime: "19:00",
+      });
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/reservations");
+      expect(options?.method).toBe("POST");
+    });
+
+    it("returns the created reservation", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeReservation }));
+
+      const result = await makeClient().create({
+        venueId: "v1",
+        guestId: "g1",
+        tableId: "t1",
+        partySize: 2,
+        date: "2026-06-01",
+        startTime: "19:00",
+      });
+      expect(result).toEqual(fakeReservation);
+    });
+  });
+
+  describe("update", () => {
+    it("sends PATCH /api/v1/reservations/:id", async () => {
+      const updated = { ...fakeReservation, partySize: 4 };
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: updated }));
+
+      await makeClient().update("r1", { partySize: 4 });
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/reservations/r1");
+      expect(options?.method).toBe("PATCH");
+      expect(JSON.parse(options?.body as string)).toMatchObject({ partySize: 4 });
+    });
+  });
+
+  describe("cancel", () => {
+    it("sends DELETE /api/v1/reservations/:id", async () => {
+      const cancelled = { ...fakeReservation, status: "CANCELLED" };
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: cancelled }));
+
+      await makeClient().cancel("r1");
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/reservations/r1");
+      expect(options?.method).toBe("DELETE");
+    });
+  });
+
+  describe("cancelWithReason", () => {
+    it("delegates to update with CANCELLED status", async () => {
+      const cancelled = { ...fakeReservation, status: "CANCELLED" };
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: cancelled }));
+
+      await makeClient().cancelWithReason("r1", {
+        cancellationReason: "guest_request",
+        cancellationNote: "Changed plans",
+      });
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/reservations/r1");
+      expect(options?.method).toBe("PATCH");
+      const body = JSON.parse(options?.body as string);
+      expect(body.status).toBe("CANCELLED");
+      expect(body.cancellationReason).toBe("guest_request");
+    });
+  });
+
+  describe("walkIn", () => {
+    it("sends POST /api/v1/reservations/walk-in", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeReservation }));
+
+      await makeClient().walkIn({ partySize: 2, tableId: "t1", venueId: "v1" });
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/reservations/walk-in");
+      expect(options?.method).toBe("POST");
+    });
+  });
+
+  describe("error handling", () => {
+    it("propagates 404 errors", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ error: "Not Found", message: "Not found", statusCode: 404 }, 404)
+      );
+
+      await expect(makeClient().get("bad")).rejects.toThrow();
+    });
+
+    it("propagates network errors", async () => {
+      mockFetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+
+      await expect(makeClient().list()).rejects.toThrow(TypeError);
+    });
+  });
+});

--- a/packages/api-client/src/tables.test.ts
+++ b/packages/api-client/src/tables.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ApiClient } from "./client.js";
+import { TablesClient } from "./tables.js";
+
+const mockFetch = vi.fn<typeof fetch>();
+vi.stubGlobal("fetch", mockFetch);
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeClient() {
+  const apiClient = new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 0 });
+  return new TablesClient(apiClient);
+}
+
+const fakeTable = {
+  id: "t1",
+  venueId: "v1",
+  name: "Table 1",
+  minCapacity: 2,
+  maxCapacity: 4,
+  status: "AVAILABLE",
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+describe("TablesClient", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  describe("list", () => {
+    it("requests /api/v1/tables with no params by default", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ data: [fakeTable], total: 1, page: 1, limit: 10 })
+      );
+
+      await makeClient().list();
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/tables");
+    });
+
+    it("appends filter params when provided", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ data: [], total: 0, page: 1, limit: 10 })
+      );
+
+      await makeClient().list({ venueId: "v1", activeOnly: true, page: 1, limit: 20 });
+
+      const [url] = mockFetch.mock.calls[0]!;
+      const parsed = new URL(url as string);
+      expect(parsed.searchParams.get("venueId")).toBe("v1");
+      expect(parsed.searchParams.get("activeOnly")).toBe("true");
+      expect(parsed.searchParams.get("page")).toBe("1");
+      expect(parsed.searchParams.get("limit")).toBe("20");
+    });
+
+    it("returns the paginated response", async () => {
+      const body = { data: [fakeTable], total: 1, page: 1, limit: 10 };
+      mockFetch.mockResolvedValueOnce(jsonResponse(body));
+
+      const result = await makeClient().list();
+      expect(result).toEqual(body);
+    });
+  });
+
+  describe("get", () => {
+    it("requests GET /api/v1/tables/:id and unwraps data", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeTable }));
+
+      const result = await makeClient().get("t1");
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/tables/t1");
+      expect(result).toEqual(fakeTable);
+    });
+  });
+
+  describe("create", () => {
+    it("sends POST /api/v1/tables with body", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeTable }));
+
+      await makeClient().create({
+        venueId: "v1",
+        name: "Table 1",
+        minCapacity: 2,
+        maxCapacity: 4,
+      });
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/tables");
+      expect(options?.method).toBe("POST");
+      expect(JSON.parse(options?.body as string)).toMatchObject({ name: "Table 1" });
+    });
+
+    it("returns the created table", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeTable }));
+
+      const result = await makeClient().create({
+        venueId: "v1",
+        name: "Table 1",
+        minCapacity: 2,
+        maxCapacity: 4,
+      });
+      expect(result).toEqual(fakeTable);
+    });
+  });
+
+  describe("update", () => {
+    it("sends PATCH /api/v1/tables/:id", async () => {
+      const updated = { ...fakeTable, name: "Table 1A" };
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: updated }));
+
+      await makeClient().update("t1", { name: "Table 1A" });
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/tables/t1");
+      expect(options?.method).toBe("PATCH");
+    });
+  });
+
+  describe("delete", () => {
+    it("sends DELETE /api/v1/tables/:id", async () => {
+      mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+      await makeClient().delete("t1");
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/tables/t1");
+      expect(options?.method).toBe("DELETE");
+    });
+  });
+
+  describe("updateStatus", () => {
+    it("sends PATCH /api/v1/tables/:id/status with status body", async () => {
+      const updated = { ...fakeTable, status: "OCCUPIED" };
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: updated }));
+
+      await makeClient().updateStatus("t1", "OCCUPIED");
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/tables/t1/status");
+      expect(options?.method).toBe("PATCH");
+      expect(JSON.parse(options?.body as string)).toEqual({ status: "OCCUPIED" });
+    });
+
+    it("returns the updated table", async () => {
+      const updated = { ...fakeTable, status: "OCCUPIED" };
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: updated }));
+
+      const result = await makeClient().updateStatus("t1", "OCCUPIED");
+      expect(result).toEqual(updated);
+    });
+  });
+
+  describe("error handling", () => {
+    it("propagates 404 errors", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ error: "Not Found", message: "Table not found", statusCode: 404 }, 404)
+      );
+
+      await expect(makeClient().get("bad")).rejects.toThrow();
+    });
+
+    it("propagates network errors", async () => {
+      mockFetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+
+      await expect(makeClient().list()).rejects.toThrow(TypeError);
+    });
+  });
+});

--- a/packages/api-client/src/users.test.ts
+++ b/packages/api-client/src/users.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ApiClient } from "./client.js";
+import { UsersClient } from "./users.js";
+
+const mockFetch = vi.fn<typeof fetch>();
+vi.stubGlobal("fetch", mockFetch);
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeClient() {
+  const apiClient = new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 0 });
+  return new UsersClient(apiClient);
+}
+
+const fakeUser = {
+  id: "u1",
+  email: "alice@example.com",
+  name: "Alice",
+  role: "ADMIN",
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+describe("UsersClient", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  describe("list", () => {
+    it("requests the correct URL with default pagination", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ data: [fakeUser], total: 1, page: 1, limit: 10 })
+      );
+
+      const client = makeClient();
+      await client.list();
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/users?page=1&limit=10");
+    });
+
+    it("passes custom page and limit", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ data: [], total: 0, page: 2, limit: 5 })
+      );
+
+      await makeClient().list(2, 5);
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/users?page=2&limit=5");
+    });
+
+    it("returns the paginated response", async () => {
+      const body = { data: [fakeUser], total: 1, page: 1, limit: 10 };
+      mockFetch.mockResolvedValueOnce(jsonResponse(body));
+
+      const result = await makeClient().list();
+      expect(result).toEqual(body);
+    });
+  });
+
+  describe("get", () => {
+    it("requests GET /api/v1/users/:id", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeUser }));
+
+      await makeClient().get("u1");
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/users/u1");
+      expect(options?.method ?? "GET").toBe("GET");
+    });
+
+    it("unwraps data from ApiResponse", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeUser }));
+
+      const result = await makeClient().get("u1");
+      expect(result).toEqual(fakeUser);
+    });
+  });
+
+  describe("me", () => {
+    it("requests GET /api/v1/users/me", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeUser }));
+
+      await makeClient().me();
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/users/me");
+    });
+
+    it("returns the current user", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeUser }));
+
+      const result = await makeClient().me();
+      expect(result).toEqual(fakeUser);
+    });
+  });
+
+  describe("create", () => {
+    it("sends POST /api/v1/users with body", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeUser }));
+
+      await makeClient().create({ email: "alice@example.com", name: "Alice" });
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/users");
+      expect(options?.method).toBe("POST");
+      expect(JSON.parse(options?.body as string)).toMatchObject({
+        email: "alice@example.com",
+        name: "Alice",
+      });
+    });
+
+    it("returns the created user", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeUser }));
+
+      const result = await makeClient().create({ email: "alice@example.com", name: "Alice" });
+      expect(result).toEqual(fakeUser);
+    });
+  });
+
+  describe("update", () => {
+    it("sends PATCH /api/v1/users/:id with body", async () => {
+      const updated = { ...fakeUser, name: "Alicia" };
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: updated }));
+
+      await makeClient().update("u1", { name: "Alicia" });
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/users/u1");
+      expect(options?.method).toBe("PATCH");
+      expect(JSON.parse(options?.body as string)).toMatchObject({ name: "Alicia" });
+    });
+  });
+
+  describe("delete", () => {
+    it("sends DELETE /api/v1/users/:id", async () => {
+      mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+      await makeClient().delete("u1");
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/users/u1");
+      expect(options?.method).toBe("DELETE");
+    });
+  });
+
+  describe("updatePreferences", () => {
+    it("sends PATCH /api/v1/users/me/preferences with body", async () => {
+      const updated = { ...fakeUser };
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: updated }));
+
+      await makeClient().updatePreferences({ theme: "dark" });
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/users/me/preferences");
+      expect(options?.method).toBe("PATCH");
+      expect(JSON.parse(options?.body as string)).toMatchObject({ theme: "dark" });
+    });
+  });
+
+  describe("error handling", () => {
+    it("propagates 404 errors", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ error: "Not Found", message: "User not found", statusCode: 404 }, 404)
+      );
+
+      await expect(makeClient().get("bad-id")).rejects.toThrow();
+    });
+
+    it("propagates network errors", async () => {
+      mockFetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+
+      await expect(makeClient().list()).rejects.toThrow(TypeError);
+    });
+  });
+});

--- a/packages/api-client/src/venues.test.ts
+++ b/packages/api-client/src/venues.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ApiClient } from "./client.js";
+import { VenuesClient, VenueGroupsClient } from "./venues.js";
+
+const mockFetch = vi.fn<typeof fetch>();
+vi.stubGlobal("fetch", mockFetch);
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeVenuesClient() {
+  const apiClient = new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 0 });
+  return new VenuesClient(apiClient);
+}
+
+function makeGroupsClient() {
+  const apiClient = new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 0 });
+  return new VenueGroupsClient(apiClient);
+}
+
+const fakeVenue = {
+  id: "v1",
+  name: "The Grand",
+  slug: "the-grand",
+  venueGroupId: "vg1",
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+const fakeVenueGroup = {
+  id: "vg1",
+  name: "Grand Group",
+  slug: "grand-group",
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+describe("VenuesClient", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  describe("list", () => {
+    it("requests /api/v1/venues with no query when called with defaults", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ data: [fakeVenue], total: 1, page: 1, limit: 10 })
+      );
+
+      await makeVenuesClient().list();
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/venues");
+    });
+
+    it("appends filter params when provided", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ data: [], total: 0, page: 1, limit: 10 })
+      );
+
+      await makeVenuesClient().list({ page: 2, limit: 5, venueGroupId: "vg1" });
+
+      const [url] = mockFetch.mock.calls[0]!;
+      const parsed = new URL(url as string);
+      expect(parsed.searchParams.get("page")).toBe("2");
+      expect(parsed.searchParams.get("limit")).toBe("5");
+      expect(parsed.searchParams.get("venueGroupId")).toBe("vg1");
+    });
+
+    it("returns the paginated response", async () => {
+      const body = { data: [fakeVenue], total: 1, page: 1, limit: 10 };
+      mockFetch.mockResolvedValueOnce(jsonResponse(body));
+
+      const result = await makeVenuesClient().list();
+      expect(result).toEqual(body);
+    });
+  });
+
+  describe("get", () => {
+    it("requests GET /api/v1/venues/:id", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeVenue }));
+
+      await makeVenuesClient().get("v1");
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/venues/v1");
+    });
+
+    it("unwraps data", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeVenue }));
+
+      const result = await makeVenuesClient().get("v1");
+      expect(result).toEqual(fakeVenue);
+    });
+  });
+
+  describe("getBySlug", () => {
+    it("requests GET /api/v1/venues/by-slug/:slug", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeVenue }));
+
+      await makeVenuesClient().getBySlug("the-grand");
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/venues/by-slug/the-grand");
+    });
+  });
+
+  describe("create", () => {
+    it("sends POST /api/v1/venues with body", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeVenue }));
+
+      await makeVenuesClient().create({ name: "The Grand", venueGroupId: "vg1" });
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/venues");
+      expect(options?.method).toBe("POST");
+    });
+
+    it("returns the created venue", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeVenue }));
+
+      const result = await makeVenuesClient().create({ name: "The Grand", venueGroupId: "vg1" });
+      expect(result).toEqual(fakeVenue);
+    });
+  });
+
+  describe("update", () => {
+    it("sends PATCH /api/v1/venues/:id", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeVenue }));
+
+      await makeVenuesClient().update("v1", { name: "The Grand Updated" });
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/venues/v1");
+      expect(options?.method).toBe("PATCH");
+    });
+  });
+
+  describe("delete", () => {
+    it("sends DELETE /api/v1/venues/:id", async () => {
+      mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+      await makeVenuesClient().delete("v1");
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/venues/v1");
+      expect(options?.method).toBe("DELETE");
+    });
+  });
+
+  describe("error handling", () => {
+    it("propagates 4xx errors", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ error: "Not Found", message: "Venue not found", statusCode: 404 }, 404)
+      );
+
+      await expect(makeVenuesClient().get("bad")).rejects.toThrow();
+    });
+  });
+});
+
+describe("VenueGroupsClient", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  describe("list", () => {
+    it("requests /api/v1/venues/groups with default pagination", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ data: [fakeVenueGroup], total: 1, page: 1, limit: 10 })
+      );
+
+      await makeGroupsClient().list();
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/venues/groups?page=1&limit=10");
+    });
+  });
+
+  describe("get", () => {
+    it("requests GET /api/v1/venues/groups/:id and unwraps data", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeVenueGroup }));
+
+      const result = await makeGroupsClient().get("vg1");
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/venues/groups/vg1");
+      expect(result).toEqual(fakeVenueGroup);
+    });
+  });
+
+  describe("getBySlug", () => {
+    it("requests /api/v1/venues/groups/by-slug/:slug", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeVenueGroup }));
+
+      await makeGroupsClient().getBySlug("grand-group");
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/venues/groups/by-slug/grand-group");
+    });
+  });
+
+  describe("create", () => {
+    it("sends POST /api/v1/venues/groups with body", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeVenueGroup }));
+
+      await makeGroupsClient().create({ name: "Grand Group" });
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/venues/groups");
+      expect(options?.method).toBe("POST");
+    });
+  });
+
+  describe("update", () => {
+    it("sends PATCH /api/v1/venues/groups/:id", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeVenueGroup }));
+
+      await makeGroupsClient().update("vg1", { name: "Updated Group" });
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/venues/groups/vg1");
+      expect(options?.method).toBe("PATCH");
+    });
+  });
+
+  describe("delete", () => {
+    it("sends DELETE /api/v1/venues/groups/:id", async () => {
+      mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+      await makeGroupsClient().delete("vg1");
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/venues/groups/vg1");
+      expect(options?.method).toBe("DELETE");
+    });
+  });
+});

--- a/packages/api-client/vitest.config.ts
+++ b/packages/api-client/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts", "src/index.ts"],
+      thresholds: {
+        lines: 80,
+        branches: 80,
+        functions: 80,
+        statements: 80,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Adds `.test.ts` files for all 7 previously untested domain client modules: `availability`, `reservations`, `venues`, `guests`, `floor-plans`, `tables`, `users`
- 134 tests across 10 test files — all passing
- Adds `packages/api-client/vitest.config.ts` so the package uses its own config rather than falling back to the broken root workspace config (`defineWorkspace` is not exported in vitest 4.x)

Each test file covers: URL/path construction, query parameter encoding, HTTP method, request body, response unwrapping (`ApiResponse<T>` → `T`), and 4xx/network error propagation. Pattern follows existing `client.test.ts` using `vi.stubGlobal("fetch", mockFetch)`.

## Test plan

- [x] `pnpm --dir packages/api-client test` — 134 tests pass
- [x] Pre-commit hooks pass (ESLint + check-adr)
- [ ] CI passes on this PR

Closes #1114

https://claude.ai/code/session_01P3ko8KiXQxGLGvEGxKPTAj

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3ko8KiXQxGLGvEGxKPTAj)_