### PR TITLE
test(types): add schema validation tests for types package

### DIFF
--- a/packages/types/src/agent.test.ts
+++ b/packages/types/src/agent.test.ts
@@ -1,63 +1,259 @@
 import { describe, it, expect } from "vitest";
-import { 
+import {
   AgentSessionSchema,
   AgentSessionStatusSchema,
   AgentSessionEventSchema,
-  CreateAgentSessionRequestSchema
+  CreateAgentSessionRequestSchema,
 } from "./schemas/agent.js";
 
-describe("Agent Schemas", () => {
-  it("validates a valid agent session", () => {
-    const validSession = {
-      id: "session-456",
-      status: "RUNNING",
-      taskDescription: "Running task",
-      branchName: null,
-      baseBranch: "main",
-      model: "claude-sonnet-4-6",
-      maxTurns: 50,
-      maxBudgetUsd: 1.0,
-      prUrl: null,
-      prNumber: null,
-      resultText: null,
-      costUsd: null,
-      inputTokens: null,
-      outputTokens: null,
-      numTurns: null,
-      durationMs: null,
-      parentId: null,
-      errors: [],
-      startedAt: null,
-      completedAt: null,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
+describe("AgentSessionStatusSchema", () => {
+  const validStatuses = ["PENDING", "RUNNING", "SUCCEEDED", "FAILED", "CANCELLED"];
+
+  it.each(validStatuses)("accepts valid status: %s", (status) => {
+    expect(AgentSessionStatusSchema.safeParse(status).success).toBe(true);
+  });
+
+  it("rejects lowercase variants", () => {
+    expect(AgentSessionStatusSchema.safeParse("pending").success).toBe(false);
+    expect(AgentSessionStatusSchema.safeParse("running").success).toBe(false);
+  });
+
+  it("rejects unknown statuses", () => {
+    expect(AgentSessionStatusSchema.safeParse("INVALID").success).toBe(false);
+    expect(AgentSessionStatusSchema.safeParse("QUEUED").success).toBe(false);
+    expect(AgentSessionStatusSchema.safeParse("").success).toBe(false);
+  });
+
+  it("rejects non-string types", () => {
+    expect(AgentSessionStatusSchema.safeParse(42).success).toBe(false);
+    expect(AgentSessionStatusSchema.safeParse(null).success).toBe(false);
+    expect(AgentSessionStatusSchema.safeParse(undefined).success).toBe(false);
+  });
+});
+
+describe("AgentSessionSchema", () => {
+  const validSession = {
+    id: "session-456",
+    status: "RUNNING",
+    taskDescription: "Running task",
+    branchName: null,
+    baseBranch: "main",
+    model: "claude-sonnet-4-6",
+    maxTurns: 50,
+    maxBudgetUsd: 1.0,
+    prUrl: null,
+    prNumber: null,
+    resultText: null,
+    costUsd: null,
+    inputTokens: null,
+    outputTokens: null,
+    numTurns: null,
+    durationMs: null,
+    parentId: null,
+    errors: [],
+    startedAt: null,
+    completedAt: null,
+    createdAt: "2026-05-10T00:00:00.000Z",
+    updatedAt: "2026-05-10T00:00:00.000Z",
+  };
+
+  it("accepts a fully populated valid session", () => {
+    const populated = {
+      ...validSession,
+      status: "SUCCEEDED",
+      branchName: "fix/login-bug",
+      prUrl: "https://github.com/org/repo/pull/42",
+      prNumber: 42,
+      resultText: "Fixed the login bug",
+      costUsd: 0.85,
+      inputTokens: 12000,
+      outputTokens: 3500,
+      numTurns: 15,
+      durationMs: 45000,
+      parentId: "parent-session-1",
+      errors: ["Warning: rate limited once"],
+      startedAt: "2026-05-10T00:01:00.000Z",
+      completedAt: "2026-05-10T00:02:00.000Z",
+      createPr: true,
     };
+    const result = AgentSessionSchema.safeParse(populated);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a minimal valid session with all nullable fields null", () => {
     const result = AgentSessionSchema.safeParse(validSession);
     expect(result.success).toBe(true);
   });
 
-  it("validates valid status", () => {
-    expect(AgentSessionStatusSchema.safeParse("RUNNING").success).toBe(true);
-    expect(AgentSessionStatusSchema.safeParse("INVALID").success).toBe(false);
+  it("rejects missing required fields", () => {
+    const { id: _, ...noId } = validSession;
+    expect(AgentSessionSchema.safeParse(noId).success).toBe(false);
+
+    const { taskDescription: _td, ...noTask } = validSession;
+    expect(AgentSessionSchema.safeParse(noTask).success).toBe(false);
+
+    const { baseBranch: _bb, ...noBranch } = validSession;
+    expect(AgentSessionSchema.safeParse(noBranch).success).toBe(false);
+
+    const { model: _m, ...noModel } = validSession;
+    expect(AgentSessionSchema.safeParse(noModel).success).toBe(false);
+
+    const { errors: _e, ...noErrors } = validSession;
+    expect(AgentSessionSchema.safeParse(noErrors).success).toBe(false);
   });
 
-  it("validates session events", () => {
+  it("rejects invalid status values", () => {
+    const result = AgentSessionSchema.safeParse({ ...validSession, status: "INVALID" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects wrong types for numeric fields", () => {
+    expect(AgentSessionSchema.safeParse({ ...validSession, maxTurns: "50" }).success).toBe(false);
+    expect(AgentSessionSchema.safeParse({ ...validSession, maxBudgetUsd: "1.0" }).success).toBe(false);
+  });
+
+  it("rejects non-array errors field", () => {
+    expect(AgentSessionSchema.safeParse({ ...validSession, errors: "error" }).success).toBe(false);
+    expect(AgentSessionSchema.safeParse({ ...validSession, errors: null }).success).toBe(false);
+  });
+
+  it("accepts errors array with multiple entries", () => {
+    const result = AgentSessionSchema.safeParse({
+      ...validSession,
+      errors: ["err1", "err2", "err3"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects non-string values in errors array", () => {
+    const result = AgentSessionSchema.safeParse({
+      ...validSession,
+      errors: [42, "valid"],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("AgentSessionEventSchema", () => {
+  it("accepts a valid event with data", () => {
     const event = {
       id: "evt-1",
-      sessionId: "s1",
+      sessionId: "session-1",
       type: "TOOL_CALL",
-      data: { tool: "ls" },
-      createdAt: new Date().toISOString(),
+      data: { tool: "ls", args: ["-la"] },
+      createdAt: "2026-05-10T00:00:00.000Z",
     };
     expect(AgentSessionEventSchema.safeParse(event).success).toBe(true);
   });
 
-  it("validates create session request", () => {
+  it("accepts an event without data (optional)", () => {
+    const event = {
+      id: "evt-2",
+      sessionId: "session-1",
+      type: "MESSAGE",
+      createdAt: "2026-05-10T00:00:00.000Z",
+    };
+    expect(AgentSessionEventSchema.safeParse(event).success).toBe(true);
+  });
+
+  it("accepts an event with empty data object", () => {
+    const event = {
+      id: "evt-3",
+      sessionId: "session-1",
+      type: "START",
+      data: {},
+      createdAt: "2026-05-10T00:00:00.000Z",
+    };
+    expect(AgentSessionEventSchema.safeParse(event).success).toBe(true);
+  });
+
+  it("rejects missing required fields", () => {
+    expect(AgentSessionEventSchema.safeParse({ sessionId: "s1", type: "X", createdAt: "t" }).success).toBe(false);
+    expect(AgentSessionEventSchema.safeParse({ id: "e1", type: "X", createdAt: "t" }).success).toBe(false);
+    expect(AgentSessionEventSchema.safeParse({ id: "e1", sessionId: "s1", createdAt: "t" }).success).toBe(false);
+    expect(AgentSessionEventSchema.safeParse({ id: "e1", sessionId: "s1", type: "X" }).success).toBe(false);
+  });
+
+  it("rejects non-string id", () => {
+    const event = { id: 123, sessionId: "s1", type: "X", createdAt: "t" };
+    expect(AgentSessionEventSchema.safeParse(event).success).toBe(false);
+  });
+});
+
+describe("CreateAgentSessionRequestSchema", () => {
+  it("accepts a minimal valid request", () => {
+    const req = { taskDescription: "Fix the bug" };
+    expect(CreateAgentSessionRequestSchema.safeParse(req).success).toBe(true);
+  });
+
+  it("accepts a fully specified request", () => {
     const req = {
-      taskDescription: "Fix bugs",
-      model: "sonnet",
-      maxTurns: 10,
+      taskDescription: "Refactor auth module",
+      model: "claude-sonnet-4-6",
+      maxTurns: 30,
+      maxBudgetUsd: 5.0,
+      baseBranch: "develop",
+      createPr: true,
+      parentId: "parent-123",
     };
     expect(CreateAgentSessionRequestSchema.safeParse(req).success).toBe(true);
+  });
+
+  it("rejects empty taskDescription", () => {
+    const req = { taskDescription: "" };
+    const result = CreateAgentSessionRequestSchema.safeParse(req);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects taskDescription exceeding 10,000 chars", () => {
+    const req = { taskDescription: "x".repeat(10_001) };
+    const result = CreateAgentSessionRequestSchema.safeParse(req);
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts taskDescription at max boundary (10,000 chars)", () => {
+    const req = { taskDescription: "x".repeat(10_000) };
+    const result = CreateAgentSessionRequestSchema.safeParse(req);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects maxTurns below minimum (1)", () => {
+    const req = { taskDescription: "task", maxTurns: 0 };
+    expect(CreateAgentSessionRequestSchema.safeParse(req).success).toBe(false);
+  });
+
+  it("rejects maxTurns above maximum (200)", () => {
+    const req = { taskDescription: "task", maxTurns: 201 };
+    expect(CreateAgentSessionRequestSchema.safeParse(req).success).toBe(false);
+  });
+
+  it("accepts maxTurns at boundaries", () => {
+    expect(CreateAgentSessionRequestSchema.safeParse({ taskDescription: "t", maxTurns: 1 }).success).toBe(true);
+    expect(CreateAgentSessionRequestSchema.safeParse({ taskDescription: "t", maxTurns: 200 }).success).toBe(true);
+  });
+
+  it("rejects maxBudgetUsd below minimum (0.01)", () => {
+    const req = { taskDescription: "task", maxBudgetUsd: 0.001 };
+    expect(CreateAgentSessionRequestSchema.safeParse(req).success).toBe(false);
+  });
+
+  it("rejects maxBudgetUsd above maximum (10.0)", () => {
+    const req = { taskDescription: "task", maxBudgetUsd: 10.01 };
+    expect(CreateAgentSessionRequestSchema.safeParse(req).success).toBe(false);
+  });
+
+  it("accepts maxBudgetUsd at boundaries", () => {
+    expect(CreateAgentSessionRequestSchema.safeParse({ taskDescription: "t", maxBudgetUsd: 0.01 }).success).toBe(true);
+    expect(CreateAgentSessionRequestSchema.safeParse({ taskDescription: "t", maxBudgetUsd: 10.0 }).success).toBe(true);
+  });
+
+  it("rejects missing taskDescription", () => {
+    const req = { model: "sonnet" };
+    expect(CreateAgentSessionRequestSchema.safeParse(req).success).toBe(false);
+  });
+
+  it("rejects non-boolean createPr", () => {
+    const req = { taskDescription: "task", createPr: "yes" };
+    expect(CreateAgentSessionRequestSchema.safeParse(req).success).toBe(false);
   });
 });

--- a/packages/types/src/api.test.ts
+++ b/packages/types/src/api.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { createProblemDetails } from "./api.js";
+
+describe("createProblemDetails", () => {
+  it("creates a valid problem details object with defaults", () => {
+    const result = createProblemDetails(404, "Not Found", "The resource was not found");
+    expect(result).toEqual({
+      type: "about:blank",
+      title: "Not Found",
+      status: 404,
+      detail: "The resource was not found",
+      instance: undefined,
+      error: "Not Found",
+      message: "The resource was not found",
+      statusCode: 404,
+    });
+  });
+
+  it("creates problem details with custom type and instance", () => {
+    const result = createProblemDetails(
+      422,
+      "Validation Error",
+      "partySize must be positive",
+      "https://api.example.com/errors/validation",
+      "/reservations/123"
+    );
+    expect(result.type).toBe("https://api.example.com/errors/validation");
+    expect(result.instance).toBe("/reservations/123");
+    expect(result.status).toBe(422);
+    expect(result.statusCode).toBe(422);
+  });
+
+  it("merges extensions into the returned object", () => {
+    const result = createProblemDetails(
+      400,
+      "Bad Request",
+      "Invalid input",
+      "about:blank",
+      undefined,
+      { fieldErrors: [{ field: "email", message: "required" }], traceId: "abc-123" }
+    );
+    expect(result.fieldErrors).toEqual([{ field: "email", message: "required" }]);
+    expect(result.traceId).toBe("abc-123");
+  });
+
+  it("maintains backward compatibility (has both error/message and title/detail)", () => {
+    const result = createProblemDetails(500, "Internal Error", "Something broke");
+    // RFC 7807 fields
+    expect(result.title).toBe("Internal Error");
+    expect(result.detail).toBe("Something broke");
+    expect(result.status).toBe(500);
+    // Legacy fields
+    expect(result.error).toBe("Internal Error");
+    expect(result.message).toBe("Something broke");
+    expect(result.statusCode).toBe(500);
+  });
+
+  it("uses about:blank as default type", () => {
+    const result = createProblemDetails(503, "Service Unavailable", "Try again later");
+    expect(result.type).toBe("about:blank");
+  });
+});

--- a/packages/types/src/date.test.ts
+++ b/packages/types/src/date.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { toDateString } from "./date.js";
+
+describe("toDateString", () => {
+  it("formats a date as YYYY-MM-DD", () => {
+    const date = new Date("2026-04-05T15:30:00.000Z");
+    expect(toDateString(date)).toBe("2026-04-05");
+  });
+
+  it("pads single-digit months and days", () => {
+    const date = new Date("2026-01-09T00:00:00.000Z");
+    expect(toDateString(date)).toBe("2026-01-09");
+  });
+
+  it("handles end of year", () => {
+    const date = new Date("2026-12-31T23:59:59.999Z");
+    expect(toDateString(date)).toBe("2026-12-31");
+  });
+
+  it("handles start of year", () => {
+    const date = new Date("2026-01-01T00:00:00.000Z");
+    expect(toDateString(date)).toBe("2026-01-01");
+  });
+
+  it("returns ISO date portion regardless of time component", () => {
+    const morning = new Date("2026-05-10T08:00:00.000Z");
+    const evening = new Date("2026-05-10T23:59:59.999Z");
+    expect(toDateString(morning)).toBe("2026-05-10");
+    expect(toDateString(evening)).toBe("2026-05-10");
+  });
+});

--- a/packages/types/src/json-schema.test.ts
+++ b/packages/types/src/json-schema.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from "vitest";
+import {
+  userPreferencesJsonSchema,
+  userJsonSchema,
+  tableShapeMetadataJsonSchema,
+  tableJsonSchema,
+  reservationJsonSchema,
+  venueGroupJsonSchema,
+  venueJsonSchema,
+  guestJsonSchema,
+  guestSegmentJsonSchema,
+  floorPlanLayoutJsonSchema,
+  floorPlanJsonSchema,
+  sessionJsonSchema,
+  sessionEventJsonSchema,
+  createSessionBodyJsonSchema,
+  paginationJsonSchema,
+  errorJsonSchema,
+  problemDetailsJsonSchema,
+} from "./schemas/json-schema.js";
+
+describe("JSON Schema generation (toFastifyJsonSchema)", () => {
+  describe("structural requirements", () => {
+    const allSchemas = [
+      { name: "userPreferencesJsonSchema", schema: userPreferencesJsonSchema },
+      { name: "userJsonSchema", schema: userJsonSchema },
+      { name: "tableShapeMetadataJsonSchema", schema: tableShapeMetadataJsonSchema },
+      { name: "tableJsonSchema", schema: tableJsonSchema },
+      { name: "reservationJsonSchema", schema: reservationJsonSchema },
+      { name: "venueGroupJsonSchema", schema: venueGroupJsonSchema },
+      { name: "venueJsonSchema", schema: venueJsonSchema },
+      { name: "guestJsonSchema", schema: guestJsonSchema },
+      { name: "guestSegmentJsonSchema", schema: guestSegmentJsonSchema },
+      { name: "floorPlanLayoutJsonSchema", schema: floorPlanLayoutJsonSchema },
+      { name: "floorPlanJsonSchema", schema: floorPlanJsonSchema },
+      { name: "sessionJsonSchema", schema: sessionJsonSchema },
+      { name: "sessionEventJsonSchema", schema: sessionEventJsonSchema },
+      { name: "createSessionBodyJsonSchema", schema: createSessionBodyJsonSchema },
+      { name: "paginationJsonSchema", schema: paginationJsonSchema },
+      { name: "errorJsonSchema", schema: errorJsonSchema },
+      { name: "problemDetailsJsonSchema", schema: problemDetailsJsonSchema },
+    ];
+
+    it.each(allSchemas)("$name has a $id", ({ schema }) => {
+      expect(schema).toHaveProperty("$id");
+      expect(typeof schema.$id).toBe("string");
+      expect(schema.$id.length).toBeGreaterThan(0);
+    });
+
+    it.each(allSchemas)("$name does not have $schema (stripped for Fastify)", ({ schema }) => {
+      expect(schema).not.toHaveProperty("$schema");
+    });
+
+    it.each(allSchemas)("$name has type 'object'", ({ schema }) => {
+      expect(schema).toHaveProperty("type", "object");
+    });
+  });
+
+  describe("additionalProperties stripping", () => {
+    it("does not contain additionalProperties at any level", () => {
+      const checkNoAdditionalProperties = (obj: unknown, path = ""): void => {
+        if (obj === null || typeof obj !== "object") return;
+        if (Array.isArray(obj)) {
+          obj.forEach((item, i) => checkNoAdditionalProperties(item, `${path}[${i}]`));
+          return;
+        }
+        const record = obj as Record<string, unknown>;
+        expect(record, `Found additionalProperties at ${path}`).not.toHaveProperty("additionalProperties");
+        expect(record, `Found propertyNames at ${path}`).not.toHaveProperty("propertyNames");
+        for (const [key, value] of Object.entries(record)) {
+          checkNoAdditionalProperties(value, `${path}.${key}`);
+        }
+      };
+
+      checkNoAdditionalProperties(userJsonSchema);
+      checkNoAdditionalProperties(reservationJsonSchema);
+      checkNoAdditionalProperties(sessionJsonSchema);
+      checkNoAdditionalProperties(venueJsonSchema);
+    });
+  });
+
+  describe("specific schema $id values", () => {
+    it("maps schema names to expected $id values", () => {
+      expect(userJsonSchema.$id).toBe("User");
+      expect(userPreferencesJsonSchema.$id).toBe("UserPreferences");
+      expect(tableJsonSchema.$id).toBe("Table");
+      expect(reservationJsonSchema.$id).toBe("Reservation");
+      expect(venueGroupJsonSchema.$id).toBe("VenueGroup");
+      expect(venueJsonSchema.$id).toBe("Venue");
+      expect(guestJsonSchema.$id).toBe("Guest");
+      expect(guestSegmentJsonSchema.$id).toBe("GuestSegment");
+      expect(floorPlanLayoutJsonSchema.$id).toBe("FloorPlanLayout");
+      expect(floorPlanJsonSchema.$id).toBe("FloorPlan");
+      expect(sessionJsonSchema.$id).toBe("Session");
+      expect(sessionEventJsonSchema.$id).toBe("SessionEvent");
+      expect(createSessionBodyJsonSchema.$id).toBe("CreateSessionBody");
+      expect(paginationJsonSchema.$id).toBe("Pagination");
+      expect(errorJsonSchema.$id).toBe("Error");
+      expect(problemDetailsJsonSchema.$id).toBe("ProblemDetails");
+      expect(tableShapeMetadataJsonSchema.$id).toBe("TableShapeMetadata");
+    });
+  });
+
+  describe("schema properties", () => {
+    it("User schema has expected properties", () => {
+      const schema = userJsonSchema as Record<string, unknown>;
+      const props = schema.properties as Record<string, unknown>;
+      expect(props).toHaveProperty("id");
+      expect(props).toHaveProperty("email");
+      expect(props).toHaveProperty("name");
+      expect(props).toHaveProperty("emailVerified");
+      expect(props).toHaveProperty("preferences");
+    });
+
+    it("Reservation schema has expected properties", () => {
+      const schema = reservationJsonSchema as Record<string, unknown>;
+      const props = schema.properties as Record<string, unknown>;
+      expect(props).toHaveProperty("id");
+      expect(props).toHaveProperty("date");
+      expect(props).toHaveProperty("startTime");
+      expect(props).toHaveProperty("partySize");
+      expect(props).toHaveProperty("status");
+      expect(props).toHaveProperty("tableId");
+    });
+
+    it("Session schema has expected properties", () => {
+      const schema = sessionJsonSchema as Record<string, unknown>;
+      const props = schema.properties as Record<string, unknown>;
+      expect(props).toHaveProperty("id");
+      expect(props).toHaveProperty("status");
+      expect(props).toHaveProperty("taskDescription");
+      expect(props).toHaveProperty("model");
+      expect(props).toHaveProperty("maxTurns");
+      expect(props).toHaveProperty("errors");
+    });
+
+    it("CreateSessionBody schema has expected properties", () => {
+      const schema = createSessionBodyJsonSchema as Record<string, unknown>;
+      const props = schema.properties as Record<string, unknown>;
+      expect(props).toHaveProperty("taskDescription");
+      expect(props).toHaveProperty("model");
+      expect(props).toHaveProperty("maxTurns");
+      expect(props).toHaveProperty("maxBudgetUsd");
+    });
+
+    it("Pagination schema has all required fields", () => {
+      const schema = paginationJsonSchema as Record<string, unknown>;
+      const props = schema.properties as Record<string, unknown>;
+      expect(props).toHaveProperty("page");
+      expect(props).toHaveProperty("limit");
+      expect(props).toHaveProperty("total");
+      expect(props).toHaveProperty("totalPages");
+      expect(props).toHaveProperty("hasNext");
+      expect(props).toHaveProperty("hasPrev");
+    });
+  });
+});

--- a/packages/types/src/reservation.test.ts
+++ b/packages/types/src/reservation.test.ts
@@ -1,83 +1,464 @@
 import { describe, it, expect } from "vitest";
-import { 
-  ReservationSchema, 
+import {
+  ReservationSchema,
   ReservationStatusSchema,
-  TableSchema
+  TableSchema,
+  TableStatusSchema,
 } from "./schemas/reservation.js";
-import { VenueSchema } from "./schemas/venue.js";
+import {
+  VenueSchema,
+  VenueGroupSchema,
+  DayScheduleSchema,
+} from "./schemas/venue.js";
+import {
+  TableShapeMetadataSchema,
+  FloorPlanLayoutSchema,
+  FloorPlanSchema,
+} from "./schemas/floor-plan.js";
 
-describe("Reservation Schemas", () => {
-  it("validates a valid reservation", () => {
-    const validRes = {
-      id: "res-123",
-      venueId: "venue-456",
-      guestId: "guest-789",
-      tableId: "table-10",
-      partySize: 4,
-      date: "2026-05-10",
-      startTime: "18:00",
-      endTime: "20:00",
-      status: "CONFIRMED",
-      notes: null,
-      cancellationReason: null,
-      cancellationNote: null,
-      guestName: "John Doe",
-      guestEmail: "john@example.com",
-      guestPhone: null,
-      userId: null,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    };
-    const result = ReservationSchema.safeParse(validRes);
-    expect(result.success).toBe(true);
+// ── ReservationStatusSchema ────────────────────────────────────────
+
+describe("ReservationStatusSchema", () => {
+  const validStatuses = ["PENDING", "CONFIRMED", "CANCELLED", "COMPLETED", "NO_SHOW"];
+
+  it.each(validStatuses)("accepts valid status: %s", (status) => {
+    expect(ReservationStatusSchema.safeParse(status).success).toBe(true);
   });
 
-  it("validates reservation status", () => {
-    expect(ReservationStatusSchema.safeParse("CONFIRMED").success).toBe(true);
-    expect(ReservationStatusSchema.safeParse("CANCELLED").success).toBe(true);
+  it("rejects lowercase variants", () => {
     expect(ReservationStatusSchema.safeParse("pending").success).toBe(false);
+    expect(ReservationStatusSchema.safeParse("confirmed").success).toBe(false);
+    expect(ReservationStatusSchema.safeParse("no_show").success).toBe(false);
   });
 
-  it("validates venue and table", () => {
-    const venue = { 
-      id: "v1", 
-      venueGroupId: null,
-      name: "The Grill", 
-      slug: "the-grill",
-      ianaTimezone: "UTC",
-      currencyCode: "USD",
-      operatingHours: null,
-      settings: null,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString()
+  it("rejects unknown statuses", () => {
+    expect(ReservationStatusSchema.safeParse("ACTIVE").success).toBe(false);
+    expect(ReservationStatusSchema.safeParse("").success).toBe(false);
+  });
+
+  it("rejects non-string types", () => {
+    expect(ReservationStatusSchema.safeParse(1).success).toBe(false);
+    expect(ReservationStatusSchema.safeParse(null).success).toBe(false);
+  });
+});
+
+// ── TableStatusSchema ──────────────────────────────────────────────
+
+describe("TableStatusSchema", () => {
+  const validStatuses = ["AVAILABLE", "OCCUPIED", "DIRTY", "READY"];
+
+  it.each(validStatuses)("accepts valid status: %s", (status) => {
+    expect(TableStatusSchema.safeParse(status).success).toBe(true);
+  });
+
+  it("rejects invalid statuses", () => {
+    expect(TableStatusSchema.safeParse("CLOSED").success).toBe(false);
+    expect(TableStatusSchema.safeParse("available").success).toBe(false);
+  });
+});
+
+// ── ReservationSchema ──────────────────────────────────────────────
+
+describe("ReservationSchema", () => {
+  const validReservation = {
+    id: "res-123",
+    venueId: "venue-456",
+    guestId: "guest-789",
+    tableId: "table-10",
+    partySize: 4,
+    date: "2026-05-10",
+    startTime: "18:00",
+    endTime: "20:00",
+    status: "CONFIRMED",
+    notes: null,
+    cancellationReason: null,
+    cancellationNote: null,
+    guestName: "John Doe",
+    guestEmail: "john@example.com",
+    guestPhone: null,
+    userId: null,
+    createdAt: "2026-05-10T00:00:00.000Z",
+    updatedAt: "2026-05-10T00:00:00.000Z",
+  };
+
+  it("accepts a valid reservation", () => {
+    expect(ReservationSchema.safeParse(validReservation).success).toBe(true);
+  });
+
+  it("accepts reservation with all optional nullable fields populated", () => {
+    const populated = {
+      ...validReservation,
+      notes: "Window seat preferred",
+      cancellationReason: "GUEST_REQUEST",
+      cancellationNote: "Changed plans",
+      guestPhone: "+1-555-0100",
+      userId: "user-abc",
     };
-    const table = { 
-      id: "t1", 
+    expect(ReservationSchema.safeParse(populated).success).toBe(true);
+  });
+
+  it("accepts reservation with optional table included", () => {
+    const table = {
+      id: "t1",
       name: "Table 1",
       tableNumber: "1",
-      capacity: 4, 
+      capacity: 4,
       minCovers: 1,
       maxCovers: 6,
       location: "Main Floor",
       isActive: true,
       priority: 1,
       status: "AVAILABLE",
-      venueId: "v1", 
+      venueId: "v1",
       floorPlanId: "fp1",
+      shapeMetadata: null,
+      createdAt: "2026-05-10T00:00:00.000Z",
+      updatedAt: "2026-05-10T00:00:00.000Z",
+    };
+    const withTable = { ...validReservation, table };
+    expect(ReservationSchema.safeParse(withTable).success).toBe(true);
+  });
+
+  it("rejects missing required fields", () => {
+    const { id: _, ...noId } = validReservation;
+    expect(ReservationSchema.safeParse(noId).success).toBe(false);
+
+    const { partySize: _ps, ...noParty } = validReservation;
+    expect(ReservationSchema.safeParse(noParty).success).toBe(false);
+
+    const { tableId: _tid, ...noTable } = validReservation;
+    expect(ReservationSchema.safeParse(noTable).success).toBe(false);
+  });
+
+  it("rejects invalid status", () => {
+    expect(
+      ReservationSchema.safeParse({ ...validReservation, status: "ACTIVE" }).success
+    ).toBe(false);
+  });
+
+  it("rejects non-number partySize", () => {
+    expect(
+      ReservationSchema.safeParse({ ...validReservation, partySize: "4" }).success
+    ).toBe(false);
+  });
+
+  it("rejects completely empty object", () => {
+    expect(ReservationSchema.safeParse({}).success).toBe(false);
+  });
+});
+
+// ── TableSchema ────────────────────────────────────────────────────
+
+describe("TableSchema", () => {
+  const validTable = {
+    id: "t1",
+    name: "Table 1",
+    tableNumber: "1",
+    capacity: 4,
+    minCovers: 1,
+    maxCovers: 6,
+    location: "Main Floor",
+    isActive: true,
+    priority: 1,
+    status: "AVAILABLE",
+    venueId: "v1",
+    floorPlanId: "fp1",
+    shapeMetadata: {
+      x: 10,
+      y: 20,
+      width: 100,
+      height: 80,
+      shape: "rectangle",
+    },
+    createdAt: "2026-05-10T00:00:00.000Z",
+    updatedAt: "2026-05-10T00:00:00.000Z",
+  };
+
+  it("accepts a valid table", () => {
+    expect(TableSchema.safeParse(validTable).success).toBe(true);
+  });
+
+  it("accepts table with null optional fields", () => {
+    const table = {
+      ...validTable,
+      tableNumber: null,
+      maxCovers: null,
+      location: null,
+      venueId: null,
+      floorPlanId: null,
+      shapeMetadata: null,
+    };
+    expect(TableSchema.safeParse(table).success).toBe(true);
+  });
+
+  it("accepts table with shape metadata including optional fields", () => {
+    const table = {
+      ...validTable,
       shapeMetadata: {
         x: 0,
         y: 0,
-        width: 100,
-        height: 100,
-        shape: "rectangle"
+        width: 50,
+        height: 50,
+        rotation: 45,
+        shape: "circle",
+        color: "#ff0000",
       },
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString()
     };
-    const venueResult = VenueSchema.safeParse(venue);
-    expect(venueResult.success).toBe(true);
+    expect(TableSchema.safeParse(table).success).toBe(true);
+  });
 
-    const tableResult = TableSchema.safeParse(table);
-    expect(tableResult.success).toBe(true);
+  it("rejects invalid table status", () => {
+    expect(TableSchema.safeParse({ ...validTable, status: "CLOSED" }).success).toBe(false);
+  });
+
+  it("rejects non-boolean isActive", () => {
+    expect(TableSchema.safeParse({ ...validTable, isActive: 1 }).success).toBe(false);
+  });
+
+  it("rejects invalid shapeMetadata shape enum", () => {
+    const table = {
+      ...validTable,
+      shapeMetadata: { x: 0, y: 0, width: 50, height: 50, shape: "triangle" },
+    };
+    expect(TableSchema.safeParse(table).success).toBe(false);
+  });
+});
+
+// ── TableShapeMetadataSchema ───────────────────────────────────────
+
+describe("TableShapeMetadataSchema", () => {
+  it("accepts valid rectangle metadata", () => {
+    const metadata = { x: 0, y: 0, width: 100, height: 80, shape: "rectangle" };
+    expect(TableShapeMetadataSchema.safeParse(metadata).success).toBe(true);
+  });
+
+  it("accepts valid circle metadata", () => {
+    const metadata = { x: 50, y: 50, width: 60, height: 60, shape: "circle" };
+    expect(TableShapeMetadataSchema.safeParse(metadata).success).toBe(true);
+  });
+
+  it("accepts valid square metadata with optional rotation and color", () => {
+    const metadata = { x: 10, y: 20, width: 50, height: 50, rotation: 90, shape: "square", color: "#333" };
+    expect(TableShapeMetadataSchema.safeParse(metadata).success).toBe(true);
+  });
+
+  it("rejects invalid shape values", () => {
+    const metadata = { x: 0, y: 0, width: 100, height: 80, shape: "hexagon" };
+    expect(TableShapeMetadataSchema.safeParse(metadata).success).toBe(false);
+  });
+
+  it("rejects missing required coordinates", () => {
+    expect(TableShapeMetadataSchema.safeParse({ width: 100, height: 80, shape: "rectangle" }).success).toBe(false);
+  });
+});
+
+// ── FloorPlanLayoutSchema ──────────────────────────────────────────
+
+describe("FloorPlanLayoutSchema", () => {
+  it("accepts minimal layout", () => {
+    expect(FloorPlanLayoutSchema.safeParse({ width: 800, height: 600 }).success).toBe(true);
+  });
+
+  it("accepts fully specified layout", () => {
+    const layout = {
+      width: 1200,
+      height: 900,
+      backgroundImage: "https://cdn.example.com/floorplan.png",
+      gridSize: 20,
+      showGrid: true,
+    };
+    expect(FloorPlanLayoutSchema.safeParse(layout).success).toBe(true);
+  });
+
+  it("rejects missing dimensions", () => {
+    expect(FloorPlanLayoutSchema.safeParse({ height: 600 }).success).toBe(false);
+    expect(FloorPlanLayoutSchema.safeParse({ width: 800 }).success).toBe(false);
+  });
+
+  it("rejects non-number dimensions", () => {
+    expect(FloorPlanLayoutSchema.safeParse({ width: "800", height: 600 }).success).toBe(false);
+  });
+});
+
+// ── FloorPlanSchema ────────────────────────────────────────────────
+
+describe("FloorPlanSchema", () => {
+  const validFloorPlan = {
+    id: "fp-1",
+    venueId: "v-1",
+    name: "Main Floor",
+    isActive: true,
+    layoutJson: { width: 800, height: 600 },
+    createdAt: "2026-05-10T00:00:00.000Z",
+    updatedAt: "2026-05-10T00:00:00.000Z",
+  };
+
+  it("accepts a valid floor plan without tables", () => {
+    expect(FloorPlanSchema.safeParse(validFloorPlan).success).toBe(true);
+  });
+
+  it("accepts a floor plan with tables array", () => {
+    const floorPlan = {
+      ...validFloorPlan,
+      tables: [
+        {
+          id: "t1",
+          name: "Table 1",
+          tableNumber: "1",
+          capacity: 4,
+          minCovers: 1,
+          maxCovers: 6,
+          location: null,
+          isActive: true,
+          priority: 1,
+          status: "AVAILABLE",
+          venueId: "v-1",
+          floorPlanId: "fp-1",
+          shapeMetadata: null,
+          createdAt: "2026-05-10T00:00:00.000Z",
+          updatedAt: "2026-05-10T00:00:00.000Z",
+        },
+      ],
+    };
+    expect(FloorPlanSchema.safeParse(floorPlan).success).toBe(true);
+  });
+
+  it("rejects missing layoutJson", () => {
+    const { layoutJson: _, ...noLayout } = validFloorPlan;
+    expect(FloorPlanSchema.safeParse(noLayout).success).toBe(false);
+  });
+
+  it("rejects invalid layoutJson", () => {
+    expect(FloorPlanSchema.safeParse({ ...validFloorPlan, layoutJson: "invalid" }).success).toBe(false);
+  });
+});
+
+// ── VenueGroupSchema ───────────────────────────────────────────────
+
+describe("VenueGroupSchema", () => {
+  it("accepts a valid venue group", () => {
+    const group = {
+      id: "vg-1",
+      name: "Restaurant Group",
+      slug: "restaurant-group",
+      settings: { theme: "dark" },
+      createdAt: "2026-05-10T00:00:00.000Z",
+    };
+    expect(VenueGroupSchema.safeParse(group).success).toBe(true);
+  });
+
+  it("accepts venue group with null settings", () => {
+    const group = {
+      id: "vg-2",
+      name: "Solo",
+      slug: "solo",
+      settings: null,
+      createdAt: "2026-05-10T00:00:00.000Z",
+    };
+    expect(VenueGroupSchema.safeParse(group).success).toBe(true);
+  });
+
+  it("rejects missing required name", () => {
+    const group = { id: "vg-1", slug: "s", settings: null, createdAt: "t" };
+    expect(VenueGroupSchema.safeParse(group).success).toBe(false);
+  });
+});
+
+// ── DayScheduleSchema ──────────────────────────────────────────────
+
+describe("DayScheduleSchema", () => {
+  it("accepts a valid open day", () => {
+    expect(DayScheduleSchema.safeParse({ open: "09:00", close: "22:00" }).success).toBe(true);
+  });
+
+  it("accepts a closed day", () => {
+    expect(DayScheduleSchema.safeParse({ open: "00:00", close: "00:00", closed: true }).success).toBe(true);
+  });
+
+  it("rejects missing open/close", () => {
+    expect(DayScheduleSchema.safeParse({ close: "22:00" }).success).toBe(false);
+    expect(DayScheduleSchema.safeParse({ open: "09:00" }).success).toBe(false);
+  });
+});
+
+// ── VenueSchema ────────────────────────────────────────────────────
+
+describe("VenueSchema", () => {
+  const validVenue = {
+    id: "v-1",
+    venueGroupId: null,
+    name: "The Grill",
+    slug: "the-grill",
+    ianaTimezone: "America/New_York",
+    currencyCode: "USD",
+    operatingHours: null,
+    settings: null,
+    createdAt: "2026-05-10T00:00:00.000Z",
+    updatedAt: "2026-05-10T00:00:00.000Z",
+  };
+
+  it("accepts a minimal valid venue", () => {
+    expect(VenueSchema.safeParse(validVenue).success).toBe(true);
+  });
+
+  it("accepts venue with full operating hours", () => {
+    const venue = {
+      ...validVenue,
+      operatingHours: {
+        monday: { open: "11:00", close: "23:00" },
+        tuesday: { open: "11:00", close: "23:00" },
+        wednesday: { open: "11:00", close: "23:00" },
+        thursday: { open: "11:00", close: "23:00" },
+        friday: { open: "11:00", close: "00:00" },
+        saturday: { open: "10:00", close: "00:00" },
+        sunday: { open: "10:00", close: "22:00", closed: true },
+      },
+    };
+    expect(VenueSchema.safeParse(venue).success).toBe(true);
+  });
+
+  it("accepts venue with partial operating hours (some days omitted)", () => {
+    const venue = {
+      ...validVenue,
+      operatingHours: {
+        monday: { open: "09:00", close: "17:00" },
+        friday: { open: "09:00", close: "21:00" },
+      },
+    };
+    expect(VenueSchema.safeParse(venue).success).toBe(true);
+  });
+
+  it("accepts venue with venueGroup included", () => {
+    const venue = {
+      ...validVenue,
+      venueGroupId: "vg-1",
+      venueGroup: {
+        id: "vg-1",
+        name: "Group",
+        slug: "group",
+        settings: null,
+        createdAt: "2026-05-10T00:00:00.000Z",
+      },
+    };
+    expect(VenueSchema.safeParse(venue).success).toBe(true);
+  });
+
+  it("rejects missing required fields", () => {
+    const { name: _, ...noName } = validVenue;
+    expect(VenueSchema.safeParse(noName).success).toBe(false);
+
+    const { slug: _s, ...noSlug } = validVenue;
+    expect(VenueSchema.safeParse(noSlug).success).toBe(false);
+
+    const { ianaTimezone: _tz, ...noTz } = validVenue;
+    expect(VenueSchema.safeParse(noTz).success).toBe(false);
+  });
+
+  it("rejects non-string currencyCode", () => {
+    expect(VenueSchema.safeParse({ ...validVenue, currencyCode: 840 }).success).toBe(false);
+  });
+
+  it("rejects invalid operatingHours structure", () => {
+    expect(VenueSchema.safeParse({ ...validVenue, operatingHours: "always" }).success).toBe(false);
   });
 });

--- a/packages/types/src/schema-compat.test.ts
+++ b/packages/types/src/schema-compat.test.ts
@@ -1,128 +1,420 @@
 import { describe, it, expect } from "vitest";
 import { compareSchema } from "./schema-compat.js";
 
-describe("Schema Compatibility Utility", () => {
-  it("detects compatible schemas", () => {
-    const baseline = {
-      type: "object",
-      properties: { id: { type: "string" } },
-      required: ["id"],
-    };
-    const current = {
-      type: "object",
-      properties: { 
-        id: { type: "string" },
-        name: { type: "string" } 
-      },
-      required: ["id"],
-    };
-    
-    const result = compareSchema("Test", baseline, current);
-    expect(result.breaking).toHaveLength(0);
-    expect(result.nonBreaking).toHaveLength(1);
-    expect(result.nonBreaking[0]).toContain("optional property \"name\" was added");
+describe("compareSchema", () => {
+  describe("schema-level changes", () => {
+    it("detects schema removal as breaking", () => {
+      const result = compareSchema("MySchema", { type: "object" }, undefined);
+      expect(result.breaking).toHaveLength(1);
+      expect(result.breaking[0]).toContain("was removed");
+      expect(result.nonBreaking).toHaveLength(0);
+    });
+
+    it("detects new schema as non-breaking", () => {
+      const result = compareSchema("NewSchema", undefined, { type: "object" });
+      expect(result.nonBreaking).toHaveLength(1);
+      expect(result.nonBreaking[0]).toContain("is new");
+      expect(result.breaking).toHaveLength(0);
+    });
+
+    it("returns empty arrays for identical schemas", () => {
+      const schema = {
+        type: "object",
+        properties: { id: { type: "string" } },
+        required: ["id"],
+      };
+      const result = compareSchema("Same", schema, schema);
+      expect(result.breaking).toHaveLength(0);
+      expect(result.nonBreaking).toHaveLength(0);
+    });
+
+    it("handles schemas with no properties", () => {
+      const result = compareSchema("Empty", { type: "object" }, { type: "object" });
+      expect(result.breaking).toHaveLength(0);
+      expect(result.nonBreaking).toHaveLength(0);
+    });
   });
 
-  it("detects breaking changes (field removal)", () => {
-    const baseline = {
-      type: "object",
-      properties: { id: { type: "string" }, old: { type: "number" } },
-      required: ["id"],
-    };
-    const current = {
-      type: "object",
-      properties: { id: { type: "string" } },
-      required: ["id"],
-    };
-    
-    const result = compareSchema("Test", baseline, current);
-    expect(result.breaking).toHaveLength(1);
-    expect(result.breaking[0]).toContain("property \"old\" was removed");
+  describe("property addition", () => {
+    it("detects optional property addition as non-breaking", () => {
+      const baseline = {
+        type: "object",
+        properties: { id: { type: "string" } },
+        required: ["id"],
+      };
+      const current = {
+        type: "object",
+        properties: { id: { type: "string" }, name: { type: "string" } },
+        required: ["id"],
+      };
+      const result = compareSchema("Test", baseline, current);
+      expect(result.breaking).toHaveLength(0);
+      expect(result.nonBreaking).toHaveLength(1);
+      expect(result.nonBreaking[0]).toContain("optional property \"name\" was added");
+    });
+
+    it("detects required property addition as breaking", () => {
+      const baseline = {
+        type: "object",
+        properties: { id: { type: "string" } },
+        required: ["id"],
+      };
+      const current = {
+        type: "object",
+        properties: { id: { type: "string" }, email: { type: "string" } },
+        required: ["id", "email"],
+      };
+      const result = compareSchema("Test", baseline, current);
+      expect(result.breaking).toHaveLength(1);
+      expect(result.breaking[0]).toContain("required property \"email\" was added");
+    });
+
+    it("handles multiple new optional properties", () => {
+      const baseline = {
+        type: "object",
+        properties: { id: { type: "string" } },
+      };
+      const current = {
+        type: "object",
+        properties: {
+          id: { type: "string" },
+          name: { type: "string" },
+          age: { type: "number" },
+        },
+      };
+      const result = compareSchema("Test", baseline, current);
+      expect(result.nonBreaking).toHaveLength(2);
+    });
   });
 
-  it("detects breaking changes (type change)", () => {
-    const baseline = {
-      type: "object",
-      properties: { id: { type: "string" } },
-    };
-    const current = {
-      type: "object",
-      properties: { id: { type: "number" } },
-    };
-    
-    const result = compareSchema("Test", baseline, current);
-    expect(result.breaking).toHaveLength(1);
-    expect(result.breaking[0]).toContain("type changed from \"string\" to \"number\"");
+  describe("property removal", () => {
+    it("detects field removal as breaking", () => {
+      const baseline = {
+        type: "object",
+        properties: { id: { type: "string" }, old: { type: "number" } },
+        required: ["id"],
+      };
+      const current = {
+        type: "object",
+        properties: { id: { type: "string" } },
+        required: ["id"],
+      };
+      const result = compareSchema("Test", baseline, current);
+      expect(result.breaking).toHaveLength(1);
+      expect(result.breaking[0]).toContain("property \"old\" was removed");
+    });
+
+    it("detects multiple field removals", () => {
+      const baseline = {
+        type: "object",
+        properties: { a: { type: "string" }, b: { type: "string" }, c: { type: "string" } },
+      };
+      const current = {
+        type: "object",
+        properties: { a: { type: "string" } },
+      };
+      const result = compareSchema("Test", baseline, current);
+      expect(result.breaking).toHaveLength(2);
+    });
   });
 
-  it("detects breaking changes (new required field)", () => {
-    const baseline = { type: "object", properties: { a: { type: "string" } } };
-    const current = { 
-      type: "object", 
-      properties: { a: { type: "string" }, b: { type: "string" } },
-      required: ["b"]
-    };
-    const result = compareSchema("Test", baseline, current);
-    expect(result.breaking).toHaveLength(1);
-    expect(result.breaking[0]).toContain("required property \"b\" was added");
+  describe("type changes", () => {
+    it("detects type change as breaking", () => {
+      const baseline = {
+        type: "object",
+        properties: { count: { type: "string" } },
+      };
+      const current = {
+        type: "object",
+        properties: { count: { type: "number" } },
+      };
+      const result = compareSchema("Test", baseline, current);
+      expect(result.breaking).toHaveLength(1);
+      expect(result.breaking[0]).toContain("type changed from \"string\" to \"number\"");
+    });
+
+    it("does not report type change when types match", () => {
+      const baseline = {
+        type: "object",
+        properties: { name: { type: "string" } },
+      };
+      const current = {
+        type: "object",
+        properties: { name: { type: "string" } },
+      };
+      const result = compareSchema("Test", baseline, current);
+      expect(result.breaking).toHaveLength(0);
+    });
+
+    it("skips type comparison when one side has no type", () => {
+      const baseline = {
+        type: "object",
+        properties: { data: {} },
+      };
+      const current = {
+        type: "object",
+        properties: { data: { type: "string" } },
+      };
+      const result = compareSchema("Test", baseline, current);
+      // No type change because baseline has no explicit type
+      expect(result.breaking).toHaveLength(0);
+    });
   });
 
-  it("detects non-breaking changes (required to optional)", () => {
-    const baseline = { type: "object", properties: { a: { type: "string" } }, required: ["a"] };
-    const current = { type: "object", properties: { a: { type: "string" } } };
-    const result = compareSchema("Test", baseline, current);
-    expect(result.nonBreaking).toHaveLength(1);
-    expect(result.nonBreaking[0]).toContain("property \"a\" became optional");
+  describe("required constraint changes", () => {
+    it("detects optional-to-required transition as breaking", () => {
+      const baseline = {
+        type: "object",
+        properties: { name: { type: "string" } },
+      };
+      const current = {
+        type: "object",
+        properties: { name: { type: "string" } },
+        required: ["name"],
+      };
+      const result = compareSchema("Test", baseline, current);
+      expect(result.breaking).toHaveLength(1);
+      expect(result.breaking[0]).toContain("property \"name\" became required");
+    });
+
+    it("detects required-to-optional transition as non-breaking", () => {
+      const baseline = {
+        type: "object",
+        properties: { name: { type: "string" } },
+        required: ["name"],
+      };
+      const current = {
+        type: "object",
+        properties: { name: { type: "string" } },
+      };
+      const result = compareSchema("Test", baseline, current);
+      expect(result.nonBreaking).toHaveLength(1);
+      expect(result.nonBreaking[0]).toContain("property \"name\" became optional");
+    });
+
+    it("does not report required change for newly added fields", () => {
+      // This is tested by the "required property addition" test path
+      const baseline = {
+        type: "object",
+        properties: { id: { type: "string" } },
+        required: ["id"],
+      };
+      const current = {
+        type: "object",
+        properties: { id: { type: "string" }, email: { type: "string" } },
+        required: ["id", "email"],
+      };
+      const result = compareSchema("Test", baseline, current);
+      // "email" is a new field, so it goes through the "new property" path, not "became required"
+      const becameRequired = result.breaking.filter((m) => m.includes("became required"));
+      expect(becameRequired).toHaveLength(0);
+    });
+
+    it("does not report required change for removed fields", () => {
+      const baseline = {
+        type: "object",
+        properties: { a: { type: "string" }, b: { type: "string" } },
+        required: ["a", "b"],
+      };
+      const current = {
+        type: "object",
+        properties: { a: { type: "string" } },
+        required: ["a"],
+      };
+      const result = compareSchema("Test", baseline, current);
+      // "b" was removed — only counts as "removed", not as "became optional"
+      expect(result.breaking).toHaveLength(1);
+      expect(result.breaking[0]).toContain("removed");
+      expect(result.nonBreaking).toHaveLength(0);
+    });
   });
 
-  it("detects enum changes", () => {
-    const baseline = { type: "object", properties: { e: { enum: ["a", "b"] } } };
-    const currentNarrow = { type: "object", properties: { e: { enum: ["a"] } } };
-    const currentWider = { type: "object", properties: { e: { enum: ["a", "b", "c"] } } };
+  describe("enum changes", () => {
+    it("detects enum narrowing as breaking", () => {
+      const baseline = {
+        type: "object",
+        properties: { status: { enum: ["active", "inactive", "pending"] } },
+      };
+      const current = {
+        type: "object",
+        properties: { status: { enum: ["active", "inactive"] } },
+      };
+      const result = compareSchema("Test", baseline, current);
+      expect(result.breaking).toHaveLength(1);
+      expect(result.breaking[0]).toContain("enum values removed: pending");
+    });
 
-    const res1 = compareSchema("Test", baseline, currentNarrow);
-    expect(res1.breaking).toHaveLength(1);
-    expect(res1.breaking[0]).toContain("enum values removed: b");
+    it("detects enum widening as non-breaking", () => {
+      const baseline = {
+        type: "object",
+        properties: { role: { enum: ["admin", "user"] } },
+      };
+      const current = {
+        type: "object",
+        properties: { role: { enum: ["admin", "user", "moderator"] } },
+      };
+      const result = compareSchema("Test", baseline, current);
+      expect(result.nonBreaking).toHaveLength(1);
+      expect(result.nonBreaking[0]).toContain("enum values added: moderator");
+    });
 
-    const res2 = compareSchema("Test", baseline, currentWider);
-    expect(res2.nonBreaking).toHaveLength(1);
-    expect(res2.nonBreaking[0]).toContain("enum values added: c");
+    it("detects simultaneous enum addition and removal", () => {
+      const baseline = {
+        type: "object",
+        properties: { color: { enum: ["red", "blue"] } },
+      };
+      const current = {
+        type: "object",
+        properties: { color: { enum: ["blue", "green"] } },
+      };
+      const result = compareSchema("Test", baseline, current);
+      expect(result.breaking).toHaveLength(1);
+      expect(result.breaking[0]).toContain("removed: red");
+      expect(result.nonBreaking).toHaveLength(1);
+      expect(result.nonBreaking[0]).toContain("added: green");
+    });
+
+    it("reports no change for identical enum values", () => {
+      const baseline = {
+        type: "object",
+        properties: { status: { enum: ["a", "b"] } },
+      };
+      const current = {
+        type: "object",
+        properties: { status: { enum: ["a", "b"] } },
+      };
+      const result = compareSchema("Test", baseline, current);
+      expect(result.breaking).toHaveLength(0);
+      expect(result.nonBreaking).toHaveLength(0);
+    });
   });
 
-  it("detects nullable changes", () => {
-    const baseline = { type: "object", properties: { n: { type: "string", nullable: true } } };
-    const currentNotNull = { type: "object", properties: { n: { type: "string" } } };
-    const res1 = compareSchema("Test", baseline, currentNotNull);
-    expect(res1.breaking).toHaveLength(1);
-    expect(res1.breaking[0]).toContain("no longer nullable");
+  describe("nullable changes", () => {
+    it("detects nullable removal as breaking", () => {
+      const baseline = {
+        type: "object",
+        properties: { name: { type: "string", nullable: true } },
+      };
+      const current = {
+        type: "object",
+        properties: { name: { type: "string" } },
+      };
+      const result = compareSchema("Test", baseline, current);
+      expect(result.breaking).toHaveLength(1);
+      expect(result.breaking[0]).toContain("no longer nullable");
+    });
 
-    const currentNullable = { type: "object", properties: { n: { type: "string", nullable: true } } };
-    const res2 = compareSchema("Test", currentNotNull, currentNullable);
-    expect(res2.nonBreaking).toHaveLength(1);
-    expect(res2.nonBreaking[0]).toContain("became nullable");
+    it("detects nullable addition as non-breaking", () => {
+      const baseline = {
+        type: "object",
+        properties: { name: { type: "string" } },
+      };
+      const current = {
+        type: "object",
+        properties: { name: { type: "string", nullable: true } },
+      };
+      const result = compareSchema("Test", baseline, current);
+      expect(result.nonBreaking).toHaveLength(1);
+      expect(result.nonBreaking[0]).toContain("became nullable");
+    });
+
+    it("reports no change when nullable stays true", () => {
+      const baseline = {
+        type: "object",
+        properties: { name: { type: "string", nullable: true } },
+      };
+      const current = {
+        type: "object",
+        properties: { name: { type: "string", nullable: true } },
+      };
+      const result = compareSchema("Test", baseline, current);
+      expect(result.breaking).toHaveLength(0);
+      expect(result.nonBreaking).toHaveLength(0);
+    });
   });
 
-  it("detects cosmetic changes", () => {
-    const baseline = { type: "object", properties: { a: { type: "string", description: "old" } } };
-    const current = { type: "object", properties: { a: { type: "string", description: "new" } } };
-    const result = compareSchema("Test", baseline, current);
-    expect(result.nonBreaking).toHaveLength(1);
-    expect(result.nonBreaking[0]).toContain("description changed");
+  describe("cosmetic changes", () => {
+    it("detects description change as non-breaking", () => {
+      const baseline = {
+        type: "object",
+        properties: { id: { type: "string", description: "The unique ID" } },
+      };
+      const current = {
+        type: "object",
+        properties: { id: { type: "string", description: "Unique identifier" } },
+      };
+      const result = compareSchema("Test", baseline, current);
+      expect(result.breaking).toHaveLength(0);
+      expect(result.nonBreaking).toHaveLength(1);
+      expect(result.nonBreaking[0]).toContain("description changed");
+    });
+
+    it("detects example change as non-breaking", () => {
+      const baseline = {
+        type: "object",
+        properties: { name: { type: "string", example: "John" } },
+      };
+      const current = {
+        type: "object",
+        properties: { name: { type: "string", example: "Jane" } },
+      };
+      const result = compareSchema("Test", baseline, current);
+      expect(result.nonBreaking).toHaveLength(1);
+      expect(result.nonBreaking[0]).toContain("example changed");
+    });
+
+    it("detects examples (plural) change as non-breaking", () => {
+      const baseline = {
+        type: "object",
+        properties: { tag: { type: "string", examples: ["a", "b"] } },
+      };
+      const current = {
+        type: "object",
+        properties: { tag: { type: "string", examples: ["x", "y", "z"] } },
+      };
+      const result = compareSchema("Test", baseline, current);
+      expect(result.nonBreaking).toHaveLength(1);
+      expect(result.nonBreaking[0]).toContain("examples changed");
+    });
   });
 
-  it("detects breaking changes (optional to required transition)", () => {
-    const baseline = { type: "object", properties: { a: { type: "string" } } };
-    const current = { type: "object", properties: { a: { type: "string" } }, required: ["a"] };
-    const result = compareSchema("Test", baseline, current);
-    expect(result.breaking).toHaveLength(1);
-    expect(result.breaking[0]).toContain("property \"a\" became required");
-  });
+  describe("complex multi-change scenarios", () => {
+    it("handles combined breaking and non-breaking changes", () => {
+      const baseline = {
+        type: "object",
+        properties: {
+          id: { type: "string" },
+          name: { type: "string", description: "old" },
+          legacy: { type: "number" },
+        },
+        required: ["id"],
+      };
+      const current = {
+        type: "object",
+        properties: {
+          id: { type: "number" }, // type change (breaking)
+          name: { type: "string", description: "new" }, // cosmetic (non-breaking)
+          // legacy removed (breaking)
+          newField: { type: "boolean" }, // new optional (non-breaking)
+        },
+        required: ["id"],
+      };
+      const result = compareSchema("Complex", baseline, current);
+      expect(result.breaking.length).toBeGreaterThanOrEqual(2); // type change + removal
+      expect(result.nonBreaking.length).toBeGreaterThanOrEqual(2); // description + new field
+    });
 
-  it("handles missing schemas", () => {
-    const res1 = compareSchema("Test", { type: "object" }, undefined);
-    expect(res1.breaking[0]).toContain("removed");
-
-    const res2 = compareSchema("Test", undefined, { type: "object" });
-    expect(res2.nonBreaking[0]).toContain("new");
+    it("schema ID is included in messages", () => {
+      const baseline = {
+        type: "object",
+        properties: { x: { type: "string" } },
+      };
+      const current = {
+        type: "object",
+        properties: {},
+      };
+      const result = compareSchema("UserProfile", baseline, current);
+      expect(result.breaking[0]).toContain("UserProfile");
+    });
   });
 });

--- a/packages/types/src/schemas.test.ts
+++ b/packages/types/src/schemas.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect } from "vitest";
+import {
+  UserSchema,
+  UserPreferencesSchema,
+  UserProfileSchema,
+} from "./schemas/user.js";
+import {
+  GuestSchema,
+  GuestSegmentSchema,
+} from "./schemas/guest.js";
+import {
+  PaginationSchema,
+  ErrorResponseSchema,
+} from "./schemas/common.js";
+import { ProblemDetailsSchema } from "./schemas/api.js";
+
+// ── UserPreferencesSchema ──────────────────────────────────────────
+
+describe("UserPreferencesSchema", () => {
+  it("accepts empty object (all fields optional)", () => {
+    expect(UserPreferencesSchema.safeParse({}).success).toBe(true);
+  });
+
+  it("accepts all preferences populated", () => {
+    const prefs = { theme: "dark", emailNotifications: true, marketingEmails: false };
+    expect(UserPreferencesSchema.safeParse(prefs).success).toBe(true);
+  });
+
+  it("accepts valid theme values", () => {
+    expect(UserPreferencesSchema.safeParse({ theme: "light" }).success).toBe(true);
+    expect(UserPreferencesSchema.safeParse({ theme: "dark" }).success).toBe(true);
+    expect(UserPreferencesSchema.safeParse({ theme: "system" }).success).toBe(true);
+  });
+
+  it("rejects invalid theme values", () => {
+    expect(UserPreferencesSchema.safeParse({ theme: "blue" }).success).toBe(false);
+    expect(UserPreferencesSchema.safeParse({ theme: "" }).success).toBe(false);
+  });
+
+  it("rejects non-boolean notification fields", () => {
+    expect(UserPreferencesSchema.safeParse({ emailNotifications: "yes" }).success).toBe(false);
+    expect(UserPreferencesSchema.safeParse({ marketingEmails: 1 }).success).toBe(false);
+  });
+});
+
+// ── UserSchema ─────────────────────────────────────────────────────
+
+describe("UserSchema", () => {
+  const validUser = {
+    id: "user-123",
+    email: "test@example.com",
+    name: "Test User",
+    picture: "https://example.com/avatar.png",
+    emailVerified: true,
+    preferences: {},
+    createdAt: "2026-05-10T00:00:00.000Z",
+    updatedAt: "2026-05-10T00:00:00.000Z",
+  };
+
+  it("accepts a valid user", () => {
+    expect(UserSchema.safeParse(validUser).success).toBe(true);
+  });
+
+  it("accepts user with null optional fields", () => {
+    const user = { ...validUser, name: null, picture: null };
+    expect(UserSchema.safeParse(user).success).toBe(true);
+  });
+
+  it("accepts user with full preferences", () => {
+    const user = {
+      ...validUser,
+      preferences: { theme: "dark", emailNotifications: true, marketingEmails: false },
+    };
+    expect(UserSchema.safeParse(user).success).toBe(true);
+  });
+
+  it("rejects invalid email format", () => {
+    expect(UserSchema.safeParse({ ...validUser, email: "not-an-email" }).success).toBe(false);
+    expect(UserSchema.safeParse({ ...validUser, email: "" }).success).toBe(false);
+  });
+
+  it("rejects missing required fields", () => {
+    const { id: _, ...noId } = validUser;
+    expect(UserSchema.safeParse(noId).success).toBe(false);
+
+    const { email: _e, ...noEmail } = validUser;
+    expect(UserSchema.safeParse(noEmail).success).toBe(false);
+
+    const { emailVerified: _ev, ...noVerified } = validUser;
+    expect(UserSchema.safeParse(noVerified).success).toBe(false);
+
+    const { preferences: _p, ...noPrefs } = validUser;
+    expect(UserSchema.safeParse(noPrefs).success).toBe(false);
+  });
+
+  it("rejects non-boolean emailVerified", () => {
+    expect(UserSchema.safeParse({ ...validUser, emailVerified: "yes" }).success).toBe(false);
+  });
+});
+
+// ── UserProfileSchema ──────────────────────────────────────────────
+
+describe("UserProfileSchema", () => {
+  it("accepts a valid profile", () => {
+    expect(UserProfileSchema.safeParse({ id: "u1", name: "Alice", picture: "url" }).success).toBe(true);
+  });
+
+  it("accepts profile with null name and picture", () => {
+    expect(UserProfileSchema.safeParse({ id: "u1", name: null, picture: null }).success).toBe(true);
+  });
+
+  it("rejects missing id", () => {
+    expect(UserProfileSchema.safeParse({ name: "Alice", picture: null }).success).toBe(false);
+  });
+});
+
+// ── GuestSchema ────────────────────────────────────────────────────
+
+describe("GuestSchema", () => {
+  const validGuest = {
+    id: "guest-1",
+    venueId: "venue-1",
+    email: "guest@example.com",
+    phone: "+1-555-0100",
+    name: "Jane Smith",
+    notes: "VIP guest",
+    visitCount: 12,
+    lifetimeSpend: "4500.00",
+    lastVisit: "2026-05-01T12:00:00.000Z",
+    tags: ["vip", "regular"],
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-05-10T00:00:00.000Z",
+  };
+
+  it("accepts a fully populated guest", () => {
+    expect(GuestSchema.safeParse(validGuest).success).toBe(true);
+  });
+
+  it("accepts guest with all nullable fields null", () => {
+    const guest = {
+      ...validGuest,
+      email: null,
+      phone: null,
+      notes: null,
+      lifetimeSpend: null,
+      lastVisit: null,
+      tags: null,
+    };
+    expect(GuestSchema.safeParse(guest).success).toBe(true);
+  });
+
+  it("accepts guest with empty tags array", () => {
+    const guest = { ...validGuest, tags: [] };
+    expect(GuestSchema.safeParse(guest).success).toBe(true);
+  });
+
+  it("rejects missing required name", () => {
+    const { name: _, ...noName } = validGuest;
+    expect(GuestSchema.safeParse(noName).success).toBe(false);
+  });
+
+  it("rejects non-number visitCount", () => {
+    expect(GuestSchema.safeParse({ ...validGuest, visitCount: "12" }).success).toBe(false);
+  });
+
+  it("rejects non-string array elements in tags", () => {
+    expect(GuestSchema.safeParse({ ...validGuest, tags: [1, 2] }).success).toBe(false);
+  });
+});
+
+// ── GuestSegmentSchema ─────────────────────────────────────────────
+
+describe("GuestSegmentSchema", () => {
+  it("accepts a valid segment", () => {
+    const segment = { name: "VIP", description: "High-value guests", count: 42 };
+    expect(GuestSegmentSchema.safeParse(segment).success).toBe(true);
+  });
+
+  it("rejects missing fields", () => {
+    expect(GuestSegmentSchema.safeParse({ name: "VIP" }).success).toBe(false);
+    expect(GuestSegmentSchema.safeParse({ name: "VIP", description: "x" }).success).toBe(false);
+  });
+
+  it("rejects non-number count", () => {
+    expect(GuestSegmentSchema.safeParse({ name: "VIP", description: "x", count: "42" }).success).toBe(false);
+  });
+});
+
+// ── PaginationSchema ───────────────────────────────────────────────
+
+describe("PaginationSchema", () => {
+  it("accepts valid pagination", () => {
+    const pagination = {
+      page: 1,
+      limit: 20,
+      total: 100,
+      totalPages: 5,
+      hasNext: true,
+      hasPrev: false,
+    };
+    expect(PaginationSchema.safeParse(pagination).success).toBe(true);
+  });
+
+  it("rejects missing fields", () => {
+    expect(PaginationSchema.safeParse({ page: 1, limit: 20 }).success).toBe(false);
+  });
+
+  it("rejects non-number page/limit", () => {
+    const pagination = { page: "1", limit: 20, total: 100, totalPages: 5, hasNext: true, hasPrev: false };
+    expect(PaginationSchema.safeParse(pagination).success).toBe(false);
+  });
+
+  it("rejects non-boolean hasNext/hasPrev", () => {
+    const pagination = { page: 1, limit: 20, total: 100, totalPages: 5, hasNext: 1, hasPrev: 0 };
+    expect(PaginationSchema.safeParse(pagination).success).toBe(false);
+  });
+});
+
+// ── ErrorResponseSchema ────────────────────────────────────────────
+
+describe("ErrorResponseSchema", () => {
+  it("accepts a valid error response", () => {
+    const err = { error: "NotFound", message: "Resource not found", statusCode: 404 };
+    expect(ErrorResponseSchema.safeParse(err).success).toBe(true);
+  });
+
+  it("rejects missing error field", () => {
+    expect(ErrorResponseSchema.safeParse({ message: "msg", statusCode: 500 }).success).toBe(false);
+  });
+
+  it("rejects non-number statusCode", () => {
+    expect(ErrorResponseSchema.safeParse({ error: "E", message: "m", statusCode: "404" }).success).toBe(false);
+  });
+});
+
+// ── ProblemDetailsSchema (RFC 9457) ────────────────────────────────
+
+describe("ProblemDetailsSchema", () => {
+  it("accepts a valid problem details response", () => {
+    const problem = {
+      type: "https://example.com/errors/not-found",
+      title: "Not Found",
+      status: 404,
+      detail: "The requested reservation was not found",
+    };
+    expect(ProblemDetailsSchema.safeParse(problem).success).toBe(true);
+  });
+
+  it("accepts about:blank as type", () => {
+    const problem = {
+      type: "about:blank",
+      title: "Bad Request",
+      status: 400,
+      detail: "Invalid input",
+    };
+    expect(ProblemDetailsSchema.safeParse(problem).success).toBe(true);
+  });
+
+  it("accepts problem with optional instance and extra fields", () => {
+    const problem = {
+      type: "https://example.com/errors/validation",
+      title: "Validation Error",
+      status: 422,
+      detail: "partySize must be positive",
+      instance: "/reservations/123",
+      fieldErrors: [{ field: "partySize", message: "must be > 0" }],
+    };
+    expect(ProblemDetailsSchema.safeParse(problem).success).toBe(true);
+  });
+
+  it("rejects invalid type (not a URL or about:blank)", () => {
+    const problem = {
+      type: "not-a-url",
+      title: "Error",
+      status: 500,
+      detail: "Something failed",
+    };
+    expect(ProblemDetailsSchema.safeParse(problem).success).toBe(false);
+  });
+
+  it("rejects status outside valid HTTP range", () => {
+    expect(
+      ProblemDetailsSchema.safeParse({ type: "about:blank", title: "X", status: 99, detail: "d" }).success
+    ).toBe(false);
+    expect(
+      ProblemDetailsSchema.safeParse({ type: "about:blank", title: "X", status: 600, detail: "d" }).success
+    ).toBe(false);
+  });
+
+  it("rejects non-integer status", () => {
+    expect(
+      ProblemDetailsSchema.safeParse({ type: "about:blank", title: "X", status: 404.5, detail: "d" }).success
+    ).toBe(false);
+  });
+
+  it("rejects missing required fields", () => {
+    expect(ProblemDetailsSchema.safeParse({ title: "X", status: 400, detail: "d" }).success).toBe(false);
+    expect(ProblemDetailsSchema.safeParse({ type: "about:blank", status: 400, detail: "d" }).success).toBe(false);
+    expect(ProblemDetailsSchema.safeParse({ type: "about:blank", title: "X", detail: "d" }).success).toBe(false);
+    expect(ProblemDetailsSchema.safeParse({ type: "about:blank", title: "X", status: 400 }).success).toBe(false);
+  });
+});

--- a/packages/types/vitest.config.ts
+++ b/packages/types/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts", "src/index.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Adds comprehensive Zod schema validation tests for all schemas in `@mbe/types` (agent, reservation, venue, table, floor-plan, user, guest, common, API, date utility, JSON Schema conversion, and schema-compat)
- Tests cover valid inputs, invalid inputs, missing required fields, boundary conditions, and edge cases
- Adds `vitest.config.ts` to exclude `dist/` from test discovery (was running tests from both src and dist)
- Achieves 100% statement, branch, function, and line coverage

## Test plan
- [x] `pnpm --dir packages/types test` — 219 tests pass across 7 test files
- [x] `pnpm --dir packages/types test -- --coverage` — 100% coverage on all metrics
- [x] `pnpm --dir packages/types lint` — no errors
- [x] `pnpm --dir packages/types typecheck` — no errors

Closes #1146

🤖 Generated with [Claude Code](https://claude.com/claude-code)