### PR TITLE
test(mcp-server): add unit tests for all 7 tool modules

### DIFF
--- a/packages/mcp-server/llms-full.txt
+++ b/packages/mcp-server/llms-full.txt
@@ -1,0 +1,175 @@
+<codebase path="packages/mcp-server">
+  <section priority="medium" role="src">
+  <file path="src/index.ts">
+    async function main() {
+      const transport = new StdioServerTransport();
+      await server.connect(transport);
+      console.error("MBE Infra MCP Server running on stdio");
+    }
+  </file>
+  </section>
+  <section priority="medium" role="tools">
+  <file path="src/tools/pulumi.ts">
+    export async function pulumiStackOutputs(): Promise<string> {
+      try {
+        const output = execSync("pulumi stack output --json", {
+          encoding: "utf-8",
+          timeout: 30000,
+        });
+        return output;
+      } catch (error) {
+        return JSON.stringify({ error: "Failed to get Pulumi outputs", message: error instanceof Error ? error.message : String(error) });
+      }
+    }
+  </file>
+  <file path="src/tools/logs.ts">
+    export async function checkLogs(service?: string) {
+      const logDir = service ? join("services", service, "logs") : "services/*/logs";
+      const files = await glob(join(logDir, "*.log"));
+      
+      if (files.length === 0) {
+        return "No log files found.";
+      }
+    
+      let result = "Recent Logs:\n\n";
+      for (const file of files.slice(-3)) { // Limit to 3 most recent files
+        const content = await readFile(file, "utf8");
+        result += `--- ${file} ---\n${content.split("\n").slice(-20).join("\n")}\n\n`;
+      }
+      
+      return result;
+    }
+  </file>
+  <file path="src/tools/health.ts">
+    export async function serviceHealthCheck(): Promise<string> {
+      const results = await Promise.allSettled(
+        SERVICES.map(async (svc) => {
+          const start = Date.now();
+          try {
+            const res = await fetch(svc.url, { method: "GET" });
+            const latency = Date.now() - start;
+            return {
+              service: svc.name,
+              status: res.ok ? "healthy" : "unhealthy",
+              statusCode: res.status,
+              latencyMs: latency,
+            };
+          } catch {
+            return {
+              service: svc.name,
+              status: "unreachable",
+              statusCode: null,
+              latencyMs: null,
+            };
+          }
+        })
+      );
+    
+      const output = results.map((r) => (r.status === "fulfilled" ? r.value : r.reason));
+      return JSON.stringify(output, null, 2);
+    }
+  </file>
+  <file path="src/tools/git.ts">
+    export async function gitWorkflowStatus(): Promise<string> {
+      try {
+        const branch = execSync("git rev-parse --abbrev-ref HEAD", { encoding: "utf-8" }).trim();
+        const status = execSync("git status --porcelain", { encoding: "utf-8" }).trim();
+        const commits = execSync("git log --oneline -5", { encoding: "utf-8" }).trim();
+        
+        let ciStatus = "unknown";
+        try {
+          const run = execSync("gh run list --branch main --limit 1 --json conclusion", { encoding: "utf-8" });
+          const result = JSON.parse(run);
+          ciStatus = result[0]?.conclusion || "unknown";
+        } catch {
+          // gh CLI not available or failed - ciStatus remains "unknown"
+        }
+    
+        return JSON.stringify({
+          currentBranch: branch,
+          hasUncommittedChanges: status.length > 0,
+          pendingChanges: status.split("\n").filter(Boolean),
+          recentCommits: commits.split("\n"),
+          mainBranchCI: ciStatus,
+        }, null, 2);
+      } catch (error) {
+        return JSON.stringify({ error: "Failed to get git status", message: error instanceof Error ? error.message : String(error) });
+      }
+    }
+  </file>
+  <file path="src/tools/deploy_status.ts">
+    export async function deployStatus(): Promise<string> {
+      try {
+        const output = execSync(`doctl apps list --format ID,Spec.Name,ActiveDeployment.Phase,InProgressDeployment.Phase --no-header`, {
+          encoding: "utf-8",
+        });
+        const lines = output.trim().split("\n").filter(Boolean);
+        const apps = lines.map((line) => {
+          const parts = line.trim().split(/\s{2,}/);
+          return {
+            id: parts[0],
+            name: parts[1],
+            activePhase: parts[2] || "unknown",
+            inProgressPhase: parts[3] || "none",
+          };
+        });
+        return JSON.stringify({ apps }, null, 2);
+      } catch (error) {
+        return JSON.stringify({
+          error: "Failed to get deploy status",
+          message: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  </file>
+  <file path="src/tools/database.ts">
+    export async function dbListTables(): Promise<string> {
+      try {
+        const dbUrl = process.env.DATABASE_URL;
+        if (!dbUrl) {
+          return JSON.stringify({ error: "DATABASE_URL not set" });
+        }
+    
+        const output = execSync(
+          `psql "${dbUrl}" -t -c "SELECT tablename FROM pg_tables WHERE schemaname = 'public' ORDER BY tablename;"`,
+          { encoding: "utf-8" }
+        );
+        const tables = output.trim().split("\n").filter(Boolean);
+        return JSON.stringify({ tables }, null, 2);
+      } catch (error) {
+        return JSON.stringify({ error: "Failed to list tables", message: error instanceof Error ? error.message : String(error) });
+      }
+    }
+    export async function dbMigrationStatus(): Promise<string> {
+      try {
+        const dbUrl = process.env.DATABASE_URL;
+        if (!dbUrl) {
+          return JSON.stringify({ error: "DATABASE_URL not set" });
+        }
+    
+        const output = execSync(
+          `psql "${dbUrl}" -t -c "SELECT migration_name, finished_at FROM _prisma_migrations ORDER BY finished_at DESC LIMIT 20;"`,
+          { encoding: "utf-8" }
+        );
+        const migrations = output.trim().split("\n").filter(Boolean).map((line) => line.trim());
+        return JSON.stringify({ migrations }, null, 2);
+      } catch (error) {
+        return JSON.stringify({ error: "Failed to get migration status", message: error instanceof Error ? error.message : String(error) });
+      }
+    }
+  </file>
+  <file path="src/tools/ci.ts">
+    export async function ciRunStatus(): Promise<string> {
+      try {
+        const output = execSync(`gh run list --limit 10 --json name,status,conclusion,workflowName`, {
+          encoding: "utf-8",
+        });
+        const runs = JSON.parse(output);
+        return JSON.stringify(runs, null, 2);
+      } catch (error) {
+        return JSON.stringify({ error: "Failed to get CI status", message: error instanceof Error ? error.message : String(error) });
+      }
+    }
+  </file>
+  </section>
+</codebase>

--- a/packages/mcp-server/llms.txt
+++ b/packages/mcp-server/llms.txt
@@ -1,5 +1,49 @@
 <codebase path="packages/mcp-server">
+  <section priority="medium" role="src">
   <file path="src/index.ts">
-    async function main() { /* implementation omitted */ }
+    <item priority="low">
+      async function main() { /* ... */ }
+    </item>
   </file>
+  </section>
+  <section priority="medium" role="tools">
+  <file path="src/tools/pulumi.ts">
+    <item priority="high">
+      export async function pulumiStackOutputs(): Promise<string> { /* ... */ }
+    </item>
+  </file>
+  <file path="src/tools/logs.ts">
+    <item priority="high">
+      export async function checkLogs(service?: string) { /* ... */ }
+    </item>
+  </file>
+  <file path="src/tools/health.ts">
+    <item priority="high">
+      export async function serviceHealthCheck(): Promise<string> { /* ... */ }
+    </item>
+  </file>
+  <file path="src/tools/git.ts">
+    <item priority="high">
+      export async function gitWorkflowStatus(): Promise<string> { /* ... */ }
+    </item>
+  </file>
+  <file path="src/tools/deploy_status.ts">
+    <item priority="high">
+      export async function deployStatus(): Promise<string> { /* ... */ }
+    </item>
+  </file>
+  <file path="src/tools/database.ts">
+    <item priority="high">
+      export async function dbListTables(): Promise<string> { /* ... */ }
+    </item>
+    <item priority="high">
+      export async function dbMigrationStatus(): Promise<string> { /* ... */ }
+    </item>
+  </file>
+  <file path="src/tools/ci.ts">
+    <item priority="high">
+      export async function ciRunStatus(): Promise<string> { /* ... */ }
+    </item>
+  </file>
+  </section>
 </codebase>

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -10,6 +10,8 @@
     "build": "tsc",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "start": "tsx src/index.ts"
   },
   "dependencies": {
@@ -21,7 +23,9 @@
     "@mbe/config": "workspace:*",
     "@types/node": "catalog:",
     "@types/pg": "^8.20.0",
+    "@vitest/coverage-v8": "catalog:",
     "tsx": "^4.19.0",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/mcp-server/src/tools/ci.test.ts
+++ b/packages/mcp-server/src/tools/ci.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { execSync } from "node:child_process";
+
+vi.mock("node:child_process", () => ({
+  execSync: vi.fn(),
+}));
+
+import { ciRunStatus } from "./ci.js";
+
+describe("ciRunStatus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns CI runs as formatted JSON string", async () => {
+    const runs = [
+      { name: "CI", status: "completed", conclusion: "success", workflowName: "CI" },
+      { name: "Deploy", status: "in_progress", conclusion: null, workflowName: "Deploy" },
+    ];
+    vi.mocked(execSync).mockReturnValue(JSON.stringify(runs));
+
+    const result = await ciRunStatus();
+
+    expect(typeof result).toBe("string");
+    const parsed = JSON.parse(result) as typeof runs;
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0].conclusion).toBe("success");
+  });
+
+  it("result can be used as MCP text content", async () => {
+    vi.mocked(execSync).mockReturnValue("[]");
+
+    const result = await ciRunStatus();
+    const mcpContent = [{ type: "text" as const, text: result }];
+
+    expect(mcpContent[0].type).toBe("text");
+    expect(typeof mcpContent[0].text).toBe("string");
+  });
+
+  it("returns error JSON when execSync throws an Error", async () => {
+    vi.mocked(execSync).mockImplementation(() => {
+      throw new Error("gh: command not found");
+    });
+
+    const result = await ciRunStatus();
+    const parsed = JSON.parse(result) as { error: string; message: string };
+
+    expect(parsed.error).toBe("Failed to get CI status");
+    expect(parsed.message).toBe("gh: command not found");
+  });
+
+  it("returns error JSON when non-Error is thrown", async () => {
+    vi.mocked(execSync).mockImplementation(() => {
+       
+      throw "unexpected string error";
+    });
+
+    const result = await ciRunStatus();
+    const parsed = JSON.parse(result) as { error: string; message: string };
+
+    expect(parsed.error).toBe("Failed to get CI status");
+    expect(parsed.message).toBe("unexpected string error");
+  });
+
+  it("parses JSON output from gh CLI", async () => {
+    const runs = [{ name: "Test", status: "queued", conclusion: null, workflowName: "Test" }];
+    vi.mocked(execSync).mockReturnValue(JSON.stringify(runs));
+
+    const result = await ciRunStatus();
+    const parsed = JSON.parse(result) as typeof runs;
+
+    expect(parsed[0].status).toBe("queued");
+    expect(parsed[0].workflowName).toBe("Test");
+  });
+});

--- a/packages/mcp-server/src/tools/database.test.ts
+++ b/packages/mcp-server/src/tools/database.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { execSync } from "node:child_process";
+
+vi.mock("node:child_process", () => ({
+  execSync: vi.fn(),
+}));
+
+import { dbListTables, dbMigrationStatus } from "./database.js";
+
+describe("dbListTables", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env["DATABASE_URL"];
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    delete process.env["DATABASE_URL"];
+  });
+
+  it("returns error JSON when DATABASE_URL is not set", async () => {
+    const result = await dbListTables();
+    const parsed = JSON.parse(result) as { error: string };
+
+    expect(parsed.error).toBe("DATABASE_URL not set");
+    expect(vi.mocked(execSync)).not.toHaveBeenCalled();
+  });
+
+  it("returns tables list when query succeeds", async () => {
+    vi.stubEnv("DATABASE_URL", "postgresql://localhost/test");
+    vi.mocked(execSync).mockReturnValue("users\norders\nproducts\n");
+
+    const result = await dbListTables();
+    const parsed = JSON.parse(result) as { tables: string[] };
+
+    expect(Array.isArray(parsed.tables)).toBe(true);
+    expect(parsed.tables).toContain("users");
+    expect(parsed.tables).toContain("orders");
+    expect(parsed.tables).toContain("products");
+  });
+
+  it("filters empty lines from psql output", async () => {
+    vi.stubEnv("DATABASE_URL", "postgresql://localhost/test");
+    vi.mocked(execSync).mockReturnValue("users\n\norders\n\n");
+
+    const result = await dbListTables();
+    const parsed = JSON.parse(result) as { tables: string[] };
+
+    expect(parsed.tables).not.toContain("");
+    expect(parsed.tables).toHaveLength(2);
+  });
+
+  it("returns error JSON when psql command fails", async () => {
+    vi.stubEnv("DATABASE_URL", "postgresql://localhost/test");
+    vi.mocked(execSync).mockImplementation(() => {
+      throw new Error("psql: connection refused");
+    });
+
+    const result = await dbListTables();
+    const parsed = JSON.parse(result) as { error: string; message: string };
+
+    expect(parsed.error).toBe("Failed to list tables");
+    expect(parsed.message).toBe("psql: connection refused");
+  });
+
+  it("result is a valid MCP text content string", async () => {
+    vi.stubEnv("DATABASE_URL", "postgresql://localhost/test");
+    vi.mocked(execSync).mockReturnValue(" users\n");
+
+    const result = await dbListTables();
+    const mcpContent = [{ type: "text" as const, text: result }];
+
+    expect(mcpContent[0].type).toBe("text");
+    expect(typeof mcpContent[0].text).toBe("string");
+  });
+});
+
+describe("dbMigrationStatus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env["DATABASE_URL"];
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    delete process.env["DATABASE_URL"];
+  });
+
+  it("returns error JSON when DATABASE_URL is not set", async () => {
+    const result = await dbMigrationStatus();
+    const parsed = JSON.parse(result) as { error: string };
+
+    expect(parsed.error).toBe("DATABASE_URL not set");
+    expect(vi.mocked(execSync)).not.toHaveBeenCalled();
+  });
+
+  it("returns migrations list when query succeeds", async () => {
+    vi.stubEnv("DATABASE_URL", "postgresql://localhost/test");
+    vi.mocked(execSync).mockReturnValue(
+      " 20240101_initial | 2024-01-01 00:00:00\n 20240201_users | 2024-02-01 00:00:00\n"
+    );
+
+    const result = await dbMigrationStatus();
+    const parsed = JSON.parse(result) as { migrations: string[] };
+
+    expect(Array.isArray(parsed.migrations)).toBe(true);
+    expect(parsed.migrations).toHaveLength(2);
+  });
+
+  it("filters empty lines from psql output", async () => {
+    vi.stubEnv("DATABASE_URL", "postgresql://localhost/test");
+    vi.mocked(execSync).mockReturnValue(" 20240101_initial | 2024-01-01\n\n");
+
+    const result = await dbMigrationStatus();
+    const parsed = JSON.parse(result) as { migrations: string[] };
+
+    expect(parsed.migrations).not.toContain("");
+    expect(parsed.migrations).toHaveLength(1);
+  });
+
+  it("returns error JSON when psql command fails", async () => {
+    vi.stubEnv("DATABASE_URL", "postgresql://localhost/test");
+    vi.mocked(execSync).mockImplementation(() => {
+      throw new Error("connection error");
+    });
+
+    const result = await dbMigrationStatus();
+    const parsed = JSON.parse(result) as { error: string; message: string };
+
+    expect(parsed.error).toBe("Failed to get migration status");
+    expect(parsed.message).toBe("connection error");
+  });
+
+  it("handles non-Error thrown values", async () => {
+    vi.stubEnv("DATABASE_URL", "postgresql://localhost/test");
+    vi.mocked(execSync).mockImplementation(() => {
+       
+      throw 42;
+    });
+
+    const result = await dbMigrationStatus();
+    const parsed = JSON.parse(result) as { error: string; message: string };
+
+    expect(parsed.error).toBe("Failed to get migration status");
+    expect(parsed.message).toBe("42");
+  });
+});

--- a/packages/mcp-server/src/tools/deploy_status.test.ts
+++ b/packages/mcp-server/src/tools/deploy_status.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { execSync } from "node:child_process";
+
+vi.mock("node:child_process", () => ({
+  execSync: vi.fn(),
+}));
+
+import { deployStatus } from "./deploy_status.js";
+
+describe("deployStatus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("parses doctl output into structured app list", async () => {
+    vi.mocked(execSync).mockReturnValue(
+      "abc123  my-app  ACTIVE  none\ndef456  other-app  DEPLOYING  DEPLOYING\n"
+    );
+
+    const result = await deployStatus();
+    const parsed = JSON.parse(result) as {
+      apps: Array<{ id: string; name: string; activePhase: string; inProgressPhase: string }>;
+    };
+
+    expect(Array.isArray(parsed.apps)).toBe(true);
+    expect(parsed.apps).toHaveLength(2);
+    expect(parsed.apps[0].id).toBe("abc123");
+    expect(parsed.apps[0].name).toBe("my-app");
+    expect(parsed.apps[0].activePhase).toBe("ACTIVE");
+  });
+
+  it("returns empty apps array when doctl output is empty", async () => {
+    vi.mocked(execSync).mockReturnValue("");
+
+    const result = await deployStatus();
+    const parsed = JSON.parse(result) as { apps: unknown[] };
+
+    expect(parsed.apps).toEqual([]);
+  });
+
+  it("sets inProgressPhase to 'none' when column is absent", async () => {
+    vi.mocked(execSync).mockReturnValue("abc123  my-app  ACTIVE\n");
+
+    const result = await deployStatus();
+    const parsed = JSON.parse(result) as {
+      apps: Array<{ inProgressPhase: string }>;
+    };
+
+    expect(parsed.apps[0].inProgressPhase).toBe("none");
+  });
+
+  it("returns error JSON when doctl command fails", async () => {
+    vi.mocked(execSync).mockImplementation(() => {
+      throw new Error("doctl: not authenticated");
+    });
+
+    const result = await deployStatus();
+    const parsed = JSON.parse(result) as { error: string; message: string };
+
+    expect(parsed.error).toBe("Failed to get deploy status");
+    expect(parsed.message).toBe("doctl: not authenticated");
+  });
+
+  it("returns error JSON when non-Error is thrown", async () => {
+    vi.mocked(execSync).mockImplementation(() => {
+       
+      throw "auth expired";
+    });
+
+    const result = await deployStatus();
+    const parsed = JSON.parse(result) as { error: string; message: string };
+
+    expect(parsed.error).toBe("Failed to get deploy status");
+    expect(parsed.message).toBe("auth expired");
+  });
+
+  it("result is a valid MCP text content string", async () => {
+    vi.mocked(execSync).mockReturnValue("");
+
+    const result = await deployStatus();
+    const mcpContent = [{ type: "text" as const, text: result }];
+
+    expect(mcpContent[0].type).toBe("text");
+    expect(typeof mcpContent[0].text).toBe("string");
+  });
+});

--- a/packages/mcp-server/src/tools/git.test.ts
+++ b/packages/mcp-server/src/tools/git.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { execSync } from "node:child_process";
+
+vi.mock("node:child_process", () => ({
+  execSync: vi.fn(),
+}));
+
+import { gitWorkflowStatus } from "./git.js";
+
+const BRANCH_OUTPUT = "main\n";
+const CLEAN_STATUS = "";
+const DIRTY_STATUS = "M src/index.ts\nA src/new.ts\n";
+const COMMITS_OUTPUT = "abc1234 Fix something\ndef5678 Add feature\n";
+const CI_OUTPUT = JSON.stringify([{ conclusion: "success" }]);
+
+describe("gitWorkflowStatus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns full git status with CI info", async () => {
+    vi.mocked(execSync)
+      .mockReturnValueOnce(BRANCH_OUTPUT)
+      .mockReturnValueOnce(CLEAN_STATUS)
+      .mockReturnValueOnce(COMMITS_OUTPUT)
+      .mockReturnValueOnce(CI_OUTPUT);
+
+    const result = await gitWorkflowStatus();
+    const parsed = JSON.parse(result) as {
+      currentBranch: string;
+      hasUncommittedChanges: boolean;
+      pendingChanges: string[];
+      recentCommits: string[];
+      mainBranchCI: string;
+    };
+
+    expect(parsed.currentBranch).toBe("main");
+    expect(parsed.hasUncommittedChanges).toBe(false);
+    expect(parsed.pendingChanges).toEqual([]);
+    expect(parsed.recentCommits).toContain("abc1234 Fix something");
+    expect(parsed.mainBranchCI).toBe("success");
+  });
+
+  it("reports uncommitted changes when working tree is dirty", async () => {
+    vi.mocked(execSync)
+      .mockReturnValueOnce("feature/my-branch\n")
+      .mockReturnValueOnce(DIRTY_STATUS)
+      .mockReturnValueOnce(COMMITS_OUTPUT)
+      .mockReturnValueOnce(CI_OUTPUT);
+
+    const result = await gitWorkflowStatus();
+    const parsed = JSON.parse(result) as {
+      currentBranch: string;
+      hasUncommittedChanges: boolean;
+      pendingChanges: string[];
+    };
+
+    expect(parsed.currentBranch).toBe("feature/my-branch");
+    expect(parsed.hasUncommittedChanges).toBe(true);
+    expect(parsed.pendingChanges).toContain("M src/index.ts");
+    expect(parsed.pendingChanges).toContain("A src/new.ts");
+  });
+
+  it("returns unknown CI status when gh CLI fails", async () => {
+    vi.mocked(execSync)
+      .mockReturnValueOnce(BRANCH_OUTPUT)
+      .mockReturnValueOnce(CLEAN_STATUS)
+      .mockReturnValueOnce(COMMITS_OUTPUT)
+      .mockImplementationOnce(() => {
+        throw new Error("gh: command not found");
+      });
+
+    const result = await gitWorkflowStatus();
+    const parsed = JSON.parse(result) as { mainBranchCI: string };
+
+    expect(parsed.mainBranchCI).toBe("unknown");
+  });
+
+  it("returns unknown CI when gh returns empty array", async () => {
+    vi.mocked(execSync)
+      .mockReturnValueOnce(BRANCH_OUTPUT)
+      .mockReturnValueOnce(CLEAN_STATUS)
+      .mockReturnValueOnce(COMMITS_OUTPUT)
+      .mockReturnValueOnce("[]");
+
+    const result = await gitWorkflowStatus();
+    const parsed = JSON.parse(result) as { mainBranchCI: string };
+
+    expect(parsed.mainBranchCI).toBe("unknown");
+  });
+
+  it("returns error JSON when git commands fail", async () => {
+    vi.mocked(execSync).mockImplementation(() => {
+      throw new Error("fatal: not a git repository");
+    });
+
+    const result = await gitWorkflowStatus();
+    const parsed = JSON.parse(result) as { error: string; message: string };
+
+    expect(parsed.error).toBe("Failed to get git status");
+    expect(parsed.message).toBe("fatal: not a git repository");
+  });
+
+  it("returns error JSON when non-Error is thrown", async () => {
+    vi.mocked(execSync).mockImplementation(() => {
+       
+      throw { code: 128 };
+    });
+
+    const result = await gitWorkflowStatus();
+    const parsed = JSON.parse(result) as { error: string; message: string };
+
+    expect(parsed.error).toBe("Failed to get git status");
+  });
+
+  it("result is a valid MCP text content string", async () => {
+    vi.mocked(execSync)
+      .mockReturnValueOnce(BRANCH_OUTPUT)
+      .mockReturnValueOnce(CLEAN_STATUS)
+      .mockReturnValueOnce(COMMITS_OUTPUT)
+      .mockReturnValueOnce(CI_OUTPUT);
+
+    const result = await gitWorkflowStatus();
+    const mcpContent = [{ type: "text" as const, text: result }];
+
+    expect(mcpContent[0].type).toBe("text");
+    expect(typeof mcpContent[0].text).toBe("string");
+  });
+});

--- a/packages/mcp-server/src/tools/health.test.ts
+++ b/packages/mcp-server/src/tools/health.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { serviceHealthCheck } from "./health.js";
+
+describe("serviceHealthCheck", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns healthy status for all responsive services", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, status: 200 } as unknown as Response)
+    );
+
+    const result = await serviceHealthCheck();
+    const parsed = JSON.parse(result) as Array<{
+      service: string;
+      status: string;
+      statusCode: number;
+      latencyMs: number;
+    }>;
+
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toHaveLength(3);
+    parsed.forEach((svc) => {
+      expect(svc.status).toBe("healthy");
+      expect(svc.statusCode).toBe(200);
+      expect(typeof svc.latencyMs).toBe("number");
+    });
+  });
+
+  it("returns unhealthy status for non-ok responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 503 } as unknown as Response)
+    );
+
+    const result = await serviceHealthCheck();
+    const parsed = JSON.parse(result) as Array<{ status: string; statusCode: number }>;
+
+    parsed.forEach((svc) => {
+      expect(svc.status).toBe("unhealthy");
+      expect(svc.statusCode).toBe(503);
+    });
+  });
+
+  it("returns unreachable status when fetch throws", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("ECONNREFUSED"))
+    );
+
+    const result = await serviceHealthCheck();
+    const parsed = JSON.parse(result) as Array<{
+      status: string;
+      statusCode: null;
+      latencyMs: null;
+    }>;
+
+    parsed.forEach((svc) => {
+      expect(svc.status).toBe("unreachable");
+      expect(svc.statusCode).toBeNull();
+      expect(svc.latencyMs).toBeNull();
+    });
+  });
+
+  it("includes all three service names in results", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, status: 200 } as unknown as Response)
+    );
+
+    const result = await serviceHealthCheck();
+    const parsed = JSON.parse(result) as Array<{ service: string }>;
+    const serviceNames = parsed.map((r) => r.service);
+
+    expect(serviceNames).toContain("users");
+    expect(serviceNames).toContain("reservations");
+    expect(serviceNames).toContain("agent");
+  });
+
+  it("handles mixed healthy and unreachable services", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, status: 200 } as unknown as Response)
+      .mockRejectedValueOnce(new Error("timeout"))
+      .mockResolvedValueOnce({ ok: false, status: 503 } as unknown as Response);
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await serviceHealthCheck();
+    const parsed = JSON.parse(result) as Array<{ status: string }>;
+
+    expect(parsed[0].status).toBe("healthy");
+    expect(parsed[1].status).toBe("unreachable");
+    expect(parsed[2].status).toBe("unhealthy");
+  });
+
+  it("result is a valid MCP text content string", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("offline"))
+    );
+
+    const result = await serviceHealthCheck();
+    const mcpContent = [{ type: "text" as const, text: result }];
+
+    expect(mcpContent[0].type).toBe("text");
+    expect(typeof mcpContent[0].text).toBe("string");
+    expect(() => JSON.parse(result)).not.toThrow();
+  });
+});

--- a/packages/mcp-server/src/tools/logs.test.ts
+++ b/packages/mcp-server/src/tools/logs.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGlob = vi.hoisted(() => vi.fn<(pattern: string) => Promise<string[]>>());
+const mockReadFile = vi.hoisted(() => vi.fn<() => Promise<string>>());
+
+vi.mock("glob", () => ({
+  glob: mockGlob,
+}));
+
+vi.mock("node:fs/promises", () => ({
+  readFile: mockReadFile,
+}));
+
+import { checkLogs } from "./logs.js";
+
+describe("checkLogs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 'No log files found.' when glob finds no files", async () => {
+    mockGlob.mockResolvedValue([]);
+
+    const result = await checkLogs();
+
+    expect(result).toBe("No log files found.");
+  });
+
+  it("returns 'No log files found.' when called with a service and no files found", async () => {
+    mockGlob.mockResolvedValue([]);
+
+    const result = await checkLogs("users");
+
+    expect(result).toBe("No log files found.");
+  });
+
+  it("passes service name into glob path when service is provided", async () => {
+    mockGlob.mockResolvedValue([]);
+
+    await checkLogs("users");
+
+    const calledWith = mockGlob.mock.calls[0]?.[0] as string;
+    expect(calledWith).toContain("users");
+  });
+
+  it("uses wildcard glob path when no service is provided", async () => {
+    mockGlob.mockResolvedValue([]);
+
+    await checkLogs();
+
+    const calledWith = mockGlob.mock.calls[0]?.[0] as string;
+    expect(calledWith).toContain("*");
+  });
+
+  it("returns formatted log content for found files", async () => {
+    mockGlob.mockResolvedValue(["services/users/logs/app.log"]);
+    mockReadFile.mockResolvedValue(
+      "2024-01-01 info: server started\n2024-01-01 info: request received\n"
+    );
+
+    const result = await checkLogs();
+
+    expect(result).toContain("Recent Logs:");
+    expect(result).toContain("services/users/logs/app.log");
+    expect(result).toContain("server started");
+  });
+
+  it("limits output to the last 20 lines per file", async () => {
+    mockGlob.mockResolvedValue(["services/users/logs/app.log"]);
+    const lines = Array.from({ length: 30 }, (_, i) => `line ${i + 1}`).join("\n");
+    mockReadFile.mockResolvedValue(lines);
+
+    const result = await checkLogs();
+
+    expect(result).toContain("line 30");
+    expect(result).toContain("line 11");
+    expect(result).not.toContain("line 1\n");
+  });
+
+  it("reads at most 3 files when more are available", async () => {
+    const files = [
+      "services/users/logs/app1.log",
+      "services/users/logs/app2.log",
+      "services/users/logs/app3.log",
+      "services/users/logs/app4.log",
+    ];
+    mockGlob.mockResolvedValue(files);
+    mockReadFile.mockResolvedValue("log line\n");
+
+    await checkLogs();
+
+    expect(mockReadFile).toHaveBeenCalledTimes(3);
+  });
+
+  it("includes file path as section header in output", async () => {
+    mockGlob.mockResolvedValue(["services/agent/logs/server.log"]);
+    mockReadFile.mockResolvedValue("startup complete\n");
+
+    const result = await checkLogs();
+
+    expect(result).toContain("--- services/agent/logs/server.log ---");
+  });
+
+  it("result can be used as MCP text content", async () => {
+    mockGlob.mockResolvedValue([]);
+
+    const result = await checkLogs();
+    const mcpContent = [{ type: "text" as const, text: result }];
+
+    expect(mcpContent[0].type).toBe("text");
+    expect(typeof mcpContent[0].text).toBe("string");
+  });
+});

--- a/packages/mcp-server/src/tools/pulumi.test.ts
+++ b/packages/mcp-server/src/tools/pulumi.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { execSync } from "node:child_process";
+
+vi.mock("node:child_process", () => ({
+  execSync: vi.fn(),
+}));
+
+import { pulumiStackOutputs } from "./pulumi.js";
+
+describe("pulumiStackOutputs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns raw stack output string from pulumi CLI", async () => {
+    const outputs = JSON.stringify({
+      apiUrl: "https://api.example.com",
+      dbHost: "db.example.com",
+    });
+    vi.mocked(execSync).mockReturnValue(outputs);
+
+    const result = await pulumiStackOutputs();
+
+    expect(result).toBe(outputs);
+  });
+
+  it("passes the correct pulumi command to execSync", async () => {
+    vi.mocked(execSync).mockReturnValue("{}");
+
+    await pulumiStackOutputs();
+
+    expect(vi.mocked(execSync)).toHaveBeenCalledWith(
+      "pulumi stack output --json",
+      expect.objectContaining({ encoding: "utf-8", timeout: 30000 })
+    );
+  });
+
+  it("result can be used directly as MCP text content", async () => {
+    const outputs = '{"key": "value"}';
+    vi.mocked(execSync).mockReturnValue(outputs);
+
+    const result = await pulumiStackOutputs();
+    const mcpContent = [{ type: "text" as const, text: result }];
+
+    expect(mcpContent[0].type).toBe("text");
+    expect(mcpContent[0].text).toBe(outputs);
+  });
+
+  it("returns error JSON when pulumi command fails", async () => {
+    vi.mocked(execSync).mockImplementation(() => {
+      throw new Error("pulumi: stack not found");
+    });
+
+    const result = await pulumiStackOutputs();
+    const parsed = JSON.parse(result) as { error: string; message: string };
+
+    expect(parsed.error).toBe("Failed to get Pulumi outputs");
+    expect(parsed.message).toBe("pulumi: stack not found");
+  });
+
+  it("returns error JSON when non-Error is thrown", async () => {
+    vi.mocked(execSync).mockImplementation(() => {
+       
+      throw "exit code 1";
+    });
+
+    const result = await pulumiStackOutputs();
+    const parsed = JSON.parse(result) as { error: string; message: string };
+
+    expect(parsed.error).toBe("Failed to get Pulumi outputs");
+    expect(parsed.message).toBe("exit code 1");
+  });
+
+  it("handles empty stack output", async () => {
+    vi.mocked(execSync).mockReturnValue("{}");
+
+    const result = await pulumiStackOutputs();
+
+    expect(result).toBe("{}");
+  });
+
+  it("applies 30 second timeout to pulumi command", async () => {
+    vi.mocked(execSync).mockReturnValue("{}");
+
+    await pulumiStackOutputs();
+
+    expect(vi.mocked(execSync)).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ timeout: 30000 })
+    );
+  });
+});

--- a/packages/mcp-server/vitest.config.ts
+++ b/packages/mcp-server/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+      include: ["src/tools/**/*.ts"],
+      exclude: ["**/*.test.ts"],
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        statements: 80,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -630,12 +630,18 @@ importers:
       '@types/pg':
         specifier: ^8.20.0
         version: 8.20.0
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.5(@vitest/browser@4.1.5)(vitest@4.1.5)
       tsx:
         specifier: ^4.19.0
         version: 4.21.0
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/observability:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds `vitest.config.ts` for `packages/mcp-server`
- Adds `.test.ts` files for all 7 previously untested tool modules: `ci.ts`, `database.ts`, `deploy_status.ts`, `git.ts`, `health.ts`, `logs.ts`, `pulumi.ts`
- 50 tests across 7 files — all external calls (`execSync`, `fetch`, `readFile`, `glob`) fully mocked so tests run offline
- ≥80% line coverage per file
- Updates `packages/mcp-server/package.json` to add vitest test script

## Test plan

- [x] `pnpm --dir packages/mcp-server test` — 50 tests pass
- [x] All external calls mocked (no real infrastructure hit)
- [ ] CI passes

Closes #1118

https://claude.ai/code/session_01EyhadhzHKaaYThFPEZuaxS

---
_Generated by [Claude Code](https://claude.ai/code/session_01EyhadhzHKaaYThFPEZuaxS)_