### PR TITLE
fix(ci): fix CLI TypeScript errors + stale dep-graph from refactor

### DIFF
--- a/infrastructure/worker/dep-graph.json
+++ b/infrastructure/worker/dep-graph.json
@@ -66,6 +66,11 @@
       "path": "packages/config"
     },
     {
+      "name": "@mbe/database",
+      "type": "package",
+      "path": "packages/database"
+    },
+    {
       "name": "@mbe/feature-flags",
       "type": "package",
       "path": "packages/feature-flags"
@@ -99,6 +104,11 @@
       "name": "@mbe/rialto-plugin",
       "type": "package",
       "path": "packages/rialto-plugin"
+    },
+    {
+      "name": "@mbe/sentry",
+      "type": "package",
+      "path": "packages/sentry"
     },
     {
       "name": "@mbe/types",
@@ -139,6 +149,11 @@
     },
     {
       "from": "@mbe/gen",
+      "to": "@mbe/sentry",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/gen",
       "to": "@mbe/config",
       "type": "devDependency"
     },
@@ -169,6 +184,11 @@
     },
     {
       "from": "@mbe/hospitality",
+      "to": "@mbe/sentry",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/hospitality",
       "to": "@mbe/config",
       "type": "devDependency"
     },
@@ -179,12 +199,22 @@
     },
     {
       "from": "@mbe/marketing",
+      "to": "@mbe/sentry",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/marketing",
       "to": "@mbe/config",
       "type": "devDependency"
     },
     {
       "from": "@mbe/rialto-web",
       "to": "@mbe/observability",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/rialto-web",
+      "to": "@mbe/sentry",
       "type": "dependency"
     },
     {
@@ -214,12 +244,22 @@
     },
     {
       "from": "@mbe/agent-service",
+      "to": "@mbe/sentry",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/agent-service",
       "to": "@mbe/rialto-catalog",
       "type": "dependency"
     },
     {
       "from": "@mbe/agent-service",
       "to": "@mbe/types",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/agent-service",
+      "to": "@mbe/database",
       "type": "dependency"
     },
     {
@@ -254,7 +294,17 @@
     },
     {
       "from": "@mbe/reservations-service",
+      "to": "@mbe/sentry",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/reservations-service",
       "to": "@mbe/types",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/reservations-service",
+      "to": "@mbe/database",
       "type": "dependency"
     },
     {
@@ -279,7 +329,17 @@
     },
     {
       "from": "@mbe/users-service",
+      "to": "@mbe/sentry",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/users-service",
       "to": "@mbe/types",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/users-service",
+      "to": "@mbe/database",
       "type": "dependency"
     },
     {
@@ -338,6 +398,11 @@
       "type": "devDependency"
     },
     {
+      "from": "@mbe/database",
+      "to": "@mbe/config",
+      "type": "devDependency"
+    },
+    {
       "from": "@mbe/feature-flags",
       "to": "@mbe/config",
       "type": "devDependency"
@@ -379,6 +444,16 @@
     },
     {
       "from": "@mbe/rialto-plugin",
+      "to": "@mbe/config",
+      "type": "devDependency"
+    },
+    {
+      "from": "@mbe/sentry",
+      "to": "@mbe/types",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/sentry",
       "to": "@mbe/config",
       "type": "devDependency"
     },

--- a/tools/cli/src/__tests__/agent.test.ts
+++ b/tools/cli/src/__tests__/agent.test.ts
@@ -853,14 +853,13 @@ describe("agent orchestrate subcommand", () => {
 });
 
 describe("agent run – invalid adapter and non-default option branches", () => {
-  let _logSpy: ReturnType<typeof vi.spyOn>;
   let errorSpy: ReturnType<typeof vi.spyOn>;
   let exitSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     vi.resetModules();
     vi.resetAllMocks();
-    _logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
     errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
     vi.spyOn(process, "cwd").mockReturnValue("/repo");
@@ -880,12 +879,16 @@ describe("agent run – invalid adapter and non-default option branches", () => 
   it("uses non-default model when --model is explicitly provided", async () => {
     const { runSession } = await import("@mbe/agent-core");
     vi.mocked(runSession).mockResolvedValue({
-      success: true,
+      sessionId: "test-id",
+      status: "succeeded",
+      branchName: "fix/test",
+      durationMs: 100,
       costUsd: 0.1,
       numTurns: 2,
-      stuck: false,
-      evaluationConfidence: 1,
-      outputs: [],
+      tokenUsage: { inputTokens: 100, outputTokens: 50 },
+      prUrl: null,
+      errors: [],
+      resultText: "",
     });
 
     const { agentCommand } = await import("../commands/agent.js");
@@ -901,12 +904,16 @@ describe("agent run – invalid adapter and non-default option branches", () => 
   it("uses non-default budget when --max-budget is explicitly provided", async () => {
     const { runSession } = await import("@mbe/agent-core");
     vi.mocked(runSession).mockResolvedValue({
-      success: true,
+      sessionId: "test-id",
+      status: "succeeded",
+      branchName: "fix/test",
+      durationMs: 100,
       costUsd: 0.5,
       numTurns: 3,
-      stuck: false,
-      evaluationConfidence: 1,
-      outputs: [],
+      tokenUsage: { inputTokens: 100, outputTokens: 50 },
+      prUrl: null,
+      errors: [],
+      resultText: "",
     });
 
     const { agentCommand } = await import("../commands/agent.js");
@@ -922,12 +929,16 @@ describe("agent run – invalid adapter and non-default option branches", () => 
   it("uses non-default maxTurns when --max-turns is explicitly provided", async () => {
     const { runSession } = await import("@mbe/agent-core");
     vi.mocked(runSession).mockResolvedValue({
-      success: true,
+      sessionId: "test-id",
+      status: "succeeded",
+      branchName: "fix/test",
+      durationMs: 100,
       costUsd: 0.1,
       numTurns: 1,
-      stuck: false,
-      evaluationConfidence: 1,
-      outputs: [],
+      tokenUsage: { inputTokens: 100, outputTokens: 50 },
+      prUrl: null,
+      errors: [],
+      resultText: "",
     });
 
     const { agentCommand } = await import("../commands/agent.js");

--- a/tools/cli/src/__tests__/health.test.ts
+++ b/tools/cli/src/__tests__/health.test.ts
@@ -179,14 +179,13 @@ describe("health command", () => {
 
 describe("health command – additional branch coverage", () => {
   let logSpy: ReturnType<typeof vi.spyOn>;
-  let _errorSpy: ReturnType<typeof vi.spyOn>;
   let exitSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     vi.resetModules();
     vi.resetAllMocks();
     logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    _errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
     exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
   });
 


### PR DESCRIPTION
## Summary

- Fixes 5 TypeScript errors in `@mbe/cli` test files that caused Architecture Audit and ADR compliance CI checks to fail on both open PRs
- Regenerates `infrastructure/worker/dep-graph.json` which was missing `@mbe/database` and `@mbe/sentry` added in the recent refactor

## Root cause

`pnpm build --filter @mbe/cli...` failed due to test files using the old `SessionResult` shape. The adapter refactor removed the `success`, `stuck`, `evaluationConfidence`, and `outputs` fields from `SessionResult`, but 3 test mocks in `agent.test.ts` still used the old shape (`TS2353`). Two unused `_logSpy` / `_errorSpy` spy variables (`TS6133`) were also flagged.

Since both Architecture Audit and ADR compliance workflows run `pnpm build --filter @mbe/cli...` as the first step, both were blocked by this build failure.

## Changes

- `tools/cli/src/__tests__/agent.test.ts` — remove unused `_logSpy` declaration; fix 3 `SessionResult` mocks to use `{ status, sessionId, branchName, durationMs, costUsd, numTurns, tokenUsage, prUrl, errors, resultText }`
- `tools/cli/src/__tests__/health.test.ts` — remove unused `_errorSpy` declaration
- `infrastructure/worker/dep-graph.json` — add `@mbe/database` and `@mbe/sentry` nodes + edges

## Test plan

- [x] `pnpm build --filter @mbe/cli...` passes locally (was failing before)
- [x] Pre-push hook passes (34 packages, all tests green)

https://claude.ai/code/session_011BVGrX1m6u3CiDRUozpdpg

---
_Generated by [Claude Code](https://claude.ai/code/session_011BVGrX1m6u3CiDRUozpdpg)_