### PR TITLE
fix(ci): fix preview deploy links for SPA routing

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -108,10 +108,9 @@ jobs:
           if [ "$FILTER" != "true" ]; then exit 0; fi
           WORKER_NAME="mbe-preview-${PR_NUM}-${APP}"
           npx wrangler deploy \
+            --config "apps/${APP}/wrangler.toml" \
             --name "$WORKER_NAME" \
-            --assets "apps/${APP}/dist" \
-            --compatibility-date "2026-03-25" \
-            --no-bundle 2>&1 || echo "::warning::Preview deploy failed for $APP"
+            --no-bundle
 
   comment-preview:
     needs: [detect-changes, deploy-preview]


### PR DESCRIPTION
## Summary

- Preview deploy used bare `--assets` CLI flag which bypassed each app's `wrangler.toml` config, specifically `not_found_handling = "single-page-application"` under `[assets]`
- This caused all non-root routes (e.g. `/status`, `/hospitality/timeline`) to return 404 because Cloudflare had no SPA fallback configured for preview workers
- Fix: use `--config apps/${APP}/wrangler.toml` so preview deploys inherit the same SPA routing, asset directory, compatibility date, and cache headers as production
- Also removes error-swallowing `|| echo "::warning::..."` pattern so deploy failures are properly surfaced

### Root cause

Each app's `wrangler.toml` has:
```toml
[assets]
directory = "./dist"
not_found_handling = "single-page-application"
```

The preview deploy was bypassing this with `--assets "apps/${APP}/dist"` on the CLI, which creates a bare asset worker with no SPA fallback. The `not_found_handling` setting is only configurable via `wrangler.toml`, not via CLI flags.

Closes #1259

## Test plan

- [ ] Open a PR that changes an app (e.g. marketing) and verify the preview deploy workflow runs
- [ ] Visit the preview URL at a non-root route (e.g. `https://mbe-preview-{PR}-marketing.workers.dev/status`) and confirm it loads instead of returning 404
- [ ] Verify deploy failures are no longer silently swallowed (check workflow step exits non-zero on error)