### PR TITLE
fix(ci): integrity job needs turbo env vars and build dep; fix evals pnpm version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,8 +295,11 @@ jobs:
 
   integrity:
     name: Integrity
-    needs: [prepare]
+    needs: [prepare, build]
     runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4/v5
 
@@ -322,7 +325,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build CLI
-        run: pnpm --filter @mbe/cli build
+        run: pnpm build --filter @mbe/cli
 
       - name: Check instruction sync (llms.txt)
         run: |

--- a/.github/workflows/instruction-regression.yml
+++ b/.github/workflows/instruction-regression.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
         with:
-          version: 8
+          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
## Summary
Fixes two CI issues from merged ACMM PRs:

1. Integrity job in ci.yml: needs `TURBO_TOKEN`/`TURBO_TEAM` env vars and `needs: [prepare, build]` to resolve @mbe/agent-core via remote cache
2. instruction-regression.yml: pnpm version pinned to 8, needs >=9

## Changes
- Add `TURBO_TOKEN` and `TURBO_TEAM` env vars to integrity job
- Change integrity job `needs:` from `[prepare]` to `[prepare, build]`
- Change `pnpm --filter @mbe/cli build` to `pnpm build --filter @mbe/cli` for turbo resolution
- Fix pnpm version in instruction-regression.yml from 8 to 9