### PR TITLE
feat(cli): add adapter/model/budget/turns options to wave command

### DIFF
--- a/tools/cli/src/commands/wave.ts
+++ b/tools/cli/src/commands/wave.ts
@@ -34,11 +34,18 @@ interface WaveResult {
 export const waveCommand = new Command("wave")
   .description("Execute multiple tasks in parallel using git worktrees")
   .argument("<tasks...>", "List of tasks to execute")
-  .option("--max-parallel <number>", "Maximum parallel sub-agents", parseInt, 3)
+  .option("--max-parallel <number>", "Maximum parallel sub-agents", "3")
   .option("--base-branch <branch>", "Base branch to branch from", "main")
+  .option("--adapter <type>", "Agent adapter: auto, claude, gemini, opencode", "claude")
+  .option("--model <model>", "Model to use for the agent", "claude-sonnet-4-6")
+  .option("--max-budget <usd>", "Maximum budget per agent in USD", "2")
+  .option("--max-turns <n>", "Maximum turns per agent", "100")
   .action(async (tasks: string[], options) => {
     const root = findMonorepoRoot(process.cwd());
-    console.log(`🚀 Starting Wave with ${tasks.length} tasks (max parallel: ${options.maxParallel})...`);
+    const maxParallel = parseInt(options.maxParallel, 10) || 3;
+    const maxBudget = parseFloat(options.maxBudget) || 2;
+    const maxTurns = parseInt(options.maxTurns, 10) || 100;
+    console.log(`🚀 Starting Wave with ${tasks.length} tasks (max parallel: ${maxParallel})...`);
 
     const results: WaveResult[] = [];
     const queue = [...tasks];
@@ -54,7 +61,14 @@ export const waveCommand = new Command("wave")
             console.log(`   Path:   ${worktree.path}`);
 
             // Run agent in the worktree
-            const agentProcess = spawn("mbe", ["agent", "run", task, "--no-pr"], {
+            const agentArgs = [
+                "agent", "run", task, "--no-pr",
+                "--adapter", options.adapter,
+                "--model", options.model,
+                "--max-budget", String(maxBudget),
+                "--max-turns", String(maxTurns),
+            ];
+            const agentProcess = spawn("mbe", agentArgs, {
                 cwd: worktree.path,
                 stdio: "inherit",
             });
@@ -90,7 +104,7 @@ export const waveCommand = new Command("wave")
     };
 
     while (queue.length > 0 || active.size > 0) {
-        while (queue.length > 0 && active.size < options.maxParallel) {
+        while (queue.length > 0 && active.size < maxParallel) {
             const task = queue.shift()!;
             const promise = runTask(task).then(() => {
                 active.delete(promise);


### PR DESCRIPTION
## Summary
Enhances the `mbe wave` command with configurable agent options.

## Changes
- Add `--adapter` option (auto, claude, gemini, opencode)
- Add `--model` option
- Add `--max-budget` option
- Add `--max-turns` option
- Fix NaN issue with numeric option defaults in Commander