### PR TITLE
fix(acmm): persist governor state when gh CLI unavailable

### DIFF
--- a/docs/architecture/dependency-graph.md
+++ b/docs/architecture/dependency-graph.md
@@ -123,9 +123,9 @@ flowchart TD
 
 ## Legend
 
-| Color | Category |
-|-------|----------|
-| Blue | Frontend Apps (`apps/*`) |
-| Amber | Backend Services (`services/*`) |
-| Indigo | Shared Packages (`packages/*`) |
-| Green | Developer Tools (`tools/*`) |
+| Color  | Category                        |
+| ------ | ------------------------------- |
+| Blue   | Frontend Apps (`apps/*`)        |
+| Amber  | Backend Services (`services/*`) |
+| Indigo | Shared Packages (`packages/*`)  |
+| Green  | Developer Tools (`tools/*`)     |

--- a/packages/rialto-catalog/src/generated-schemas.ts
+++ b/packages/rialto-catalog/src/generated-schemas.ts
@@ -130,7 +130,18 @@ export const generatedSchemas = {
   }),
   Text: z.object({
     variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-    color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+    color: z
+      .enum([
+        "success",
+        "warning",
+        "error",
+        "accent",
+        "primary",
+        "secondary",
+        "tertiary",
+        "on-accent",
+      ])
+      .optional(),
     align: z.enum(["center", "left", "right"]).optional(),
     mono: z.boolean().optional(),
     truncate: z.boolean().optional(),

--- a/plugins/acmm/scripts/__tests__/cadence-governor.test.js
+++ b/plugins/acmm/scripts/__tests__/cadence-governor.test.js
@@ -10,6 +10,7 @@ import {
   loadState,
   saveState,
   buildNextState,
+  buildFallbackState,
 } from "../cadence-governor.js";
 
 // ── determineMode ───────────────────────────────────────────────
@@ -200,6 +201,66 @@ test("buildNextState: caps history at MAX_HISTORY (100)", () => {
 
   const result = buildNextState({ readyCount: 7, previousState, now });
   assert.equal(result.history.length, 100);
+});
+
+// ── buildFallbackState ──────────────────────────────────────────
+
+test("buildFallbackState: writes history entry with gh-unavailable reason", () => {
+  const now = Date.parse("2026-05-16T10:00:00.000Z");
+  const previousState = {
+    mode: "BUSY",
+    readyCount: 5,
+    lastCheck: "2026-05-16T09:00:00.000Z",
+    lastExecution: "2026-05-16T09:00:00.000Z",
+    shouldExecute: true,
+    history: [],
+  };
+
+  const result = buildFallbackState(previousState, now);
+  assert.equal(result.lastCheck, "2026-05-16T10:00:00.000Z");
+  assert.equal(result.shouldExecute, true);
+  assert.equal(result.history.length, 1);
+  assert.equal(result.history[0].reason, "gh-unavailable");
+  assert.equal(result.history[0].readyCount, null);
+  assert.equal(result.history[0].executed, true);
+  assert.equal(result.history[0].mode, "BUSY");
+});
+
+test("buildFallbackState: mode defaults to UNKNOWN when no prior mode", () => {
+  const now = Date.parse("2026-05-16T10:00:00.000Z");
+  const previousState = {
+    mode: null,
+    readyCount: 0,
+    lastCheck: null,
+    lastExecution: null,
+    shouldExecute: true,
+    history: [],
+  };
+
+  const result = buildFallbackState(previousState, now);
+  assert.equal(result.history[0].mode, "UNKNOWN");
+});
+
+test("buildFallbackState: preserves lastExecution, caps history at 100", () => {
+  const now = Date.parse("2026-05-16T10:00:00.000Z");
+  const longHistory = Array.from({ length: 150 }, (_, i) => ({
+    date: new Date(now - (150 - i) * 60 * 1000).toISOString(),
+    mode: "BUSY",
+    readyCount: 5,
+    executed: true,
+  }));
+  const previousState = {
+    mode: "BUSY",
+    readyCount: 5,
+    lastCheck: null,
+    lastExecution: "2026-05-16T08:00:00.000Z",
+    shouldExecute: true,
+    history: longHistory,
+  };
+
+  const result = buildFallbackState(previousState, now);
+  assert.equal(result.history.length, 100);
+  assert.equal(result.lastExecution, "2026-05-16T08:00:00.000Z");
 });
 
 test("buildNextState: IDLE → skip even with no prior execution", () => {

--- a/plugins/acmm/scripts/cadence-governor.js
+++ b/plugins/acmm/scripts/cadence-governor.js
@@ -117,6 +117,32 @@ export function saveState(state, statePath = DEFAULT_STATE_PATH) {
 }
 
 /**
+ * Build fallback state when gh CLI is unavailable.
+ * Persists a history entry so state accumulates even without metrics.
+ * @param {object} previousState
+ * @param {number} [now] - current time in ms (for testing)
+ * @returns {object} fallback state
+ */
+export function buildFallbackState(previousState, now = Date.now()) {
+  const timestamp = new Date(now).toISOString();
+  return {
+    ...previousState,
+    lastCheck: timestamp,
+    shouldExecute: true,
+    history: [
+      ...previousState.history.slice(-(MAX_HISTORY - 1)),
+      {
+        date: timestamp,
+        mode: previousState.mode ?? "UNKNOWN",
+        readyCount: null,
+        executed: true,
+        reason: "gh-unavailable",
+      },
+    ],
+  };
+}
+
+/**
  * Build updated state from current inputs.
  * @param {object} params
  * @param {number} params.readyCount
@@ -160,6 +186,9 @@ function main() {
   const readyCount = getReadyCount();
   if (readyCount === null) {
     console.log("Governor: gh CLI unavailable, defaulting to execute");
+    const previousState = loadState(statePath);
+    const fallbackState = buildFallbackState(previousState);
+    saveState(fallbackState, statePath);
     process.exit(0);
   }
 


### PR DESCRIPTION
## Summary

- `cadence-governor.js` exited without writing state when gh CLI unavailable (remote sessions), so `.claude/governor-state.json` never existed after 2 weeks
- Extract `buildFallbackState()` — called in the `null` path before exit, appends history entry with `reason: "gh-unavailable"` and `readyCount: null`
- State file now accumulates on every remote trigger firing regardless of gh availability

## Test plan

- [x] 22/22 unit tests pass (`node --test scripts/__tests__/cadence-governor.test.js`)
- [x] 3 new tests cover `buildFallbackState`: history entry written, UNKNOWN mode fallback when no prior mode, history capped at 100 + lastExecution preserved

Closes #1404

https://claude.ai/code/session_01Cc7tWoQVxyTiq5cMLgHqPb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cc7tWoQVxyTiq5cMLgHqPb)_