### PR TITLE
fix(ci): replace broken setup-node v6 SHA in post-deploy-check workflow

### DIFF
--- a/.github/workflows/post-deploy-check.yml
+++ b/.github/workflows/post-deploy-check.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Install pnpm
         run: npm install -g pnpm@9
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm


### PR DESCRIPTION
## Summary

- Replaces the stale/non-existent `actions/setup-node@48b55a0` (`# v6`) SHA with the working `# v4` SHA (`49933ea5`) used by `ci.yml` everywhere else
- This is the same bad pin that PR #1167 just fixed in `acmm-cold-start.yml` — the `playwright-smoke` job in `post-deploy-check.yml` had the identical issue, causing the Node setup step to fail and the smoke tests to never run

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, trigger `Post-Deploy Check` via `workflow_dispatch` and confirm the `playwright-smoke` job completes without setup errors

Closes #1161

https://claude.ai/code/session_01TYC8FTkqqkf2UQEoEtbwGH

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYC8FTkqqkf2UQEoEtbwGH)_