### PR TITLE
fix(ci): repair nightly-compliance and acmm-cold-start workflows

### DIFF
--- a/.github/workflows/acmm-cold-start.yml
+++ b/.github/workflows/acmm-cold-start.yml
@@ -42,7 +42,7 @@ jobs:
 
       # Note: NO `cache: pnpm` — we want cold-start, not cache-warm.
       - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/nightly-compliance.yml
+++ b/.github/workflows/nightly-compliance.yml
@@ -45,7 +45,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+        uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
 
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -64,13 +64,15 @@ jobs:
             echo '## Lint, typecheck, test'
             echo
             for cmd in lint typecheck test; do
-              if pnpm "$cmd" 2>&1 | tail -10 > "/tmp/$cmd.out"; then
+              pnpm "$cmd" > "/tmp/$cmd.out" 2>&1
+              cmd_status=$?
+              if [ "$cmd_status" -eq 0 ]; then
                 echo "- ✓ \`pnpm $cmd\` passed"
               else
                 echo "- ✗ \`pnpm $cmd\` FAILED"
                 echo
                 echo '  ```'
-                sed 's/^/  /' "/tmp/$cmd.out"
+                tail -10 "/tmp/$cmd.out" | sed 's/^/  /'
                 echo '  ```'
               fi
               echo
@@ -86,7 +88,7 @@ jobs:
             echo
               for script in scripts/check-*.js; do
               name=$(basename "$script" .js)
-              if node "$script" 2>&1 > "/tmp/$name.out"; then
+              if node "$script" > "/tmp/$name.out" 2>&1; then
                 echo "- ✓ \`$name\` passed"
               else
                 echo "- ✗ \`$name\` FAILED"


### PR DESCRIPTION
## Summary

- **`nightly-compliance.yml`**: Update `pnpm/action-setup` from stale v4 SHA (`f40ffcd`) to the v5 SHA (`a8198c4`) used by `ci.yml`. Also fix two shell bugs: lint/typecheck/test loop was checking `tail`'s exit code instead of `pnpm`'s (drift was never detected); gating-scripts redirect order was wrong so stderr escaped capture.
- **`acmm-cold-start.yml`**: Replace a non-existent `setup-node # v6` SHA (`48b55a0`) with the working `# v4` SHA (`49933ea`) used by `ci.yml`. Stale/invalid action pins are the most likely root cause of both workflows failing at setup.

## Test plan

- [ ] Trigger `nightly-compliance` via `workflow_dispatch` and verify it completes without failure
- [ ] Trigger `acmm-cold-start` via `workflow_dispatch` and verify the setup steps pass
- [ ] Confirm drift detection now correctly surfaces `✗` when `pnpm lint` / `typecheck` / `test` fail

Closes #1157

https://claude.ai/code/session_01QGZUWQbjWsHzhrNko8r6Cr

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGZUWQbjWsHzhrNko8r6Cr)_