### PR TITLE
fix(ci): pin @opentelemetry >=0.217.0 + regenerate llms.txt (unblocks all PRs)

### DIFF
--- a/apps/gen/llms.txt
+++ b/apps/gen/llms.txt
@@ -16,7 +16,7 @@
   </file>
   <file path="e2e/fixtures.ts">
     <item priority="high">
-      export const test: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const test: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   </section>
@@ -28,7 +28,7 @@
     <item priority="low">
       interface UseGenStreamOptions {
         api: string;
-        onComplete?: ((spec: import("/Users/mbutler/github/mattbutlerengineeri...;
+        onComplete?: ((spec: import("/home/user/mattbutlerengineering/node_mod...;
         onError?: ((error: Error) => void) | undefined;
       }
     </item>
@@ -54,10 +54,10 @@
     </item>
     <item priority="low">
       interface UseSpecsApiReturn {
-        specs: import("/Users/mbutler/github/mattbutlerengineering/apps/...;
+        specs: import("/home/user/mattbutlerengineering/apps/gen/src/typ...;
         isLoading: boolean;
         fetchSpecs: () => Promise<void>;
-        saveSpec: (data: import("/Users/mbutler/github/mattbutlerengineerin...;
+        saveSpec: (data: import("/home/user/mattbutlerengineering/apps/gen/...;
         toggleFavorite: (id: string) => Promise<void>;
       }
     </item>
@@ -69,7 +69,7 @@
       interface HistoryEntry {
         id: string;
         prompt: string;
-        spec: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+        spec: import("/home/user/mattbutlerengineering/node_modules/.pn...;
         rawLines: string[];
         timestamp: Date;
       }

--- a/apps/hospitality/llms.txt
+++ b/apps/hospitality/llms.txt
@@ -16,7 +16,7 @@
   </file>
   <file path="src/constants/copilotContext.ts">
     <item priority="high">
-      export const HOSPITALITY_DOMAIN_CONTEXT: import("/Users/mbutler/github/mattbutlerengineering/packa...;
+      export const HOSPITALITY_DOMAIN_CONTEXT: DomainContext;
     </item>
   </file>
   </section>
@@ -37,7 +37,7 @@
   </file>
   <file path="e2e/fixtures.ts">
     <item priority="high">
-      export const test: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const test: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   </section>
@@ -45,7 +45,7 @@
   <file path="src/hooks/use-command-palette.ts">
     <item priority="high">
       interface UseCommandPaletteOptions {
-        sections: readonly import("/Users/mbutler/github/mattbutlerengineer...;
+        sections: readonly import("/home/user/mattbutlerengineering/apps/ho...;
         navigate: (path: string) => void;
         toggleTheme: () => void;
         signOut: () => void;
@@ -55,7 +55,7 @@
       interface UseCommandPaletteResult {
         open: boolean;
         setOpen: (open: boolean) => void;
-        items: import("/Users/mbutler/github/mattbutlerengineering/packa...;
+        items: CommandItem[];
         groups: string[];
       }
     </item>
@@ -63,12 +63,12 @@
   <file path="src/hooks/use-theme.ts">
     <item priority="low">
       interface ThemeContextValue {
-        theme: import("/Users/mbutler/github/mattbutlerengineering/packa...;
-        setTheme: (theme: import("/Users/mbutler/github/mattbutlerengineeri...;
+        theme: ThemePreference;
+        setTheme: (theme: ThemePreference) => void;
       }
     </item>
     <item priority="high">
-      export const ThemeContext: React.Context<import("/Users/mbutler/github/mattbutlereng...;
+      export const ThemeContext: React.Context<import("/home/user/mattbutlerengineering/ap...;
     </item>
   </file>
   <file path="src/hooks/useApiCall.ts">
@@ -107,8 +107,8 @@
     </item>
     <item priority="low">
       interface UseDashboardStatsResult {
-        reservations: readonly import("/Users/mbutler/github/mattbutlerengineer...;
-        stats: import("/Users/mbutler/github/mattbutlerengineering/apps/...;
+        reservations: readonly import("/home/user/mattbutlerengineering/package...;
+        stats: import("/home/user/mattbutlerengineering/apps/hospitality...;
         isLoading: boolean;
         error: string | null;
         refetch: () => Promise<void>;
@@ -121,10 +121,10 @@
     </item>
     <item priority="low">
       interface ReservationEvent {
-        type: import("/Users/mbutler/github/mattbutlerengineering/apps/...;
+        type: import("/home/user/mattbutlerengineering/apps/hospitality...;
         venueId: string;
         timestamp: string;
-        data: import("/Users/mbutler/github/mattbutlerengineering/packa...;
+        data: import("/home/user/mattbutlerengineering/packages/types/s...;
       }
     </item>
   </file>
@@ -135,8 +135,8 @@
     <item priority="low">
       interface VenueReadiness {
         status: "no-venue" | "setup" | "operational";
-        completedSteps: readonly import("/Users/mbutler/github/mattbutlerengineer...;
-        nextStep: import("/Users/mbutler/github/mattbutlerengineering/apps/...;
+        completedSteps: readonly import("/home/user/mattbutlerengineering/apps/ho...;
+        nextStep: import("/home/user/mattbutlerengineering/apps/hospitality...;
         progress: number;
       }
     </item>
@@ -156,7 +156,7 @@
     <item priority="low">
       interface NavSection {
         label?: string | undefined;
-        items: import("/Users/mbutler/github/mattbutlerengineering/apps/...;
+        items: import("/home/user/mattbutlerengineering/apps/hospitality...;
       }
     </item>
   </file>

--- a/apps/marketing/llms.txt
+++ b/apps/marketing/llms.txt
@@ -10,7 +10,7 @@
       }
     </item>
     <item priority="high">
-      export const PROJECTS: import("/Users/mbutler/github/mattbutlerengineering/apps/...;
+      export const PROJECTS: import("/home/user/mattbutlerengineering/apps/marketing/s...;
     </item>
   </file>
   <file path="src/data/tech-stack.ts">
@@ -21,7 +21,7 @@
       }
     </item>
     <item priority="high">
-      export const TECH_STACK: import("/Users/mbutler/github/mattbutlerengineering/apps/...;
+      export const TECH_STACK: import("/home/user/mattbutlerengineering/apps/marketing/s...;
     </item>
   </file>
   <file path="src/data/weekly-intake.ts">
@@ -35,7 +35,7 @@
       }
     </item>
     <item priority="high">
-      export const weeklyResources: readonly import("/Users/mbutler/github/mattbutlerengineer...;
+      export const weeklyResources: readonly import("/home/user/mattbutlerengineering/apps/ma...;
     </item>
   </file>
   </section>

--- a/apps/rialto-web/llms.txt
+++ b/apps/rialto-web/llms.txt
@@ -12,7 +12,7 @@
     <item priority="high">
       interface ConsentState {
         consented: boolean;
-        preferences: import("/Users/mbutler/github/mattbutlerengineering/apps/...;
+        preferences: import("/home/user/mattbutlerengineering/apps/rialto-web/...;
       }
     </item>
   </file>
@@ -30,7 +30,7 @@
     <item priority="low">
       interface NavSection {
         label: string;
-        items: import("/Users/mbutler/github/mattbutlerengineering/apps/...;
+        items: import("/home/user/mattbutlerengineering/apps/rialto-web/...;
       }
     </item>
   </file>
@@ -56,10 +56,10 @@
     </item>
     <item priority="high">
       interface DriverContextValue {
-        drivers: import("/Users/mbutler/github/mattbutlerengineering/apps/...;
-        getDriver: (id: string) => import("/Users/mbutler/github/mattbutlere...;
-        addDriver: (driver: Omit<import("/Users/mbutler/github/mattbutlereng...;
-        updateDriver: (id: string, updates: Partial<Omit<import("/Users/mbutler...;
+        drivers: import("/home/user/mattbutlerengineering/apps/rialto-web/...;
+        getDriver: (id: string) => import("/home/user/mattbutlerengineering/...;
+        addDriver: (driver: Omit<import("/home/user/mattbutlerengineering/ap...;
+        updateDriver: (id: string, updates: Partial<Omit<import("/home/user/mat...;
         deleteDriver: (id: string) => void;
       }
     </item>

--- a/package.json
+++ b/package.json
@@ -103,7 +103,9 @@
       "@hono/node-server@<1.19.13": ">=1.19.13",
       "@fastify/static@<9.1.1": ">=9.1.1",
       "uuid@<14.0.0": ">=14.0.0",
-      "@babel/plugin-transform-modules-systemjs@<7.29.4": "^7.29.4"
+      "@babel/plugin-transform-modules-systemjs@<7.29.4": "^7.29.4",
+      "@opentelemetry/sdk-node@<0.217.0": "^0.217.0",
+      "@opentelemetry/exporter-prometheus@<0.217.0": "^0.217.0"
     }
   },
   "license": "MIT"

--- a/packages/agent-core/llms.txt
+++ b/packages/agent-core/llms.txt
@@ -31,7 +31,7 @@
       type Zone = "marketing" | "hospitality" | "rialto" | "gen" | "api:users" | "api:reservations" | "api:agent";
     </item>
     <item priority="high">
-      export const ZONES: readonly import("/Users/mbutler/github/mattbutlerengineer...;
+      export const ZONES: readonly import("/home/user/mattbutlerengineering/package...;
     </item>
   </file>
   <file path="src/bundle-size-tracker.ts">
@@ -45,7 +45,7 @@
       interface BundleSizeEntry {
         app: string;
         totalBytes: number;
-        files: readonly import("/Users/mbutler/github/mattbutlerengineer...;
+        files: readonly import("/home/user/mattbutlerengineering/package...;
         timestamp: string;
       }
     </item>
@@ -66,7 +66,7 @@
       interface CircuitBreakerOptions {
         failureThreshold: number;
         resetTimeoutMs: number;
-        onStateChange?: ((state: import("/Users/mbutler/github/mattbutlerengineer...;
+        onStateChange?: ((state: import("/home/user/mattbutlerengineering/package...;
       }
     </item>
   </file>
@@ -154,7 +154,7 @@
     <item priority="low">
       interface StaticAnalysisResult {
         clean: boolean;
-        violations: readonly import("/Users/mbutler/github/mattbutlerengineer...;
+        violations: readonly import("/home/user/mattbutlerengineering/package...;
         durationMs: number;
       }
     </item>
@@ -199,7 +199,7 @@
     </item>
     <item priority="low">
       interface FailureMemory {
-        records: readonly import("/Users/mbutler/github/mattbutlerengineer...;
+        records: readonly import("/home/user/mattbutlerengineering/package...;
       }
     </item>
   </file>
@@ -258,7 +258,7 @@
   </file>
   <file path="src/observability.ts">
     <item priority="high">
-      export const observabilityTracer: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const observabilityTracer: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
     <item priority="medium">
       function containsInOrder(str: string, a: string, b: string): boolean { /* ... */ }
@@ -320,7 +320,7 @@
     </item>
     <item priority="low">
       interface PromptBuilderConfig {
-        sourceFileEntries?: readonly import("/Users/mbutler/github/mattbutlerengineer...;
+        sourceFileEntries?: readonly import("/home/user/mattbutlerengineering/package...;
         relevantLlmsFiles?: readonly string[] | undefined;
         relevantIssueContext?: string | undefined;
         failureContext?: string | undefined;
@@ -342,15 +342,15 @@
       interface QaTuningConfig {
         version: number;
         lastTunedAt: string;
-        thresholds: import("/Users/mbutler/github/mattbutlerengineering/packa...;
+        thresholds: import("/home/user/mattbutlerengineering/packages/agent-c...;
       }
     </item>
   </file>
   <file path="src/quality-gates.ts">
     <item priority="low">
       interface QualityGatesResult {
-        evaluation?: import("/Users/mbutler/github/mattbutlerengineering/packa...;
-        securityReview?: import("/Users/mbutler/github/mattbutlerengineering/packa...;
+        evaluation?: import("/home/user/mattbutlerengineering/packages/agent-c...;
+        securityReview?: import("/home/user/mattbutlerengineering/packages/agent-c...;
         staticAnalysisClean: boolean;
         errors: string[];
       }
@@ -375,7 +375,7 @@
     </item>
     <item priority="high">
       class RateLimitDetector {
-        states: Map<string, import("/Users/mbutler/github/mattbutlerengin...;
+        states: Map<string, import("/home/user/mattbutlerengineering/pack...;
         cooldownMs: number;
         async markRateLimited(): Promise<unknown>;
         async markSuccess(): Promise<unknown>;
@@ -464,7 +464,7 @@
     </item>
     <item priority="low">
       interface SyntheticBugConfig {
-        type: import("/Users/mbutler/github/mattbutlerengineering/packa...;
+        type: import("/home/user/mattbutlerengineering/packages/agent-c...;
         repoPath: string;
         filePath: string;
         fileContent: string;
@@ -483,7 +483,7 @@
       }
     </item>
     <item priority="high">
-      export const DEFAULT_ORCHESTRATOR_CONFIG: Omit<import("/Users/mbutler/github/mattbutlerengineering/...;
+      export const DEFAULT_ORCHESTRATOR_CONFIG: Omit<import("/home/user/mattbutlerengineering/packages/ag...;
     </item>
   </file>
   <file path="src/task-intelligence.ts">

--- a/packages/api-client/llms.txt
+++ b/packages/api-client/llms.txt
@@ -25,7 +25,7 @@
         getAccessToken?: (() => string | Promise<string | null> | null) | undefined;
         timeout?: number | undefined;
         maxRetries?: number | undefined;
-        onError?: ((error: import("/Users/mbutler/github/mattbutlerengineer...;
+        onError?: ((error: import("/home/user/mattbutlerengineering/package...;
       }
     </item>
     <item priority="low">
@@ -78,7 +78,7 @@
         page?: number | undefined;
         limit?: number | undefined;
         date?: string | undefined;
-        status?: import("/Users/mbutler/github/mattbutlerengineering/packa...;
+        status?: import("/home/user/mattbutlerengineering/packages/types/s...;
         tableId?: string | undefined;
       }
     </item>

--- a/packages/observability/llms.txt
+++ b/packages/observability/llms.txt
@@ -92,7 +92,7 @@
     <item priority="low">
       interface ReadinessSnapshot {
         ready: boolean;
-        checks: readonly import("/Users/mbutler/github/mattbutlerengineer...;
+        checks: readonly import("/home/user/mattbutlerengineering/package...;
         timestamp: string;
       }
     </item>

--- a/packages/rialto-catalog/llms.txt
+++ b/packages/rialto-catalog/llms.txt
@@ -23,17 +23,17 @@
       }
     </item>
     <item priority="high">
-      export const catalogConfig: Record<string, import("/Users/mbutler/github/mattbutleren...;
+      export const catalogConfig: Record<string, import("/home/user/mattbutlerengineering/p...;
     </item>
   </file>
   <file path="src/catalog.ts">
     <item priority="high">
-      export const catalog: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const catalog: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   <file path="src/generated-schemas.ts">
     <item priority="high">
-      export const generatedSchemas: { readonly Accordion: import("/Users/mbutler/github/mattb...;
+      export const generatedSchemas: { readonly Accordion: import("/home/user/mattbutlerengine...;
     </item>
   </file>
   </section>

--- a/packages/rialto/llms.txt
+++ b/packages/rialto/llms.txt
@@ -18,7 +18,7 @@
         frames?: readonly (readonly (readonly boolean[])[])[] | undefined;
         rows: number;
         cols: number;
-        mode?: import("/Users/mbutler/github/mattbutlerengineering/packa...;
+        mode?: import("/home/user/mattbutlerengineering/packages/rialto/...;
       }
     </item>
   </file>
@@ -47,7 +47,7 @@
         api: string;
         domainContext: DomainContext;
         getAccessToken: () => string | Promise<string | null> | null;
-        onComplete?: ((spec: import("/Users/mbutler/github/mattbutlerengineeri...;
+        onComplete?: ((spec: import("/home/user/mattbutlerengineering/node_mod...;
         onError?: ((error: Error) => void) | undefined;
       }
     </item>
@@ -114,7 +114,7 @@
     <item priority="high">
       interface MediaEntry {
         query: string;
-        key: keyof import("/Users/mbutler/github/mattbutlerengineering...;
+        key: keyof import("/home/user/mattbutlerengineering/packages/r...;
         matchValue: boolean | "fine" | "coarse" | "mobile" | "tablet" | "desk...;
         noMatchValue: boolean | "fine" | "coarse" | "mobile" | "tablet" | "desk...;
       }
@@ -123,13 +123,13 @@
   <file path="src/providers/useUIEnvironment.ts">
     <item priority="low">
       interface UIEnvironment {
-        device: import("/Users/mbutler/github/mattbutlerengineering/packa...;
-        vibe: import("/Users/mbutler/github/mattbutlerengineering/packa...;
+        device: import("/home/user/mattbutlerengineering/packages/rialto/...;
+        vibe: import("/home/user/mattbutlerengineering/packages/rialto/...;
         theme: "light" | "dark";
       }
     </item>
     <item priority="high">
-      export const UIEnvironmentContext: React.Context<import("/Users/mbutler/github/mattbutlereng...;
+      export const UIEnvironmentContext: React.Context<import("/home/user/mattbutlerengineering/pa...;
     </item>
   </file>
   <file path="src/providers/vibes.ts">
@@ -152,7 +152,7 @@
       }
     </item>
     <item priority="high">
-      export const characterLimits: import("/Users/mbutler/github/mattbutlerengineering/packa...;
+      export const characterLimits: import("/home/user/mattbutlerengineering/packages/rialto/...;
     </item>
   </file>
   <file path="scripts/generate-exports.ts">
@@ -257,7 +257,7 @@
           "reservationA...;
     </item>
     <item priority="high">
-      export const DEFAULT_STRINGS: import("/Users/mbutler/github/mattbutlerengineering/packa...;
+      export const DEFAULT_STRINGS: import("/home/user/mattbutlerengineering/packages/rialto/...;
     </item>
   </file>
   <file path="src/components/TapeChart/types.ts">
@@ -306,7 +306,7 @@
         id: string;
         title: string;
         description?: string | undefined;
-        variant?: import("/Users/mbutler/github/mattbutlerengineering/packa...;
+        variant?: import("/home/user/mattbutlerengineering/packages/rialto/...;
         duration?: number | undefined;
       }
     </item>
@@ -323,7 +323,7 @@
   </file>
   <file path="src/tokens/motion.ts">
     <item priority="high">
-      export const ms: (s: React.CSSProperties) => import("/Users/mbutler/github...;
+      export const ms: (s: React.CSSProperties) => import("/home/user/mattbutler...;
     </item>
     <item priority="high">
       export const precision: { duration: number; ease: readonly [0.2, 0, 0, 1]; };

--- a/packages/types/llms.txt
+++ b/packages/types/llms.txt
@@ -2,39 +2,39 @@
   <section priority="medium" role="schemas">
   <file path="src/schemas/agent.ts">
     <item priority="high">
-      export const AgentSessionStatusSchema: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const AgentSessionStatusSchema: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
     <item priority="high">
-      export const AgentSessionSchema: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const AgentSessionSchema: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   <file path="src/schemas/api.ts">
     <item priority="high">
-      export const ProblemDetailsSchema: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const ProblemDetailsSchema: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   <file path="src/schemas/common.ts">
     <item priority="high">
-      export const PaginationSchema: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const PaginationSchema: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
     <item priority="high">
-      export const ErrorResponseSchema: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const ErrorResponseSchema: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   <file path="src/schemas/floor-plan.ts">
     <item priority="high">
-      export const TableShapeMetadataSchema: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const TableShapeMetadataSchema: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
     <item priority="high">
-      export const FloorPlanLayoutSchema: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const FloorPlanLayoutSchema: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   <file path="src/schemas/guest.ts">
     <item priority="high">
-      export const GuestSchema: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const GuestSchema: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
     <item priority="high">
-      export const GuestSegmentSchema: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const GuestSegmentSchema: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   <file path="src/schemas/json-schema.ts">
@@ -47,26 +47,26 @@
   </file>
   <file path="src/schemas/reservation.ts">
     <item priority="high">
-      export const ReservationStatusSchema: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const ReservationStatusSchema: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
     <item priority="high">
-      export const ReservationSchema: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const ReservationSchema: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   <file path="src/schemas/user.ts">
     <item priority="high">
-      export const UserPreferencesSchema: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const UserPreferencesSchema: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
     <item priority="high">
-      export const UserSchema: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const UserSchema: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   <file path="src/schemas/venue.ts">
     <item priority="high">
-      export const DayScheduleSchema: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const DayScheduleSchema: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
     <item priority="high">
-      export const VenueGroupSchema: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const VenueGroupSchema: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   </section>
@@ -78,7 +78,7 @@
     <item priority="low">
       interface AgentSession {
         id: string;
-        status: import("/Users/mbutler/github/mattbutlerengineering/packa...;
+        status: import("/home/user/mattbutlerengineering/packages/types/s...;
         taskDescription: string;
         branchName: string | null;
         baseBranch: string;
@@ -89,7 +89,7 @@
     <item priority="low">
       interface ApiResponse {
         data: T;
-        meta?: import("/Users/mbutler/github/mattbutlerengineering/packa...;
+        meta?: import("/home/user/mattbutlerengineering/packages/types/s...;
       }
     </item>
     <item priority="low">
@@ -104,7 +104,7 @@
       interface TimeSlot {
         time: string;
         available: boolean;
-        tables?: import("/Users/mbutler/github/mattbutlerengineering/packa...;
+        tables?: import("/home/user/mattbutlerengineering/packages/types/s...;
       }
     </item>
     <item priority="low">
@@ -129,7 +129,7 @@
         venueId: string;
         name: string;
         isActive: boolean;
-        layoutJson: import("/Users/mbutler/github/mattbutlerengineering/packa...;
+        layoutJson: import("/home/user/mattbutlerengineering/packages/types/s...;
       }
     </item>
     <item priority="low">
@@ -147,7 +147,7 @@
       interface Guest {
         id: string;
         venueId: string;
-        venue?: import("/Users/mbutler/github/mattbutlerengineering/packa...;
+        venue?: import("/home/user/mattbutlerengineering/packages/types/s...;
         email: string | null;
         phone: string | null;
       }
@@ -221,7 +221,7 @@
       interface Venue {
         id: string;
         venueGroupId: string | null;
-        venueGroup?: import("/Users/mbutler/github/mattbutlerengineering/packa...;
+        venueGroup?: import("/home/user/mattbutlerengineering/packages/types/s...;
         name: string;
         slug: string;
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,8 @@ overrides:
   '@fastify/static@<9.1.1': '>=9.1.1'
   uuid@<14.0.0: '>=14.0.0'
   '@babel/plugin-transform-modules-systemjs@<7.29.4': ^7.29.4
+  '@opentelemetry/sdk-node@<0.217.0': ^0.217.0
+  '@opentelemetry/exporter-prometheus@<0.217.0': ^0.217.0
 
 importers:
 
@@ -762,8 +764,8 @@ importers:
         specifier: ^2.7.1
         version: 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-node':
-        specifier: ^0.216.0
-        version: 0.216.0(@opentelemetry/api@1.9.1)
+        specifier: ^0.217.0
+        version: 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base':
         specifier: ^2.7.1
         version: 2.7.1(@opentelemetry/api@1.9.1)
@@ -2957,6 +2959,10 @@ packages:
     resolution: {integrity: sha512-KmGTgvxTJ0J01d4mOeX1wMV5NUTNf9HebIuOOGDfIn0a/IrnXIQbOnlylDyl9tkDv4h0DUpdI/GqCdLzfTkUXg==}
     engines: {node: '>=8.0.0'}
 
+  '@opentelemetry/api-logs@0.217.0':
+    resolution: {integrity: sha512-Cdq0jW2lknrNfrAm92MyEAvpe2cRsKjdnQLHUL6xRA4IVUnsWx6P65E7NcUO0Y+L4w1Aee5iV8FvjSwd+lrs9A==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api-logs@0.57.2':
     resolution: {integrity: sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==}
     engines: {node: '>=14'}
@@ -2969,8 +2975,8 @@ packages:
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
 
-  '@opentelemetry/configuration@0.216.0':
-    resolution: {integrity: sha512-B7/LbHEIefF3ZartdrXSuTj1lRWrLfu+srV2Ts+xHrArvPs3U8y7l9i3lk0cjorlgt0lChKQm2XO4QoYI3uWyA==}
+  '@opentelemetry/configuration@0.217.0':
+    resolution: {integrity: sha512-xCtrYOhBqdy6ZOMfe0Oa73ZKF+2LMhoOv4L5vmwAHVvOXUg+V3fvKuEIr9ZyD0Ow+vxllEjWO6PV1wd0DOtyvw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
@@ -3005,26 +3011,26 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
-  '@opentelemetry/exporter-logs-otlp-grpc@0.216.0':
-    resolution: {integrity: sha512-iyCkid5z3FUOB3MzHCeDYKv0MJ5JyL1PUgQDRfhK+HjFwB8PRSzizs5wr/+BdQOZzn1wTBaYwcgmzNcelK769g==}
+  '@opentelemetry/exporter-logs-otlp-grpc@0.217.0':
+    resolution: {integrity: sha512-vC5S0Dc+noxD86CVtNu1+awCHPA5Kewi1Sg23ps+9lh4YifwsKXh3pe4XTNEKtUJiAcjpJ5dqStGakLbrSE+YQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/exporter-logs-otlp-http@0.216.0':
-    resolution: {integrity: sha512-8SUzQY/aExKkz6Ab3vOf6gu690Xk4wHH90dGwXinejQzazn5HCIRR7yPVU/2fEuiZ73R92MU4qI3djHfYP7NJg==}
+  '@opentelemetry/exporter-logs-otlp-http@0.217.0':
+    resolution: {integrity: sha512-KfLAdt1uilVE+3FxbgVnp2ZrzqbIawzcesnRoi+Kh9ckB5Ld5D8btUgoBvwTbdmuNx1j6b132Wsh72azq+pPNQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/exporter-logs-otlp-proto@0.216.0':
-    resolution: {integrity: sha512-fjnNDdsoG98yIcv4yCaw07+9aZeh28gyq1YPXDb0yBksaMWCMR11VGDKANd6CJHdgFloWv9G12x95symD7fq9g==}
+  '@opentelemetry/exporter-logs-otlp-proto@0.217.0':
+    resolution: {integrity: sha512-Se0GG/ZO24mQTlQj7zprR4pNI0nKe4lPDPBsuJmi6508b9TlZEuUd3EfyuHk6oJxzL7fGyDFYAbxNigQvRP2ZQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/exporter-metrics-otlp-grpc@0.216.0':
-    resolution: {integrity: sha512-62ZAduALHuMucuBpNGFhdxFJZ5IQafLW17UE0nVvPVuem3zNslLR0H+4R1xraU07/HCL11AbuicSXlqUkdkotA==}
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.217.0':
+    resolution: {integrity: sha512-0GpJKnCoVaVA1rKBMVPHziznfOQlXgH72S9ktjBAF1AnAVPzX7vVEBGrhwiSxxHDAiefXk+J8znApsMb/K6Z3w==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -3035,20 +3041,26 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/exporter-metrics-otlp-proto@0.216.0':
-    resolution: {integrity: sha512-N7GCCXbw/le32/MrVL4Oj/FU9emFfHEHyGwubpcZLOtcuhUtFFAZWzPKJL1Etm0iNo37JA2JvG4W+5zNe/1NKQ==}
+  '@opentelemetry/exporter-metrics-otlp-http@0.217.0':
+    resolution: {integrity: sha512-1zkMzzhiNJdVmLxuwkltqWGw4fOOam47bqRxmuQNjyKJe/9NmY5cIrZ4kiQV7sVGxoOgT0ZvGUfLcjvtpC/b9Q==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/exporter-prometheus@0.216.0':
-    resolution: {integrity: sha512-faltPHeLPyHCGm0MuSrQxv8UXvckZbWo9hUHNwGYiDPF687gaVj5UN24vHlz7VeADnBb6UXTfuw1t4MK4xmcrA==}
+  '@opentelemetry/exporter-metrics-otlp-proto@0.217.0':
+    resolution: {integrity: sha512-nfxt/KxVGFkjkO/M+58y1ugHu/dwPtxG4eYq0KApcQ7xk5CHzhdn+IuLZfDSvNDrJ3Uy5q++Fj/wbK7i8yryfQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/exporter-trace-otlp-grpc@0.216.0':
-    resolution: {integrity: sha512-XTU//H/Gn+8F9LOWdOC9uyjgcIq/v7T+8aYMr+orBaOpzds05MpFD0jJASZ0mWimt0JWJTuQ8eto/k5/jvtwmw==}
+  '@opentelemetry/exporter-prometheus@0.217.0':
+    resolution: {integrity: sha512-U9MCXxJu0sBCh5aEkylYRR4xVIL8D1CW6dGwvYXbfFr0qveSorfD0XJchCAWoW6QfAAIcY/yxjf4Dj8OgkHBPw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.217.0':
+    resolution: {integrity: sha512-fPZs2fw7veLH3pEKu8vSepUa2fQpAE2P7al6qU10aH9GrEJJ8YaPgsd5xON7by5rbcEVS71FOU2aWyK6nzB7VQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -3065,8 +3077,14 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/exporter-trace-otlp-proto@0.216.0':
-    resolution: {integrity: sha512-MlUFZlQCm2hWHADU1GntUIziy3A4QcqM9uSZfbqeEolZWk1QdbPQjO2t4LTE4QAA1niEXcYZC2SC23i/gVk8Pw==}
+  '@opentelemetry/exporter-trace-otlp-http@0.217.0':
+    resolution: {integrity: sha512-38YQoqtYjglz2GV94LGUN/djLvxtvGIQO68o6qAFPVshjmwSdX1F2i0c7vn3lEl1L5B/YqjB/bgKXaVx7KO+RQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.217.0':
+    resolution: {integrity: sha512-nPV8gKHUiSuTZpQcnZU3/pBlK7crSyEGpZuh5MtWySB0vv6NNG0QvvfKitQt+Fc2Mc6qfyU54KlZcurwoTbrVg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -3258,6 +3276,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/instrumentation@0.217.0':
+    resolution: {integrity: sha512-24ucQMjz7Y34Kw3trbxL2ZrssbtgWnR+Clpaa+YdeWuuyH3Cvk23Q03PcQvqiZrDvt8AmQmjgg9v6Y9PHoxG7w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation@0.57.2':
     resolution: {integrity: sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==}
     engines: {node: '>=14'}
@@ -3270,14 +3294,20 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/otlp-exporter-base@0.217.0':
+    resolution: {integrity: sha512-eYfqnB3UhKu/5frhd1R6+FprKygbhkomuaceMXDyzxbfXB9tKgZOVmjaJ02CkLA6Tdzumxl+e2H+vo2a8jiMPQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/otlp-exporter-base@0.57.2':
     resolution: {integrity: sha512-XdxEzL23Urhidyebg5E6jZoaiW5ygP/mRjxLHixogbqwDy2Faduzb5N0o/Oi+XTIJu+iyxXdVORjXax+Qgfxag==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/otlp-grpc-exporter-base@0.216.0':
-    resolution: {integrity: sha512-CrW+2cmZR6mcgtsncWK4WmAn7SC9RwVSHMLbi0IfOXfOYXBaSVKtCCkKYJQWa31VUg7aJFJSpD0n4ISVUN1jdQ==}
+  '@opentelemetry/otlp-grpc-exporter-base@0.217.0':
+    resolution: {integrity: sha512-7RTAdZuOsCDnsyqTCG4+bDzrfnsWdzkRs7z0AVi/V3tEQx0oKeyc+OuRWYxnRsmaJXgxcmB8vb/lfxn58Dj6Ag==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -3290,6 +3320,12 @@ packages:
 
   '@opentelemetry/otlp-transformer@0.216.0':
     resolution: {integrity: sha512-g4Rb6sAsxQAo11eDjixfKxelruBsQFdJ8Wo23FCj7D6OXbidgXMu2xaRSYs4RdlomzAXSJuc86RcS3xmE8A6uA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.217.0':
+    resolution: {integrity: sha512-MKK8UHKFUOGAvbZRWh90MhwHG+Fxm6OROBdjKPCF+HQobjuJ/Kuf8Chs8CR45X1aqotxrMj7OxTdsXe8sXuGVA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -3346,6 +3382,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.4.0 <1.10.0'
 
+  '@opentelemetry/sdk-logs@0.217.0':
+    resolution: {integrity: sha512-BB+PcHItcZDL63dPMW+mJvwN9rk37wuIDjRxbVlg6pPDvDR/7GL7UJHbGsllgoggOoTimsKgENaWPoGch/oE1A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
   '@opentelemetry/sdk-logs@0.57.2':
     resolution: {integrity: sha512-TXFHJ5c+BKggWbdEQ/inpgIzEmS2BGQowLE9UhsMd7YYlUfBQJ4uax0VF/B5NYigdM/75OoJGhAV3upEhK+3gg==}
     engines: {node: '>=14'}
@@ -3364,8 +3406,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.9.0 <1.10.0'
 
-  '@opentelemetry/sdk-node@0.216.0':
-    resolution: {integrity: sha512-c2bPyD62yIhjS2STJVk5uSJMsiPZqJ747QIJQ0lAsxv6CjBlKPDO715dUjB+W5r9AI76wKhdRGVcG5dl06d65A==}
+  '@opentelemetry/sdk-node@0.217.0':
+    resolution: {integrity: sha512-K/60pSv42+NQiZKy1pAH18nYDkxltsDV4O3SJ233J0E9raU1ksyL9gsKuS8p30bYBb4AMPCfDuutHQaHYpcv0Q==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
@@ -11180,6 +11222,10 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
 
+  '@opentelemetry/api-logs@0.217.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
   '@opentelemetry/api-logs@0.57.2':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -11188,7 +11234,7 @@ snapshots:
 
   '@opentelemetry/api@1.9.1': {}
 
-  '@opentelemetry/configuration@0.216.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/configuration@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
@@ -11217,45 +11263,45 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
 
-  '@opentelemetry/exporter-logs-otlp-grpc@0.216.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/exporter-logs-otlp-grpc@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@grpc/grpc-js': 1.14.3
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.216.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-grpc-exporter-base': 0.216.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.216.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-logs': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/exporter-logs-otlp-http@0.216.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/exporter-logs-otlp-http@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.216.0
+      '@opentelemetry/api-logs': 0.217.0
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.216.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.216.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-logs': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/exporter-logs-otlp-proto@0.216.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/exporter-logs-otlp-proto@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.216.0
+      '@opentelemetry/api-logs': 0.217.0
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.216.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-logs': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/exporter-metrics-otlp-grpc@0.216.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@grpc/grpc-js': 1.14.3
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-metrics-otlp-http': 0.216.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.216.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-grpc-exporter-base': 0.216.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
 
@@ -11268,17 +11314,26 @@ snapshots:
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/exporter-metrics-otlp-proto@0.216.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/exporter-metrics-otlp-http@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-metrics-otlp-http': 0.216.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.216.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/exporter-prometheus@0.216.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/exporter-metrics-otlp-proto@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-prometheus@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
@@ -11286,14 +11341,14 @@ snapshots:
       '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
-  '@opentelemetry/exporter-trace-otlp-grpc@0.216.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/exporter-trace-otlp-grpc@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@grpc/grpc-js': 1.14.3
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.216.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-grpc-exporter-base': 0.216.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
 
@@ -11317,12 +11372,21 @@ snapshots:
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/exporter-trace-otlp-proto@0.216.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.216.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
 
@@ -11596,6 +11660,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.217.0
+      import-in-the-middle: 3.0.1
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -11614,19 +11687,25 @@ snapshots:
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.216.0(@opentelemetry/api@1.9.1)
 
+  '@opentelemetry/otlp-exporter-base@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
+
   '@opentelemetry/otlp-exporter-base@0.57.2(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/otlp-grpc-exporter-base@0.216.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/otlp-grpc-exporter-base@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@grpc/grpc-js': 1.14.3
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.216.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/otlp-grpc-exporter-base@0.57.2(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -11643,6 +11722,17 @@ snapshots:
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-logs': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      protobufjs: 8.0.1
+
+  '@opentelemetry/otlp-transformer@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.217.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
       protobufjs: 8.0.1
@@ -11700,6 +11790,14 @@ snapshots:
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
+  '@opentelemetry/sdk-logs@0.217.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.217.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
   '@opentelemetry/sdk-logs@0.57.2(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -11719,30 +11817,30 @@ snapshots:
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/sdk-node@0.216.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/sdk-node@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.216.0
-      '@opentelemetry/configuration': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/api-logs': 0.217.0
+      '@opentelemetry/configuration': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/context-async-hooks': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-logs-otlp-grpc': 0.216.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-logs-otlp-http': 0.216.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-logs-otlp-proto': 0.216.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-metrics-otlp-grpc': 0.216.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-metrics-otlp-http': 0.216.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-metrics-otlp-proto': 0.216.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-prometheus': 0.216.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-trace-otlp-grpc': 0.216.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-trace-otlp-http': 0.216.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-trace-otlp-proto': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-grpc': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-proto': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-grpc': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-proto': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-prometheus': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-grpc': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-proto': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-zipkin': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.216.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/propagator-b3': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/propagator-jaeger': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-logs': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-node': 2.7.1(@opentelemetry/api@1.9.1)

--- a/services/agent/llms.txt
+++ b/services/agent/llms.txt
@@ -9,22 +9,22 @@
   <section priority="medium" role="routes">
   <file path="src/routes/gen-chat.ts">
     <item priority="high">
-      export const genChatRoutes: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const genChatRoutes: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   <file path="src/routes/gen-specs.ts">
     <item priority="high">
-      export const genSpecsRoutes: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const genSpecsRoutes: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   <file path="src/routes/gen-ui.ts">
     <item priority="high">
-      export const genUiRoutes: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const genUiRoutes: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   <file path="src/routes/health.ts">
     <item priority="high">
-      export const healthRoutes: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const healthRoutes: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   <file path="src/routes/orchestrate.ts">
@@ -49,7 +49,7 @@
   </file>
   <file path="src/routes/ready.ts">
     <item priority="high">
-      export const readinessRoutes: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const readinessRoutes: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   <file path="src/routes/remediation.ts">
@@ -66,12 +66,12 @@
   </file>
   <file path="src/routes/session-events.ts">
     <item priority="high">
-      export const sessionEventsRoutes: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const sessionEventsRoutes: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   <file path="src/routes/sessions.ts">
     <item priority="high">
-      export const sessionRoutes: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const sessionRoutes: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   <file path="src/routes/webhooks.ts">

--- a/services/reservations/llms.txt
+++ b/services/reservations/llms.txt
@@ -12,14 +12,14 @@
   <section priority="medium" role="routes">
   <file path="src/routes/availability.ts">
     <item priority="high">
-      export const availabilityRoutes: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const availabilityRoutes: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   <file path="src/routes/events.ts">
     <item priority="medium">
       class EventBuffer {
         maxSize: number;
-        buffer: readonly import("/Users/mbutler/github/mattbutlerengineer...;
+        buffer: readonly import("/home/user/mattbutlerengineering/service...;
         _droppedCount: number;
         async push(): Promise<unknown>;
       }
@@ -30,12 +30,12 @@
   </file>
   <file path="src/routes/floor-plans.ts">
     <item priority="high">
-      export const floorPlanRoutes: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const floorPlanRoutes: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   <file path="src/routes/guests.ts">
     <item priority="high">
-      export const guestRoutes: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const guestRoutes: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   <file path="src/routes/health.ts">
@@ -45,7 +45,7 @@
         IncomingMessage...;
     </item>
     <item priority="high">
-      export const healthRoutes: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const healthRoutes: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   <file path="src/routes/holds.ts">
@@ -53,12 +53,12 @@
       function getSessionId(request: FastifyRequest): string { /* ... */ }
     </item>
     <item priority="high">
-      export const holdRoutes: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const holdRoutes: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   <file path="src/routes/ready.ts">
     <item priority="high">
-      export const readinessRoutes: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const readinessRoutes: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   <file path="src/routes/reservations.ts">
@@ -66,17 +66,17 @@
       function isAdmin(user: AuthUser | undefined): boolean { /* ... */ }
     </item>
     <item priority="high">
-      export const reservationRoutes: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const reservationRoutes: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   <file path="src/routes/tables.ts">
     <item priority="high">
-      export const tableRoutes: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const tableRoutes: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   <file path="src/routes/venues.ts">
     <item priority="high">
-      export const venueRoutes: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const venueRoutes: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   </section>
@@ -98,7 +98,7 @@
         name: string;
         slug: string;
         ianaTimezone: string;
-        settings: import("/Users/mbutler/github/mattbutlerengineering/packa...;
+        settings: import("/home/user/mattbutlerengineering/packages/types/s...;
       }
     </item>
     <item priority="high">
@@ -126,10 +126,10 @@
     </item>
     <item priority="low">
       interface ReservationEvent {
-        type: import("/Users/mbutler/github/mattbutlerengineering/servi...;
+        type: import("/home/user/mattbutlerengineering/services/reserva...;
         venueId: string;
         timestamp: string;
-        data: import("/Users/mbutler/github/mattbutlerengineering/packa...;
+        data: import("/home/user/mattbutlerengineering/packages/types/s...;
       }
     </item>
   </file>
@@ -184,7 +184,7 @@
     <item priority="low">
       interface CreateHoldResult {
         success: boolean;
-        hold?: import("/Users/mbutler/github/mattbutlerengineering/packa...;
+        hold?: import("/home/user/mattbutlerengineering/packages/types/s...;
         error?: string | undefined;
       }
     </item>
@@ -209,7 +209,7 @@
       }
     </item>
     <item priority="high">
-      export const DEFAULT_SSE_CONFIG: import("/Users/mbutler/github/mattbutlerengineering/servi...;
+      export const DEFAULT_SSE_CONFIG: import("/home/user/mattbutlerengineering/services/reserva...;
     </item>
   </file>
   <file path="src/services/table.ts">

--- a/services/users/llms.txt
+++ b/services/users/llms.txt
@@ -14,12 +14,12 @@
         IncomingMessage...;
     </item>
     <item priority="high">
-      export const healthRoutes: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const healthRoutes: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   <file path="src/routes/ready.ts">
     <item priority="high">
-      export const readinessRoutes: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const readinessRoutes: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   <file path="src/routes/users.ts">
@@ -27,7 +27,7 @@
       function isAdmin(user: AuthUser | undefined): boolean { /* ... */ }
     </item>
     <item priority="high">
-      export const userRoutes: import("/Users/mbutler/github/mattbutlerengineering/node_...;
+      export const userRoutes: import("/home/user/mattbutlerengineering/node_modules/.pn...;
     </item>
   </file>
   </section>
@@ -112,7 +112,7 @@
       }
     </item>
     <item priority="high">
-      export const MOCK_USER: import("/Users/mbutler/github/mattbutlerengineering/servi...;
+      export const MOCK_USER: import("/home/user/mattbutlerengineering/services/users/s...;
     </item>
   </file>
   </section>


### PR DESCRIPTION
## Summary

- Adds scoped `pnpm.overrides` for `@opentelemetry/sdk-node@<0.217.0` and `@opentelemetry/exporter-prometheus@<0.217.0` → clears CVE GHSA-q7rr-3cgh-j5r3, `pnpm audit --audit-level=high` exits 0
- Regenerates all 13 affected `llms.txt` files via the deterministic CLI so the `Integrity` check passes

## Why this PR instead of merging #1250 or #1256

PRs #1250 and #1256 are deadlocked:
- **PR #1250** (CVE fix): `Build` passes but `Integrity` fails — branch pre-dates the deterministic llms.txt fix
- **PR #1256** (llms.txt fix): `Integrity` would pass but `Build` fails — branch doesn't have the CVE override

This combined PR applies both fixes on the current `main` HEAD, breaking the deadlock.

## Test plan

- [x] `pnpm audit --audit-level=high` → `No known vulnerabilities found`
- [x] All 13 `llms.txt` files regenerated with deterministic CLI (`node tools/cli/dist/index.js pack <pkg>`)
- [ ] CI Build job passes (audit exits 0)
- [ ] CI Integrity job passes (llms.txt match source)

Closes #1239
Closes #1248

https://claude.ai/code/session_01LMm9DgXao4g83FmitpGhiG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMm9DgXao4g83FmitpGhiG)_