### PR TITLE
feat: add pre-push test gate for affected packages

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -11,3 +11,45 @@ if [ $? -ne 0 ]; then
   echo ""
   exit 1
 fi
+
+# Run tests for packages affected by the current changes.
+# Uses turbo's --filter='...[ref]' to test only changed packages + dependents.
+# Turbo caching means repeated pushes of unchanged code are near-instant.
+
+# Determine the comparison ref
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$current_branch" = "main" ]; then
+  compare_ref="HEAD~1"
+elif git rev-parse --verify origin/main >/dev/null 2>&1; then
+  compare_ref="origin/main"
+else
+  compare_ref="HEAD~1"
+fi
+
+# Check if any packages are affected by changes since the compare ref
+affected=$(pnpm turbo test --filter="...[$compare_ref]" --dry-run=json 2>/dev/null | grep -c '"taskId"')
+
+if [ "$affected" -gt 0 ] 2>/dev/null; then
+  echo ""
+  echo "pre-push: running tests for packages changed since $compare_ref..."
+  echo ""
+
+  # Show which packages are affected
+  pnpm turbo test --filter="...[$compare_ref]" --dry-run=text 2>/dev/null | grep '^ ' | head -20
+
+  echo ""
+
+  # Run the tests
+  pnpm turbo test --filter="...[$compare_ref]"
+  run_result=$?
+
+  if [ $run_result -ne 0 ]; then
+    echo ""
+    echo "ERROR: tests failed for affected packages."
+    echo "Fix the failing tests before pushing."
+    echo ""
+    exit 1
+  fi
+else
+  echo "pre-push: no affected packages to test (compared against $compare_ref)"
+fi


### PR DESCRIPTION
## Summary

- Adds a test gate to `.husky/pre-push` that runs `pnpm turbo test --filter='...[origin/main]'` before allowing push, testing only packages affected by current changes plus their dependents
- Falls back to `HEAD~1` comparison when on the main branch or when `origin/main` is unavailable (fresh clone)
- Prints which packages are being tested and exits non-zero on failure; skips silently when no packages are affected
- Turbo caching makes repeated pushes of unchanged code near-instant

## Test plan

- [ ] Push a branch with changes in a single package -- verify only that package (and dependents) are tested
- [ ] Push a branch with no code changes -- verify "no affected packages" message appears
- [ ] Push from main branch -- verify HEAD~1 fallback is used
- [ ] Introduce a failing test and push -- verify push is blocked with clear error message
- [ ] Push the same branch twice -- verify second push is fast due to turbo cache

Closes #1233