### PR TITLE
feat(ci): add Codecov integration with badge and per-package config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -504,7 +504,8 @@ jobs:
       - name: Upload coverage reports
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:
-          files: ./packages/auth/coverage/coverage-final.json,./services/users/coverage/coverage-final.json,./packages/agent-core/coverage/coverage-final.json
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./packages/auth/coverage/coverage-final.json,./packages/agent-core/coverage/coverage-final.json,./packages/rialto/coverage/coverage-final.json,./packages/rialto-catalog/coverage/coverage-final.json,./services/users/coverage/coverage-final.json,./services/reservations/coverage/coverage-final.json,./services/agent/coverage/coverage-final.json,./apps/hospitality/coverage/coverage-final.json,./infrastructure/pulumi/coverage/coverage-final.json
           fail_ci_if_error: false
           verbose: true
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Matt Butler Engineering
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=flat-square)](./LICENSE)
+[![codecov](https://codecov.io/gh/mattbutlerengineering/mattbutlerengineering/graph/badge.svg)](https://codecov.io/gh/mattbutlerengineering/mattbutlerengineering)
 
 <!-- acmm:begin -->![ACMM Level 3](https://img.shields.io/badge/ACMM-Level%203-7a5a36?style=flat-square)<!-- acmm:end -->
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,66 @@
+codecov:
+  require_ci_to_pass: false
+
+coverage:
+  precision: 2
+  round: down
+  range: "50...100"
+
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 2%
+        if_ci_failed: ignore
+    patch:
+      default:
+        target: 75%
+        threshold: 5%
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: false
+  require_base: false
+
+flag_management:
+  default_rules:
+    carryforward: true
+
+flags:
+  auth:
+    paths:
+      - packages/auth/
+    carryforward: true
+  agent-core:
+    paths:
+      - packages/agent-core/
+    carryforward: true
+  rialto:
+    paths:
+      - packages/rialto/
+    carryforward: true
+  rialto-catalog:
+    paths:
+      - packages/rialto-catalog/
+    carryforward: true
+  users:
+    paths:
+      - services/users/
+    carryforward: true
+  reservations:
+    paths:
+      - services/reservations/
+    carryforward: true
+  agent:
+    paths:
+      - services/agent/
+    carryforward: true
+  hospitality:
+    paths:
+      - apps/hospitality/
+    carryforward: true
+  pulumi:
+    paths:
+      - infrastructure/pulumi/
+    carryforward: true


### PR DESCRIPTION
## Summary

- Add `token: ${{ secrets.CODECOV_TOKEN }}` to existing coverage upload step in `ci.yml`
- Expand uploaded files from 3 packages to 9 (auth, agent-core, rialto, rialto-catalog, users, reservations, agent, hospitality, pulumi)
- Create `codecov.yml` with 80% project target, 75% patch target, per-package flags with carryforward enabled
- Add codecov badge to root `README.md`

## Manual setup required after merge

1. Sign up / connect repo at https://codecov.io
2. Add `CODECOV_TOKEN` to GitHub Actions secrets (repo → Settings → Secrets)
3. Verify coverage badge renders at `https://codecov.io/gh/mattbutlerengineering/mattbutlerengineering`

Note: upload already uses `fail_ci_if_error: false` so CI will not break if the token is not yet configured.

## Test plan

- [x] `codecov.yml` YAML is valid
- [x] `ci.yml` Upload step now includes token + all 9 coverage paths
- [x] README badge uses standard Codecov badge URL
- [ ] After merge + secret setup: verify Codecov bot comments on next PR

Closes #1387

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFiZBeM6ZZEJcamkjjM8UL)_