### PR TITLE
fix(api-client): correct request type usage in test files

### DIFF
--- a/packages/api-client/src/availability.test.ts
+++ b/packages/api-client/src/availability.test.ts
@@ -167,7 +167,7 @@ describe("HoldsClient", () => {
         venueId: "v1",
         tableId: "t1",
         date: "2026-06-01",
-        startTime: "19:00",
+        time: "19:00",
         partySize: 2,
       });
 
@@ -185,7 +185,7 @@ describe("HoldsClient", () => {
         venueId: "v1",
         tableId: "t1",
         date: "2026-06-01",
-        startTime: "19:00",
+        time: "19:00",
         partySize: 2,
       });
 
@@ -203,7 +203,7 @@ describe("HoldsClient", () => {
         venueId: "v1",
         tableId: "t1",
         date: "2026-06-01",
-        startTime: "19:00",
+        time: "19:00",
         partySize: 2,
       });
 

--- a/packages/api-client/src/floor-plans.test.ts
+++ b/packages/api-client/src/floor-plans.test.ts
@@ -96,7 +96,11 @@ describe("FloorPlansClient", () => {
     it("sends POST /api/v1/floor-plans with body", async () => {
       mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeFloorPlan }));
 
-      await makeClient().create({ venueId: "v1", name: "Main Floor" });
+      await makeClient().create({
+        venueId: "v1",
+        name: "Main Floor",
+        layoutJson: { width: 800, height: 600 },
+      });
 
       const [url, options] = mockFetch.mock.calls[0]!;
       expect(url).toBe("https://api.test.com/api/v1/floor-plans");
@@ -155,7 +159,12 @@ describe("FloorPlansClient", () => {
     it("sends POST /api/v1/floor-plans/:id/bulk-update-positions with positions", async () => {
       mockFetch.mockResolvedValueOnce(jsonResponse({ data: [fakeTable] }));
 
-      const positions = [{ tableId: "t1", x: 10, y: 20 }];
+      const positions = [
+        {
+          tableId: "t1",
+          shapeMetadata: { x: 10, y: 20, width: 100, height: 60, shape: "rectangle" as const },
+        },
+      ];
       const result = await makeClient().bulkUpdatePositions("fp1", positions);
 
       const [url, options] = mockFetch.mock.calls[0]!;

--- a/packages/api-client/src/reservations.test.ts
+++ b/packages/api-client/src/reservations.test.ts
@@ -125,6 +125,7 @@ describe("ReservationsClient", () => {
         partySize: 2,
         date: "2026-06-01",
         startTime: "19:00",
+        endTime: "21:00",
       });
 
       const [url, options] = mockFetch.mock.calls[0]!;
@@ -142,6 +143,7 @@ describe("ReservationsClient", () => {
         partySize: 2,
         date: "2026-06-01",
         startTime: "19:00",
+        endTime: "21:00",
       });
       expect(result).toEqual(fakeReservation);
     });

--- a/packages/api-client/src/tables.test.ts
+++ b/packages/api-client/src/tables.test.ts
@@ -89,8 +89,9 @@ describe("TablesClient", () => {
       await makeClient().create({
         venueId: "v1",
         name: "Table 1",
-        minCapacity: 2,
-        maxCapacity: 4,
+        capacity: 4,
+        minCovers: 2,
+        maxCovers: 4,
       });
 
       const [url, options] = mockFetch.mock.calls[0]!;
@@ -105,8 +106,9 @@ describe("TablesClient", () => {
       const result = await makeClient().create({
         venueId: "v1",
         name: "Table 1",
-        minCapacity: 2,
-        maxCapacity: 4,
+        capacity: 4,
+        minCovers: 2,
+        maxCovers: 4,
       });
       expect(result).toEqual(fakeTable);
     });

--- a/packages/api-client/src/venues.test.ts
+++ b/packages/api-client/src/venues.test.ts
@@ -113,7 +113,12 @@ describe("VenuesClient", () => {
     it("sends POST /api/v1/venues with body", async () => {
       mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeVenue }));
 
-      await makeVenuesClient().create({ name: "The Grand", venueGroupId: "vg1" });
+      await makeVenuesClient().create({
+        name: "The Grand",
+        slug: "the-grand",
+        ianaTimezone: "America/New_York",
+        venueGroupId: "vg1",
+      });
 
       const [url, options] = mockFetch.mock.calls[0]!;
       expect(url).toBe("https://api.test.com/api/v1/venues");
@@ -123,7 +128,12 @@ describe("VenuesClient", () => {
     it("returns the created venue", async () => {
       mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeVenue }));
 
-      const result = await makeVenuesClient().create({ name: "The Grand", venueGroupId: "vg1" });
+      const result = await makeVenuesClient().create({
+        name: "The Grand",
+        slug: "the-grand",
+        ianaTimezone: "America/New_York",
+        venueGroupId: "vg1",
+      });
       expect(result).toEqual(fakeVenue);
     });
   });
@@ -208,7 +218,7 @@ describe("VenueGroupsClient", () => {
     it("sends POST /api/v1/venues/groups with body", async () => {
       mockFetch.mockResolvedValueOnce(jsonResponse({ data: fakeVenueGroup }));
 
-      await makeGroupsClient().create({ name: "Grand Group" });
+      await makeGroupsClient().create({ name: "Grand Group", slug: "grand-group" });
 
       const [url, options] = mockFetch.mock.calls[0]!;
       expect(url).toBe("https://api.test.com/api/v1/venues/groups");


### PR DESCRIPTION
Fixes typecheck errors in api-client test files that are blocking CI on all PRs. The test files used incorrect property names for request types (e.g., startTime instead of correct field, minCapacity instead of capacity, missing required properties).