### PR TITLE
fix(seo): add og:image:alt and twitter:image:alt to all apps

### DIFF
--- a/apps/hospitality/index.html
+++ b/apps/hospitality/index.html
@@ -15,10 +15,12 @@
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:alt" content="Matt Butler Engineering Hospitality social preview" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Matt Butler Engineering — Hospitality" />
     <meta name="twitter:description" content="Hospitality management dashboard for reservations, guests, and floor plans" />
     <meta name="twitter:image" content="https://mattbutlerengineering.com/og-image.png" />
+    <meta name="twitter:image:alt" content="Matt Butler Engineering Hospitality social preview" />
     <title>Dashboard - Matt Butler Engineering</title>
   </head>
   <body>

--- a/apps/marketing/index.html
+++ b/apps/marketing/index.html
@@ -30,10 +30,12 @@
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:alt" content="Matt Butler Engineering social preview" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Matt Butler Engineering" />
     <meta name="twitter:description" content="Matt Butler Engineering — software engineering solutions for hospitality and beyond" />
     <meta name="twitter:image" content="https://mattbutlerengineering.com/og-image.png" />
+    <meta name="twitter:image:alt" content="Matt Butler Engineering social preview" />
     <meta name="robots" content="index, follow" />
     <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />

--- a/apps/rialto-web/index.html
+++ b/apps/rialto-web/index.html
@@ -35,10 +35,12 @@
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:alt" content="Rialto Design System social preview" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Rialto Design System" />
     <meta name="twitter:description" content="Rialto Design System — a precision-crafted React component library with warm material surfaces, gold accents, and full WCAG AA accessibility." />
     <meta name="twitter:image" content="https://mattbutlerengineering.com/og-image.png" />
+    <meta name="twitter:image:alt" content="Rialto Design System social preview" />
     <title>Rialto — Design System</title>
     <script type="application/ld+json">
       {


### PR DESCRIPTION
## Summary

- Adds `og:image:alt` and `twitter:image:alt` meta tags to all three public-facing apps
- Fixes Twitter/X accessibility requirement for social card images
- 6 lines added across `apps/marketing/index.html`, `apps/rialto-web/index.html`, `apps/hospitality/index.html`

## Test plan

- [ ] CI passes
- [ ] Verify meta tags present via `curl -s https://mattbutlerengineering.com | grep image:alt` after deploy

Closes #1243

https://claude.ai/code/session_011e2XbZoUjKTHUYeRXgPKXa

---
_Generated by [Claude Code](https://claude.ai/code/session_011e2XbZoUjKTHUYeRXgPKXa)_