### PR TITLE
fix(worker): add audit token bypass for Bot Fight Mode 403s

### DIFF
--- a/infrastructure/AUDIT_BYPASS.md
+++ b/infrastructure/AUDIT_BYPASS.md
@@ -1,0 +1,76 @@
+# Audit Bot Fight Mode Bypass
+
+Automated site audits (Lighthouse, Playwright, curl from RemoteTriggers) are
+blocked by Cloudflare Bot Fight Mode with HTTP 403. This document describes the
+two-layer fix.
+
+## Layer 1: Edge Router (code -- already deployed)
+
+The edge router Worker validates the `X-Audit-Token` request header against the
+`AUDIT_TOKEN` secret. Verified requests bypass rate limiting so automated audits
+can run at full speed without hitting 429 errors.
+
+**Setup:**
+
+```bash
+# Generate a random token
+AUDIT_TOKEN=$(openssl rand -hex 32)
+
+# Set it as a Worker secret
+cd infrastructure/worker
+wrangler secret put AUDIT_TOKEN
+# Paste the token value when prompted
+
+# Export in the audit environment (RemoteTrigger, CI, local)
+export AUDIT_TOKEN="<same value>"
+```
+
+## Layer 2: Cloudflare WAF Custom Rule (manual -- dashboard required)
+
+Bot Fight Mode runs *before* the Worker and cannot be controlled from code.
+A WAF custom rule is needed to skip Bot Fight Mode for requests carrying the
+audit token.
+
+**Steps:**
+
+1. Go to [Cloudflare Dashboard](https://dash.cloudflare.com) for the
+   `mattbutlerengineering.com` zone
+2. Navigate to **Security > WAF > Custom Rules**
+3. Create a new rule:
+   - **Rule name:** `Audit Bot Bypass`
+   - **Expression:**
+     ```
+     (http.request.headers["x-audit-token"][0] eq "<AUDIT_TOKEN value>")
+     ```
+   - **Action:** `Skip`
+   - **Skip options:** Check `Bot Fight Mode`
+4. Save and deploy the rule
+
+**Important:** The token value in the WAF rule must match the `AUDIT_TOKEN`
+Worker secret exactly.
+
+## Audit Script Usage
+
+The site-audit skill already sends the token when `AUDIT_TOKEN` is set:
+
+```bash
+AUDIT_CURL_OPTS=(-sf -A "Mozilla/5.0 ...")
+[ -n "${AUDIT_TOKEN:-}" ] && AUDIT_CURL_OPTS+=(-H "X-Audit-Token: $AUDIT_TOKEN")
+curl "${AUDIT_CURL_OPTS[@]}" "$URL"
+```
+
+## Verification
+
+After both layers are configured, verify the bypass works:
+
+```bash
+# Should return 200 (not 403)
+curl -s -o /dev/null -w "%{http_code}" \
+  -H "X-Audit-Token: $AUDIT_TOKEN" \
+  https://mattbutlerengineering.com/
+
+# Health endpoint should also work without rate limiting
+curl -s -o /dev/null -w "%{http_code}" \
+  -H "X-Audit-Token: $AUDIT_TOKEN" \
+  https://mattbutlerengineering.com/health/system
+```

--- a/infrastructure/worker/edge-router.js
+++ b/infrastructure/worker/edge-router.js
@@ -28,6 +28,24 @@ import {
 import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";
 import depGraph from "./dep-graph.json";
 
+// ── Audit Token Verification ─────────────────────────────────────────
+// Automated audits (Lighthouse, Playwright, curl) from the CI/cloud
+// environment are blocked by Cloudflare Bot Fight Mode. Requests that
+// carry a valid X-Audit-Token header bypass rate limiting at this Worker
+// layer. To also bypass Bot Fight Mode, a Cloudflare WAF custom rule
+// must be configured separately (see infrastructure/AUDIT_BYPASS.md).
+
+/**
+ * Check whether the request carries a valid audit token.
+ * Returns true only when AUDIT_TOKEN is configured and the request
+ * includes a matching `X-Audit-Token` header.
+ */
+function isAuditRequest(request, env) {
+  if (!env.AUDIT_TOKEN) return false;
+  const token = request.headers.get("X-Audit-Token");
+  return token !== null && token === env.AUDIT_TOKEN;
+}
+
 // ── CORS Origin Allowlist ──────────────────────────────────────────────
 // Only these production origins may receive Access-Control-Allow-Origin.
 // If a request's Origin header does not match, the header is omitted entirely.
@@ -957,11 +975,16 @@ export default {
     // Generate a per-request nonce for CSP script-src
     const nonce = generateNonce();
 
-    // ── Rate limiting ────────────────────────────────────────────────
-    const clientIp = request.headers.get("CF-Connecting-IP") ?? "unknown";
-    const rateCheck = await checkRateLimit(env.HEALTH_STATE, url.pathname, clientIp, Date.now());
-    if (!rateCheck.allowed) {
-      return rateLimitResponse();
+    // ── Audit token verification ──────────────────────────────────────
+    const auditVerified = isAuditRequest(request, env);
+
+    // ── Rate limiting (bypassed for verified audit requests) ─────────
+    if (!auditVerified) {
+      const clientIp = request.headers.get("CF-Connecting-IP") ?? "unknown";
+      const rateCheck = await checkRateLimit(env.HEALTH_STATE, url.pathname, clientIp, Date.now());
+      if (!rateCheck.allowed) {
+        return rateLimitResponse();
+      }
     }
 
     // ── Health aggregation endpoint ───────────────────────────────────

--- a/infrastructure/worker/edge-router.test.js
+++ b/infrastructure/worker/edge-router.test.js
@@ -546,4 +546,98 @@ describe("Edge Router", () => {
       expect(bindings).toHaveLength(expected.length);
     });
   });
+
+  describe("Audit token bypass", () => {
+    it("bypasses rate limiting for requests with valid X-Audit-Token", async () => {
+      const auditEnv = {
+        ...env,
+        AUDIT_TOKEN: "test-audit-secret",
+        HEALTH_STATE: {
+          ...createMockKv(),
+          get: vi.fn(async (key) => {
+            if (key.startsWith("ratelimit:")) return "999";
+            return null;
+          }),
+          put: vi.fn(),
+        },
+      };
+
+      // Without audit token, /health/system is rate-limited (limit=10)
+      const blockedResponse = await edgeRouter.fetch(
+        makeRequest("/health/system"),
+        auditEnv
+      );
+      expect(blockedResponse.status).toBe(429);
+
+      // With valid audit token, rate limiting is bypassed
+      const auditResponse = await edgeRouter.fetch(
+        makeRequest("/health/system", {
+          headers: { "X-Audit-Token": "test-audit-secret" },
+        }),
+        auditEnv
+      );
+      expect(auditResponse.status).toBe(200);
+    });
+
+    it("does not bypass rate limiting for invalid X-Audit-Token", async () => {
+      const auditEnv = {
+        ...env,
+        AUDIT_TOKEN: "test-audit-secret",
+        HEALTH_STATE: {
+          ...createMockKv(),
+          get: vi.fn(async (key) => {
+            if (key.startsWith("ratelimit:")) return "999";
+            return null;
+          }),
+          put: vi.fn(),
+        },
+      };
+
+      const response = await edgeRouter.fetch(
+        makeRequest("/health/system", {
+          headers: { "X-Audit-Token": "wrong-token" },
+        }),
+        auditEnv
+      );
+      expect(response.status).toBe(429);
+    });
+
+    it("does not bypass rate limiting when AUDIT_TOKEN is not configured", async () => {
+      const noTokenEnv = {
+        ...env,
+        HEALTH_STATE: {
+          ...createMockKv(),
+          get: vi.fn(async (key) => {
+            if (key.startsWith("ratelimit:")) return "999";
+            return null;
+          }),
+          put: vi.fn(),
+        },
+      };
+
+      const response = await edgeRouter.fetch(
+        makeRequest("/health/system", {
+          headers: { "X-Audit-Token": "some-token" },
+        }),
+        noTokenEnv
+      );
+      expect(response.status).toBe(429);
+    });
+
+    it("serves static site content normally for audit-verified requests", async () => {
+      const auditEnv = {
+        ...env,
+        AUDIT_TOKEN: "test-audit-secret",
+      };
+
+      const response = await edgeRouter.fetch(
+        makeRequest("/", {
+          headers: { "X-Audit-Token": "test-audit-secret" },
+        }),
+        auditEnv
+      );
+      expect(response.status).toBe(200);
+      expect(env.MARKETING.fetch).toHaveBeenCalled();
+    });
+  });
 });

--- a/infrastructure/worker/wrangler.toml
+++ b/infrastructure/worker/wrangler.toml
@@ -10,6 +10,11 @@ routes = [
 [vars]
 API_ORIGIN = "https://api.mattbutlerengineering.com"
 
+# Secrets (set via `wrangler secret put <NAME>`):
+#   HEALTH_TOKEN  — Bearer token for detailed /health/system responses
+#   ADMIN_TOKEN   — Bearer token for feature flag admin API
+#   AUDIT_TOKEN   — Token for automated site audits (bypasses rate limiting)
+
 [[services]]
 binding = "MARKETING"
 service = "mattbutlerengineering-marketing"


### PR DESCRIPTION
## Summary

- Adds `X-Audit-Token` header validation to the edge router Worker, bypassing rate limiting for verified automated audit requests
- Documents the required Cloudflare WAF custom rule (manual dashboard step) in `infrastructure/AUDIT_BYPASS.md`
- Adds 4 tests covering valid token bypass, invalid token rejection, unconfigured token fallback, and normal static site serving

## Context

Automated site audits (Lighthouse, Playwright, curl from RemoteTriggers) get HTTP 403 from Cloudflare Bot Fight Mode. The edge router Worker itself never returns 403 -- it comes from Cloudflare's Bot Fight Mode layer which runs *before* the Worker.

This PR implements the code side of the fix (rate limit bypass for `X-Audit-Token`). A manual Cloudflare WAF custom rule is still needed to bypass Bot Fight Mode itself -- steps are documented in `AUDIT_BYPASS.md`.

Closes #1274

## Setup required after merge

1. `wrangler secret put AUDIT_TOKEN` on the edge router Worker
2. Configure WAF custom rule per `infrastructure/AUDIT_BYPASS.md`
3. Export `AUDIT_TOKEN` in the audit environment (RemoteTrigger env vars)

## Test plan

- [x] All 4 new audit token bypass tests pass
- [x] All 41 existing edge router tests still pass (1 pre-existing failure on `generatedAt` unrelated to this change)
- [ ] After merge: set `AUDIT_TOKEN` secret and verify `curl -H "X-Audit-Token: $TOKEN" https://mattbutlerengineering.com/` returns 200
- [ ] After WAF rule: verify automated audit no longer gets 403