### PR TITLE
test(cli): raise coverage to 80% lines

### DIFF
--- a/tools/cli/src/__tests__/compound.test.ts
+++ b/tools/cli/src/__tests__/compound.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { existsSync } from "node:fs";
+import { execSync } from "node:child_process";
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  execSync: vi.fn(),
+}));
+
+const mockExistsSync = vi.mocked(existsSync);
+const mockExecSync = vi.mocked(execSync);
+
+describe("compound command", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
+    vi.spyOn(process, "cwd").mockReturnValue("/repo");
+    // findMonorepoRoot: return true for pnpm-workspace.yaml check
+    mockExistsSync.mockImplementation((p: unknown) =>
+      String(p).endsWith("pnpm-workspace.yaml")
+    );
+  });
+
+  async function runCompound(): Promise<void> {
+    const { compoundCommand } = await import("../commands/compound.js");
+    await compoundCommand.parseAsync([], { from: "user" });
+  }
+
+  it("prints no recommendations when diff contains no recognized patterns", async () => {
+    mockExecSync.mockReturnValue("some-other-change.txt\n" as never);
+
+    await runCompound();
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Starting Compounding Phase");
+    expect(output).toContain("No obvious compounding tasks found");
+  });
+
+  it("detects empty diff and prints message about committing work", async () => {
+    mockExecSync.mockReturnValue("" as never);
+
+    await runCompound();
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("No changes detected");
+  });
+
+  it("detects new package change in diff", async () => {
+    mockExecSync.mockReturnValue(
+      '+  "name": "@mbe/new-pkg"\npackage.json\n' as never
+    );
+
+    await runCompound();
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("New internal package detected");
+  });
+
+  it("detects new API route in diff", async () => {
+    mockExecSync.mockReturnValue(
+      "services/users/routes/users.ts\n+  fastify.get('/users', handler)\n" as never
+    );
+
+    await runCompound();
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("New API endpoints detected");
+  });
+
+  it("detects ADR change in diff", async () => {
+    mockExecSync.mockReturnValue("ADR-001.md\n+status: active\n" as never);
+
+    await runCompound();
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("New architectural decision established");
+  });
+
+  it("detects UI pattern change in diff", async () => {
+    mockExecSync.mockReturnValue(
+      "packages/rialto/src/Button.ts\n+export function Button\n" as never
+    );
+
+    await runCompound();
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("New design system component detected");
+  });
+
+  it("handles execSync error gracefully", async () => {
+    mockExecSync.mockImplementation(() => {
+      throw new Error("git failed");
+    });
+
+    await runCompound();
+
+    const errOutput = errorSpy.mock.calls.flat().join("\n");
+    expect(errOutput).toContain("git failed");
+  });
+
+  it("shows compounding knowledge reminder at end", async () => {
+    mockExecSync.mockReturnValue("some-change.md\n" as never);
+
+    await runCompound();
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("A task is not done until the knowledge gained has been codified");
+  });
+});

--- a/tools/cli/src/__tests__/login.test.ts
+++ b/tools/cli/src/__tests__/login.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const store = new Map<string, unknown>();
+
+vi.mock("conf", () => ({
+  default: class MockConf {
+    get(key: string) { return store.get(key); }
+    set(key: string, value: unknown) { store.set(key, value); }
+    delete(key: string) { store.delete(key); }
+  },
+}));
+
+describe("login command", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    store.clear();
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
+  });
+
+  async function runLogin(args: string[]): Promise<void> {
+    const { loginCommand } = await import("../commands/login.js");
+    await loginCommand.parseAsync(args, { from: "user" });
+  }
+
+  it("logs in with --token flag and stores token", async () => {
+    await runLogin(["--token", "my-access-token"]);
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Logged in successfully");
+    // Token should be stored in config
+    expect(store.get("accessToken")).toBe("my-access-token");
+  });
+
+  it("sets api URL when --api-url is provided", async () => {
+    await runLogin(["--api-url", "https://api.example.com", "--token", "t"]);
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("API URL set to: https://api.example.com");
+    expect(store.get("apiUrl")).toBe("https://api.example.com");
+  });
+
+  it("shows device flow instructions when no token provided", async () => {
+    await runLogin([]);
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Device Authorization Flow");
+    expect(output).toContain("mbe login --token");
+  });
+});

--- a/tools/cli/src/__tests__/logout.test.ts
+++ b/tools/cli/src/__tests__/logout.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const store = new Map<string, unknown>();
+
+vi.mock("conf", () => ({
+  default: class MockConf {
+    get(key: string) { return store.get(key); }
+    set(key: string, value: unknown) { store.set(key, value); }
+    delete(key: string) { store.delete(key); }
+  },
+}));
+
+describe("logout command", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    store.clear();
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  async function runLogout(): Promise<void> {
+    const { logoutCommand } = await import("../commands/logout.js");
+    await logoutCommand.parseAsync([], { from: "user" });
+  }
+
+  it("clears tokens and logs success message", async () => {
+    store.set("accessToken", "some-token");
+    store.set("refreshToken", "some-refresh");
+    store.set("tokenExpiry", Date.now() + 60_000);
+
+    await runLogout();
+
+    expect(store.has("accessToken")).toBe(false);
+    expect(store.has("refreshToken")).toBe(false);
+    expect(store.has("tokenExpiry")).toBe(false);
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Logged out successfully");
+  });
+
+  it("works even when no tokens are stored", async () => {
+    await runLogout();
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Logged out successfully");
+  });
+});

--- a/tools/cli/src/__tests__/loop.test.ts
+++ b/tools/cli/src/__tests__/loop.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Expose mock functions so we can reference them without importing @mbe/agent-core
+const mockRunSession = vi.fn();
+const mockResolveBudget = vi.fn().mockReturnValue({ budgetUsd: 1.0 });
+const mockResolveModel = vi.fn().mockReturnValue("claude-sonnet-4-6");
+
+vi.mock("@mbe/agent-core", () => ({
+  runSession: mockRunSession,
+  DEFAULT_SESSION_CONFIG: {
+    taskDescription: "",
+    repoPath: ".",
+    model: "claude-sonnet-4-6",
+    maxBudgetUsd: 1.0,
+    maxTurns: 50,
+  },
+  resolveBudget: mockResolveBudget,
+  resolveModel: mockResolveModel,
+}));
+
+describe("loop command", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    // Restore default implementations after resetAllMocks
+    mockResolveBudget.mockReturnValue({ budgetUsd: 1.0 });
+    mockResolveModel.mockReturnValue("claude-sonnet-4-6");
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
+    vi.spyOn(process, "cwd").mockReturnValue("/repo");
+  });
+
+  async function runLoop(args: string[]): Promise<void> {
+    const { loopCommand } = await import("../commands/loop.js");
+    await loopCommand.parseAsync(args, { from: "user" });
+  }
+
+  it("runs one iteration and reports completion when agent returns COMPLETE", async () => {
+    mockResolveBudget.mockReturnValue({ budgetUsd: 2.0 });
+    mockRunSession.mockResolvedValue({
+      status: "succeeded",
+      costUsd: 0.1,
+      resultText: "<promise>COMPLETE</promise>",
+    });
+
+    await runLoop(["Fix the bug", "--max-loops", "3"]);
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Successfully completed task");
+    expect(output).toContain("1 iterations");
+  });
+
+  it("continues looping when no COMPLETE token is found", async () => {
+    mockResolveBudget.mockReturnValue({ budgetUsd: 2.0 });
+    mockRunSession.mockResolvedValue({
+      status: "succeeded",
+      costUsd: 0.1,
+      resultText: "Some output without completion token",
+    });
+
+    await runLoop(["Fix the bug", "--max-loops", "2"]);
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Reached maximum iterations (2)");
+    expect(mockRunSession).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops when budget is exhausted", async () => {
+    mockResolveBudget.mockReturnValue({ budgetUsd: 0.05 });
+    mockRunSession.mockResolvedValue({
+      status: "succeeded",
+      costUsd: 0.1, // More than budget
+      resultText: "No completion",
+    });
+
+    await runLoop(["Fix the bug", "--max-loops", "5", "--max-budget", "0.05"]);
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Budget limit reached");
+    expect(mockRunSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs error and continues when iteration fails", async () => {
+    mockResolveBudget.mockReturnValue({ budgetUsd: 5.0 });
+    mockRunSession
+      .mockRejectedValueOnce(new Error("iteration error"))
+      .mockResolvedValueOnce({
+        status: "succeeded",
+        costUsd: 0.1,
+        resultText: "<promise>COMPLETE</promise>",
+      });
+
+    await runLoop(["Fix the bug", "--max-loops", "3"]);
+
+    const errOutput = errorSpy.mock.calls.flat().join("\n");
+    expect(errOutput).toContain("iteration error");
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Successfully completed task");
+  });
+
+  it("reports failed status without stopping", async () => {
+    mockResolveBudget.mockReturnValue({ budgetUsd: 5.0 });
+    mockRunSession.mockResolvedValue({
+      status: "failed",
+      costUsd: 0.1,
+      resultText: "",
+    });
+
+    await runLoop(["Fix the bug", "--max-loops", "2"]);
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Iteration failed with status");
+    expect(mockRunSession).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows verbose events when --verbose flag is set", async () => {
+    mockResolveBudget.mockReturnValue({ budgetUsd: 2.0 });
+
+    // Simulate the callback being called with events
+    mockRunSession.mockImplementation(
+      async (_config: unknown, callback: (event: unknown) => void) => {
+        if (callback) {
+          callback({
+            type: "session:start",
+            timestamp: Date.now(),
+            data: { message: "Starting session" },
+          });
+          callback({
+            type: "session:result",
+            timestamp: Date.now(),
+            data: { message: "Session complete" },
+          });
+        }
+        return {
+          status: "succeeded",
+          costUsd: 0.1,
+          resultText: "<promise>COMPLETE</promise>",
+        };
+      }
+    );
+
+    await runLoop(["Fix the bug", "--max-loops", "1", "--verbose"]);
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Starting session");
+    expect(output).toContain("Session complete");
+  });
+});

--- a/tools/cli/src/__tests__/mcp.test.ts
+++ b/tools/cli/src/__tests__/mcp.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { existsSync } from "node:fs";
+import { spawn } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+const mockExistsSync = vi.mocked(existsSync);
+const mockSpawn = vi.mocked(spawn);
+
+function makeFakeProcess(closeCode: number = 0): Partial<ChildProcess> {
+  const proc = {
+    on(event: string, cb: (...args: unknown[]) => void) {
+      if (event === "close") {
+        Promise.resolve().then(() => cb(closeCode));
+      }
+      return proc;
+    },
+  };
+  return proc as unknown as Partial<ChildProcess>;
+}
+
+describe("mcp command", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
+    vi.spyOn(process, "cwd").mockReturnValue("/repo");
+    mockSpawn.mockReturnValue(makeFakeProcess(0) as ChildProcess);
+  });
+
+  async function runMcpStart(): Promise<void> {
+    const { mcpCommand } = await import("../commands/mcp.js");
+    await mcpCommand.commands[0].parseAsync([], { from: "user" });
+  }
+
+  it("exits with error when mcp-server package directory does not exist", async () => {
+    mockExistsSync.mockImplementation((p: unknown) => {
+      const path = String(p);
+      // workspace found but no mcp-server dir
+      return path.endsWith("pnpm-workspace.yaml");
+    });
+
+    await runMcpStart();
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.flat().join("\n");
+    expect(errOutput).toContain("MCP server package not found");
+  });
+
+  it("spawns pnpm start in the mcp-server directory when package exists", async () => {
+    mockExistsSync.mockImplementation((p: unknown) => {
+      const path = String(p);
+      if (path.endsWith("pnpm-workspace.yaml")) return true;
+      if (path.includes("packages/mcp-server")) return true;
+      return false;
+    });
+
+    await runMcpStart();
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "pnpm",
+      ["start"],
+      expect.objectContaining({ cwd: expect.stringContaining("packages/mcp-server") })
+    );
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Starting MBE Infra MCP Server");
+  });
+
+  it("exits with the server close code when server exits", async () => {
+    mockExistsSync.mockImplementation((p: unknown) => {
+      const path = String(p);
+      if (path.endsWith("pnpm-workspace.yaml")) return true;
+      if (path.includes("packages/mcp-server")) return true;
+      return false;
+    });
+    mockSpawn.mockReturnValue(makeFakeProcess(2) as ChildProcess);
+
+    await runMcpStart();
+
+    expect(exitSpy).toHaveBeenCalledWith(2);
+  });
+});

--- a/tools/cli/src/__tests__/new.test.ts
+++ b/tools/cli/src/__tests__/new.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { existsSync, mkdirSync, writeFileSync, readdirSync } from "node:fs";
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  readdirSync: vi.fn(),
+  readFileSync: vi.fn(),
+}));
+
+const mockExistsSync = vi.mocked(existsSync);
+const mockMkdirSync = vi.mocked(mkdirSync);
+const mockWriteFileSync = vi.mocked(writeFileSync);
+const mockReaddirSync = vi.mocked(readdirSync);
+
+describe("new command", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
+    vi.spyOn(process, "cwd").mockReturnValue("/repo");
+
+    // Default: workspace found, app dir does not exist, apps dir exists
+    mockExistsSync.mockImplementation((p: unknown) => {
+      const path = String(p);
+      if (path.endsWith("pnpm-workspace.yaml")) return true;
+      if (path.endsWith("/repo/apps")) return true;
+      return false;
+    });
+    mockReaddirSync.mockReturnValue([] as never);
+  });
+
+  async function runNew(args: string[]): Promise<void> {
+    const { newCommand } = await import("../commands/new.js");
+    await newCommand.parseAsync(args, { from: "user" });
+  }
+
+  it("rejects invalid app names", async () => {
+    await runNew(["Invalid-Name"]);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.flat().join("\n");
+    expect(errOutput).toContain("invalid");
+  });
+
+  it("rejects names that start with numbers", async () => {
+    await runNew(["123app"]);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("exits when app directory already exists", async () => {
+    mockExistsSync.mockImplementation((p: unknown) => {
+      const path = String(p);
+      if (path.endsWith("pnpm-workspace.yaml")) return true;
+      if (path.includes("apps/my-app")) return true;
+      return false;
+    });
+
+    await runNew(["my-app"]);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.flat().join("\n");
+    expect(errOutput).toContain("already exists");
+  });
+
+  it("scaffolds a new app with correct files", async () => {
+    await runNew(["my-new-app"]);
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(mockWriteFileSync).toHaveBeenCalled();
+    expect(mockMkdirSync).toHaveBeenCalled();
+
+    // Check that package.json was written
+    const packageJsonCall = mockWriteFileSync.mock.calls.find(
+      ([path]) => String(path).endsWith("package.json") && String(path).includes("my-new-app")
+    );
+    expect(packageJsonCall).toBeDefined();
+    expect(String(packageJsonCall![1])).toContain("@mbe/my-new-app");
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Scaffolded apps/my-new-app/");
+  });
+
+  it("uses provided --port option", async () => {
+    await runNew(["my-app", "--port", "4000"]);
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    const viteConfigCall = mockWriteFileSync.mock.calls.find(
+      ([path]) => String(path).endsWith("vite.config.ts")
+    );
+    expect(viteConfigCall).toBeDefined();
+    expect(String(viteConfigCall![1])).toContain("4000");
+  });
+
+  it("rejects invalid port values", async () => {
+    await runNew(["my-app", "--port", "99999"]);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.flat().join("\n");
+    expect(errOutput).toContain("Invalid port");
+  });
+
+  it("auto-detects next available port from existing vite configs", async () => {
+    const { readFileSync } = await import("node:fs");
+    const mockReadFileSync = vi.mocked(readFileSync);
+
+    mockReaddirSync.mockReturnValue([
+      { name: "existing-app", isDirectory: () => true },
+    ] as never);
+    mockExistsSync.mockImplementation((p: unknown) => {
+      const path = String(p);
+      if (path.endsWith("pnpm-workspace.yaml")) return true;
+      if (path.endsWith("apps")) return true;
+      if (path.endsWith("vite.config.ts")) return true;
+      return false;
+    });
+    mockReadFileSync.mockReturnValue("port: 3005" as never);
+
+    await runNew(["new-app"]);
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    // Port 3005 is taken, so 3006 should be used
+    const viteConfigCall = mockWriteFileSync.mock.calls.find(
+      ([path]) => String(path).endsWith("vite.config.ts")
+    );
+    expect(viteConfigCall).toBeDefined();
+    expect(String(viteConfigCall![1])).toContain("3006");
+  });
+});

--- a/tools/cli/src/__tests__/pack-helpers.test.ts
+++ b/tools/cli/src/__tests__/pack-helpers.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Tests for pack.ts helper functions using real ts-morph.
+ * These tests don't mock ts-morph, so they exercise the AST skeleton
+ * generator functions (truncateType, getSkeleton, detectPriority, getSectionName)
+ * that are otherwise unreachable through CLI-level tests.
+ *
+ * We test packDirectory indirectly by writing a real .ts file to a temp dir
+ * and calling the packCommand with that path.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execSync } from "node:child_process";
+
+// Only mock child_process (used by pack-changed) and keep fs real
+vi.mock("node:child_process", () => ({
+  execSync: vi.fn(),
+}));
+
+const mockExecSync = vi.mocked(execSync);
+
+describe("pack command (real ts-morph skeleton generation)", () => {
+  let tmpDir: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
+    mockExecSync.mockReturnValue("" as never);
+
+    // Create a temp directory structure simulating a monorepo package
+    tmpDir = mkdtempSync(join(tmpdir(), "pack-test-"));
+    // Create pnpm-workspace.yaml so findMonorepoRoot returns tmpDir
+    writeFileSync(join(tmpDir, "pnpm-workspace.yaml"), "packages:\n  - packages/*\n");
+    vi.spyOn(process, "cwd").mockReturnValue(tmpDir);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function runPack(targetPath: string, extraArgs: string[] = []): Promise<void> {
+    const { packCommand } = await import("../commands/pack.js");
+    await packCommand.parseAsync([targetPath, ...extraArgs], { from: "user" });
+  }
+
+  it("generates llms.txt from a package with TypeScript interfaces", async () => {
+    // Create a real TypeScript file in the temp package dir
+    const pkgDir = join(tmpDir, "packages/my-pkg");
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(
+      join(pkgDir, "index.ts"),
+      `
+export interface User {
+  id: string;
+  email: string;
+  name?: string;
+}
+
+export type Status = "active" | "inactive";
+
+export enum Role {
+  Admin = "admin",
+  User = "user",
+}
+
+export function greet(name: string): string {
+  return \`Hello, \${name}!\`;
+}
+
+export const VERSION = "1.0.0";
+`.trim()
+    );
+
+    await runPack("packages/my-pkg");
+
+    // Should have written the llms.txt
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("llms.txt");
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("generates llms.txt from a package with class declarations", async () => {
+    const pkgDir = join(tmpDir, "packages/class-pkg");
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(
+      join(pkgDir, "service.ts"),
+      `
+export class UserService {
+  private db: unknown;
+
+  async findAll(): Promise<unknown[]> {
+    return [];
+  }
+
+  async findById(id: string): Promise<unknown | null> {
+    return null;
+  }
+
+  create(data: Record<string, unknown>): Promise<unknown> {
+    return Promise.resolve(data);
+  }
+}
+`.trim()
+    );
+
+    await runPack("packages/class-pkg");
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("llms.txt");
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("generates full output with --full flag", async () => {
+    const pkgDir = join(tmpDir, "packages/full-pkg");
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(
+      join(pkgDir, "types.ts"),
+      `
+export interface Config {
+  apiUrl: string;
+  timeout: number;
+}
+`.trim()
+    );
+
+    await runPack("packages/full-pkg", ["--full"]);
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("full context");
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("handles --check mode when llms.txt is in sync", async () => {
+    const pkgDir = join(tmpDir, "packages/sync-pkg");
+    mkdirSync(pkgDir, { recursive: true });
+    // Empty package (no .ts files) → skeleton = `<codebase ...>\n</codebase>\n`
+    writeFileSync(join(pkgDir, "pnpm-empty.txt"), "");
+
+    // First pack to generate the files
+    await runPack("packages/sync-pkg");
+
+    // Reset module cache so the next import gets a fresh instance
+    vi.resetModules();
+
+    // Second check should pass (already in sync)
+    const { packCommand } = await import("../commands/pack.js");
+    await packCommand.parseAsync(["packages/sync-pkg", "--check"], { from: "user" });
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("in sync");
+  });
+
+  it("generates skeletons for arrow function exported variables", async () => {
+    const pkgDir = join(tmpDir, "packages/arrow-pkg");
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(
+      join(pkgDir, "handlers.ts"),
+      `
+export const handleRequest = async (req: unknown): Promise<string> => {
+  const data = req as Record<string, unknown>;
+  return JSON.stringify(data);
+};
+
+export const config = {
+  timeout: 5000,
+  retries: 3,
+};
+`.trim()
+    );
+
+    await runPack("packages/arrow-pkg");
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("llms.txt");
+  });
+
+  it("handles type aliases with union types", async () => {
+    const pkgDir = join(tmpDir, "packages/union-pkg");
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(
+      join(pkgDir, "types.ts"),
+      `
+export type Theme = "light" | "dark" | "system";
+export type Size = "sm" | "md" | "lg" | "xl";
+export type Status = "pending" | "active" | "inactive" | "deleted";
+`.trim()
+    );
+
+    await runPack("packages/union-pkg");
+
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("handles a type alias with a long complex type (triggers truncation)", async () => {
+    const pkgDir = join(tmpDir, "packages/complex-pkg");
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(
+      join(pkgDir, "types.ts"),
+      `
+export type ComplexType = Record<string, Map<string, Array<Set<WeakMap<object, Promise<unknown>>>>>>;
+`.trim()
+    );
+
+    await runPack("packages/complex-pkg");
+
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tools/cli/src/__tests__/pack.test.ts
+++ b/tools/cli/src/__tests__/pack.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { glob } from "glob";
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  execSync: vi.fn(),
+}));
+
+// ts-morph is complex - mock it entirely
+vi.mock("ts-morph", () => ({
+  Project: class {
+    addSourceFileAtPath() {
+      return {
+        getStatements: () => [],
+      };
+    }
+  },
+  Node: {
+    isFunctionDeclaration: () => false,
+    isMethodDeclaration: () => false,
+    isConstructorDeclaration: () => false,
+    isArrowFunction: () => false,
+    isClassDeclaration: () => false,
+    isInterfaceDeclaration: () => false,
+    isTypeAliasDeclaration: () => false,
+    isEnumDeclaration: () => false,
+    isVariableStatement: () => false,
+    isUnionTypeNode: () => false,
+    isObjectLiteralExpression: () => false,
+    isArrayLiteralExpression: () => false,
+  },
+}));
+
+vi.mock("glob", () => ({
+  glob: vi.fn(),
+}));
+
+const mockExistsSync = vi.mocked(existsSync);
+const mockReadFileSync = vi.mocked(readFileSync);
+const mockWriteFileSync = vi.mocked(writeFileSync);
+const mockExecSync = vi.mocked(execSync);
+const mockGlob = vi.mocked(glob);
+
+describe("pack command", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
+    vi.spyOn(process, "cwd").mockReturnValue("/repo");
+    // Default glob mock: return empty array (no .ts files found)
+    mockGlob.mockResolvedValue([]);
+  });
+
+  async function runPack(args: string[]): Promise<void> {
+    const { packCommand } = await import("../commands/pack.js");
+    await packCommand.parseAsync(args, { from: "user" });
+  }
+
+  async function runPackChanged(args: string[] = []): Promise<void> {
+    const { packChangedCommand } = await import("../commands/pack.js");
+    await packChangedCommand.parseAsync(args, { from: "user" });
+  }
+
+  describe("pack", () => {
+    it("warns when target path does not exist", async () => {
+      mockExistsSync.mockImplementation((p: unknown) => {
+        const path = String(p);
+        return path.endsWith("pnpm-workspace.yaml");
+        // target path does not exist
+      });
+
+      await runPack(["services/missing"]);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Path not found")
+      );
+    });
+
+    it("writes llms.txt and llms-full.txt when target path exists", async () => {
+      mockExistsSync.mockImplementation(() => {
+        return true; // everything exists
+      });
+
+      await runPack(["services/users"]);
+
+      // Should have written files
+      expect(mockWriteFileSync).toHaveBeenCalled();
+      const output = logSpy.mock.calls.flat().join("\n");
+      expect(output).toContain("Packing context");
+    });
+
+    it("runs in check mode and exits when llms.txt content is out of sync", async () => {
+      mockExistsSync.mockImplementation(() => true);
+      // Return content that differs from what the code would generate
+      mockReadFileSync.mockReturnValue("outdated content" as never);
+
+      await runPack(["services/users", "--check"]);
+
+      // In check mode with mismatched content, it should exit with error
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+    });
+
+    it("exits in check mode when llms.txt is missing", async () => {
+      mockExistsSync.mockImplementation((p: unknown) => {
+        const path = String(p);
+        if (path.endsWith("pnpm-workspace.yaml")) return true;
+        if (path.includes("services/users") && !path.endsWith("llms.txt")) return true;
+        return false; // llms.txt does not exist
+      });
+
+      await runPack(["services/users", "--check"]);
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      const errOutput = errorSpy.mock.calls.flat().join("\n");
+      expect(errOutput).toContain("does not exist");
+    });
+  });
+
+  describe("pack-changed", () => {
+    it("logs message when no relevant changes detected", async () => {
+      mockExistsSync.mockImplementation((p: unknown) =>
+        String(p).endsWith("pnpm-workspace.yaml")
+      );
+      mockExecSync.mockReturnValue("README.md\nsome-file.json\n" as never);
+
+      await runPackChanged();
+
+      const output = logSpy.mock.calls.flat().join("\n");
+      expect(output).toContain("No relevant code changes detected");
+    });
+
+    it("packs changed packages for .ts files in recognized dirs", async () => {
+      mockExistsSync.mockImplementation(() => true);
+      mockExecSync.mockImplementation((cmd: unknown) => {
+        if (String(cmd).includes("git diff")) {
+          return "services/users/src/index.ts\npackages/rialto/src/Button.ts\n" as never;
+        }
+        return "" as never;
+      });
+
+      await runPackChanged();
+
+      const output = logSpy.mock.calls.flat().join("\n");
+      expect(output).toContain("Detected changes");
+    });
+
+    it("handles git diff errors gracefully", async () => {
+      mockExistsSync.mockImplementation((p: unknown) =>
+        String(p).endsWith("pnpm-workspace.yaml")
+      );
+      mockExecSync.mockImplementation(() => {
+        throw new Error("git error");
+      });
+
+      await runPackChanged();
+
+      const errOutput = errorSpy.mock.calls.flat().join("\n");
+      expect(errOutput).toContain("Error detecting changed files");
+    });
+
+    it("uses checkout mode diff when --mode checkout is passed", async () => {
+      mockExistsSync.mockImplementation((p: unknown) =>
+        String(p).endsWith("pnpm-workspace.yaml")
+      );
+      mockExecSync.mockReturnValue("" as never);
+
+      await runPackChanged(["--mode", "checkout"]);
+
+      const calls = mockExecSync.mock.calls.map(([cmd]) => String(cmd));
+      expect(calls.some((cmd) => cmd.includes("@{1}"))).toBe(true);
+    });
+  });
+});

--- a/tools/cli/src/__tests__/prime.test.ts
+++ b/tools/cli/src/__tests__/prime.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { existsSync } from "node:fs";
+import { execSync } from "node:child_process";
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  execSync: vi.fn(),
+}));
+
+const mockExistsSync = vi.mocked(existsSync);
+const mockExecSync = vi.mocked(execSync);
+
+describe("prime command", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "cwd").mockReturnValue("/repo");
+    mockExistsSync.mockImplementation((p: unknown) =>
+      String(p).endsWith("pnpm-workspace.yaml")
+    );
+    mockExecSync.mockReturnValue("" as never);
+  });
+
+  async function runPrime(directive: string): Promise<void> {
+    const { primeCommand } = await import("../commands/prime.js");
+    await primeCommand.parseAsync([directive], { from: "user" });
+  }
+
+  it("primes user-related packages for 'user' directive", async () => {
+    await runPrime("Fix the user login page");
+
+    expect(mockExecSync).toHaveBeenCalledWith(
+      expect.stringContaining("services/users"),
+      expect.any(Object)
+    );
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Context primed");
+  });
+
+  it("primes reservations for 'reservation' keyword", async () => {
+    await runPrime("Fix the table reservation flow");
+
+    expect(mockExecSync).toHaveBeenCalledWith(
+      expect.stringContaining("services/reservations"),
+      expect.any(Object)
+    );
+  });
+
+  it("primes agent service for 'agent' keyword", async () => {
+    await runPrime("Debug agent session issue");
+
+    expect(mockExecSync).toHaveBeenCalledWith(
+      expect.stringContaining("services/agent"),
+      expect.any(Object)
+    );
+  });
+
+  it("primes rialto package for 'component' keyword", async () => {
+    await runPrime("Build a new UI component");
+
+    expect(mockExecSync).toHaveBeenCalledWith(
+      expect.stringContaining("packages/rialto"),
+      expect.any(Object)
+    );
+  });
+
+  it("primes auth package for 'auth' keyword", async () => {
+    await runPrime("Improve auth flow");
+
+    expect(mockExecSync).toHaveBeenCalledWith(
+      expect.stringContaining("packages/auth"),
+      expect.any(Object)
+    );
+  });
+
+  it("primes api-client package for 'api' keyword", async () => {
+    await runPrime("Fix the API client");
+
+    expect(mockExecSync).toHaveBeenCalledWith(
+      expect.stringContaining("packages/api-client"),
+      expect.any(Object)
+    );
+  });
+
+  it("falls back to all core services when no keyword matches", async () => {
+    await runPrime("Do something generic");
+
+    const calls = mockExecSync.mock.calls.map(([cmd]) => String(cmd));
+    expect(calls.some((cmd) => cmd.includes("services/users"))).toBe(true);
+    expect(calls.some((cmd) => cmd.includes("services/agent"))).toBe(true);
+    expect(calls.some((cmd) => cmd.includes("services/reservations"))).toBe(true);
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("No specific packages identified");
+  });
+
+  it("handles pack failure gracefully", async () => {
+    mockExecSync.mockImplementation(() => {
+      throw new Error("pack failed");
+    });
+
+    await runPrime("Fix the user service");
+
+    const errOutput = errorSpy.mock.calls.flat().join("\n");
+    expect(errOutput).toContain("Failed to pack");
+  });
+
+  it("prints priming completion message", async () => {
+    await runPrime("Fix the user service");
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Context primed");
+    expect(output).toContain("fresh semantic skeletons");
+  });
+});

--- a/tools/cli/src/__tests__/stats-extended.test.ts
+++ b/tools/cli/src/__tests__/stats-extended.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { existsSync, readFileSync, appendFileSync, mkdirSync, writeFileSync } from "node:fs";
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  appendFileSync: vi.fn(),
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+const mockExistsSync = vi.mocked(existsSync);
+const mockReadFileSync = vi.mocked(readFileSync);
+const mockAppendFileSync = vi.mocked(appendFileSync);
+const mockMkdirSync = vi.mocked(mkdirSync);
+const mockWriteFileSync = vi.mocked(writeFileSync);
+
+describe("stats extended commands", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
+    vi.spyOn(process, "cwd").mockReturnValue("/repo");
+    mockExistsSync.mockImplementation((p: unknown) =>
+      String(p).endsWith("pnpm-workspace.yaml") || String(p).includes("docs/logs")
+    );
+  });
+
+  // ── log-session ───────────────────────────────────────────────────────────
+
+  describe("log-session command", () => {
+    async function runLogSession(args: string[]): Promise<void> {
+      const { logSessionCommand } = await import("../commands/stats.js");
+      await logSessionCommand.parseAsync(args, { from: "user" });
+    }
+
+    it("appends session record to log file", async () => {
+      await runLogSession([
+        "--id", "session-123",
+        "--research", "3",
+        "--execution", "5",
+        "--success",
+        "--cost", "0.15",
+        "--model", "claude-sonnet-4-6",
+      ]);
+
+      expect(mockAppendFileSync).toHaveBeenCalledOnce();
+      const [filePath, content] = mockAppendFileSync.mock.calls[0];
+      expect(String(filePath)).toContain("agent-perf.jsonl");
+      const record = JSON.parse(String(content).trim());
+      expect(record.sessionId).toBe("session-123");
+      expect(record.researchTurns).toBe(3);
+      expect(record.executionTurns).toBe(5);
+      expect(record.totalTurns).toBe(8);
+      expect(record.firstPassSuccess).toBe(true);
+      expect(record.costUsd).toBe(0.15);
+      expect(record.modelId).toBe("claude-sonnet-4-6");
+
+      const output = logSpy.mock.calls.flat().join("\n");
+      expect(output).toContain("session-123");
+      expect(output).toContain("logged");
+    });
+
+    it("creates log directory if missing", async () => {
+      mockExistsSync.mockImplementation((p: unknown) => {
+        const path = String(p);
+        if (path.endsWith("pnpm-workspace.yaml")) return true;
+        return false; // docs/logs does not exist
+      });
+
+      await runLogSession([
+        "--id", "s1",
+        "--research", "1",
+        "--execution", "2",
+      ]);
+
+      expect(mockMkdirSync).toHaveBeenCalledWith(
+        expect.stringContaining("docs/logs"),
+        { recursive: true }
+      );
+    });
+
+    it("records milestone when provided", async () => {
+      await runLogSession([
+        "--id", "s2",
+        "--research", "1",
+        "--execution", "1",
+        "--milestone", "v1.5",
+      ]);
+
+      const [, content] = mockAppendFileSync.mock.calls[0];
+      const record = JSON.parse(String(content).trim());
+      expect(record.milestone).toBe("v1.5");
+    });
+  });
+
+  // ── stats (no-data path) ──────────────────────────────────────────────────
+
+  describe("stats command (no data)", () => {
+    async function runStats(): Promise<void> {
+      const { statsCommand } = await import("../commands/stats.js");
+      await statsCommand.parseAsync([], { from: "user" });
+    }
+
+    it("prints no-data message when log file does not exist", async () => {
+      mockExistsSync.mockImplementation((p: unknown) => {
+        const path = String(p);
+        return path.endsWith("pnpm-workspace.yaml");
+        // logFile not found
+      });
+
+      await runStats();
+
+      const output = logSpy.mock.calls.flat().join("\n");
+      expect(output).toContain("No performance data found");
+    });
+  });
+
+  // ── audit-perf ─────────────────────────────────────────────────────────────
+
+  describe("audit-perf command", () => {
+    async function runAuditPerf(args: string[] = []): Promise<void> {
+      const { auditPerfCommand } = await import("../commands/stats.js");
+      await auditPerfCommand.parseAsync(args, { from: "user" });
+    }
+
+    it("prints no-data message when log file does not exist", async () => {
+      mockExistsSync.mockImplementation((p: unknown) =>
+        String(p).endsWith("pnpm-workspace.yaml")
+      );
+
+      await runAuditPerf();
+
+      const output = logSpy.mock.calls.flat().join("\n");
+      expect(output).toContain("No performance data found");
+    });
+
+    it("shows no bottlenecks when data is clean", async () => {
+      mockExistsSync.mockReturnValue(true);
+      const cleanRecord = {
+        sessionId: "s1",
+        researchTurns: 2,
+        executionTurns: 3,
+        firstPassSuccess: true,
+        humanInterventions: 0,
+        costUsd: 0.1,
+        modelId: "claude-sonnet-4-6",
+        timestamp: new Date().toISOString(),
+        totalTurns: 5,
+      };
+      mockReadFileSync.mockReturnValue(JSON.stringify(cleanRecord) as never);
+
+      await runAuditPerf();
+
+      const output = logSpy.mock.calls.flat().join("\n");
+      expect(output).toContain("No significant process bottlenecks detected");
+    });
+
+    it("detects high research turns", async () => {
+      mockExistsSync.mockReturnValue(true);
+      const record = {
+        sessionId: "s1",
+        researchTurns: 9,
+        executionTurns: 3,
+        firstPassSuccess: true,
+        humanInterventions: 0,
+        costUsd: 0.1,
+        modelId: "claude-sonnet-4-6",
+        timestamp: new Date().toISOString(),
+        totalTurns: 12,
+      };
+      mockReadFileSync.mockReturnValue(JSON.stringify(record) as never);
+
+      await runAuditPerf();
+
+      const output = logSpy.mock.calls.flat().join("\n");
+      expect(output).toContain("High Research Turns detected");
+    });
+
+    it("detects low first-pass success rate", async () => {
+      mockExistsSync.mockReturnValue(true);
+      const records = [
+        { sessionId: "s1", researchTurns: 2, executionTurns: 3, firstPassSuccess: false, humanInterventions: 0, costUsd: 0.1, modelId: "m", timestamp: "t", totalTurns: 5 },
+        { sessionId: "s2", researchTurns: 2, executionTurns: 3, firstPassSuccess: false, humanInterventions: 0, costUsd: 0.1, modelId: "m", timestamp: "t", totalTurns: 5 },
+        { sessionId: "s3", researchTurns: 2, executionTurns: 3, firstPassSuccess: false, humanInterventions: 0, costUsd: 0.1, modelId: "m", timestamp: "t", totalTurns: 5 },
+      ];
+      mockReadFileSync.mockReturnValue(records.map(r => JSON.stringify(r)).join("\n") as never);
+
+      await runAuditPerf();
+
+      const output = logSpy.mock.calls.flat().join("\n");
+      expect(output).toContain("failed on first pass");
+    });
+
+    it("detects human interventions", async () => {
+      mockExistsSync.mockReturnValue(true);
+      const record = {
+        sessionId: "s1",
+        researchTurns: 2,
+        executionTurns: 3,
+        firstPassSuccess: true,
+        humanInterventions: 2,
+        costUsd: 0.1,
+        modelId: "m",
+        timestamp: "t",
+        totalTurns: 5,
+      };
+      mockReadFileSync.mockReturnValue(JSON.stringify(record) as never);
+
+      await runAuditPerf();
+
+      const output = logSpy.mock.calls.flat().join("\n");
+      expect(output).toContain("Human interventions detected");
+    });
+
+    it("creates auto-plan when --auto-plan is provided and improvements exist", async () => {
+      mockExistsSync.mockReturnValue(true);
+      const record = {
+        sessionId: "s1",
+        researchTurns: 2,
+        executionTurns: 3,
+        firstPassSuccess: false,
+        humanInterventions: 2,
+        costUsd: 0.1,
+        modelId: "m",
+        timestamp: "t",
+        totalTurns: 5,
+      };
+      mockReadFileSync.mockReturnValue(JSON.stringify(record) as never);
+
+      await runAuditPerf(["--auto-plan"]);
+
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        expect.stringContaining("AUTO-PERF-OPTIMIZATION.md"),
+        expect.stringContaining("Auto-Generated Performance Optimization")
+      );
+
+      const output = logSpy.mock.calls.flat().join("\n");
+      expect(output).toContain("Created autonomous optimization plan");
+    });
+  });
+});

--- a/tools/cli/src/__tests__/sync-rules.test.ts
+++ b/tools/cli/src/__tests__/sync-rules.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+const mockExistsSync = vi.mocked(existsSync);
+const mockReadFileSync = vi.mocked(readFileSync);
+const mockWriteFileSync = vi.mocked(writeFileSync);
+
+describe("sync-rules command", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
+    vi.spyOn(process, "cwd").mockReturnValue("/repo");
+  });
+
+  async function runSyncRules(): Promise<void> {
+    const { syncRulesCommand } = await import("../commands/sync-rules.js");
+    await syncRulesCommand.parseAsync([], { from: "user" });
+  }
+
+  it("exits with error when AGENTS.md not found", async () => {
+    mockExistsSync.mockImplementation((p: unknown) => {
+      const path = String(p);
+      if (path.endsWith("pnpm-workspace.yaml")) return true;
+      return false;
+    });
+
+    await runSyncRules();
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.flat().join("\n");
+    expect(errOutput).toContain("AGENTS.md not found");
+  });
+
+  it("writes .cursorrules when AGENTS.md exists (no GEMINI.md)", async () => {
+    mockExistsSync.mockImplementation((p: unknown) => {
+      const path = String(p);
+      if (path.endsWith("pnpm-workspace.yaml")) return true;
+      if (path.endsWith("AGENTS.md")) return true;
+      return false; // no GEMINI.md
+    });
+
+    mockReadFileSync.mockReturnValue("# Agents content" as never);
+
+    await runSyncRules();
+
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      expect.stringContaining(".cursorrules"),
+      expect.stringContaining("# Agents content")
+    );
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Updated .cursorrules");
+    expect(output).toContain("Successfully synchronized");
+  });
+
+  it("updates GEMINI.md when it exists and lacks AGENTS.md reference", async () => {
+    mockExistsSync.mockImplementation((p: unknown) => {
+      const path = String(p);
+      if (path.endsWith("pnpm-workspace.yaml")) return true;
+      if (path.endsWith("AGENTS.md")) return true;
+      if (path.endsWith("GEMINI.md")) return true;
+      return false;
+    });
+
+    mockReadFileSync.mockImplementation((p: unknown) => {
+      const path = String(p);
+      if (path.endsWith("GEMINI.md")) return "# Gemini specific content" as never;
+      return "# Agents content" as never;
+    });
+
+    await runSyncRules();
+
+    // Should write to GEMINI.md since it doesn't contain AGENTS.md reference
+    const geminiWrite = mockWriteFileSync.mock.calls.find(
+      ([path]) => String(path).endsWith("GEMINI.md")
+    );
+    expect(geminiWrite).toBeDefined();
+    expect(String(geminiWrite![1])).toContain("AGENTS.md");
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Verified GEMINI.md reference");
+  });
+
+  it("skips GEMINI.md update when AGENTS.md reference already present", async () => {
+    mockExistsSync.mockImplementation((p: unknown) => {
+      const path = String(p);
+      if (path.endsWith("pnpm-workspace.yaml")) return true;
+      if (path.endsWith("AGENTS.md")) return true;
+      if (path.endsWith("GEMINI.md")) return true;
+      return false;
+    });
+
+    mockReadFileSync.mockImplementation((p: unknown) => {
+      const path = String(p);
+      if (path.endsWith("GEMINI.md"))
+        return "# Gemini specific content\nSee AGENTS.md for details" as never;
+      return "# Agents content" as never;
+    });
+
+    await runSyncRules();
+
+    // GEMINI.md should NOT be rewritten since it already has the reference
+    const geminiWrite = mockWriteFileSync.mock.calls.find(
+      ([path]) => String(path).endsWith("GEMINI.md")
+    );
+    expect(geminiWrite).toBeUndefined();
+  });
+});

--- a/tools/cli/src/__tests__/up.test.ts
+++ b/tools/cli/src/__tests__/up.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { existsSync } from "node:fs";
+import { execSync, spawn } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  execSync: vi.fn(),
+  spawn: vi.fn(),
+}));
+
+const mockExistsSync = vi.mocked(existsSync);
+const mockExecSync = vi.mocked(execSync);
+const mockSpawn = vi.mocked(spawn);
+
+function makeFakeProcess(closeCode: number = 0): Partial<ChildProcess> {
+  const listeners: Record<string, ((...args: unknown[]) => void)[]> = {};
+  const proc = {
+    on(event: string, cb: (...args: unknown[]) => void) {
+      if (!listeners[event]) listeners[event] = [];
+      listeners[event].push(cb);
+      if (event === "close") {
+        Promise.resolve().then(() => cb(closeCode));
+      }
+      return proc;
+    },
+  };
+  return proc as unknown as Partial<ChildProcess>;
+}
+
+describe("up command", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
+    vi.spyOn(process, "cwd").mockReturnValue("/repo");
+
+    // Default: workspace found, no seed scripts
+    mockExistsSync.mockImplementation((p: unknown) => {
+      const path = String(p);
+      return path.endsWith("pnpm-workspace.yaml");
+    });
+
+    mockExecSync.mockReturnValue("" as never);
+    mockSpawn.mockReturnValue(makeFakeProcess(0) as ChildProcess);
+  });
+
+  async function runUp(args: string[] = []): Promise<void> {
+    const { upCommand } = await import("../commands/up.js");
+    await upCommand.parseAsync(args, { from: "user" });
+  }
+
+  it("exits when docker is not available", async () => {
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      if (String(cmd).includes("docker --version")) {
+        throw new Error("docker not found");
+      }
+      return "" as never;
+    });
+
+    await runUp();
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.flat().join("\n");
+    expect(errOutput).toContain("Docker is not installed");
+  });
+
+  it("runs full stack when docker is available", async () => {
+    mockExecSync.mockReturnValue("Docker version 24.0.0" as never);
+
+    await runUp();
+
+    // Should have called docker-compose
+    const execCalls = mockExecSync.mock.calls.map(([cmd]) => String(cmd));
+    expect(execCalls.some((cmd) => cmd.includes("docker compose"))).toBe(true);
+    // Should have spawned pnpm dev
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "pnpm",
+      ["dev"],
+      expect.any(Object)
+    );
+  });
+
+  it("skips infra when --skip-infra is passed", async () => {
+    mockExecSync.mockReturnValue("Docker version 24.0.0" as never);
+
+    await runUp(["--skip-infra"]);
+
+    const execCalls = mockExecSync.mock.calls.map(([cmd]) => String(cmd));
+    expect(execCalls.some((cmd) => cmd.includes("docker compose"))).toBe(false);
+  });
+
+  it("skips database setup when --skip-db is passed", async () => {
+    mockExecSync.mockReturnValue("Docker version 24.0.0" as never);
+
+    await runUp(["--skip-db", "--skip-infra"]);
+
+    const execCalls = mockExecSync.mock.calls.map(([cmd]) => String(cmd));
+    expect(execCalls.some((cmd) => cmd.includes("db:push"))).toBe(false);
+  });
+
+  it("runs db:seed when seed script exists", async () => {
+    mockExecSync.mockReturnValue("Docker version 24.0.0" as never);
+    mockExistsSync.mockImplementation((p: unknown) => {
+      const path = String(p);
+      if (path.endsWith("pnpm-workspace.yaml")) return true;
+      if (path.includes("scripts/seed.js")) return true;
+      return false;
+    });
+
+    await runUp();
+
+    const execCalls = mockExecSync.mock.calls.map(([cmd]) => String(cmd));
+    expect(execCalls.some((cmd) => cmd.includes("db:seed"))).toBe(true);
+  });
+
+  it("exits with 1 and logs error when bootstrapping throws non-docker error", async () => {
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const c = String(cmd);
+      if (c.includes("docker --version")) return "Docker 24.0.0" as never;
+      if (c.includes("env:init")) throw new Error("env init failed");
+      return "" as never;
+    });
+
+    await runUp();
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.flat().join("\n");
+    expect(errOutput).toContain("Bootstrapping failed");
+    expect(errOutput).toContain("env init failed");
+  });
+
+  it("continues when db:seed fails", async () => {
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const c = String(cmd);
+      if (c.includes("db:seed")) throw new Error("seed failed");
+      return "" as never;
+    });
+    mockExistsSync.mockImplementation((p: unknown) => {
+      const path = String(p);
+      if (path.endsWith("pnpm-workspace.yaml")) return true;
+      if (path.includes("scripts/seed.js")) return true;
+      return false;
+    });
+
+    await runUp();
+
+    // Should still have spawned pnpm dev
+    expect(mockSpawn).toHaveBeenCalled();
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("No db:seed script found");
+  });
+});

--- a/tools/cli/src/__tests__/users.test.ts
+++ b/tools/cli/src/__tests__/users.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const store = new Map<string, unknown>();
+
+vi.mock("conf", () => ({
+  default: class MockConf {
+    get(key: string) { return store.get(key); }
+    set(key: string, value: unknown) { store.set(key, value); }
+    delete(key: string) { store.delete(key); }
+  },
+}));
+
+vi.mock("../api.js", () => ({
+  apiRequest: vi.fn(),
+}));
+
+describe("users command", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    store.clear();
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
+  });
+
+  // ── users list ────────────────────────────────────────────────────────────
+
+  describe("users list", () => {
+    async function runUsersList(args: string[] = []): Promise<void> {
+      const { usersCommand } = await import("../commands/users.js");
+      await usersCommand.commands[0].parseAsync(args, { from: "user" });
+    }
+
+    it("exits when not authenticated", async () => {
+      await runUsersList();
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      const output = logSpy.mock.calls.flat().join("\n");
+      expect(output).toContain("Not logged in");
+    });
+
+    it("lists users when authenticated", async () => {
+      store.set("accessToken", "valid-token");
+      store.set("tokenExpiry", Date.now() + 60_000);
+
+      const { apiRequest } = await import("../api.js");
+      vi.mocked(apiRequest).mockResolvedValue({
+        data: [
+          { id: "u1", email: "alice@example.com", name: "Alice" },
+          { id: "u2", email: "bob@example.com", name: null },
+        ],
+        pagination: { page: 1, totalPages: 1, total: 2 },
+      } as never);
+
+      await runUsersList();
+
+      expect(exitSpy).not.toHaveBeenCalled();
+      const output = logSpy.mock.calls.flat().join("\n");
+      expect(output).toContain("alice@example.com");
+      expect(output).toContain("bob@example.com");
+      expect(output).toContain("Page 1 of 1");
+    });
+
+    it("shows 'No users found' when list is empty", async () => {
+      store.set("accessToken", "valid-token");
+      store.set("tokenExpiry", Date.now() + 60_000);
+
+      const { apiRequest } = await import("../api.js");
+      vi.mocked(apiRequest).mockResolvedValue({
+        data: [],
+        pagination: { page: 1, totalPages: 0, total: 0 },
+      } as never);
+
+      await runUsersList();
+
+      const output = logSpy.mock.calls.flat().join("\n");
+      expect(output).toContain("No users found");
+    });
+
+    it("exits with error when API fails", async () => {
+      store.set("accessToken", "valid-token");
+      store.set("tokenExpiry", Date.now() + 60_000);
+
+      const { apiRequest } = await import("../api.js");
+      vi.mocked(apiRequest).mockRejectedValue(new Error("Network error"));
+
+      await runUsersList();
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      const errOutput = errorSpy.mock.calls.flat().join("\n");
+      expect(errOutput).toContain("Network error");
+    });
+  });
+
+  // ── users get ─────────────────────────────────────────────────────────────
+
+  describe("users get", () => {
+    async function runUsersGet(id: string): Promise<void> {
+      const { usersCommand } = await import("../commands/users.js");
+      await usersCommand.commands[1].parseAsync([id], { from: "user" });
+    }
+
+    it("exits when not authenticated", async () => {
+      await runUsersGet("user-123");
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      const output = logSpy.mock.calls.flat().join("\n");
+      expect(output).toContain("Not logged in");
+    });
+
+    it("displays user details when authenticated", async () => {
+      store.set("accessToken", "valid-token");
+      store.set("tokenExpiry", Date.now() + 60_000);
+
+      const { apiRequest } = await import("../api.js");
+      vi.mocked(apiRequest).mockResolvedValue({
+        data: {
+          id: "user-123",
+          email: "alice@example.com",
+          name: "Alice",
+          emailVerified: true,
+          createdAt: "2026-01-01T00:00:00Z",
+          updatedAt: "2026-01-02T00:00:00Z",
+        },
+      } as never);
+
+      await runUsersGet("user-123");
+
+      expect(exitSpy).not.toHaveBeenCalled();
+      const output = logSpy.mock.calls.flat().join("\n");
+      expect(output).toContain("user-123");
+      expect(output).toContain("alice@example.com");
+      expect(output).toContain("Yes"); // emailVerified
+    });
+
+    it("exits with error when API fails", async () => {
+      store.set("accessToken", "valid-token");
+      store.set("tokenExpiry", Date.now() + 60_000);
+
+      const { apiRequest } = await import("../api.js");
+      vi.mocked(apiRequest).mockRejectedValue(new Error("Not found"));
+
+      await runUsersGet("bad-id");
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/tools/cli/src/__tests__/visual.test.ts
+++ b/tools/cli/src/__tests__/visual.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { existsSync } from "node:fs";
+import { spawn } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+const mockExistsSync = vi.mocked(existsSync);
+const mockSpawn = vi.mocked(spawn);
+
+function makeFakeProcess(closeCode: number = 0): Partial<ChildProcess> {
+  const proc = {
+    on(event: string, cb: (...args: unknown[]) => void) {
+      if (event === "close") {
+        Promise.resolve().then(() => cb(closeCode));
+      }
+      return proc;
+    },
+  };
+  return proc as unknown as Partial<ChildProcess>;
+}
+
+describe("visual command", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
+    vi.spyOn(process, "cwd").mockReturnValue("/repo");
+    mockExistsSync.mockImplementation((p: unknown) =>
+      String(p).endsWith("pnpm-workspace.yaml")
+    );
+    mockSpawn.mockReturnValue(makeFakeProcess(0) as ChildProcess);
+  });
+
+  async function runVisual(args: string[] = []): Promise<void> {
+    const { visualCommand } = await import("../commands/visual.js");
+    await visualCommand.parseAsync(args, { from: "user" });
+  }
+
+  it("runs playwright tests without filter", async () => {
+    await runVisual();
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "pnpm",
+      expect.arrayContaining(["playwright", "test", "e2e/visual.spec.ts"]),
+      expect.any(Object)
+    );
+
+    const args = mockSpawn.mock.calls[0][1] as string[];
+    expect(args).not.toContain("-g");
+    expect(args).not.toContain("--update-snapshots");
+  });
+
+  it("adds -g filter when a filter argument is provided", async () => {
+    await runVisual(["button"]);
+
+    const args = mockSpawn.mock.calls[0][1] as string[];
+    expect(args).toContain("-g");
+    expect(args).toContain("button");
+  });
+
+  it("adds --update-snapshots when -u flag is passed", async () => {
+    await runVisual(["-u"]);
+
+    const args = mockSpawn.mock.calls[0][1] as string[];
+    expect(args).toContain("--update-snapshots");
+  });
+
+  it("shows success message when tests pass", async () => {
+    await runVisual();
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Visual tests passed");
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it("shows failure message when tests fail", async () => {
+    mockSpawn.mockReturnValue(makeFakeProcess(1) as ChildProcess);
+
+    await runVisual();
+
+    const errOutput = errorSpy.mock.calls.flat().join("\n");
+    expect(errOutput).toContain("Visual tests failed");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/tools/cli/src/__tests__/wave.test.ts
+++ b/tools/cli/src/__tests__/wave.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { existsSync } from "node:fs";
+import { spawn, execSync } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(),
+  execSync: vi.fn(),
+}));
+
+// Expose mock functions to avoid importing @mbe/agent-core (no dist built)
+const mockCreateWorktree = vi.fn();
+const mockRemoveWorktree = vi.fn();
+
+vi.mock("@mbe/agent-core", () => ({
+  createWorktree: mockCreateWorktree,
+  removeWorktree: mockRemoveWorktree,
+}));
+
+const mockExistsSync = vi.mocked(existsSync);
+const mockSpawn = vi.mocked(spawn);
+const mockExecSync = vi.mocked(execSync);
+
+function makeFakeProcess(closeCode: number = 0): Partial<ChildProcess> {
+  const proc = {
+    on(event: string, cb: (...args: unknown[]) => void) {
+      if (event === "close") {
+        Promise.resolve().then(() => cb(closeCode));
+      }
+      return proc;
+    },
+  };
+  return proc as unknown as Partial<ChildProcess>;
+}
+
+describe("wave command", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
+    vi.spyOn(process, "cwd").mockReturnValue("/repo");
+    mockExistsSync.mockImplementation((p: unknown) =>
+      String(p).endsWith("pnpm-workspace.yaml")
+    );
+    mockExecSync.mockReturnValue("" as never);
+    mockSpawn.mockReturnValue(makeFakeProcess(0) as ChildProcess);
+    mockCreateWorktree.mockResolvedValue({
+      branchName: "agent/task-1",
+      path: "/repo/.worktrees/task-1",
+    });
+    mockRemoveWorktree.mockResolvedValue(undefined);
+  });
+
+  async function runWave(args: string[]): Promise<void> {
+    const { waveCommand } = await import("../commands/wave.js");
+    await waveCommand.parseAsync(args, { from: "user" });
+  }
+
+  it("runs tasks and reports completion", async () => {
+    await runWave(["fix the bug"]);
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Wave execution complete");
+    expect(output).toContain("Done");
+  });
+
+  it("exits with 1 when all tasks fail", async () => {
+    mockSpawn.mockReturnValue(makeFakeProcess(1) as ChildProcess);
+
+    await runWave(["fix the bug"]);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("tasks failed");
+  });
+
+  it("merges successful branches", async () => {
+    await runWave(["fix the bug"]);
+
+    const execCalls = mockExecSync.mock.calls.map(([cmd]) => String(cmd));
+    expect(execCalls.some((cmd) => cmd.includes("git merge"))).toBe(true);
+  });
+
+  it("handles worktree creation errors gracefully", async () => {
+    mockCreateWorktree.mockRejectedValue(new Error("worktree failed"));
+
+    await runWave(["fix the bug"]);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.flat().join("\n");
+    expect(errOutput).toContain("worktree failed");
+  });
+
+  it("handles multiple tasks in parallel", async () => {
+    mockCreateWorktree
+      .mockResolvedValueOnce({ branchName: "agent/task-1", path: "/repo/.worktrees/task-1" })
+      .mockResolvedValueOnce({ branchName: "agent/task-2", path: "/repo/.worktrees/task-2" });
+
+    await runWave(["task one", "task two"]);
+
+    expect(mockCreateWorktree).toHaveBeenCalledTimes(2);
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Wave execution complete");
+  });
+
+  it("skips merge for failed tasks", async () => {
+    mockSpawn.mockReturnValue(makeFakeProcess(1) as ChildProcess);
+
+    await runWave(["fail task"]);
+
+    // git merge should NOT be called for a failed task
+    const execCalls = mockExecSync.mock.calls.map(([cmd]) => String(cmd));
+    expect(execCalls.some((cmd) => cmd.includes("git merge"))).toBe(false);
+  });
+
+  it("logs merge failure message when git merge throws", async () => {
+    // Task succeeds but git merge fails
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      if (String(cmd).includes("git merge")) throw new Error("merge conflict");
+      return "" as never;
+    });
+
+    await runWave(["fix the bug"]);
+
+    const errOutput = errorSpy.mock.calls.flat().join("\n");
+    expect(errOutput).toContain("Failed to merge");
+    expect(errOutput).toContain("conflicts");
+  });
+});

--- a/tools/cli/src/__tests__/whoami.test.ts
+++ b/tools/cli/src/__tests__/whoami.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const store = new Map<string, unknown>();
+
+vi.mock("conf", () => ({
+  default: class MockConf {
+    get(key: string) { return store.get(key); }
+    set(key: string, value: unknown) { store.set(key, value); }
+    delete(key: string) { store.delete(key); }
+  },
+}));
+
+vi.mock("../api.js", () => ({
+  apiRequest: vi.fn(),
+}));
+
+describe("whoami command", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    store.clear();
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
+  });
+
+  async function runWhoami(): Promise<void> {
+    const { whoamiCommand } = await import("../commands/whoami.js");
+    await whoamiCommand.parseAsync([], { from: "user" });
+  }
+
+  it("exits with error message when not authenticated", async () => {
+    // No token in store -> not authenticated
+    await runWhoami();
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Not logged in");
+  });
+
+  it("displays user info when authenticated", async () => {
+    // Set valid token
+    store.set("accessToken", "valid-token");
+    store.set("tokenExpiry", Date.now() + 60_000);
+
+    const { apiRequest } = await import("../api.js");
+    vi.mocked(apiRequest).mockResolvedValue({
+      data: {
+        id: "user-123",
+        email: "test@example.com",
+        name: "Test User",
+      },
+    } as never);
+
+    await runWhoami();
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("user-123");
+    expect(output).toContain("test@example.com");
+    expect(output).toContain("Test User");
+  });
+
+  it("shows (not set) when user name is null", async () => {
+    store.set("accessToken", "valid-token");
+    store.set("tokenExpiry", Date.now() + 60_000);
+
+    const { apiRequest } = await import("../api.js");
+    vi.mocked(apiRequest).mockResolvedValue({
+      data: {
+        id: "user-456",
+        email: "noname@example.com",
+        name: null,
+      },
+    } as never);
+
+    await runWhoami();
+
+    const output = logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("(not set)");
+  });
+
+  it("exits with error when API request fails", async () => {
+    store.set("accessToken", "valid-token");
+    store.set("tokenExpiry", Date.now() + 60_000);
+
+    const { apiRequest } = await import("../api.js");
+    vi.mocked(apiRequest).mockRejectedValue(new Error("API unavailable"));
+
+    await runWhoami();
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const errOutput = errorSpy.mock.calls.flat().join("\n");
+    expect(errOutput).toContain("API unavailable");
+  });
+});


### PR DESCRIPTION
## Summary

- Add 16 new test files covering all previously-untested CLI commands (login, logout, compound, sync-rules, prime, whoami, users, up, visual, mcp, wave, loop, new, pack, stats extended)
- Add real ts-morph integration test (`pack-helpers.test.ts`) that exercises AST skeleton generator helpers using actual temp TypeScript files
- Push line coverage from 40.39% to **82.77%** (174 tests, 27 test files)

## Coverage delta

| Metric | Before | After |
|--------|--------|-------|
| Lines | 40.39% | 82.77% |
| Functions | 47.05% | 94.77% |
| Statements | 39.95% | 82.34% |
| Branches | 27.93% | 67.90% |

## Test plan

- [x] `pnpm --dir tools/cli test -- --coverage` passes (174/174 tests)
- [x] `pnpm --dir tools/cli lint` passes (no ESLint errors)
- [x] `pnpm --dir tools/cli typecheck` has no NEW errors (pre-existing TS2307 on `@mbe/agent-core` dist not built was already present)

Closes #1222