### PR TITLE
ci: add merge queue support to complete broken-main prevention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ on:
       - "LICENSE"
   pull_request:
     branches: [main]
+  merge_group:
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

- Adds `merge_group` trigger to `.github/workflows/ci.yml` so GitHub's merge queue validates PRs through the full CI pipeline before they land on main
- The other two items from #1202 (dependency audit job via `scripts/check-dep-sync.mjs`, revert watchdog workflow) were already implemented in prior commits

All three defense-in-depth mechanisms from the issue are now in place:
1. **Dependency Audit** — `dependency-audit` job runs `check-dep-sync.mjs` on every PR
2. **Revert Watchdog** — `.github/workflows/revert-watchdog.yml` auto-proposes revert PRs on main CI failure
3. **Merge Queue** — `merge_group` trigger ensures CI runs in the queue context before merge

Closes #1202

## Test plan

- [ ] Verify CI passes on this PR (the `merge_group` trigger is additive and does not affect PR/push behavior)
- [ ] Once merged, enable merge queue in GitHub repo settings (Settings > Branch protection > Require merge queue) to activate the feature