### PR TITLE
chore(infra): downgrade Node.js engine requirement to >=20

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "packageManager": "pnpm@9.15.4",
   "engines": {
-    "node": ">=22",
+    "node": ">=20",
     "pnpm": ">=9"
   },
   "scripts": {


### PR DESCRIPTION
## Summary
- Relaxes `engines.node` from `>=22` to `>=20` in root `package.json`
- Eliminates the "Unsupported engine" pnpm warning that fired on every install
- No other workspace packages declared `>=22`; only the root needed updating

Closes #1181

## Test plan
- [x] `pnpm install` runs without engine warning
- [x] `pnpm build` succeeds
- [x] Pre-commit hooks pass