### PR TITLE
test(observability): add integration module tests (#1116)

### DIFF
--- a/packages/observability/src/baggage.test.ts
+++ b/packages/observability/src/baggage.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Use vi.hoisted so variables are available inside the vi.mock factory (which is hoisted)
+const { mockSetBaggage, mockGetBaggage, mockCreateBaggage, mockContextActive } = vi.hoisted(
+  () => ({
+    mockSetBaggage: vi.fn(),
+    mockGetBaggage: vi.fn(),
+    mockCreateBaggage: vi.fn(),
+    mockContextActive: vi.fn(),
+  }),
+);
+
+vi.mock("@opentelemetry/api", () => {
+  return {
+    propagation: {
+      createBaggage: mockCreateBaggage,
+      setBaggage: mockSetBaggage,
+      getBaggage: mockGetBaggage,
+    },
+    context: {
+      active: mockContextActive,
+    },
+  };
+});
+
+import {
+  createBaggageContext,
+  extractAgentBaggage,
+  BAGGAGE_KEYS,
+} from "./baggage.js";
+
+describe("BAGGAGE_KEYS", () => {
+  it("exposes expected key constants", () => {
+    expect(BAGGAGE_KEYS.SESSION_ID).toBe("agent.session_id");
+    expect(BAGGAGE_KEYS.PR_NUMBER).toBe("agent.pr_number");
+    expect(BAGGAGE_KEYS.ISSUE_NUMBER).toBe("agent.issue_number");
+    expect(BAGGAGE_KEYS.DEPLOY_SHA).toBe("deploy.sha");
+  });
+});
+
+describe("createBaggageContext", () => {
+  const fakeActiveContext = Symbol("active-ctx");
+  const fakeBaggageInstance = Symbol("baggage-instance");
+  const fakeEnrichedContext = Symbol("enriched-ctx");
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockContextActive.mockReturnValue(fakeActiveContext);
+    mockCreateBaggage.mockReturnValue(fakeBaggageInstance);
+    mockSetBaggage.mockReturnValue(fakeEnrichedContext);
+  });
+
+  it("returns the enriched context from propagation.setBaggage", () => {
+    const result = createBaggageContext({ sessionId: "abc" });
+    expect(result).toBe(fakeEnrichedContext);
+  });
+
+  it("calls propagation.createBaggage with sessionId entry", () => {
+    createBaggageContext({ sessionId: "sess-123" });
+
+    expect(mockCreateBaggage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        [BAGGAGE_KEYS.SESSION_ID]: { value: "sess-123" },
+      }),
+    );
+  });
+
+  it("calls propagation.createBaggage with prNumber entry", () => {
+    createBaggageContext({ prNumber: "42" });
+
+    expect(mockCreateBaggage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        [BAGGAGE_KEYS.PR_NUMBER]: { value: "42" },
+      }),
+    );
+  });
+
+  it("calls propagation.createBaggage with issueNumber entry", () => {
+    createBaggageContext({ issueNumber: "99" });
+
+    expect(mockCreateBaggage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        [BAGGAGE_KEYS.ISSUE_NUMBER]: { value: "99" },
+      }),
+    );
+  });
+
+  it("calls propagation.createBaggage with deploySha entry", () => {
+    createBaggageContext({ deploySha: "deadbeef" });
+
+    expect(mockCreateBaggage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        [BAGGAGE_KEYS.DEPLOY_SHA]: { value: "deadbeef" },
+      }),
+    );
+  });
+
+  it("includes all fields when all are provided", () => {
+    createBaggageContext({
+      sessionId: "s1",
+      prNumber: "10",
+      issueNumber: "20",
+      deploySha: "abc123",
+    });
+
+    expect(mockCreateBaggage).toHaveBeenCalledWith({
+      [BAGGAGE_KEYS.SESSION_ID]: { value: "s1" },
+      [BAGGAGE_KEYS.PR_NUMBER]: { value: "10" },
+      [BAGGAGE_KEYS.ISSUE_NUMBER]: { value: "20" },
+      [BAGGAGE_KEYS.DEPLOY_SHA]: { value: "abc123" },
+    });
+  });
+
+  it("omits undefined fields from baggage entries", () => {
+    createBaggageContext({ sessionId: "s1" });
+
+    const calledWith = mockCreateBaggage.mock.calls[0][0] as Record<string, unknown>;
+    expect(Object.keys(calledWith)).toEqual([BAGGAGE_KEYS.SESSION_ID]);
+  });
+
+  it("creates empty baggage when bag is empty", () => {
+    createBaggageContext({});
+
+    expect(mockCreateBaggage).toHaveBeenCalledWith({});
+  });
+
+  it("calls setBaggage with active context and the baggage instance", () => {
+    createBaggageContext({ sessionId: "s1" });
+
+    expect(mockSetBaggage).toHaveBeenCalledWith(fakeActiveContext, fakeBaggageInstance);
+  });
+});
+
+describe("extractAgentBaggage", () => {
+  const fakeActiveContext = Symbol("active-ctx");
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockContextActive.mockReturnValue(fakeActiveContext);
+  });
+
+  it("returns empty object when no baggage in context", () => {
+    mockGetBaggage.mockReturnValue(null);
+
+    const result = extractAgentBaggage();
+    expect(result).toEqual({});
+  });
+
+  it("returns empty object when baggage is undefined", () => {
+    mockGetBaggage.mockReturnValue(undefined);
+
+    const result = extractAgentBaggage();
+    expect(result).toEqual({});
+  });
+
+  it("extracts sessionId from baggage", () => {
+    const mockBaggage = {
+      getEntry: vi.fn((key: string) => {
+        if (key === BAGGAGE_KEYS.SESSION_ID) return { value: "session-xyz" };
+        return undefined;
+      }),
+    };
+    mockGetBaggage.mockReturnValue(mockBaggage);
+
+    const result = extractAgentBaggage();
+    expect(result.sessionId).toBe("session-xyz");
+  });
+
+  it("extracts prNumber from baggage", () => {
+    const mockBaggage = {
+      getEntry: vi.fn((key: string) => {
+        if (key === BAGGAGE_KEYS.PR_NUMBER) return { value: "55" };
+        return undefined;
+      }),
+    };
+    mockGetBaggage.mockReturnValue(mockBaggage);
+
+    const result = extractAgentBaggage();
+    expect(result.prNumber).toBe("55");
+  });
+
+  it("extracts issueNumber from baggage", () => {
+    const mockBaggage = {
+      getEntry: vi.fn((key: string) => {
+        if (key === BAGGAGE_KEYS.ISSUE_NUMBER) return { value: "100" };
+        return undefined;
+      }),
+    };
+    mockGetBaggage.mockReturnValue(mockBaggage);
+
+    const result = extractAgentBaggage();
+    expect(result.issueNumber).toBe("100");
+  });
+
+  it("extracts deploySha from baggage", () => {
+    const mockBaggage = {
+      getEntry: vi.fn((key: string) => {
+        if (key === BAGGAGE_KEYS.DEPLOY_SHA) return { value: "sha-abc" };
+        return undefined;
+      }),
+    };
+    mockGetBaggage.mockReturnValue(mockBaggage);
+
+    const result = extractAgentBaggage();
+    expect(result.deploySha).toBe("sha-abc");
+  });
+
+  it("extracts all fields when all are present", () => {
+    const entries: Record<string, { value: string }> = {
+      [BAGGAGE_KEYS.SESSION_ID]: { value: "s1" },
+      [BAGGAGE_KEYS.PR_NUMBER]: { value: "10" },
+      [BAGGAGE_KEYS.ISSUE_NUMBER]: { value: "20" },
+      [BAGGAGE_KEYS.DEPLOY_SHA]: { value: "sha999" },
+    };
+    const mockBaggage = {
+      getEntry: vi.fn((key: string) => entries[key]),
+    };
+    mockGetBaggage.mockReturnValue(mockBaggage);
+
+    const result = extractAgentBaggage();
+    expect(result).toEqual({
+      sessionId: "s1",
+      prNumber: "10",
+      issueNumber: "20",
+      deploySha: "sha999",
+    });
+  });
+
+  it("returns undefined fields when baggage entries are absent", () => {
+    const mockBaggage = {
+      getEntry: vi.fn(() => undefined),
+    };
+    mockGetBaggage.mockReturnValue(mockBaggage);
+
+    const result = extractAgentBaggage();
+    expect(result.sessionId).toBeUndefined();
+    expect(result.prNumber).toBeUndefined();
+    expect(result.issueNumber).toBeUndefined();
+    expect(result.deploySha).toBeUndefined();
+  });
+
+  it("calls getBaggage with active context", () => {
+    mockGetBaggage.mockReturnValue(null);
+    extractAgentBaggage();
+
+    expect(mockGetBaggage).toHaveBeenCalledWith(fakeActiveContext);
+  });
+});

--- a/packages/observability/src/error-rates.test.ts
+++ b/packages/observability/src/error-rates.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createErrorRateTracker } from "./error-rates.js";
+
+describe("createErrorRateTracker", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns empty snapshot when no requests recorded", () => {
+    const tracker = createErrorRateTracker();
+    const snap = tracker.snapshot();
+
+    expect(snap.endpoints).toEqual([]);
+    expect(snap.degraded).toBe(false);
+  });
+
+  it("records a successful request (2xx) with isError=false", () => {
+    const tracker = createErrorRateTracker();
+
+    tracker.record("/api/v1/users", 200);
+
+    const snap = tracker.snapshot();
+    expect(snap.endpoints).toHaveLength(1);
+    expect(snap.endpoints[0].endpoint).toBe("/api/v1/users");
+    expect(snap.endpoints[0].total).toBe(1);
+    expect(snap.endpoints[0].errors).toBe(0);
+    expect(snap.endpoints[0].rate).toBe(0);
+  });
+
+  it("records an error request (4xx/5xx) with isError=true", () => {
+    const tracker = createErrorRateTracker();
+
+    tracker.record("/api/v1/reservations", 500);
+
+    const snap = tracker.snapshot();
+    expect(snap.endpoints[0].errors).toBe(1);
+    expect(snap.endpoints[0].total).toBe(1);
+    expect(snap.endpoints[0].rate).toBe(1);
+  });
+
+  it("treats status >= 400 as an error", () => {
+    const tracker = createErrorRateTracker();
+    [400, 401, 403, 404, 422, 500, 503].forEach((code) => {
+      tracker.record(`/api/${code}`, code);
+    });
+
+    const snap = tracker.snapshot();
+    for (const ep of snap.endpoints) {
+      expect(ep.errors).toBe(1);
+    }
+  });
+
+  it("treats status < 400 as success", () => {
+    const tracker = createErrorRateTracker();
+    [200, 201, 204, 301, 302, 304, 399].forEach((code) => {
+      tracker.record(`/api/${code}`, code);
+    });
+
+    const snap = tracker.snapshot();
+    for (const ep of snap.endpoints) {
+      expect(ep.errors).toBe(0);
+    }
+  });
+
+  it("calculates error rate correctly", () => {
+    const tracker = createErrorRateTracker();
+
+    // 2 errors out of 4 requests = 0.5 rate
+    tracker.record("/api/v1/tables", 200);
+    tracker.record("/api/v1/tables", 200);
+    tracker.record("/api/v1/tables", 500);
+    tracker.record("/api/v1/tables", 500);
+
+    const snap = tracker.snapshot();
+    expect(snap.endpoints[0].rate).toBe(0.5);
+    expect(snap.endpoints[0].total).toBe(4);
+    expect(snap.endpoints[0].errors).toBe(2);
+  });
+
+  it("rounds error rate to 3 decimal places", () => {
+    const tracker = createErrorRateTracker();
+
+    // 1 error out of 3 = 0.333...
+    tracker.record("/api/v1/users", 500);
+    tracker.record("/api/v1/users", 200);
+    tracker.record("/api/v1/users", 200);
+
+    const snap = tracker.snapshot();
+    expect(snap.endpoints[0].rate).toBe(0.333);
+  });
+
+  it("tracks multiple endpoints independently", () => {
+    const tracker = createErrorRateTracker();
+
+    tracker.record("/api/v1/users", 200);
+    tracker.record("/api/v1/users", 500);
+    tracker.record("/api/v1/reservations", 200);
+    tracker.record("/api/v1/reservations", 200);
+
+    const snap = tracker.snapshot();
+    expect(snap.endpoints).toHaveLength(2);
+
+    const users = snap.endpoints.find((e) => e.endpoint === "/api/v1/users");
+    const reservations = snap.endpoints.find((e) => e.endpoint === "/api/v1/reservations");
+
+    expect(users!.rate).toBe(0.5);
+    expect(reservations!.rate).toBe(0);
+  });
+
+  it("marks degraded=true when error rate exceeds 10% with >= 5 requests", () => {
+    const tracker = createErrorRateTracker();
+
+    // 2 errors out of 10 = 20% > 10% threshold
+    for (let i = 0; i < 8; i++) {
+      tracker.record("/api/v1/users", 200);
+    }
+    tracker.record("/api/v1/users", 500);
+    tracker.record("/api/v1/users", 500);
+
+    const snap = tracker.snapshot();
+    expect(snap.degraded).toBe(true);
+  });
+
+  it("does NOT mark degraded when error rate is exactly 10%", () => {
+    const tracker = createErrorRateTracker();
+
+    // 1 error out of 10 = 10% — exactly at threshold, not above
+    for (let i = 0; i < 9; i++) {
+      tracker.record("/api/v1/users", 200);
+    }
+    tracker.record("/api/v1/users", 500);
+
+    const snap = tracker.snapshot();
+    expect(snap.degraded).toBe(false);
+  });
+
+  it("does NOT mark degraded when high error rate but fewer than 5 requests", () => {
+    const tracker = createErrorRateTracker();
+
+    // 3 errors out of 4 = 75% — but only 4 requests (< 5 minimum)
+    tracker.record("/api/v1/users", 500);
+    tracker.record("/api/v1/users", 500);
+    tracker.record("/api/v1/users", 500);
+    tracker.record("/api/v1/users", 200);
+
+    const snap = tracker.snapshot();
+    expect(snap.degraded).toBe(false);
+  });
+
+  it("prunes requests older than 5-minute window", () => {
+    const tracker = createErrorRateTracker();
+
+    tracker.record("/api/v1/users", 500);
+
+    // Advance past the 5-minute window
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+
+    const snap = tracker.snapshot();
+    expect(snap.endpoints).toHaveLength(0);
+  });
+
+  it("removes endpoint entry entirely when all records are pruned", () => {
+    const tracker = createErrorRateTracker();
+
+    tracker.record("/api/v1/users", 200);
+    tracker.record("/api/v1/users", 500);
+
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+
+    const snap = tracker.snapshot();
+    expect(snap.endpoints).toHaveLength(0);
+    expect(snap.degraded).toBe(false);
+  });
+
+  it("keeps recent records while pruning old ones", () => {
+    const tracker = createErrorRateTracker();
+
+    // Record old error
+    tracker.record("/api/v1/users", 500);
+
+    // Advance 4 minutes
+    vi.advanceTimersByTime(4 * 60 * 1000);
+
+    // Record new success
+    tracker.record("/api/v1/users", 200);
+
+    // Advance another 1.5 minutes (total 5.5 minutes — old record is pruned)
+    vi.advanceTimersByTime(1.5 * 60 * 1000);
+
+    const snap = tracker.snapshot();
+    // Only the recent success should remain
+    expect(snap.endpoints).toHaveLength(1);
+    expect(snap.endpoints[0].total).toBe(1);
+    expect(snap.endpoints[0].errors).toBe(0);
+  });
+
+  it("sorts endpoints by error rate descending", () => {
+    const tracker = createErrorRateTracker();
+
+    // low error rate
+    tracker.record("/api/v1/users", 200);
+    tracker.record("/api/v1/users", 200);
+    tracker.record("/api/v1/users", 500);
+
+    // high error rate
+    tracker.record("/api/v1/critical", 500);
+    tracker.record("/api/v1/critical", 500);
+    tracker.record("/api/v1/critical", 200);
+
+    // zero error rate
+    tracker.record("/api/v1/health", 200);
+
+    const snap = tracker.snapshot();
+    const rates = snap.endpoints.map((e) => e.rate);
+    expect(rates[0]).toBeGreaterThanOrEqual(rates[1]);
+    expect(rates[1]).toBeGreaterThanOrEqual(rates[2]);
+  });
+});

--- a/packages/observability/src/request-id.test.ts
+++ b/packages/observability/src/request-id.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi } from "vitest";
+import { createRequestIdMiddleware, getRequestId, logWithRequestId } from "./request-id.js";
+
+// We test the plugin logic by directly interacting with the plugin's hook callbacks.
+// fastify-plugin just registers the plugin function, so we simulate it inline.
+
+describe("createRequestIdMiddleware", () => {
+  it("returns a plugin function (fastify-plugin wrapped)", () => {
+    const plugin = createRequestIdMiddleware();
+    expect(typeof plugin).toBe("function");
+  });
+
+  it("uses default header name x-request-id", async () => {
+    const plugin = createRequestIdMiddleware();
+    const hooks: Record<string, ((req: Record<string, unknown>) => Promise<void>)[]> = {};
+
+    const fakeFastify = {
+      addHook: vi.fn((hookName: string, fn: (req: Record<string, unknown>) => Promise<void>) => {
+        hooks[hookName] = hooks[hookName] ?? [];
+        hooks[hookName].push(fn);
+      }),
+    };
+
+    // Invoke the inner function directly (fp wraps but calls the fn as-is in tests)
+    await (plugin as unknown as (f: typeof fakeFastify) => Promise<void>)(fakeFastify);
+    expect(fakeFastify.addHook).toHaveBeenCalledWith("onRequest", expect.any(Function));
+  });
+
+  it("uses incoming x-request-id header when present", async () => {
+    const plugin = createRequestIdMiddleware();
+    let capturedHook: ((req: Record<string, unknown>) => Promise<void>) | undefined;
+
+    const fakeFastify = {
+      addHook: vi.fn((_: string, fn: (req: Record<string, unknown>) => Promise<void>) => {
+        capturedHook = fn;
+      }),
+    };
+
+    await (plugin as unknown as (f: typeof fakeFastify) => Promise<void>)(fakeFastify);
+
+    const fakeRequest: Record<string, unknown> = {
+      headers: { "x-request-id": "my-custom-id" },
+      id: "",
+    };
+
+    await capturedHook!(fakeRequest);
+    expect(fakeRequest.id).toBe("my-custom-id");
+  });
+
+  it("generates a UUID when no x-request-id header present", async () => {
+    const plugin = createRequestIdMiddleware();
+    let capturedHook: ((req: Record<string, unknown>) => Promise<void>) | undefined;
+
+    const fakeFastify = {
+      addHook: vi.fn((_: string, fn: (req: Record<string, unknown>) => Promise<void>) => {
+        capturedHook = fn;
+      }),
+    };
+
+    await (plugin as unknown as (f: typeof fakeFastify) => Promise<void>)(fakeFastify);
+
+    const fakeRequest: Record<string, unknown> = {
+      headers: {},
+      id: "",
+    };
+
+    await capturedHook!(fakeRequest);
+    expect(typeof fakeRequest.id).toBe("string");
+    // UUID v4 pattern
+    expect(fakeRequest.id as string).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  it("generates a UUID when x-request-id header is empty string", async () => {
+    const plugin = createRequestIdMiddleware();
+    let capturedHook: ((req: Record<string, unknown>) => Promise<void>) | undefined;
+
+    const fakeFastify = {
+      addHook: vi.fn((_: string, fn: (req: Record<string, unknown>) => Promise<void>) => {
+        capturedHook = fn;
+      }),
+    };
+
+    await (plugin as unknown as (f: typeof fakeFastify) => Promise<void>)(fakeFastify);
+
+    const fakeRequest: Record<string, unknown> = {
+      headers: { "x-request-id": "" },
+      id: "",
+    };
+
+    await capturedHook!(fakeRequest);
+    expect(fakeRequest.id as string).toMatch(/^[0-9a-f]{8}-/i);
+  });
+
+  it("respects a custom headerName option", async () => {
+    const plugin = createRequestIdMiddleware({ headerName: "x-trace-id" });
+    let capturedHook: ((req: Record<string, unknown>) => Promise<void>) | undefined;
+
+    const fakeFastify = {
+      addHook: vi.fn((_: string, fn: (req: Record<string, unknown>) => Promise<void>) => {
+        capturedHook = fn;
+      }),
+    };
+
+    await (plugin as unknown as (f: typeof fakeFastify) => Promise<void>)(fakeFastify);
+
+    const fakeRequest: Record<string, unknown> = {
+      headers: { "x-trace-id": "trace-abc-123" },
+      id: "",
+    };
+
+    await capturedHook!(fakeRequest);
+    expect(fakeRequest.id).toBe("trace-abc-123");
+  });
+
+  it("uses a custom generator function when provided", async () => {
+    const customGenerator = vi.fn().mockReturnValue("custom-id-xyz");
+    const plugin = createRequestIdMiddleware({ generator: customGenerator });
+    let capturedHook: ((req: Record<string, unknown>) => Promise<void>) | undefined;
+
+    const fakeFastify = {
+      addHook: vi.fn((_: string, fn: (req: Record<string, unknown>) => Promise<void>) => {
+        capturedHook = fn;
+      }),
+    };
+
+    await (plugin as unknown as (f: typeof fakeFastify) => Promise<void>)(fakeFastify);
+
+    const fakeRequest: Record<string, unknown> = {
+      headers: {},
+      id: "",
+    };
+
+    await capturedHook!(fakeRequest);
+    expect(customGenerator).toHaveBeenCalledTimes(1);
+    expect(fakeRequest.id).toBe("custom-id-xyz");
+  });
+
+  it("ignores x-request-id when custom headerName is set", async () => {
+    const plugin = createRequestIdMiddleware({ headerName: "x-trace-id" });
+    let capturedHook: ((req: Record<string, unknown>) => Promise<void>) | undefined;
+
+    const fakeFastify = {
+      addHook: vi.fn((_: string, fn: (req: Record<string, unknown>) => Promise<void>) => {
+        capturedHook = fn;
+      }),
+    };
+
+    await (plugin as unknown as (f: typeof fakeFastify) => Promise<void>)(fakeFastify);
+
+    const fakeRequest: Record<string, unknown> = {
+      headers: { "x-request-id": "should-be-ignored", "x-trace-id": "from-trace" },
+      id: "",
+    };
+
+    await capturedHook!(fakeRequest);
+    expect(fakeRequest.id).toBe("from-trace");
+  });
+});
+
+describe("getRequestId", () => {
+  it("returns request.id when it exists", () => {
+    expect(getRequestId({ id: "req-123" })).toBe("req-123");
+  });
+
+  it("returns 'unknown' when id is undefined", () => {
+    expect(getRequestId({})).toBe("unknown");
+  });
+
+  it("returns 'unknown' when id is explicitly undefined", () => {
+    expect(getRequestId({ id: undefined })).toBe("unknown");
+  });
+});
+
+describe("logWithRequestId", () => {
+  it("calls logger.info with message and merged context including requestId", () => {
+    const logger = { info: vi.fn() };
+    logWithRequestId(logger, "req-abc", "User logged in", { userId: "u1" });
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith("User logged in", {
+      userId: "u1",
+      requestId: "req-abc",
+    });
+  });
+
+  it("works with empty context (defaults to {})", () => {
+    const logger = { info: vi.fn() };
+    logWithRequestId(logger, "req-xyz", "Health check");
+
+    expect(logger.info).toHaveBeenCalledWith("Health check", { requestId: "req-xyz" });
+  });
+
+  it("does not mutate the original context object", () => {
+    const logger = { info: vi.fn() };
+    const ctx = { key: "value" };
+    const original = { ...ctx };
+
+    logWithRequestId(logger, "req-1", "Test", ctx);
+
+    expect(ctx).toEqual(original);
+  });
+});

--- a/packages/observability/src/sentry/node.test.ts
+++ b/packages/observability/src/sentry/node.test.ts
@@ -1,0 +1,433 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockSentryInit, mockWithScope, mockCaptureException, mockCaptureMessage } = vi.hoisted(
+  () => ({
+    mockSentryInit: vi.fn(),
+    mockWithScope: vi.fn(),
+    mockCaptureException: vi.fn(),
+    mockCaptureMessage: vi.fn(),
+  }),
+);
+
+vi.mock("@sentry/node", () => ({
+  init: mockSentryInit,
+  withScope: mockWithScope,
+  captureException: mockCaptureException,
+  captureMessage: mockCaptureMessage,
+}));
+
+vi.mock("@mbe/types", () => ({
+  createProblemDetails: vi.fn(
+    (status: number, title: string, message: string, type: string, instance: string) => ({
+      status,
+      title,
+      detail: message,
+      type,
+      instance,
+    }),
+  ),
+}));
+
+import { initSentry } from "./node.js";
+
+// Helper to build a fake Fastify instance for plugin testing
+function buildFakeFastify() {
+  const hooks: Record<string, ((...args: unknown[]) => unknown)[]> = {};
+  let errorHandler: ((err: unknown, req: unknown, reply: unknown) => void) | null = null;
+
+  const fastify = {
+    addHook: vi.fn((hookName: string, fn: (...args: unknown[]) => unknown) => {
+      hooks[hookName] = hooks[hookName] ?? [];
+      hooks[hookName].push(fn);
+    }),
+    setErrorHandler: vi.fn((fn: (err: unknown, req: unknown, reply: unknown) => void) => {
+      errorHandler = fn;
+    }),
+    getErrorHandler: () => errorHandler,
+    getHook: (name: string) => hooks[name] ?? [],
+  };
+
+  return fastify;
+}
+
+function buildFakeRequest(overrides: Record<string, unknown> = {}) {
+  return {
+    method: "GET",
+    url: "/api/v1/test",
+    id: "req-123",
+    headers: {},
+    ...overrides,
+  };
+}
+
+function buildFakeReply(statusCode = 200) {
+  const reply = {
+    statusCode,
+    status: vi.fn().mockReturnThis(),
+    send: vi.fn(),
+    __sentryErrorCaptured: false,
+  };
+  return reply;
+}
+
+describe("initSentry (node)", () => {
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    savedEnv.SENTRY_DSN = process.env.SENTRY_DSN;
+    savedEnv.NODE_ENV = process.env.NODE_ENV;
+    savedEnv.SENTRY_ENVIRONMENT = process.env.SENTRY_ENVIRONMENT;
+    delete process.env.SENTRY_DSN;
+    delete process.env.NODE_ENV;
+    delete process.env.SENTRY_ENVIRONMENT;
+  });
+
+  afterEach(() => {
+    for (const [key, val] of Object.entries(savedEnv)) {
+      if (val === undefined) delete process.env[key];
+      else process.env[key] = val;
+    }
+  });
+
+  it("does NOT call Sentry.init when SENTRY_DSN is unset", () => {
+    initSentry({ serviceName: "my-service" });
+    expect(mockSentryInit).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call Sentry.init when SENTRY_DSN is empty string", () => {
+    process.env.SENTRY_DSN = "";
+    initSentry({ serviceName: "my-service" });
+    expect(mockSentryInit).not.toHaveBeenCalled();
+  });
+
+  it("calls Sentry.init with correct config when DSN is set", () => {
+    process.env.SENTRY_DSN = "https://key@sentry.io/123";
+    process.env.NODE_ENV = "production";
+
+    initSentry({ serviceName: "my-service" });
+
+    expect(mockSentryInit).toHaveBeenCalledTimes(1);
+    const callArg = mockSentryInit.mock.calls[0][0];
+    expect(callArg.dsn).toBe("https://key@sentry.io/123");
+    expect(callArg.serverName).toBe("my-service");
+    expect(callArg.environment).toBe("production");
+    expect(callArg.skipOpenTelemetrySetup).toBe(true);
+    expect(callArg.tracesSampleRate).toBe(0);
+  });
+});
+
+describe("sentryFastifyPlugin", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function setupPlugin(dsn: string | undefined) {
+    // We dynamically re-import to get a fresh reference each time for env isolation
+    vi.stubEnv("SENTRY_DSN", dsn ?? "");
+    const { sentryFastifyPlugin } = await import("./node.js");
+    const fakeFastify = buildFakeFastify();
+
+    // The plugin is wrapped by fastify-plugin; call the inner fn directly
+    await (sentryFastifyPlugin as unknown as (f: typeof fakeFastify) => Promise<void>)(fakeFastify);
+
+    return fakeFastify;
+  }
+
+  it("registers no hooks when DSN is not set", async () => {
+    const fakeFastify = await setupPlugin(undefined);
+    expect(fakeFastify.setErrorHandler).not.toHaveBeenCalled();
+    expect(fakeFastify.addHook).not.toHaveBeenCalled();
+  });
+
+  it("sets an error handler when DSN is configured", async () => {
+    const fakeFastify = await setupPlugin("https://key@sentry.io/123");
+    expect(fakeFastify.setErrorHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers an onResponse hook when DSN is configured", async () => {
+    const fakeFastify = await setupPlugin("https://key@sentry.io/123");
+    expect(fakeFastify.addHook).toHaveBeenCalledWith("onResponse", expect.any(Function));
+  });
+
+  describe("error handler", () => {
+    it("captures exception with Sentry and sends problem details response", async () => {
+      const fakeFastify = await setupPlugin("https://key@sentry.io/123");
+      const errorHandler = fakeFastify.getErrorHandler()!;
+
+      const fakeScope = {
+        setTag: vi.fn(),
+        setUser: vi.fn(),
+        setLevel: vi.fn(),
+      };
+      mockWithScope.mockImplementation((fn: (scope: typeof fakeScope) => void) => fn(fakeScope));
+
+      const error = Object.assign(new Error("Something broke"), { statusCode: 500 });
+      const request = buildFakeRequest();
+      const reply = buildFakeReply(500);
+
+      errorHandler(error, request, reply);
+
+      expect(mockWithScope).toHaveBeenCalledTimes(1);
+      expect(mockCaptureException).toHaveBeenCalledWith(error);
+    });
+
+    it("sets scope tags from request", async () => {
+      const fakeFastify = await setupPlugin("https://key@sentry.io/123");
+      const errorHandler = fakeFastify.getErrorHandler()!;
+
+      const fakeScope = {
+        setTag: vi.fn(),
+        setUser: vi.fn(),
+        setLevel: vi.fn(),
+      };
+      mockWithScope.mockImplementation((fn: (scope: typeof fakeScope) => void) => fn(fakeScope));
+
+      const error = Object.assign(new Error("Boom"), { statusCode: 500 });
+      const request = buildFakeRequest({ method: "POST", url: "/api/v1/things", id: "rid-1" });
+      const reply = buildFakeReply(500);
+
+      errorHandler(error, request, reply);
+
+      expect(fakeScope.setTag).toHaveBeenCalledWith("method", "POST");
+      expect(fakeScope.setTag).toHaveBeenCalledWith("url", "/api/v1/things");
+      expect(fakeScope.setTag).toHaveBeenCalledWith("requestId", "rid-1");
+    });
+
+    it("sets user context when request.user has id", async () => {
+      const fakeFastify = await setupPlugin("https://key@sentry.io/123");
+      const errorHandler = fakeFastify.getErrorHandler()!;
+
+      const fakeScope = {
+        setTag: vi.fn(),
+        setUser: vi.fn(),
+        setLevel: vi.fn(),
+      };
+      mockWithScope.mockImplementation((fn: (scope: typeof fakeScope) => void) => fn(fakeScope));
+
+      const error = Object.assign(new Error("Boom"), { statusCode: 403 });
+      const request = buildFakeRequest({ user: { id: "user-42", email: "a@b.com" } });
+      const reply = buildFakeReply(403);
+
+      errorHandler(error, request, reply);
+
+      expect(fakeScope.setUser).toHaveBeenCalledWith({ id: "user-42", email: "a@b.com" });
+    });
+
+    it("does NOT set user context when request.user is absent", async () => {
+      const fakeFastify = await setupPlugin("https://key@sentry.io/123");
+      const errorHandler = fakeFastify.getErrorHandler()!;
+
+      const fakeScope = {
+        setTag: vi.fn(),
+        setUser: vi.fn(),
+        setLevel: vi.fn(),
+      };
+      mockWithScope.mockImplementation((fn: (scope: typeof fakeScope) => void) => fn(fakeScope));
+
+      const error = Object.assign(new Error("Boom"), { statusCode: 500 });
+      const request = buildFakeRequest();
+      const reply = buildFakeReply(500);
+
+      errorHandler(error, request, reply);
+
+      expect(fakeScope.setUser).not.toHaveBeenCalled();
+    });
+
+    it("marks reply as __sentryErrorCaptured to prevent double capture", async () => {
+      const fakeFastify = await setupPlugin("https://key@sentry.io/123");
+      const errorHandler = fakeFastify.getErrorHandler()!;
+
+      mockWithScope.mockImplementation((fn: (scope: unknown) => void) => fn({ setTag: vi.fn(), setUser: vi.fn() }));
+
+      const error = Object.assign(new Error("Boom"), { statusCode: 500 });
+      const request = buildFakeRequest();
+      const reply = buildFakeReply(500) as Record<string, unknown>;
+
+      errorHandler(error, request, reply);
+
+      expect(reply.__sentryErrorCaptured).toBe(true);
+    });
+
+    it("replies with 500 and obscured message for 5xx errors", async () => {
+      const fakeFastify = await setupPlugin("https://key@sentry.io/123");
+      const errorHandler = fakeFastify.getErrorHandler()!;
+
+      mockWithScope.mockImplementation((fn: (scope: unknown) => void) => fn({ setTag: vi.fn(), setUser: vi.fn() }));
+
+      const error = Object.assign(new Error("DB connection failed"), { statusCode: 500 });
+      const request = buildFakeRequest();
+      const reply = buildFakeReply(500);
+
+      errorHandler(error, request, reply);
+
+      expect(reply.status).toHaveBeenCalledWith(500);
+      // The actual message should be obscured for 5xx
+      const sentPayload = reply.send.mock.calls[0][0];
+      expect(sentPayload.detail).toBe("Internal Server Error");
+    });
+
+    it("replies with original message for 4xx errors", async () => {
+      const fakeFastify = await setupPlugin("https://key@sentry.io/123");
+      const errorHandler = fakeFastify.getErrorHandler()!;
+
+      mockWithScope.mockImplementation((fn: (scope: unknown) => void) => fn({ setTag: vi.fn(), setUser: vi.fn() }));
+
+      const error = Object.assign(new Error("Resource not found"), {
+        statusCode: 404,
+        name: "NotFoundError",
+      });
+      const request = buildFakeRequest();
+      const reply = buildFakeReply(404);
+
+      errorHandler(error, request, reply);
+
+      expect(reply.status).toHaveBeenCalledWith(404);
+      const sentPayload = reply.send.mock.calls[0][0];
+      expect(sentPayload.detail).toBe("Resource not found");
+    });
+
+    it("defaults to 500 when error has no statusCode", async () => {
+      const fakeFastify = await setupPlugin("https://key@sentry.io/123");
+      const errorHandler = fakeFastify.getErrorHandler()!;
+
+      mockWithScope.mockImplementation((fn: (scope: unknown) => void) => fn({ setTag: vi.fn(), setUser: vi.fn() }));
+
+      const error = new Error("Unexpected");
+      const request = buildFakeRequest();
+      const reply = buildFakeReply(500);
+
+      errorHandler(error, request, reply);
+
+      expect(reply.status).toHaveBeenCalledWith(500);
+    });
+  });
+
+  describe("onResponse hook", () => {
+    it("captures 5xx as message when not already captured by error handler", async () => {
+      const fakeFastify = await setupPlugin("https://key@sentry.io/123");
+      const onResponseHooks = fakeFastify.getHook("onResponse");
+      const hook = onResponseHooks[0];
+
+      const fakeScope = {
+        setTag: vi.fn(),
+        setUser: vi.fn(),
+        setLevel: vi.fn(),
+      };
+      mockWithScope.mockImplementation((fn: (scope: typeof fakeScope) => void) => fn(fakeScope));
+
+      const request = buildFakeRequest({ method: "GET", url: "/api/v1/fail" });
+      const reply = buildFakeReply(503);
+
+      await hook(request, reply);
+
+      expect(mockWithScope).toHaveBeenCalled();
+      expect(mockCaptureMessage).toHaveBeenCalledWith("HTTP 503: GET /api/v1/fail");
+      expect(fakeScope.setLevel).toHaveBeenCalledWith("error");
+    });
+
+    it("does NOT double-capture 5xx when __sentryErrorCaptured is true", async () => {
+      const fakeFastify = await setupPlugin("https://key@sentry.io/123");
+      const onResponseHooks = fakeFastify.getHook("onResponse");
+      const hook = onResponseHooks[0];
+
+      const request = buildFakeRequest();
+      const reply = { ...buildFakeReply(500), __sentryErrorCaptured: true };
+
+      await hook(request, reply);
+
+      expect(mockCaptureMessage).not.toHaveBeenCalled();
+    });
+
+    it("captures notable 4xx (409) as warning", async () => {
+      const fakeFastify = await setupPlugin("https://key@sentry.io/123");
+      const onResponseHooks = fakeFastify.getHook("onResponse");
+      const hook = onResponseHooks[0];
+
+      const fakeScope = {
+        setTag: vi.fn(),
+        setUser: vi.fn(),
+        setLevel: vi.fn(),
+      };
+      mockWithScope.mockImplementation((fn: (scope: typeof fakeScope) => void) => fn(fakeScope));
+
+      const request = buildFakeRequest({ method: "POST", url: "/api/v1/bookings" });
+      const reply = buildFakeReply(409);
+
+      await hook(request, reply);
+
+      expect(mockCaptureMessage).toHaveBeenCalledWith("HTTP 409: POST /api/v1/bookings");
+      expect(fakeScope.setLevel).toHaveBeenCalledWith("warning");
+    });
+
+    it("captures notable 4xx (422) as warning", async () => {
+      const fakeFastify = await setupPlugin("https://key@sentry.io/123");
+      const onResponseHooks = fakeFastify.getHook("onResponse");
+      const hook = onResponseHooks[0];
+
+      const fakeScope = {
+        setTag: vi.fn(),
+        setUser: vi.fn(),
+        setLevel: vi.fn(),
+      };
+      mockWithScope.mockImplementation((fn: (scope: typeof fakeScope) => void) => fn(fakeScope));
+
+      const request = buildFakeRequest({ url: "/api/v1/validate" });
+      const reply = buildFakeReply(422);
+
+      await hook(request, reply);
+
+      expect(fakeScope.setLevel).toHaveBeenCalledWith("warning");
+    });
+
+    it("captures notable 4xx (429) as warning", async () => {
+      const fakeFastify = await setupPlugin("https://key@sentry.io/123");
+      const onResponseHooks = fakeFastify.getHook("onResponse");
+      const hook = onResponseHooks[0];
+
+      const fakeScope = {
+        setTag: vi.fn(),
+        setUser: vi.fn(),
+        setLevel: vi.fn(),
+      };
+      mockWithScope.mockImplementation((fn: (scope: typeof fakeScope) => void) => fn(fakeScope));
+
+      const request = buildFakeRequest({ url: "/api/v1/rate" });
+      const reply = buildFakeReply(429);
+
+      await hook(request, reply);
+
+      expect(fakeScope.setLevel).toHaveBeenCalledWith("warning");
+    });
+
+    it("does NOT capture expected 4xx errors (400, 401, 403, 404)", async () => {
+      const fakeFastify = await setupPlugin("https://key@sentry.io/123");
+      const onResponseHooks = fakeFastify.getHook("onResponse");
+      const hook = onResponseHooks[0];
+
+      for (const code of [400, 401, 403, 404]) {
+        mockWithScope.mockClear();
+        mockCaptureMessage.mockClear();
+
+        const request = buildFakeRequest();
+        const reply = buildFakeReply(code);
+
+        await hook(request, reply);
+        expect(mockCaptureMessage).not.toHaveBeenCalled();
+      }
+    });
+
+    it("does NOT capture 2xx responses", async () => {
+      const fakeFastify = await setupPlugin("https://key@sentry.io/123");
+      const onResponseHooks = fakeFastify.getHook("onResponse");
+      const hook = onResponseHooks[0];
+
+      const request = buildFakeRequest();
+      const reply = buildFakeReply(200);
+
+      await hook(request, reply);
+
+      expect(mockCaptureMessage).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/observability/src/sentry/react.test.ts
+++ b/packages/observability/src/sentry/react.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const {
+  mockSentryInit,
+  mockSetTag,
+  mockWithScope,
+  mockCaptureException,
+  mockCaptureMessage,
+  mockAddBreadcrumb,
+} = vi.hoisted(() => ({
+  mockSentryInit: vi.fn(),
+  mockSetTag: vi.fn(),
+  mockWithScope: vi.fn(),
+  mockCaptureException: vi.fn().mockReturnValue("event-id"),
+  mockCaptureMessage: vi.fn().mockReturnValue("msg-id"),
+  mockAddBreadcrumb: vi.fn(),
+}));
+
+vi.mock("@sentry/react", () => ({
+  init: mockSentryInit,
+  setTag: mockSetTag,
+  withScope: mockWithScope,
+  captureException: mockCaptureException,
+  captureMessage: mockCaptureMessage,
+  addBreadcrumb: mockAddBreadcrumb,
+}));
+
+import {
+  initSentry,
+  handleErrorBoundary,
+  captureException,
+  captureMessage,
+  addBreadcrumb,
+} from "./react.js";
+
+describe("initSentry (react)", () => {
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    savedEnv.NODE_ENV = process.env.NODE_ENV;
+    savedEnv.SENTRY_ENVIRONMENT = process.env.SENTRY_ENVIRONMENT;
+    savedEnv.SENTRY_RELEASE = process.env.SENTRY_RELEASE;
+    delete process.env.NODE_ENV;
+    delete process.env.SENTRY_ENVIRONMENT;
+    delete process.env.SENTRY_RELEASE;
+  });
+
+  afterEach(() => {
+    for (const [key, val] of Object.entries(savedEnv)) {
+      if (val === undefined) delete process.env[key];
+      else process.env[key] = val;
+    }
+  });
+
+  it("does NOT call Sentry.init when DSN is empty string", () => {
+    initSentry({ appName: "my-app", dsn: "" });
+    expect(mockSentryInit).not.toHaveBeenCalled();
+  });
+
+  it("calls Sentry.init when DSN is provided", () => {
+    initSentry({ appName: "my-app", dsn: "https://key@sentry.io/456" });
+    expect(mockSentryInit).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes dsn to Sentry.init", () => {
+    initSentry({ appName: "my-app", dsn: "https://key@sentry.io/456" });
+    expect(mockSentryInit.mock.calls[0][0].dsn).toBe("https://key@sentry.io/456");
+  });
+
+  it("passes environment from NODE_ENV to Sentry.init", () => {
+    process.env.NODE_ENV = "production";
+    initSentry({ appName: "my-app", dsn: "https://key@sentry.io/456" });
+    expect(mockSentryInit.mock.calls[0][0].environment).toBe("production");
+  });
+
+  it("defaults environment to 'development' when NODE_ENV not set", () => {
+    initSentry({ appName: "my-app", dsn: "https://key@sentry.io/456" });
+    expect(mockSentryInit.mock.calls[0][0].environment).toBe("development");
+  });
+
+  it("sets replaysSessionSampleRate to 0", () => {
+    initSentry({ appName: "my-app", dsn: "https://key@sentry.io/456" });
+    expect(mockSentryInit.mock.calls[0][0].replaysSessionSampleRate).toBe(0);
+  });
+
+  it("sets replaysOnErrorSampleRate to 0", () => {
+    initSentry({ appName: "my-app", dsn: "https://key@sentry.io/456" });
+    expect(mockSentryInit.mock.calls[0][0].replaysOnErrorSampleRate).toBe(0);
+  });
+
+  it("passes empty integrations array", () => {
+    initSentry({ appName: "my-app", dsn: "https://key@sentry.io/456" });
+    expect(mockSentryInit.mock.calls[0][0].integrations).toEqual([]);
+  });
+
+  it("calls Sentry.setTag with app name after init", () => {
+    initSentry({ appName: "hospitality", dsn: "https://key@sentry.io/456" });
+    expect(mockSetTag).toHaveBeenCalledWith("app", "hospitality");
+  });
+
+  it("does NOT call setTag when DSN is empty (init skipped)", () => {
+    initSentry({ appName: "hospitality", dsn: "" });
+    expect(mockSetTag).not.toHaveBeenCalled();
+  });
+
+  it("uses SENTRY_ENVIRONMENT when set", () => {
+    process.env.SENTRY_ENVIRONMENT = "staging";
+    initSentry({ appName: "my-app", dsn: "https://key@sentry.io/456" });
+    expect(mockSentryInit.mock.calls[0][0].environment).toBe("staging");
+  });
+
+  it("uses SENTRY_RELEASE when set", () => {
+    process.env.SENTRY_RELEASE = "v2.0.0";
+    initSentry({ appName: "my-app", dsn: "https://key@sentry.io/456" });
+    expect(mockSentryInit.mock.calls[0][0].release).toBe("v2.0.0");
+  });
+});
+
+describe("handleErrorBoundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls Sentry.withScope", () => {
+    const error = new Error("React render failed");
+    const errorInfo = { componentStack: "\n    at MyComponent" };
+
+    handleErrorBoundary(error, errorInfo);
+
+    expect(mockWithScope).toHaveBeenCalledTimes(1);
+  });
+
+  it("sets componentStack as extra and captures exception", () => {
+    const error = new Error("Crash");
+    const errorInfo = { componentStack: "\n    at App\n    at ErrorBoundary" };
+
+    const fakeScope = {
+      setExtra: vi.fn(),
+    };
+    mockWithScope.mockImplementation((fn: (scope: typeof fakeScope) => void) => fn(fakeScope));
+
+    handleErrorBoundary(error, errorInfo);
+
+    expect(fakeScope.setExtra).toHaveBeenCalledWith(
+      "componentStack",
+      "\n    at App\n    at ErrorBoundary",
+    );
+    expect(mockCaptureException).toHaveBeenCalledWith(error);
+  });
+
+  it("captures the original error object", () => {
+    const error = new TypeError("Cannot read property 'foo' of undefined");
+    const errorInfo = { componentStack: "\n    at Widget" };
+
+    const fakeScope = { setExtra: vi.fn() };
+    mockWithScope.mockImplementation((fn: (scope: typeof fakeScope) => void) => fn(fakeScope));
+
+    handleErrorBoundary(error, errorInfo);
+
+    expect(mockCaptureException).toHaveBeenCalledWith(error);
+  });
+
+  it("works with null componentStack", () => {
+    const error = new Error("Crash");
+    const errorInfo = { componentStack: null as unknown as string };
+
+    const fakeScope = { setExtra: vi.fn() };
+    mockWithScope.mockImplementation((fn: (scope: typeof fakeScope) => void) => fn(fakeScope));
+
+    expect(() => handleErrorBoundary(error, errorInfo)).not.toThrow();
+  });
+});
+
+describe("re-exported Sentry utilities", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("captureException delegates to Sentry.captureException", () => {
+    const error = new Error("test");
+    captureException(error);
+    expect(mockCaptureException).toHaveBeenCalledWith(error);
+  });
+
+  it("captureMessage delegates to Sentry.captureMessage", () => {
+    captureMessage("Something happened");
+    expect(mockCaptureMessage).toHaveBeenCalledWith("Something happened");
+  });
+
+  it("addBreadcrumb delegates to Sentry.addBreadcrumb", () => {
+    const breadcrumb = { message: "User clicked button", category: "ui.click" };
+    addBreadcrumb(breadcrumb);
+    expect(mockAddBreadcrumb).toHaveBeenCalledWith(breadcrumb);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds unit tests for 5 previously untested integration modules in `@mbe/observability`
- Covers `request-id.ts`, `baggage.ts`, `error-rates.ts`, `sentry/node.ts`, and `sentry/react.ts`
- 126 total tests passing across 9 test files (5 new + 4 existing)

## Test plan

- [x] `request-id.test.ts` — middleware hook behavior, UUID generation, custom headers/generators, `getRequestId`, `logWithRequestId`
- [x] `baggage.test.ts` — OTel propagation mocked via `vi.hoisted`, `createBaggageContext` entry building, `extractAgentBaggage` extraction
- [x] `error-rates.test.ts` — rolling window pruning with fake timers, degradation threshold (>10% + ≥5 requests), multi-endpoint tracking, rate rounding
- [x] `sentry/node.test.ts` — `initSentry` init/no-op, Fastify plugin error handler (scope tags, user context, 5xx obscuring, `__sentryErrorCaptured` guard), onResponse hook (5xx capture, notable 4xx warning, expected 4xx skip)
- [x] `sentry/react.test.ts` — `initSentry` init/no-op, `handleErrorBoundary` scope extras, re-exported utilities delegation
- [x] All 126 tests pass: `pnpm --dir packages/observability test -- --run`

Closes #1116