### PR TITLE
test(hospitality): expand test coverage for UI components and hooks

### DIFF
--- a/apps/hospitality/src/components/SystemHealthBadge.test.tsx
+++ b/apps/hospitality/src/components/SystemHealthBadge.test.tsx
@@ -1,0 +1,154 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, react/jsx-no-undef */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import { SystemHealthBadge } from "./SystemHealthBadge.js";
+import { useAuth } from "@mbe/auth/react";
+import React from "react";
+
+vi.mock("@mbe/auth/react", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("@mattbutlerengineering/rialto", () => ({
+  Badge: ({ children, color }: { children: React.ReactNode; color?: string }) => (
+    <span data-testid="badge" data-color={color}>{children}</span>
+  ),
+  Popover: ({ trigger, children }: { trigger: React.ReactNode; children: React.ReactNode }) => (
+    <div data-testid="popover">
+      {trigger}
+      <div data-testid="popover-content">{children}</div>
+    </div>
+  ),
+}));
+
+describe("SystemHealthBadge", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders nothing for non-admin users", () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: { raw: { permissions: [] } },
+    } as any);
+
+    const { container } = render(<SystemHealthBadge />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when user has no permissions", () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: { raw: {} },
+    } as any);
+
+    const { container } = render(<SystemHealthBadge />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when user is null", () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: null,
+    } as any);
+
+    const { container } = render(<SystemHealthBadge />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("fetches health data for admin users and renders badge", async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: { raw: { permissions: ["admin"] } },
+    } as any);
+
+    const healthData = {
+      status: "healthy",
+      timestamp: "2026-01-15T12:00:00Z",
+      services: {
+        "users-api": { status: "healthy", latency: 42 },
+        "reservations-api": { status: "degraded", latency: 150 },
+      },
+      ci: { status: "healthy" },
+      deploy: { status: "healthy" },
+    };
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(healthData),
+    });
+
+    await act(async () => {
+      render(<SystemHealthBadge />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("popover")).toBeDefined();
+    });
+
+    expect(screen.getByLabelText("System health: healthy")).toBeDefined();
+    expect(screen.getByText("System Health")).toBeDefined();
+    expect(screen.getByText("healthy")).toBeDefined();
+    expect(screen.getByText("users-api")).toBeDefined();
+    expect(screen.getByText("reservations-api")).toBeDefined();
+    expect(screen.getByText("42ms")).toBeDefined();
+    expect(screen.getByText("150ms")).toBeDefined();
+    expect(screen.getByText("CI")).toBeDefined();
+    expect(screen.getByText("Deploys")).toBeDefined();
+  });
+
+  it("handles fetch failure silently", async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: { raw: { permissions: ["admin"] } },
+    } as any);
+
+    global.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+
+    await act(async () => {
+      render(<SystemHealthBadge />);
+    });
+
+    // Should render nothing since health is null after fetch failure
+    expect(screen.queryByTestId("popover")).toBeNull();
+  });
+
+  it("handles non-ok response silently", async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: { raw: { permissions: ["admin"] } },
+    } as any);
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+    });
+
+    await act(async () => {
+      render(<SystemHealthBadge />);
+    });
+
+    expect(screen.queryByTestId("popover")).toBeNull();
+  });
+
+  it("renders without services/ci/deploy sections when absent", async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: { raw: { permissions: ["admin"] } },
+    } as any);
+
+    const healthData = {
+      status: "healthy",
+      timestamp: "2026-01-15T12:00:00Z",
+    };
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(healthData),
+    });
+
+    await act(async () => {
+      render(<SystemHealthBadge />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("popover")).toBeDefined();
+    });
+
+    expect(screen.queryByText("CI")).toBeNull();
+    expect(screen.queryByText("Deploys")).toBeNull();
+  });
+});

--- a/apps/hospitality/src/components/booking-widget/ConfirmationView.test.tsx
+++ b/apps/hospitality/src/components/booking-widget/ConfirmationView.test.tsx
@@ -1,0 +1,197 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, react/jsx-no-undef */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ConfirmationView } from "./ConfirmationView.js";
+import type { Reservation } from "@mbe/types";
+import React from "react";
+
+vi.mock("@mattbutlerengineering/rialto", () => ({
+  Button: ({ children, onClick, variant }: { children: React.ReactNode; onClick?: () => void; variant?: string }) => (
+    <button onClick={onClick} data-variant={variant}>{children}</button>
+  ),
+  Text: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}));
+
+function makeReservation(overrides: Partial<Reservation> = {}): Reservation {
+  return {
+    id: "res-abcd1234",
+    date: "2026-05-20",
+    startTime: "2026-05-20T18:00:00",
+    endTime: "2026-05-20T20:00:00",
+    partySize: 4,
+    status: "CONFIRMED",
+    notes: null,
+    cancellationReason: null,
+    cancellationNote: null,
+    guestName: "John Doe",
+    guestEmail: "john@example.com",
+    guestPhone: null,
+    guestId: null,
+    userId: null,
+    tableId: "table-1",
+    venueId: "venue-1",
+    createdAt: "2026-05-20T00:00:00Z",
+    updatedAt: "2026-05-20T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("ConfirmationView", () => {
+  const mockOnNewBooking = vi.fn();
+
+  it("renders reservation confirmed heading", () => {
+    render(
+      <ConfirmationView reservation={makeReservation()} onNewBooking={mockOnNewBooking} />
+    );
+    expect(screen.getByText("Reservation Confirmed!")).toBeDefined();
+  });
+
+  it("displays the confirmation number from the reservation id", () => {
+    render(
+      <ConfirmationView reservation={makeReservation()} onNewBooking={mockOnNewBooking} />
+    );
+    // Last 8 chars of "res-abcd1234" uppercased = "BCD1234" ... actually "ABCD1234"
+    expect(screen.getByText("ABCD1234")).toBeDefined();
+  });
+
+  it("displays party size with correct pluralization", () => {
+    render(
+      <ConfirmationView reservation={makeReservation({ partySize: 4 })} onNewBooking={mockOnNewBooking} />
+    );
+    expect(screen.getByText("4 guests")).toBeDefined();
+  });
+
+  it("uses singular 'guest' for party size of 1", () => {
+    render(
+      <ConfirmationView reservation={makeReservation({ partySize: 1 })} onNewBooking={mockOnNewBooking} />
+    );
+    expect(screen.getByText("1 guest")).toBeDefined();
+  });
+
+  it("displays guest name when present", () => {
+    render(
+      <ConfirmationView reservation={makeReservation({ guestName: "Jane Smith" })} onNewBooking={mockOnNewBooking} />
+    );
+    expect(screen.getByText("Jane Smith")).toBeDefined();
+  });
+
+  it("does not display name row when guestName is null", () => {
+    render(
+      <ConfirmationView reservation={makeReservation({ guestName: null })} onNewBooking={mockOnNewBooking} />
+    );
+    expect(screen.queryByText("Name")).toBeNull();
+  });
+
+  it("displays email confirmation notice when guestEmail exists", () => {
+    render(
+      <ConfirmationView
+        reservation={makeReservation({ guestEmail: "john@example.com" })}
+        onNewBooking={mockOnNewBooking}
+      />
+    );
+    expect(screen.getByText(/A confirmation has been sent to/)).toBeDefined();
+    expect(screen.getByText(/john@example.com/)).toBeDefined();
+  });
+
+  it("displays phone confirmation notice when only guestPhone exists", () => {
+    render(
+      <ConfirmationView
+        reservation={makeReservation({ guestEmail: null, guestPhone: "+15551234" })}
+        onNewBooking={mockOnNewBooking}
+      />
+    );
+    expect(screen.getByText(/\+15551234/)).toBeDefined();
+  });
+
+  it("does not display confirmation notice when no email or phone", () => {
+    render(
+      <ConfirmationView
+        reservation={makeReservation({ guestEmail: null, guestPhone: null })}
+        onNewBooking={mockOnNewBooking}
+      />
+    );
+    expect(screen.queryByText(/A confirmation has been sent/)).toBeNull();
+  });
+
+  it("calls onNewBooking when 'Make Another Reservation' is clicked", () => {
+    render(
+      <ConfirmationView reservation={makeReservation()} onNewBooking={mockOnNewBooking} />
+    );
+    fireEvent.click(screen.getByText("Make Another Reservation"));
+    expect(mockOnNewBooking).toHaveBeenCalled();
+  });
+
+  it("shows cancel button when onCancellation is provided", () => {
+    const mockCancel = vi.fn();
+    render(
+      <ConfirmationView
+        reservation={makeReservation()}
+        onNewBooking={mockOnNewBooking}
+        onCancellation={mockCancel}
+      />
+    );
+    expect(screen.getByText("Cancel Reservation")).toBeDefined();
+  });
+
+  it("calls onCancellation when cancel button is clicked", () => {
+    const mockCancel = vi.fn();
+    render(
+      <ConfirmationView
+        reservation={makeReservation()}
+        onNewBooking={mockOnNewBooking}
+        onCancellation={mockCancel}
+      />
+    );
+    fireEvent.click(screen.getByText("Cancel Reservation"));
+    expect(mockCancel).toHaveBeenCalled();
+  });
+
+  it("navigates to cancellationUrl when provided", () => {
+    const originalLocation = window.location.href;
+    Object.defineProperty(window, "location", {
+      writable: true,
+      value: { href: originalLocation },
+    });
+
+    render(
+      <ConfirmationView
+        reservation={makeReservation()}
+        onNewBooking={mockOnNewBooking}
+        cancellationUrl="https://example.com/cancel"
+      />
+    );
+    fireEvent.click(screen.getByText("Cancel Reservation"));
+    expect(window.location.href).toBe("https://example.com/cancel");
+  });
+
+  it("does not show cancel button when neither cancellationUrl nor onCancellation is provided", () => {
+    render(
+      <ConfirmationView reservation={makeReservation()} onNewBooking={mockOnNewBooking} />
+    );
+    expect(screen.queryByText("Cancel Reservation")).toBeNull();
+  });
+
+  it("displays table info when reservation has a table", () => {
+    const resWithTable = {
+      ...makeReservation(),
+      table: { id: "t1", name: "Patio 1", tableNumber: "T1" },
+    } as any;
+
+    render(
+      <ConfirmationView reservation={resWithTable} onNewBooking={mockOnNewBooking} />
+    );
+    expect(screen.getByText("T1")).toBeDefined();
+  });
+
+  it("uses table name as fallback when tableNumber is not available", () => {
+    const resWithTable = {
+      ...makeReservation(),
+      table: { id: "t1", name: "Patio Corner", tableNumber: "" },
+    } as any;
+
+    render(
+      <ConfirmationView reservation={resWithTable} onNewBooking={mockOnNewBooking} />
+    );
+    expect(screen.getByText("Patio Corner")).toBeDefined();
+  });
+});

--- a/apps/hospitality/src/components/booking-widget/DatePartySelector.test.tsx
+++ b/apps/hospitality/src/components/booking-widget/DatePartySelector.test.tsx
@@ -1,0 +1,143 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, react/jsx-no-undef */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { DatePartySelector } from "./DatePartySelector.js";
+import React from "react";
+
+vi.mock("@mattbutlerengineering/rialto", () => ({
+  Input: (props: any) => {
+    const id = props.id || props.label?.replace(/\s+/g, "-").toLowerCase() || "input";
+    return (
+      <div>
+        <label htmlFor={id}>{props.label}</label>
+        <input
+          id={id}
+          type={props.type}
+          value={props.value}
+          min={props.min}
+          max={props.max}
+          onChange={(e) => props.onChange?.({ target: { value: e.target.value } })}
+        />
+      </div>
+    );
+  },
+  Button: ({ children, onClick, disabled }: { children: React.ReactNode; onClick?: () => void; disabled?: boolean }) => (
+    <button onClick={onClick} disabled={disabled}>{children}</button>
+  ),
+}));
+
+vi.mock("@mbe/types", () => ({
+  toDateString: (d: Date) => d.toISOString().split("T")[0],
+}));
+
+describe("DatePartySelector", () => {
+  const defaultProps = {
+    selectedDate: null as string | null,
+    partySize: 2,
+    onDateChange: vi.fn(),
+    onPartySizeChange: vi.fn(),
+    onNext: vi.fn(),
+  };
+
+  it("renders date input and party size options", () => {
+    render(<DatePartySelector {...defaultProps} />);
+    expect(screen.getByLabelText("Date")).toBeDefined();
+    expect(screen.getByText("Party Size")).toBeDefined();
+  });
+
+  it("renders party size buttons 1-8 by default", () => {
+    render(<DatePartySelector {...defaultProps} />);
+    for (let i = 1; i <= 8; i++) {
+      expect(screen.getByText(String(i))).toBeDefined();
+    }
+  });
+
+  it("limits party size options to maxPartySize", () => {
+    render(<DatePartySelector {...defaultProps} maxPartySize={4} />);
+    expect(screen.getByText("4")).toBeDefined();
+    expect(screen.queryByText("5")).toBeNull();
+  });
+
+  it("disables 'Find Available Times' when no date is selected", () => {
+    render(<DatePartySelector {...defaultProps} selectedDate={null} />);
+    const btn = screen.getByText("Find Available Times");
+    expect(btn).toHaveProperty("disabled", true);
+  });
+
+  it("enables 'Find Available Times' when date is selected", () => {
+    render(<DatePartySelector {...defaultProps} selectedDate="2026-05-20" />);
+    const btn = screen.getByText("Find Available Times");
+    expect(btn).toHaveProperty("disabled", false);
+  });
+
+  it("calls onDateChange when date is changed", () => {
+    const onDateChange = vi.fn();
+    render(<DatePartySelector {...defaultProps} onDateChange={onDateChange} />);
+    fireEvent.change(screen.getByLabelText("Date"), { target: { value: "2026-05-25" } });
+    expect(onDateChange).toHaveBeenCalledWith("2026-05-25");
+  });
+
+  it("calls onPartySizeChange when party size button is clicked", () => {
+    const onPartySizeChange = vi.fn();
+    render(<DatePartySelector {...defaultProps} onPartySizeChange={onPartySizeChange} />);
+    fireEvent.click(screen.getByText("4"));
+    expect(onPartySizeChange).toHaveBeenCalledWith(4);
+  });
+
+  it("marks selected party size with aria-pressed", () => {
+    render(<DatePartySelector {...defaultProps} partySize={3} />);
+    const btn3 = screen.getByText("3");
+    expect(btn3.getAttribute("aria-pressed")).toBe("true");
+    const btn4 = screen.getByText("4");
+    expect(btn4.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("calls onNext when submit button is clicked", () => {
+    const onNext = vi.fn();
+    render(<DatePartySelector {...defaultProps} selectedDate="2026-05-20" onNext={onNext} />);
+    fireEvent.click(screen.getByText("Find Available Times"));
+    expect(onNext).toHaveBeenCalled();
+  });
+
+  it("renders date range inputs when enableDateRange is true", () => {
+    const onEndDateChange = vi.fn();
+    render(
+      <DatePartySelector
+        {...defaultProps}
+        enableDateRange={true}
+        selectedDate="2026-05-20"
+        selectedEndDate="2026-05-25"
+        onEndDateChange={onEndDateChange}
+      />
+    );
+    expect(screen.getByLabelText("Start Date")).toBeDefined();
+    expect(screen.getByLabelText("End Date")).toBeDefined();
+  });
+
+  it("calls onEndDateChange when end date input changes", () => {
+    const onEndDateChange = vi.fn();
+    render(
+      <DatePartySelector
+        {...defaultProps}
+        enableDateRange={true}
+        selectedDate="2026-05-20"
+        selectedEndDate=""
+        onEndDateChange={onEndDateChange}
+      />
+    );
+    fireEvent.change(screen.getByLabelText("End Date"), { target: { value: "2026-05-28" } });
+    expect(onEndDateChange).toHaveBeenCalledWith("2026-05-28");
+  });
+
+  it("does not render end date input when enableDateRange is true but onEndDateChange is not provided", () => {
+    render(
+      <DatePartySelector
+        {...defaultProps}
+        enableDateRange={true}
+        selectedDate="2026-05-20"
+      />
+    );
+    expect(screen.getByLabelText("Start Date")).toBeDefined();
+    expect(screen.queryByLabelText("End Date")).toBeNull();
+  });
+});

--- a/apps/hospitality/src/components/booking-widget/TimeSlotPicker.test.tsx
+++ b/apps/hospitality/src/components/booking-widget/TimeSlotPicker.test.tsx
@@ -1,0 +1,179 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, react/jsx-no-undef */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { TimeSlotPicker } from "./TimeSlotPicker.js";
+import type { TimeSlot } from "@mbe/types";
+import React from "react";
+
+vi.mock("@mattbutlerengineering/rialto", () => ({
+  Button: ({ children, onClick, size, variant }: any) => (
+    <button onClick={onClick} data-size={size} data-variant={variant}>{children}</button>
+  ),
+  Alert: ({ children, variant, actions }: any) => (
+    <div data-testid="alert" data-variant={variant}>
+      {children}
+      {actions}
+    </div>
+  ),
+  Skeleton: ({ variant, width, height }: any) => (
+    <div data-testid="skeleton" data-variant={variant} style={{ width, height }} />
+  ),
+  SkeletonGroup: ({ children }: any) => <div data-testid="skeleton-group">{children}</div>,
+  EmptyState: ({ heading, description }: any) => (
+    <div data-testid="empty-state">
+      <span>{heading}</span>
+      <span>{description}</span>
+    </div>
+  ),
+}));
+
+function makeSlot(time: string, available = true): TimeSlot {
+  return { time, available };
+}
+
+describe("TimeSlotPicker", () => {
+  const defaultProps = {
+    slots: [] as TimeSlot[],
+    selectedSlot: null,
+    isLoading: false,
+    error: null,
+    onSelectSlot: vi.fn(),
+    onBack: vi.fn(),
+    date: "2026-05-20",
+    partySize: 2,
+  };
+
+  it("renders loading skeleton when isLoading is true", () => {
+    render(<TimeSlotPicker {...defaultProps} isLoading={true} />);
+    expect(screen.getByTestId("skeleton-group")).toBeDefined();
+    const skeletons = screen.getAllByTestId("skeleton");
+    expect(skeletons.length).toBe(8); // SKELETON_SLOT_COUNT
+  });
+
+  it("renders error alert when error is present", () => {
+    render(<TimeSlotPicker {...defaultProps} error="Something went wrong" />);
+    expect(screen.getByTestId("alert")).toBeDefined();
+    expect(screen.getByText("Something went wrong")).toBeDefined();
+  });
+
+  it("renders back button in error state", () => {
+    const onBack = vi.fn();
+    render(<TimeSlotPicker {...defaultProps} error="Error" onBack={onBack} />);
+    const backBtn = screen.getByText(/Change date or party size/);
+    fireEvent.click(backBtn);
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it("renders empty state when no slots are available", () => {
+    render(<TimeSlotPicker {...defaultProps} slots={[]} />);
+    expect(screen.getByTestId("empty-state")).toBeDefined();
+    expect(screen.getByText("No available times")).toBeDefined();
+    expect(screen.getByText("Try a different date or party size.")).toBeDefined();
+  });
+
+  it("renders slots grouped by lunch period", () => {
+    const slots = [
+      makeSlot("2026-05-20T12:00:00"),
+      makeSlot("2026-05-20T12:30:00"),
+    ];
+    render(<TimeSlotPicker {...defaultProps} slots={slots} />);
+    expect(screen.getByText("Lunch")).toBeDefined();
+  });
+
+  it("renders slots grouped by dinner period", () => {
+    const slots = [
+      makeSlot("2026-05-20T18:00:00"),
+      makeSlot("2026-05-20T19:00:00"),
+    ];
+    render(<TimeSlotPicker {...defaultProps} slots={slots} />);
+    expect(screen.getByText("Dinner")).toBeDefined();
+  });
+
+  it("renders slots grouped by late night period", () => {
+    const slots = [
+      makeSlot("2026-05-20T21:00:00"),
+      makeSlot("2026-05-20T22:00:00"),
+    ];
+    render(<TimeSlotPicker {...defaultProps} slots={slots} />);
+    expect(screen.getByText("Late Night")).toBeDefined();
+  });
+
+  it("calls onSelectSlot when a time slot is clicked", () => {
+    const onSelectSlot = vi.fn();
+    const slots = [makeSlot("2026-05-20T18:00:00")];
+    render(<TimeSlotPicker {...defaultProps} slots={slots} onSelectSlot={onSelectSlot} />);
+
+    const slotBtn = screen.getByRole("option");
+    fireEvent.click(slotBtn);
+    expect(onSelectSlot).toHaveBeenCalledWith(slots[0]);
+  });
+
+  it("marks selected slot with aria-selected", () => {
+    const slot = makeSlot("2026-05-20T18:00:00");
+    render(<TimeSlotPicker {...defaultProps} slots={[slot]} selectedSlot={slot} />);
+
+    const slotBtn = screen.getByRole("option");
+    expect(slotBtn.getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("shows selected summary when a slot is selected", () => {
+    const slot = makeSlot("2026-05-20T18:00:00");
+    render(<TimeSlotPicker {...defaultProps} slots={[slot]} selectedSlot={slot} />);
+    expect(screen.getByText("Selected:")).toBeDefined();
+  });
+
+  it("shows table count in selected summary when tables are available", () => {
+    const slot: TimeSlot = {
+      time: "2026-05-20T18:00:00",
+      available: true,
+      tables: [{ id: "t1" }, { id: "t2" }] as any,
+    };
+    render(<TimeSlotPicker {...defaultProps} slots={[slot]} selectedSlot={slot} />);
+    expect(screen.getByText(/2 tables available/)).toBeDefined();
+  });
+
+  it("shows singular 'table' when only one table available", () => {
+    const slot: TimeSlot = {
+      time: "2026-05-20T18:00:00",
+      available: true,
+      tables: [{ id: "t1" }] as any,
+    };
+    render(<TimeSlotPicker {...defaultProps} slots={[slot]} selectedSlot={slot} />);
+    expect(screen.getByText(/1 table available/)).toBeDefined();
+  });
+
+  it("renders the formatted date in the top bar", () => {
+    const slots = [makeSlot("2026-05-20T18:00:00")];
+    render(<TimeSlotPicker {...defaultProps} slots={slots} date="2026-05-20" />);
+    // Should contain "Wednesday, May 20" (locale-dependent)
+    expect(screen.getByText(/May/)).toBeDefined();
+  });
+
+  it("renders party size with correct pluralization", () => {
+    const slots = [makeSlot("2026-05-20T18:00:00")];
+    render(<TimeSlotPicker {...defaultProps} slots={slots} partySize={1} />);
+    expect(screen.getByText("1 guest")).toBeDefined();
+  });
+
+  it("renders party size with plural form", () => {
+    const slots = [makeSlot("2026-05-20T18:00:00")];
+    render(<TimeSlotPicker {...defaultProps} slots={slots} partySize={4} />);
+    expect(screen.getByText("4 guests")).toBeDefined();
+  });
+
+  it("calls onBack when Back button is clicked", () => {
+    const onBack = vi.fn();
+    const slots = [makeSlot("2026-05-20T18:00:00")];
+    render(<TimeSlotPicker {...defaultProps} slots={slots} onBack={onBack} />);
+    fireEvent.click(screen.getByText(/Back/));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it("does not render a period section if no slots fall in that period", () => {
+    const slots = [makeSlot("2026-05-20T18:00:00")]; // dinner only
+    render(<TimeSlotPicker {...defaultProps} slots={slots} />);
+    expect(screen.queryByText("Lunch")).toBeNull();
+    expect(screen.queryByText("Late Night")).toBeNull();
+    expect(screen.getByText("Dinner")).toBeDefined();
+  });
+});

--- a/apps/hospitality/src/components/dashboard/ActivityFeed.test.tsx
+++ b/apps/hospitality/src/components/dashboard/ActivityFeed.test.tsx
@@ -1,0 +1,129 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, react/jsx-no-undef */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ActivityFeed } from "./ActivityFeed.js";
+import type { ReservationEvent } from "../../hooks/useReservationEvents";
+import React from "react";
+
+vi.mock("@mattbutlerengineering/rialto", () => ({
+  Card: ({ children, title }: { children: React.ReactNode; title?: string }) => (
+    <div data-testid="card">
+      {title && <h3>{title}</h3>}
+      {children}
+    </div>
+  ),
+  Text: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}));
+
+function makeEvent(overrides: Partial<ReservationEvent> = {}): ReservationEvent {
+  return {
+    type: "reservation:created",
+    venueId: "v1",
+    timestamp: new Date().toISOString(),
+    data: { id: "res-1" },
+    ...overrides,
+  };
+}
+
+describe("ActivityFeed", () => {
+  it("shows connecting message when not connected and no events", () => {
+    render(<ActivityFeed events={[]} isConnected={false} />);
+    expect(screen.getByText("Connecting to live updates...")).toBeDefined();
+  });
+
+  it("shows 'No recent activity' when connected but no events", () => {
+    render(<ActivityFeed events={[]} isConnected={true} />);
+    expect(screen.getByText("No recent activity")).toBeDefined();
+  });
+
+  it("renders event descriptions for known event types", () => {
+    const events: ReservationEvent[] = [
+      makeEvent({ type: "reservation:created", timestamp: new Date().toISOString() }),
+      makeEvent({ type: "reservation:cancelled", timestamp: new Date().toISOString() }),
+    ];
+
+    render(<ActivityFeed events={events} isConnected={true} />);
+    expect(screen.getByText("New reservation created")).toBeDefined();
+    expect(screen.getByText("Reservation cancelled")).toBeDefined();
+  });
+
+  it("renders raw type for unknown event types", () => {
+    const events: ReservationEvent[] = [
+      makeEvent({ type: "unknown:event" as any, timestamp: new Date().toISOString() }),
+    ];
+
+    render(<ActivityFeed events={events} isConnected={true} />);
+    expect(screen.getByText("unknown:event")).toBeDefined();
+  });
+
+  it("renders the Live Activity card title", () => {
+    render(<ActivityFeed events={[]} isConnected={true} />);
+    expect(screen.getByText("Live Activity")).toBeDefined();
+  });
+
+  it("formats timestamps as 'just now' for recent events", () => {
+    const events: ReservationEvent[] = [
+      makeEvent({ timestamp: new Date().toISOString() }),
+    ];
+
+    render(<ActivityFeed events={events} isConnected={true} />);
+    expect(screen.getByText("just now")).toBeDefined();
+  });
+
+  it("formats timestamps as minutes ago", () => {
+    const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    const events: ReservationEvent[] = [makeEvent({ timestamp: fiveMinAgo })];
+
+    render(<ActivityFeed events={events} isConnected={true} />);
+    expect(screen.getByText("5m ago")).toBeDefined();
+  });
+
+  it("formats timestamps as hours ago", () => {
+    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    const events: ReservationEvent[] = [makeEvent({ timestamp: twoHoursAgo })];
+
+    render(<ActivityFeed events={events} isConnected={true} />);
+    expect(screen.getByText("2h ago")).toBeDefined();
+  });
+
+  it("formats timestamps as date for old events", () => {
+    const oldDate = new Date("2025-01-15T12:00:00Z").toISOString();
+    const events: ReservationEvent[] = [makeEvent({ timestamp: oldDate })];
+
+    render(<ActivityFeed events={events} isConnected={true} />);
+    // The date string will be locale-dependent, just verify it rendered something
+    const items = screen.getAllByRole("listitem");
+    expect(items.length).toBe(1);
+  });
+
+  it("renders all known event type labels correctly", () => {
+    const eventTypes = [
+      "reservation:created",
+      "reservation:updated",
+      "reservation:cancelled",
+      "hold:created",
+      "hold:released",
+      "hold:confirmed",
+      "table:updated",
+    ] as const;
+
+    const expectedLabels = [
+      "New reservation created",
+      "Reservation updated",
+      "Reservation cancelled",
+      "Table hold placed",
+      "Table hold released",
+      "Hold confirmed as reservation",
+      "Table status changed",
+    ];
+
+    const events = eventTypes.map((type, i) =>
+      makeEvent({ type, timestamp: new Date(Date.now() - i * 60000).toISOString() })
+    );
+
+    render(<ActivityFeed events={events} isConnected={true} />);
+    for (const label of expectedLabels) {
+      expect(screen.getByText(label)).toBeDefined();
+    }
+  });
+});

--- a/apps/hospitality/src/contexts/ReservationDataContext.test.tsx
+++ b/apps/hospitality/src/contexts/ReservationDataContext.test.tsx
@@ -1,0 +1,240 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, react/jsx-no-undef */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { ReservationDataProvider, useReservationData } from "./ReservationDataContext.js";
+import { useReservationEvents } from "../hooks/useReservationEvents.js";
+import { useVenue } from "./VenueContext.js";
+import React from "react";
+
+vi.mock("../hooks/useReservationEvents.js", () => ({
+  useReservationEvents: vi.fn(() => ({
+    isConnected: true,
+    error: null,
+    reconnect: vi.fn(),
+  })),
+}));
+
+vi.mock("./VenueContext.js", () => ({
+  useVenue: vi.fn(() => ({
+    selectedVenueId: "venue-1",
+    venues: [],
+    selectVenue: vi.fn(),
+  })),
+}));
+
+vi.mock("@mattbutlerengineering/rialto", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+function TestConsumer() {
+  const ctx = useReservationData();
+  return (
+    <div>
+      <span data-testid="connected">{String(ctx.isConnected)}</span>
+      <span data-testid="count">{ctx.reservations.length}</span>
+      <span data-testid="tables">{ctx.tables.length}</span>
+      <button data-testid="add" onClick={() => ctx.addReservation({ id: "r1", status: "CONFIRMED" } as any)}>
+        Add
+      </button>
+      <button data-testid="update" onClick={() => ctx.updateReservation({ id: "r1", status: "COMPLETED" } as any)}>
+        Update
+      </button>
+      <button data-testid="remove" onClick={() => ctx.removeReservation("r1")}>
+        Remove
+      </button>
+      <button data-testid="set" onClick={() => ctx.setReservations([{ id: "r2" } as any])}>
+        Set
+      </button>
+      <button data-testid="setTables" onClick={() => ctx.setTables([{ id: "t1" } as any])}>
+        SetTables
+      </button>
+    </div>
+  );
+}
+
+describe("ReservationDataContext", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useVenue).mockReturnValue({
+      selectedVenueId: "venue-1",
+      venues: [],
+      selectVenue: vi.fn(),
+    } as any);
+  });
+
+  it("provides initial state with empty reservations", () => {
+    render(
+      <ReservationDataProvider>
+        <TestConsumer />
+      </ReservationDataProvider>
+    );
+    expect(screen.getByTestId("count").textContent).toBe("0");
+    expect(screen.getByTestId("connected").textContent).toBe("true");
+  });
+
+  it("addReservation adds a new reservation", () => {
+    render(
+      <ReservationDataProvider>
+        <TestConsumer />
+      </ReservationDataProvider>
+    );
+    act(() => {
+      screen.getByTestId("add").click();
+    });
+    expect(screen.getByTestId("count").textContent).toBe("1");
+  });
+
+  it("addReservation updates existing reservation with same id", () => {
+    render(
+      <ReservationDataProvider>
+        <TestConsumer />
+      </ReservationDataProvider>
+    );
+    act(() => {
+      screen.getByTestId("add").click();
+    });
+    act(() => {
+      screen.getByTestId("add").click();
+    });
+    // Should still be 1 because same id
+    expect(screen.getByTestId("count").textContent).toBe("1");
+  });
+
+  it("updateReservation updates an existing reservation", () => {
+    render(
+      <ReservationDataProvider>
+        <TestConsumer />
+      </ReservationDataProvider>
+    );
+    act(() => {
+      screen.getByTestId("add").click();
+    });
+    act(() => {
+      screen.getByTestId("update").click();
+    });
+    expect(screen.getByTestId("count").textContent).toBe("1");
+  });
+
+  it("removeReservation removes a reservation by id", () => {
+    render(
+      <ReservationDataProvider>
+        <TestConsumer />
+      </ReservationDataProvider>
+    );
+    act(() => {
+      screen.getByTestId("add").click();
+    });
+    act(() => {
+      screen.getByTestId("remove").click();
+    });
+    expect(screen.getByTestId("count").textContent).toBe("0");
+  });
+
+  it("setReservations replaces all reservations", () => {
+    render(
+      <ReservationDataProvider>
+        <TestConsumer />
+      </ReservationDataProvider>
+    );
+    act(() => {
+      screen.getByTestId("add").click();
+    });
+    act(() => {
+      screen.getByTestId("set").click();
+    });
+    expect(screen.getByTestId("count").textContent).toBe("1");
+  });
+
+  it("setTables sets the tables array", () => {
+    render(
+      <ReservationDataProvider>
+        <TestConsumer />
+      </ReservationDataProvider>
+    );
+    act(() => {
+      screen.getByTestId("setTables").click();
+    });
+    expect(screen.getByTestId("tables").textContent).toBe("1");
+  });
+
+  it("subscribeToEvents allows subscribing to SSE events", () => {
+    const handler = vi.fn();
+
+    function SubscribeConsumer() {
+      const ctx = useReservationData();
+      React.useEffect(() => {
+        return ctx.subscribeToEvents(handler);
+      }, [ctx]);
+      return <div data-testid="sub">subscribed</div>;
+    }
+
+    render(
+      <ReservationDataProvider>
+        <SubscribeConsumer />
+      </ReservationDataProvider>
+    );
+    expect(screen.getByTestId("sub").textContent).toBe("subscribed");
+  });
+
+  it("throws error when useReservationData is used outside provider", () => {
+    // Suppress error output during this test
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() => render(<TestConsumer />)).toThrow(
+      "useReservationData must be used within a ReservationDataProvider"
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it("passes SSE connection state from useReservationEvents", () => {
+    vi.mocked(useReservationEvents).mockReturnValue({
+      isConnected: false,
+      error: new Error("Connection failed"),
+      reconnect: vi.fn(),
+    });
+
+    render(
+      <ReservationDataProvider>
+        <TestConsumer />
+      </ReservationDataProvider>
+    );
+    expect(screen.getByTestId("connected").textContent).toBe("false");
+  });
+
+  it("calls useReservationEvents with venue id and handlers", () => {
+    render(
+      <ReservationDataProvider>
+        <TestConsumer />
+      </ReservationDataProvider>
+    );
+
+    expect(useReservationEvents).toHaveBeenCalledWith(
+      expect.objectContaining({
+        venueId: "venue-1",
+        enabled: true,
+      })
+    );
+  });
+
+  it("disables SSE when no venue is selected", () => {
+    vi.mocked(useVenue).mockReturnValue({
+      selectedVenueId: null,
+      venues: [],
+      selectVenue: vi.fn(),
+    } as any);
+
+    render(
+      <ReservationDataProvider>
+        <TestConsumer />
+      </ReservationDataProvider>
+    );
+
+    expect(useReservationEvents).toHaveBeenCalledWith(
+      expect.objectContaining({
+        venueId: undefined,
+        enabled: false,
+      })
+    );
+  });
+});

--- a/apps/hospitality/src/hooks/use-command-palette.test.ts
+++ b/apps/hospitality/src/hooks/use-command-palette.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useCommandPalette } from "./use-command-palette.js";
+import type { NavSection } from "../nav-sections.js";
+
+vi.mock("@mattbutlerengineering/rialto", () => ({
+  useThemeState: vi.fn(() => ({ preference: "system", setTheme: vi.fn(), resolved: "light" })),
+  resolveTheme: vi.fn((t: string) => t),
+}));
+
+describe("useCommandPalette", () => {
+  const mockSections: NavSection[] = [
+    {
+      label: "Main",
+      items: [
+        { id: "dashboard", label: "Dashboard", path: "/dashboard" },
+        { id: "timeline", label: "Timeline", path: "/timeline" },
+      ],
+    },
+    {
+      label: "Settings",
+      items: [
+        { id: "profile", label: "Profile", path: "/profile" },
+      ],
+    },
+  ];
+
+  const mockNavigate = vi.fn();
+  const mockToggleTheme = vi.fn();
+  const mockSignOut = vi.fn();
+
+  const defaultOptions = {
+    sections: mockSections,
+    navigate: mockNavigate,
+    toggleTheme: mockToggleTheme,
+    signOut: mockSignOut,
+  };
+
+  it("returns open as false initially", () => {
+    const { result } = renderHook(() => useCommandPalette(defaultOptions));
+    expect(result.current.open).toBe(false);
+  });
+
+  it("setOpen toggles the open state", () => {
+    const { result } = renderHook(() => useCommandPalette(defaultOptions));
+
+    act(() => {
+      result.current.setOpen(true);
+    });
+    expect(result.current.open).toBe(true);
+
+    act(() => {
+      result.current.setOpen(false);
+    });
+    expect(result.current.open).toBe(false);
+  });
+
+  it("builds navigation items from sections", () => {
+    const { result } = renderHook(() => useCommandPalette(defaultOptions));
+
+    const navItems = result.current.items.filter((item) => item.group !== "Actions");
+    expect(navItems).toHaveLength(3);
+    expect(navItems[0]).toMatchObject({ id: "dashboard", label: "Dashboard", group: "Main" });
+    expect(navItems[1]).toMatchObject({ id: "timeline", label: "Timeline", group: "Main" });
+    expect(navItems[2]).toMatchObject({ id: "profile", label: "Profile", group: "Settings" });
+  });
+
+  it("builds action items with correct labels", () => {
+    const { result } = renderHook(() => useCommandPalette(defaultOptions));
+
+    const actionItems = result.current.items.filter((item) => item.group === "Actions");
+    expect(actionItems).toHaveLength(5);
+
+    const labels = actionItems.map((item) => item.label);
+    expect(labels).toContain("New Reservation");
+    expect(labels).toContain("Walk-in Guest");
+    expect(labels).toContain("New Floor Plan");
+    expect(labels).toContain("Toggle Theme");
+    expect(labels).toContain("Sign Out");
+  });
+
+  it("navigating via item calls navigate", () => {
+    const { result } = renderHook(() => useCommandPalette(defaultOptions));
+
+    const dashboardItem = result.current.items.find((item) => item.id === "dashboard");
+    dashboardItem?.onSelect();
+
+    expect(mockNavigate).toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("toggle theme action calls toggleTheme", () => {
+    const { result } = renderHook(() => useCommandPalette(defaultOptions));
+
+    const themeItem = result.current.items.find((item) => item.id === "action-toggle-theme");
+    themeItem?.onSelect();
+
+    expect(mockToggleTheme).toHaveBeenCalled();
+  });
+
+  it("sign out action calls signOut", () => {
+    const { result } = renderHook(() => useCommandPalette(defaultOptions));
+
+    const signOutItem = result.current.items.find((item) => item.id === "action-sign-out");
+    signOutItem?.onSelect();
+
+    expect(mockSignOut).toHaveBeenCalled();
+  });
+
+  it("builds groups in correct order", () => {
+    const { result } = renderHook(() => useCommandPalette(defaultOptions));
+
+    expect(result.current.groups).toEqual(["Main", "Settings", "Actions"]);
+  });
+
+  it("deduplicates section group names", () => {
+    const sectionsWithDupes: NavSection[] = [
+      { label: "Main", items: [{ id: "a", label: "A", path: "/a" }] },
+      { label: "Main", items: [{ id: "b", label: "B", path: "/b" }] },
+    ];
+
+    const { result } = renderHook(() =>
+      useCommandPalette({ ...defaultOptions, sections: sectionsWithDupes })
+    );
+
+    expect(result.current.groups).toEqual(["Main", "Actions"]);
+  });
+
+  it("uses 'Navigation' as group name for sections without label", () => {
+    const sectionsNoLabel: NavSection[] = [
+      { items: [{ id: "home", label: "Home", path: "/" }] },
+    ];
+
+    const { result } = renderHook(() =>
+      useCommandPalette({ ...defaultOptions, sections: sectionsNoLabel })
+    );
+
+    const homeItem = result.current.items.find((item) => item.id === "home");
+    expect(homeItem?.group).toBe("Navigation");
+    expect(result.current.groups).toContain("Navigation");
+  });
+
+  it("walk-in action navigates with query param", () => {
+    const { result } = renderHook(() => useCommandPalette(defaultOptions));
+
+    const walkinItem = result.current.items.find((item) => item.id === "action-walkin");
+    walkinItem?.onSelect();
+
+    expect(mockNavigate).toHaveBeenCalledWith("/timeline?walkin=true");
+  });
+});

--- a/apps/hospitality/src/hooks/useApiClient.test.ts
+++ b/apps/hospitality/src/hooks/useApiClient.test.ts
@@ -1,0 +1,81 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useApiClient } from "./useApiClient.js";
+import { useAuth } from "@mbe/auth/react";
+import { createApiClient } from "@mbe/api-client";
+
+vi.mock("@mbe/auth/react", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("@mbe/api-client", () => ({
+  createApiClient: vi.fn(() => ({ reservations: { list: vi.fn() } })),
+}));
+
+vi.mock("@mbe/observability/sentry/react", () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+  addBreadcrumb: vi.fn(),
+}));
+
+describe("useApiClient", () => {
+  it("creates an API client with the access token", () => {
+    vi.mocked(useAuth).mockReturnValue({
+      accessToken: "test-token-123",
+    } as any);
+
+    renderHook(() => useApiClient());
+
+    expect(createApiClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: expect.any(String),
+      })
+    );
+
+    // Verify the getAccessToken function returns the token
+    const callArgs = vi.mocked(createApiClient).mock.calls[0][0];
+    expect(callArgs.getAccessToken()).toBe("test-token-123");
+  });
+
+  it("memoizes the client across renders with same token", () => {
+    vi.mocked(useAuth).mockReturnValue({
+      accessToken: "stable-token",
+    } as any);
+
+    const { result, rerender } = renderHook(() => useApiClient());
+    const firstClient = result.current;
+
+    rerender();
+    expect(result.current).toBe(firstClient);
+  });
+
+  it("creates a new client when access token changes", () => {
+    vi.mocked(useAuth).mockReturnValue({
+      accessToken: "token-1",
+    } as any);
+
+    const { rerender } = renderHook(() => useApiClient());
+
+    const firstCallCount = vi.mocked(createApiClient).mock.calls.length;
+
+    vi.mocked(useAuth).mockReturnValue({
+      accessToken: "token-2",
+    } as any);
+
+    rerender();
+
+    expect(vi.mocked(createApiClient).mock.calls.length).toBeGreaterThan(firstCallCount);
+  });
+
+  it("passes an onError callback for Sentry reporting", () => {
+    vi.mocked(useAuth).mockReturnValue({
+      accessToken: "token",
+    } as any);
+
+    renderHook(() => useApiClient());
+
+    const callArgs = vi.mocked(createApiClient).mock.calls[0][0];
+    expect(callArgs.onError).toBeTypeOf("function");
+  });
+});

--- a/apps/hospitality/src/hooks/useDashboardStats.hook.test.ts
+++ b/apps/hospitality/src/hooks/useDashboardStats.hook.test.ts
@@ -1,0 +1,146 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useDashboardStats } from "./useDashboardStats.js";
+import { useAuth } from "@mbe/auth/react";
+import { useVenue } from "../contexts/VenueContext.js";
+import { createApiClient } from "@mbe/api-client";
+
+vi.mock("@mbe/auth/react", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("../contexts/VenueContext.js", () => ({
+  useVenue: vi.fn(),
+}));
+
+vi.mock("@mbe/api-client", () => ({
+  createApiClient: vi.fn(),
+}));
+
+describe("useDashboardStats hook", () => {
+  const mockList = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(useAuth).mockReturnValue({
+      accessToken: "test-token",
+    } as any);
+
+    vi.mocked(useVenue).mockReturnValue({
+      selectedVenueId: "venue-1",
+      venues: [],
+      selectVenue: vi.fn(),
+    } as any);
+
+    vi.mocked(createApiClient).mockReturnValue({
+      reservations: { list: mockList },
+    } as any);
+  });
+
+  it("starts in loading state", () => {
+    mockList.mockReturnValue(new Promise(() => {})); // never resolves
+    const { result } = renderHook(() => useDashboardStats());
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("fetches reservations on mount", async () => {
+    mockList.mockResolvedValue({
+      data: [
+        { id: "r1", status: "CONFIRMED", partySize: 4, startTime: "18:00", date: "2026-05-10" },
+      ],
+    });
+
+    const { result } = renderHook(() => useDashboardStats());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.reservations).toHaveLength(1);
+    expect(result.current.stats.totalReservations).toBe(1);
+    expect(result.current.stats.expectedCovers).toBe(4);
+  });
+
+  it("sets error state on fetch failure", async () => {
+    mockList.mockRejectedValue(new Error("Network error"));
+
+    const { result } = renderHook(() => useDashboardStats());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBe("Network error");
+    expect(result.current.reservations).toHaveLength(0);
+  });
+
+  it("sets generic error message for non-Error exceptions", async () => {
+    mockList.mockRejectedValue("unexpected");
+
+    const { result } = renderHook(() => useDashboardStats());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBe("Failed to load reservations");
+  });
+
+  it("passes venueId filter when a venue is selected", async () => {
+    mockList.mockResolvedValue({ data: [] });
+
+    renderHook(() => useDashboardStats());
+
+    await waitFor(() => {
+      expect(mockList).toHaveBeenCalled();
+    });
+
+    expect(mockList).toHaveBeenCalledWith(
+      expect.objectContaining({ venueId: "venue-1" })
+    );
+  });
+
+  it("does not pass venueId filter when no venue is selected", async () => {
+    vi.mocked(useVenue).mockReturnValue({
+      selectedVenueId: null,
+      venues: [],
+      selectVenue: vi.fn(),
+    } as any);
+
+    mockList.mockResolvedValue({ data: [] });
+
+    renderHook(() => useDashboardStats());
+
+    await waitFor(() => {
+      expect(mockList).toHaveBeenCalled();
+    });
+
+    const callArgs = mockList.mock.calls[0][0];
+    expect(callArgs.venueId).toBeUndefined();
+  });
+
+  it("refetch re-fetches the data", async () => {
+    mockList.mockResolvedValue({ data: [] });
+
+    const { result } = renderHook(() => useDashboardStats());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    mockList.mockResolvedValue({
+      data: [
+        { id: "r1", status: "CONFIRMED", partySize: 2, startTime: "19:00", date: "2026-05-10" },
+      ],
+    });
+
+    await result.current.refetch();
+
+    await waitFor(() => {
+      expect(result.current.reservations).toHaveLength(1);
+    });
+  });
+});

--- a/apps/hospitality/src/pages/AdminPage.test.tsx
+++ b/apps/hospitality/src/pages/AdminPage.test.tsx
@@ -1,0 +1,107 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, react/jsx-no-undef */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { AdminPage } from "./AdminPage.js";
+import { useAuth } from "@mbe/auth/react";
+import React from "react";
+
+const { mockUsersList } = vi.hoisted(() => ({
+  mockUsersList: vi.fn(),
+}));
+
+vi.mock("@mbe/auth/react", () => ({ useAuth: vi.fn() }));
+vi.mock("@mbe/api-client", () => ({
+  ApiClient: vi.fn(function (this: any) {
+    // no-op constructor
+  }),
+  UsersClient: vi.fn(function (this: any) {
+    this.list = mockUsersList;
+  }),
+}));
+
+vi.mock("../components/PageHeader", () => ({
+  PageHeader: ({ title }: any) => <div data-testid="page-header">{title}</div>,
+}));
+
+vi.mock("@mattbutlerengineering/rialto", () => ({
+  Alert: ({ children }: any) => <div data-testid="alert">{children}</div>,
+  Avatar: ({ name }: any) => <div data-testid="avatar">{name}</div>,
+  Badge: ({ children }: any) => <span data-testid="badge">{children}</span>,
+  Button: ({ children, onClick }: any) => <button onClick={onClick}>{children}</button>,
+  Card: ({ children }: any) => <div data-testid="card">{children}</div>,
+  Divider: () => <hr />,
+  Input: (props: any) => (
+    <input data-testid="search-input" placeholder={props.placeholder} value={props.value} onChange={props.onChange} />
+  ),
+  Pagination: ({ total, page }: any) => <div data-testid="pagination">{page}/{total}</div>,
+  SegmentedControl: ({ segments, value: _value, onChange }: any) => (
+    <div data-testid="segmented-control">
+      {segments?.map((s: any) => (
+        <button key={s.id} data-testid={`segment-${s.id}`} onClick={() => onChange?.(s.id)}>
+          {s.label}
+        </button>
+      ))}
+    </div>
+  ),
+  Skeleton: () => <div data-testid="skeleton" />,
+  SkeletonGroup: ({ children }: any) => <div data-testid="skeleton-group">{children}</div>,
+  Stat: ({ label, value }: any) => <div data-testid="stat"><span>{label}</span><span>{value}</span></div>,
+  Text: ({ children }: any) => <span>{children}</span>,
+}));
+
+describe("AdminPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(useAuth).mockReturnValue({
+      accessToken: "admin-token",
+      user: { sub: "admin-1", name: "Admin" },
+    } as any);
+
+    mockUsersList.mockResolvedValue({
+      data: [
+        { id: "u1", name: "Admin User", email: "admin@example.com", role: "admin", emailVerified: true, createdAt: "2026-01-01T00:00:00Z", preferences: { theme: "dark" } },
+        { id: "u2", name: "Regular User", email: "user@example.com", role: "user", emailVerified: false, createdAt: "2026-03-15T00:00:00Z", preferences: {} },
+      ],
+      pagination: { total: 2, page: 1, limit: 10 },
+    });
+  });
+
+  it("renders the admin page header", async () => {
+    render(<AdminPage />);
+    expect(screen.getByText("Admin")).toBeDefined();
+  });
+
+  it("renders user list after loading", async () => {
+    render(<AdminPage />);
+    await waitFor(() => {
+      expect(screen.getAllByText("Admin User").length).toBeGreaterThan(0);
+    });
+    expect(screen.getAllByText("Regular User").length).toBeGreaterThan(0);
+  });
+
+  it("renders status filter segments", async () => {
+    render(<AdminPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("segmented-control")).toBeDefined();
+    });
+    expect(screen.getByTestId("segment-all")).toBeDefined();
+    expect(screen.getByTestId("segment-verified")).toBeDefined();
+    expect(screen.getByTestId("segment-unverified")).toBeDefined();
+  });
+
+  it("renders search input", async () => {
+    render(<AdminPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("search-input")).toBeDefined();
+    });
+  });
+
+  it("renders user stats", async () => {
+    render(<AdminPage />);
+    await waitFor(() => {
+      const stats = screen.getAllByTestId("stat");
+      expect(stats.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/apps/hospitality/src/pages/GuestsPage.test.tsx
+++ b/apps/hospitality/src/pages/GuestsPage.test.tsx
@@ -1,0 +1,169 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, react/jsx-no-undef */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { GuestsPage } from "./GuestsPage.js";
+import { useAuth } from "@mbe/auth/react";
+import { createApiClient } from "@mbe/api-client";
+import { useVenue } from "../contexts/VenueContext.js";
+import React from "react";
+
+vi.mock("@mbe/auth/react", () => ({ useAuth: vi.fn() }));
+vi.mock("@mbe/api-client", () => ({ createApiClient: vi.fn() }));
+vi.mock("../contexts/VenueContext.js", () => ({ useVenue: vi.fn() }));
+
+vi.mock("../components/PageHeader", () => ({
+  PageHeader: ({ title, description }: any) => (
+    <div data-testid="page-header"><h1>{title}</h1><p>{description}</p></div>
+  ),
+}));
+
+vi.mock("../components/ErrorRetryBanner", () => ({
+  ErrorRetryBanner: ({ error }: any) => <div data-testid="error-banner">{error}</div>,
+}));
+
+vi.mock("@mattbutlerengineering/rialto", () => ({
+  Alert: ({ children }: any) => <div data-testid="alert">{children}</div>,
+  Badge: ({ children }: any) => <span data-testid="badge">{children}</span>,
+  Button: ({ children, onClick, disabled }: any) => (
+    <button onClick={onClick} disabled={disabled}>{children}</button>
+  ),
+  Card: ({ children, title }: any) => <div data-testid="card">{title}{children}</div>,
+  DataList: ({ children }: any) => <dl>{children}</dl>,
+  Dialog: ({ children, open, title, footer }: any) =>
+    open ? <div data-testid="dialog"><h2>{title}</h2>{children}{footer}</div> : null,
+  Divider: () => <hr />,
+  Drawer: ({ children, open }: any) => open ? <div data-testid="drawer">{children}</div> : null,
+  EmptyState: ({ heading, description }: any) => (
+    <div data-testid="empty-state"><span>{heading}</span><span>{description}</span></div>
+  ),
+  Input: (props: any) => {
+    const id = props.label?.replace(/\s+/g, "-").toLowerCase() || "input";
+    return (
+      <div>
+        <label htmlFor={id}>{props.label}</label>
+        <input id={id} value={props.value ?? ""} onChange={props.onChange} placeholder={props.placeholder} />
+      </div>
+    );
+  },
+  Select: (props: any) => (
+    <select data-testid={`select-${props.label}`} value={props.value} onChange={(e) => props.onChange?.(e.target.value)}>
+      {props.options?.map((o: any) => <option key={o.value} value={o.value}>{o.label}</option>)}
+    </select>
+  ),
+  Skeleton: () => <div data-testid="skeleton" />,
+  SkeletonGroup: ({ children }: any) => <div data-testid="skeleton-group">{children}</div>,
+  Stack: ({ children }: any) => <div>{children}</div>,
+  Stat: ({ label, value }: any) => <div data-testid="stat"><span>{label}</span><span>{value}</span></div>,
+  Tag: ({ children }: any) => <span data-testid="tag">{children}</span>,
+  Text: ({ children }: any) => <span>{children}</span>,
+  TextArea: (props: any) => <textarea data-testid="textarea" value={props.value} onChange={(e) => props.onChange?.(e)} />,
+}));
+
+describe("GuestsPage", () => {
+  const mockApi = {
+    guests: {
+      list: vi.fn(),
+      search: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      getSegments: vi.fn(),
+      findOrCreate: vi.fn(),
+    },
+    reservations: { list: vi.fn() },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(useAuth).mockReturnValue({ accessToken: "token" } as any);
+    vi.mocked(createApiClient).mockReturnValue(mockApi as any);
+    vi.mocked(useVenue).mockReturnValue({
+      selectedVenueId: "venue-1",
+      venues: [{ id: "venue-1", name: "Test Venue" }],
+      selectVenue: vi.fn(),
+      setVenueId: vi.fn(),
+      isMultiVenue: false,
+    } as any);
+
+    mockApi.guests.getSegments.mockResolvedValue([
+      { id: "s1", name: "VIP", count: 5 },
+      { id: "s2", name: "Regular", count: 10 },
+    ]);
+
+    mockApi.guests.list.mockResolvedValue({
+      data: [
+        { id: "g1", name: "John Doe", email: "john@example.com", phone: "+15551234", visitCount: 5, notes: null, tags: [], lastVisit: null, createdAt: "2026-01-01T00:00:00Z" },
+        { id: "g2", name: "Jane Smith", email: "jane@example.com", phone: null, visitCount: 2, notes: "Allergic to nuts", tags: ["vip"], lastVisit: null, createdAt: "2026-01-01T00:00:00Z" },
+      ],
+      meta: { total: 2, page: 1, limit: 50 },
+    });
+  });
+
+  it("renders the page header", async () => {
+    render(<GuestsPage />);
+    await waitFor(() => {
+      expect(screen.getByText("Guests")).toBeDefined();
+    });
+  });
+
+  it("shows loading state initially", () => {
+    // Make the API never resolve to test loading state
+    mockApi.guests.list.mockReturnValue(new Promise(() => {}));
+    mockApi.guests.getSegments.mockReturnValue(new Promise(() => {}));
+
+    render(<GuestsPage />);
+    // Should show loading skeleton
+    const skeletons = screen.getAllByTestId("skeleton");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("renders guest list after loading", async () => {
+    render(<GuestsPage />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("John Doe").length).toBeGreaterThan(0);
+    });
+    expect(screen.getAllByText("Jane Smith").length).toBeGreaterThan(0);
+  });
+
+  it("renders segment stats", async () => {
+    render(<GuestsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("VIP")).toBeDefined();
+    });
+  });
+
+  it("shows error banner when fetch fails", async () => {
+    mockApi.guests.list.mockRejectedValue(new Error("Connection failed"));
+    mockApi.guests.getSegments.mockRejectedValue(new Error("Connection failed"));
+
+    render(<GuestsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("error-banner")).toBeDefined();
+    });
+  });
+
+  it("shows Add Guest button", async () => {
+    render(<GuestsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Add Guest")).toBeDefined();
+    });
+  });
+
+  it("opens add guest dialog when button is clicked", async () => {
+    render(<GuestsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Add Guest")).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByText("Add Guest"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("dialog")).toBeDefined();
+    });
+  });
+});

--- a/apps/hospitality/src/pages/HomePage.test.tsx
+++ b/apps/hospitality/src/pages/HomePage.test.tsx
@@ -1,0 +1,199 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, react/jsx-no-undef */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { HomePage } from "./HomePage.js";
+import { useAuth } from "@mbe/auth/react";
+import { useReservationData } from "../contexts/ReservationDataContext.js";
+import { useDashboardStats } from "../hooks/useDashboardStats.js";
+import React from "react";
+
+vi.mock("@mbe/auth/react", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("../contexts/ReservationDataContext.js", () => ({
+  useReservationData: vi.fn(),
+}));
+
+vi.mock("../hooks/useDashboardStats.js", () => ({
+  useDashboardStats: vi.fn(),
+}));
+
+vi.mock("../components/PageHeader", () => ({
+  PageHeader: ({ title, description }: { title: string; description: string }) => (
+    <div data-testid="page-header">
+      <h1>{title}</h1>
+      <p>{description}</p>
+    </div>
+  ),
+}));
+
+vi.mock("../components/ErrorRetryBanner", () => ({
+  ErrorRetryBanner: ({ error, onRetry }: { error: string; onRetry: () => void }) => (
+    <button data-testid="error-banner" onClick={onRetry}>{error}</button>
+  ),
+}));
+
+vi.mock("../components/dashboard", () => ({
+  ReservationList: ({ reservations, isLoading }: any) => (
+    <div data-testid="reservation-list" data-loading={isLoading}>
+      {reservations.length} reservations
+    </div>
+  ),
+  ActivityFeed: ({ events, isConnected }: any) => (
+    <div data-testid="activity-feed" data-connected={isConnected}>
+      {events.length} events
+    </div>
+  ),
+}));
+
+vi.mock("@mattbutlerengineering/rialto", () => ({
+  Stat: ({ label, value }: { label: string; value: string | number }) => (
+    <div data-testid="stat">
+      <span>{label}</span>
+      <span>{value}</span>
+    </div>
+  ),
+  Button: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
+    <button onClick={onClick}>{children}</button>
+  ),
+  Skeleton: ({ className }: any) => <div data-testid="skeleton" className={className} />,
+}));
+
+describe("HomePage", () => {
+  const mockSubscribe = vi.fn(() => vi.fn()); // returns unsubscribe
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(useAuth).mockReturnValue({
+      user: { name: "Matt" },
+      accessToken: "token",
+    } as any);
+
+    vi.mocked(useReservationData).mockReturnValue({
+      isConnected: true,
+      subscribeToEvents: mockSubscribe,
+      reservations: [],
+      tables: [],
+      sseError: null,
+      addReservation: vi.fn(),
+      updateReservation: vi.fn(),
+      removeReservation: vi.fn(),
+      setReservations: vi.fn(),
+      setTables: vi.fn(),
+    });
+
+    vi.mocked(useDashboardStats).mockReturnValue({
+      reservations: [],
+      stats: {
+        totalReservations: 5,
+        expectedCovers: 20,
+        upcomingCount: 3,
+        cancellationRate: 10,
+        cancellationTrend: "neutral",
+      },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+  });
+
+  const renderPage = () =>
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>
+    );
+
+  it("renders the dashboard page header with user name", () => {
+    renderPage();
+    expect(screen.getByText("Dashboard")).toBeDefined();
+    expect(screen.getByText("Welcome back, Matt")).toBeDefined();
+  });
+
+  it("renders welcome message without name if user has no name", () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: { name: undefined },
+      accessToken: "token",
+    } as any);
+
+    renderPage();
+    expect(screen.getByText("Welcome back")).toBeDefined();
+  });
+
+  it("renders stats when not loading", () => {
+    renderPage();
+    const stats = screen.getAllByTestId("stat");
+    expect(stats.length).toBe(4);
+    expect(screen.getByText("Today's Reservations")).toBeDefined();
+    expect(screen.getByText("Expected Covers")).toBeDefined();
+    expect(screen.getByText("Upcoming (2 hrs)")).toBeDefined();
+    expect(screen.getByText("Cancellation Rate")).toBeDefined();
+  });
+
+  it("renders loading skeletons when stats are loading", () => {
+    vi.mocked(useDashboardStats).mockReturnValue({
+      reservations: [],
+      stats: {
+        totalReservations: 0,
+        expectedCovers: 0,
+        upcomingCount: 0,
+        cancellationRate: 0,
+        cancellationTrend: "neutral",
+      },
+      isLoading: true,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    renderPage();
+    const skeletons = screen.getAllByTestId("skeleton");
+    expect(skeletons.length).toBe(4);
+  });
+
+  it("renders error banner when there is an error", () => {
+    vi.mocked(useDashboardStats).mockReturnValue({
+      reservations: [],
+      stats: {
+        totalReservations: 0,
+        expectedCovers: 0,
+        upcomingCount: 0,
+        cancellationRate: 0,
+        cancellationTrend: "neutral",
+      },
+      isLoading: false,
+      error: "Failed to load",
+      refetch: vi.fn(),
+    });
+
+    renderPage();
+    expect(screen.getByTestId("error-banner")).toBeDefined();
+    expect(screen.getByText("Failed to load")).toBeDefined();
+  });
+
+  it("does not render error banner when there is no error", () => {
+    renderPage();
+    expect(screen.queryByTestId("error-banner")).toBeNull();
+  });
+
+  it("renders action buttons", () => {
+    renderPage();
+    expect(screen.getByText("New Walk-In")).toBeDefined();
+    expect(screen.getByText("View Floor Plan")).toBeDefined();
+    expect(screen.getByText("Guest Lookup")).toBeDefined();
+    expect(screen.getByText("Booking Widget")).toBeDefined();
+  });
+
+  it("renders ReservationList and ActivityFeed", () => {
+    renderPage();
+    expect(screen.getByTestId("reservation-list")).toBeDefined();
+    expect(screen.getByTestId("activity-feed")).toBeDefined();
+  });
+
+  it("subscribes to events on mount", () => {
+    renderPage();
+    expect(mockSubscribe).toHaveBeenCalled();
+  });
+});

--- a/apps/hospitality/src/pages/ReservationsPage.test.tsx
+++ b/apps/hospitality/src/pages/ReservationsPage.test.tsx
@@ -1,0 +1,121 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, react/jsx-no-undef */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { ReservationsPage } from "./ReservationsPage.js";
+import { useAuth } from "@mbe/auth/react";
+import { createApiClient } from "@mbe/api-client";
+import { useVenue } from "../contexts/VenueContext.js";
+import { useReservationData } from "../contexts/ReservationDataContext.js";
+import React from "react";
+
+vi.mock("@mbe/auth/react", () => ({ useAuth: vi.fn() }));
+vi.mock("@mbe/api-client", () => ({ createApiClient: vi.fn() }));
+vi.mock("../contexts/VenueContext.js", () => ({ useVenue: vi.fn() }));
+vi.mock("../contexts/ReservationDataContext.js", () => ({ useReservationData: vi.fn() }));
+
+vi.mock("../components/PageHeader", () => ({
+  PageHeader: ({ title }: any) => <div data-testid="page-header">{title}</div>,
+}));
+
+vi.mock("@mattbutlerengineering/rialto", () => ({
+  Alert: ({ children }: any) => <div data-testid="alert">{children}</div>,
+  Badge: ({ children }: any) => <span data-testid="badge">{children}</span>,
+  Card: ({ children }: any) => <div data-testid="card">{children}</div>,
+  EmptyState: ({ heading }: any) => <div data-testid="empty-state">{heading}</div>,
+  Input: (props: any) => (
+    <input data-testid="search-input" placeholder={props.placeholder} value={props.value} onChange={props.onChange} />
+  ),
+  SegmentedControl: ({ segments, value: _value, onChange }: any) => (
+    <div data-testid="segmented-control">
+      {segments?.map((s: any) => (
+        <button key={s.id} data-testid={`segment-${s.id}`} onClick={() => onChange?.(s.id)}>
+          {s.label}
+        </button>
+      ))}
+    </div>
+  ),
+  Skeleton: () => <div data-testid="skeleton" />,
+  SkeletonGroup: ({ children }: any) => <div data-testid="skeleton-group">{children}</div>,
+  Stat: ({ label, value }: any) => <div data-testid="stat"><span>{label}</span><span>{value}</span></div>,
+  Text: ({ children }: any) => <span>{children}</span>,
+}));
+
+describe("ReservationsPage", () => {
+  const mockApi = {
+    reservations: { list: vi.fn() },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(useAuth).mockReturnValue({ accessToken: "token" } as any);
+    vi.mocked(createApiClient).mockReturnValue(mockApi as any);
+    vi.mocked(useVenue).mockReturnValue({
+      selectedVenueId: "venue-1",
+      venues: [],
+      selectVenue: vi.fn(),
+    } as any);
+    vi.mocked(useReservationData).mockReturnValue({
+      reservations: [
+        { id: "r1", guestName: "Alice", date: "2026-05-10", startTime: "18:00", endTime: "20:00", partySize: 2, status: "CONFIRMED" },
+        { id: "r2", guestName: "Bob", date: "2026-05-10", startTime: "19:00", endTime: "21:00", partySize: 4, status: "PENDING" },
+        { id: "r3", guestName: "Carol", date: "2026-05-10", startTime: "20:00", endTime: "22:00", partySize: 6, status: "CANCELLED" },
+      ],
+      tables: [],
+      isConnected: true,
+      sseError: null,
+      addReservation: vi.fn(),
+      updateReservation: vi.fn(),
+      removeReservation: vi.fn(),
+      setReservations: vi.fn(),
+      setTables: vi.fn(),
+      subscribeToEvents: vi.fn(() => vi.fn()),
+    } as any);
+
+    mockApi.reservations.list.mockResolvedValue({
+      data: [
+        { id: "r1", guestName: "Alice", date: "2026-05-10", startTime: "18:00", endTime: "20:00", partySize: 2, status: "CONFIRMED" },
+      ],
+    });
+  });
+
+  const renderPage = () =>
+    render(
+      <MemoryRouter>
+        <ReservationsPage />
+      </MemoryRouter>
+    );
+
+  it("renders the page header", () => {
+    renderPage();
+    expect(screen.getByText("Reservations")).toBeDefined();
+  });
+
+  it("renders status filter segments", () => {
+    renderPage();
+    expect(screen.getByTestId("segmented-control")).toBeDefined();
+    expect(screen.getByTestId("segment-all")).toBeDefined();
+    expect(screen.getByTestId("segment-CONFIRMED")).toBeDefined();
+    expect(screen.getByTestId("segment-PENDING")).toBeDefined();
+  });
+
+  it("renders reservation stats", () => {
+    renderPage();
+    const stats = screen.getAllByTestId("stat");
+    expect(stats.length).toBeGreaterThan(0);
+  });
+
+  it("renders search inputs", () => {
+    renderPage();
+    const inputs = screen.getAllByTestId("search-input");
+    expect(inputs.length).toBeGreaterThan(0);
+  });
+
+  it("displays guest names in the reservation list", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("Alice")).toBeDefined();
+    });
+  });
+});

--- a/apps/hospitality/src/pages/SettingsPage.test.tsx
+++ b/apps/hospitality/src/pages/SettingsPage.test.tsx
@@ -1,0 +1,122 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, react/jsx-no-undef */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { SettingsPage } from "./SettingsPage.js";
+import { useAuth } from "@mbe/auth/react";
+import { useApiClient } from "../hooks/useApiClient.js";
+import { useTheme } from "../hooks/use-theme.js";
+import { UsersClient } from "@mbe/api-client";
+import React from "react";
+
+vi.mock("@mbe/auth/react", () => ({ useAuth: vi.fn() }));
+vi.mock("../hooks/useApiClient.js", () => ({ useApiClient: vi.fn() }));
+vi.mock("../hooks/use-theme.js", () => ({
+  useTheme: vi.fn(),
+}));
+
+vi.mock("@mbe/api-client", () => ({
+  UsersClient: vi.fn(function (this: any) {
+    this.me = vi.fn();
+    this.updatePreferences = vi.fn();
+  }),
+  ApiClientError: class extends Error {},
+}));
+
+vi.mock("../components/PageHeader", () => ({
+  PageHeader: ({ title, description }: any) => (
+    <div data-testid="page-header"><h1>{title}</h1><p>{description}</p></div>
+  ),
+}));
+
+vi.mock("@mattbutlerengineering/rialto", () => ({
+  Alert: ({ children }: any) => <div data-testid="alert">{children}</div>,
+  Button: ({ children, onClick, disabled }: any) => (
+    <button onClick={onClick} disabled={disabled}>{children}</button>
+  ),
+  Card: ({ children, title }: any) => <div data-testid="card"><h3>{title}</h3>{children}</div>,
+  Divider: () => <hr />,
+  Select: (props: any) => (
+    <div>
+      <label>{props.label}</label>
+      <select data-testid={`select-${props.label}`} value={props.value} onChange={(e) => props.onChange?.(e.target.value)}>
+        {props.options?.map((o: any) => <option key={o.value} value={o.value}>{o.label}</option>)}
+      </select>
+    </div>
+  ),
+  Skeleton: () => <div data-testid="skeleton" />,
+  SkeletonGroup: ({ children }: any) => <div data-testid="skeleton-group">{children}</div>,
+  Stack: ({ children }: any) => <div>{children}</div>,
+  Text: ({ children }: any) => <span>{children}</span>,
+  Toggle: ({ label, checked, onChange }: any) => (
+    <div>
+      <label>{label}</label>
+      <input type="checkbox" data-testid={`toggle-${label}`} checked={checked} onChange={(e) => onChange?.(e.target.checked)} />
+    </div>
+  ),
+}));
+
+describe("SettingsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+
+    vi.mocked(useAuth).mockReturnValue({
+      accessToken: "token",
+      isLoading: false,
+      signOut: vi.fn(),
+      user: { sub: "user-1", name: "Test User", email: "test@example.com" },
+    } as any);
+
+    vi.mocked(useTheme).mockReturnValue({
+      theme: "system",
+      setTheme: vi.fn(),
+    });
+
+    vi.mocked(useApiClient).mockReturnValue({
+      client: {},
+    } as any);
+
+    vi.mocked(UsersClient).mockImplementation(function (this: any) {
+      this.me = vi.fn().mockResolvedValue({
+        id: "u1",
+        name: "Test User",
+        email: "test@example.com",
+        preferences: { theme: "system", emailNotifications: true, marketingEmails: false },
+      });
+      this.updatePreferences = vi.fn();
+    } as any);
+  });
+
+  it("renders the settings page header", async () => {
+    render(<SettingsPage />);
+    expect(screen.getByText("Settings")).toBeDefined();
+  });
+
+  it("renders theme selection after loading", async () => {
+    render(<SettingsPage />);
+    await waitFor(() => {
+      expect(screen.getByText("Theme")).toBeDefined();
+    });
+  });
+
+  it("renders venue defaults card after loading", async () => {
+    render(<SettingsPage />);
+    await waitFor(() => {
+      expect(screen.getByText("Venue Defaults")).toBeDefined();
+    });
+  });
+
+  it("renders notifications card after loading", async () => {
+    render(<SettingsPage />);
+    await waitFor(() => {
+      expect(screen.getByText("Notifications")).toBeDefined();
+    });
+  });
+
+  it("renders sign out button", async () => {
+    render(<SettingsPage />);
+    await waitFor(() => {
+      expect(screen.getByText("Sign Out")).toBeDefined();
+    });
+  });
+});

--- a/apps/hospitality/src/pages/TimelinePage.test.tsx
+++ b/apps/hospitality/src/pages/TimelinePage.test.tsx
@@ -1,0 +1,198 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, react/jsx-no-undef */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { TimelinePage } from "./TimelinePage.js";
+import { useAuth } from "@mbe/auth/react";
+import { createApiClient } from "@mbe/api-client";
+import { useVenue } from "../contexts/VenueContext.js";
+import { useReservationData } from "../contexts/ReservationDataContext.js";
+import React from "react";
+
+vi.mock("@mbe/auth/react", () => ({ useAuth: vi.fn() }));
+vi.mock("@mbe/api-client", () => ({ createApiClient: vi.fn() }));
+vi.mock("../contexts/VenueContext.js", () => ({ useVenue: vi.fn() }));
+vi.mock("../contexts/ReservationDataContext.js", () => ({ useReservationData: vi.fn() }));
+
+vi.mock("../components/PageHeader", () => ({
+  PageHeader: ({ title }: any) => <div data-testid="page-header">{title}</div>,
+}));
+
+vi.mock("../components/timeline", () => ({
+  TimelineGrid: ({ tables, reservations, onReservationClick }: any) => (
+    <div data-testid="timeline-grid">
+      <span data-testid="table-count">{tables?.length ?? 0}</span>
+      <span data-testid="res-count">{reservations?.length ?? 0}</span>
+      {reservations?.map((r: any) => (
+        <button key={r.id} data-testid={`res-${r.id}`} onClick={() => onReservationClick?.(r)}>
+          {r.guestName}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("../components/timeline/CancelReservationDialog", () => ({
+  CancelReservationDialog: ({ open }: any) => open ? <div data-testid="cancel-dialog" /> : null,
+}));
+
+vi.mock("../components/timeline/EditReservationDrawer", () => ({
+  EditReservationDrawer: ({ open }: any) => open ? <div data-testid="edit-drawer" /> : null,
+}));
+
+vi.mock("../components/timeline/WalkInDialog", () => ({
+  WalkInDialog: () => <div data-testid="walkin-dialog" />,
+}));
+
+vi.mock("@mattbutlerengineering/rialto", () => ({
+  Drawer: ({ children, open }: any) => open ? <div data-testid="drawer">{children}</div> : null,
+  Button: ({ children, onClick, disabled, ...rest }: any) => (
+    <button onClick={onClick} disabled={disabled} aria-label={rest["aria-label"]}>{children}</button>
+  ),
+  Stack: ({ children }: any) => <div>{children}</div>,
+  Text: ({ children, className }: any) => <span className={className}>{children}</span>,
+  Card: ({ children, title, variant }: any) => <div data-variant={variant}>{title}{children}</div>,
+}));
+
+// Mock matchMedia for useIsMobile hook
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+describe("TimelinePage", () => {
+  const mockApi = {
+    tables: { list: vi.fn(), updateStatus: vi.fn() },
+    reservations: { list: vi.fn(), update: vi.fn(), cancelWithReason: vi.fn(), walkIn: vi.fn() },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(useAuth).mockReturnValue({ accessToken: "token" } as any);
+    vi.mocked(createApiClient).mockReturnValue(mockApi as any);
+    vi.mocked(useVenue).mockReturnValue({
+      selectedVenueId: "venue-1",
+      venues: [{ id: "venue-1", name: "Test Venue" }],
+      selectVenue: vi.fn(),
+    } as any);
+    vi.mocked(useReservationData).mockReturnValue({
+      reservations: [
+        {
+          id: "r1",
+          guestName: "Alice",
+          date: new Date().toLocaleDateString("en-CA"),
+          startTime: "2026-05-10T18:00:00",
+          endTime: "2026-05-10T20:00:00",
+          partySize: 4,
+          status: "CONFIRMED",
+          tableId: "t1",
+        },
+      ],
+      tables: [{ id: "t1", name: "Table 1", tableNumber: "T1", priority: 1 }],
+      isConnected: true,
+      sseError: null,
+      setReservations: vi.fn(),
+      setTables: vi.fn(),
+      addReservation: vi.fn(),
+      updateReservation: vi.fn(),
+      removeReservation: vi.fn(),
+      subscribeToEvents: vi.fn(() => vi.fn()),
+    } as any);
+
+    mockApi.tables.list.mockResolvedValue({
+      data: [{ id: "t1", name: "Table 1", tableNumber: "T1", priority: 1 }],
+    });
+    mockApi.reservations.list.mockResolvedValue({
+      data: [
+        {
+          id: "r1",
+          guestName: "Alice",
+          date: new Date().toLocaleDateString("en-CA"),
+          startTime: "2026-05-10T18:00:00",
+          endTime: "2026-05-10T20:00:00",
+          partySize: 4,
+          status: "CONFIRMED",
+          tableId: "t1",
+        },
+      ],
+    });
+  });
+
+  const renderPage = () =>
+    render(
+      <MemoryRouter>
+        <TimelinePage />
+      </MemoryRouter>
+    );
+
+  it("renders the timeline page header", async () => {
+    renderPage();
+    expect(screen.getByTestId("page-header")).toBeDefined();
+    expect(screen.getByText("Timeline")).toBeDefined();
+  });
+
+  it("renders the timeline grid after loading", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId("timeline-grid")).toBeDefined();
+    });
+  });
+
+  it("shows walk-in button", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("Walk-in")).toBeDefined();
+    });
+  });
+
+  it("opens walk-in dialog when walk-in button is clicked", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("Walk-in")).toBeDefined();
+    });
+    fireEvent.click(screen.getByText("Walk-in"));
+    expect(screen.getByTestId("walkin-dialog")).toBeDefined();
+  });
+
+  it("fetches tables and reservations on mount", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(mockApi.tables.list).toHaveBeenCalledWith(
+        expect.objectContaining({ venueId: "venue-1" })
+      );
+    });
+  });
+
+  it("shows date navigation buttons after loading", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByLabelText("Previous day")).toBeDefined();
+    });
+    expect(screen.getByLabelText("Next day")).toBeDefined();
+  });
+
+  it("shows stats when data is loaded", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText(/Reservations:/)).toBeDefined();
+    });
+    expect(screen.getByText(/Covers:/)).toBeDefined();
+  });
+
+  it("shows live connection indicator", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("Live")).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Added 15 new test files covering hooks, components, contexts, and pages in the hospitality app
- Expanded line coverage from 34% to 50%+ (target achieved)
- Key areas tested: use-command-palette hook, SystemHealthBadge, ActivityFeed, booking widget components (ConfirmationView, DatePartySelector, TimeSlotPicker), ReservationDataContext, and all major pages (Home, Timeline, Guests, Reservations, Admin, Settings)

## Test plan

- [x] `pnpm --dir apps/hospitality test -- --coverage` shows >50% line coverage (was 34.15%, now 50.43%)
- [x] All 299 tests pass
- [x] No changes to production code

Closes #1142