### PR TITLE
chore(acmm): tighten detection for 4 criteria from any-of to active/grep

### DIFF
--- a/plugins/acmm/scripts/sources/acmm.js
+++ b/plugins/acmm/scripts/sources/acmm.js
@@ -297,8 +297,8 @@ const CRITERIA= [
     description: 'A dashboard or page that renders the AI loop metrics.',
     rationale: 'L3 visibility: metrics you can see are the ones that get acted on.',
     details: 'A quality dashboard is a visible page or widget that renders your AI loop metrics — PR acceptance rates, coverage trends, review turnaround, test pass rates — in one place. Metrics that are not visible are metrics that get ignored; a dashboard makes them actionable. An AI mission will create an analytics page or embed that pulls data from your CI and displays it as charts and trend lines.',
-    detection: { type: 'any-of', pattern: ['web/public/analytics.js', 'web/src/components/analytics/'] },
-    referencePath: 'web/public/analytics.js',
+    detection: { type: 'grep', pattern: { file: 'apps/marketing/src/App.tsx', contains: '/metrics' } },
+    referencePath: 'apps/marketing/src/App.tsx',
   },
   {
     id: 'acmm:ci-matrix',
@@ -432,7 +432,7 @@ const CRITERIA= [
     description: 'Scheduled workflow that re-validates the codebase against its rules every night.',
     rationale: 'L4 drift detection: noticing when the loop itself has broken.',
     details: 'A nightly compliance scan is a scheduled CI workflow that runs your full test suite, linters, and security checks on a cron schedule (typically every night). It catches regressions that slip through PR-level checks — like a dependency update that passes its own tests but breaks an unrelated feature. An AI mission will add a nightly GitHub Actions workflow that runs your complete validation pipeline and opens issues on failure.',
-    detection: { type: 'any-of', pattern: ['.github/workflows/nightly-compliance.yml', '.github/workflows/nightly.yml', '.github/workflows/nightly-test.yml', '.github/workflows/nightly-test-suite.yml'] },
+    detection: { type: 'active', pattern: ['.github/workflows/nightly-compliance.yml', '.github/workflows/nightly.yml', '.github/workflows/nightly-test.yml', '.github/workflows/nightly-test-suite.yml'], maxAgeDays: 7 },
   },
   {
     id: 'acmm:copilot-review-apply',
@@ -744,7 +744,7 @@ const CRITERIA= [
     description: 'A published metrics endpoint or analytics page that external reviewers can audit.',
     rationale: 'The self-running codebase must be inspectable from outside.',
     details: 'A public metrics endpoint is an API or web page that exposes your project\'s health and maturity metrics to external stakeholders — CNCF reviewers, adopters, or the community. It makes the project\'s quality claims verifiable rather than self-reported. An AI mission will create an endpoint that serves your ACMM level, coverage stats, and CI pass rates as JSON or a web page.',
-    detection: { type: 'any-of', pattern: ['web/netlify/functions/analytics-accm.mts', 'web/public/analytics.js'] },
+    detection: { type: 'grep', pattern: { file: '.github/workflows/pr-metrics.yml', contains: 'pages' } },
   },
   {
     id: 'acmm:policy-as-code',

--- a/plugins/acmm/scripts/sources/fullsend.js
+++ b/plugins/acmm/scripts/sources/fullsend.js
@@ -86,7 +86,7 @@ const CRITERIA= [
     description: 'A documented or automated rollback procedure.',
     rationale: 'Fullsend: autonomy requires the ability to undo, not just to do.',
     details: 'A rollback drill is a documented or scripted procedure for reverting a bad deployment or merge to the last known-good state. Autonomy is only safe when you can undo quickly — if rolling back takes hours, the cost of an AI mistake is too high to tolerate. An AI mission will create a rollback script or document that covers your deployment method (git revert, helm rollback, image tag pin).',
-    detection: { type: 'any-of', pattern: ['docs/rollback.md', '.github/workflows/rollback.yml', 'scripts/rollback.sh'] },
+    detection: { type: 'grep', pattern: { file: 'docs/rollback.md', contains: 'Last drill:' } },
   },
 ]
 


### PR DESCRIPTION
## Summary

- `acmm:nightly-compliance`: `any-of` → `active` (maxAgeDays: 7) — only passes when the workflow has run successfully in the last 7 days, not just when the file exists
- `acmm:quality-dashboard`: `any-of` → `grep` checking `apps/marketing/src/App.tsx` for a `/metrics` route — JSON files in `docs/metrics/` ≠ a rendered dashboard
- `acmm:public-metrics`: `any-of` → `grep` checking `.github/workflows/pr-metrics.yml` for GitHub Pages config — local JSONL files ≠ a public endpoint
- `fullsend:rollback-drill`: `any-of` → `grep` checking `docs/rollback.md` for `Last drill:` — the doc exists but no drill has ever been run

## Why

These four criteria were inflating the ACMM score to L6 (105/105) via file-existence checks when the underlying features were not actually implemented. Tightening them to `active`/`grep` detection will cause the audit to report an honest L4 or L5.

## Test plan

- [x] Run ACMM audit locally and confirm level drops to L4 or L5
- [x] Confirm the 4 tightened criteria now show as failing
- [x] Confirm all other criteria are unaffected

Closes #1155

https://claude.ai/code/session_01AHvNVADi8XkYNvWkshw2fv

---
_Generated by [Claude Code](https://claude.ai/code/session_01AHvNVADi8XkYNvWkshw2fv)_