### PR TITLE
feat(reservations): confirm attendance endpoint + reminder groundwork

### DIFF
--- a/services/reservations/Dockerfile
+++ b/services/reservations/Dockerfile
@@ -17,6 +17,7 @@ COPY packages/observability/package.json ./packages/observability/
 COPY packages/feature-flags/package.json ./packages/feature-flags/
 COPY packages/sentry/package.json ./packages/sentry/
 COPY packages/database/package.json ./packages/database/
+COPY packages/notifications/package.json ./packages/notifications/
 COPY services/reservations/package.json ./services/reservations/
 
 # Install all dependencies
@@ -31,6 +32,7 @@ COPY packages/observability/tsconfig.json ./packages/observability/
 COPY packages/feature-flags/tsconfig.json ./packages/feature-flags/
 COPY packages/sentry/tsconfig.json ./packages/sentry/
 COPY packages/database/tsconfig.json ./packages/database/
+COPY packages/notifications/tsconfig.json ./packages/notifications/
 COPY services/reservations/tsconfig.json ./services/reservations/
 
 # Copy Prisma schema (needed for db:generate)
@@ -44,6 +46,7 @@ COPY packages/observability/src ./packages/observability/src
 COPY packages/feature-flags/src ./packages/feature-flags/src
 COPY packages/sentry/src ./packages/sentry/src
 COPY packages/database/src ./packages/database/src
+COPY packages/notifications/src ./packages/notifications/src
 COPY services/reservations/src ./services/reservations/src
 
 # Build workspace packages and service in a single layer
@@ -80,6 +83,7 @@ COPY packages/observability/package.json ./packages/observability/
 COPY packages/feature-flags/package.json ./packages/feature-flags/
 COPY packages/sentry/package.json ./packages/sentry/
 COPY packages/database/package.json ./packages/database/
+COPY packages/notifications/package.json ./packages/notifications/
 COPY services/reservations/package.json ./services/reservations/
 
 # Install production dependencies only (Prisma client is copied from builder)
@@ -94,6 +98,7 @@ COPY --from=builder /app/packages/observability/dist ./packages/observability/di
 COPY --from=builder /app/packages/feature-flags/dist ./packages/feature-flags/dist
 COPY --from=builder /app/packages/sentry/dist ./packages/sentry/dist
 COPY --from=builder /app/packages/database/dist ./packages/database/dist
+COPY --from=builder /app/packages/notifications/src ./packages/notifications/src
 
 # Copy built reservations service
 COPY --from=builder /app/services/reservations/dist ./services/reservations/dist

--- a/services/reservations/llms-full.txt
+++ b/services/reservations/llms-full.txt
@@ -259,6 +259,41 @@
       );
     };
   </file>
+  <file path="src/routes/confirm-attendance.ts">
+    export const confirmAttendanceRoutes: FastifyPluginAsync = async (fastify) => {
+      fastify.patch<{ Querystring: { token?: string } }>(
+        "/public/v1/reservations/confirm",
+        async (request, reply) => {
+          const { token } = request.query;
+    
+          if (!token) {
+            return reply.status(401).type("text/html").send(invalidHtml);
+          }
+    
+          const result = verifyManageToken(token);
+    
+          if (!result.valid && result.expired) {
+            return reply.status(410).type("text/html").send(expiredHtml);
+          }
+    
+          if (!result.valid) {
+            return reply.status(401).type("text/html").send(invalidHtml);
+          }
+    
+          const reservation = await reservationService.getById(result.reservationId!);
+          if (!reservation) {
+            return reply.status(401).type("text/html").send(invalidHtml);
+          }
+    
+          if (reservation.status === "PENDING") {
+            await reservationService.update(result.reservationId!, { status: "CONFIRMED" });
+          }
+    
+          return reply.status(200).type("text/html").send(successHtml);
+        }
+      );
+    };
+  </file>
   <file path="src/routes/events.ts">
     class EventBuffer {
       private readonly maxSize: number;
@@ -1645,6 +1680,7 @@
     }
     export function verifyManageToken(token: string): {
       valid: boolean;
+      expired?: boolean;
       reservationId?: string;
       guestEmail?: string;
     } {
@@ -1661,7 +1697,7 @@
         if (signature !== expected) return { valid: false };
     
         const expiry = parseInt(expiryStr, 10);
-        if (Date.now() > expiry) return { valid: false };
+        if (Date.now() > expiry) return { valid: false, expired: true };
     
         return { valid: true, reservationId, guestEmail };
       } catch {
@@ -3677,6 +3713,26 @@
       success: boolean;
       hold?: ReservationHold;
       error?: string;
+    }
+  </file>
+  <file path="src/services/reminder.ts">
+    export async function findReservationsNeedingReminder() {
+      const now = new Date();
+      const windowStart = new Date(now.getTime() + 23 * 60 * 60 * 1000);
+      const windowEnd = new Date(now.getTime() + 25 * 60 * 60 * 1000);
+    
+      return prisma.reservation.findMany({
+        where: {
+          startTime: {
+            gte: windowStart,
+            lte: windowEnd,
+          },
+          status: { in: ["PENDING", "CONFIRMED"] },
+          reminderSentAt: null,
+          guestEmail: { not: null },
+        },
+        include: { venue: true },
+      });
     }
   </file>
   <file path="src/services/reservation.ts">

--- a/services/reservations/llms.txt
+++ b/services/reservations/llms.txt
@@ -28,6 +28,11 @@
       export const availabilityRoutes: FastifyPluginAsync;
     </item>
   </file>
+  <file path="src/routes/confirm-attendance.ts">
+    <item priority="high">
+      export const confirmAttendanceRoutes: FastifyPluginAsync;
+    </item>
+  </file>
   <file path="src/routes/events.ts">
     <item priority="medium">
       class EventBuffer {
@@ -86,6 +91,7 @@
     <item priority="high">
       export function verifyManageToken(token: string): {
         valid: boolean;
+        expired?: boolean;
         reservationId?: string;
         guestEmail?: string;
       } { /* ... */ }
@@ -229,6 +235,11 @@
         hold?: ReservationHold;
         error?: string;
       }
+    </item>
+  </file>
+  <file path="src/services/reminder.ts">
+    <item priority="high">
+      export async function findReservationsNeedingReminder() { /* ... */ }
     </item>
   </file>
   <file path="src/services/reservation.ts">

--- a/services/reservations/src/app.ts
+++ b/services/reservations/src/app.ts
@@ -27,6 +27,7 @@ import { publicVenueRoutes } from "./routes/public-venues.js";
 import { publicAvailabilityRoutes } from "./routes/public-availability.js";
 import { publicHoldRoutes } from "./routes/public-holds.js";
 import { publicReservationRoutes } from "./routes/public-reservations.js";
+import { confirmAttendanceRoutes } from "./routes/confirm-attendance.js";
 
 /**
  * Validates CORS origins from the CORS_ORIGINS env var against an allowlist.
@@ -195,6 +196,7 @@ export async function buildApp(options: AppOptions = {}): Promise<FastifyInstanc
   await fastify.register(publicAvailabilityRoutes, { prefix: "/public/v1/venues" });
   await fastify.register(publicHoldRoutes, { prefix: "/public/v1/venues" });
   await fastify.register(publicReservationRoutes, { prefix: "/public/v1/venues" });
+  await fastify.register(confirmAttendanceRoutes);
 
   return fastify;
 }

--- a/services/reservations/src/routes/confirm-attendance.test.ts
+++ b/services/reservations/src/routes/confirm-attendance.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from "vitest";
+import { buildApp } from "../app.js";
+import type { FastifyInstance } from "fastify";
+import { generateManageToken } from "./public-reservations.js";
+
+vi.mock("@mbe/notifications", () => {
+  class MockResendNotificationAdapter {
+    sendBookingConfirmation = vi.fn().mockResolvedValue(undefined);
+    sendBookingReminder = vi.fn().mockResolvedValue(undefined);
+    sendBookingModified = vi.fn().mockResolvedValue(undefined);
+    sendBookingCancelled = vi.fn().mockResolvedValue(undefined);
+  }
+  return { ResendNotificationAdapter: MockResendNotificationAdapter };
+});
+
+vi.mock("../services/reservation.js", () => ({
+  reservationService: {
+    getById: vi.fn(),
+    list: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    cancel: vi.fn(),
+  },
+}));
+
+vi.mock("../services/venue.js", () => ({
+  venueService: {
+    list: vi.fn(),
+    getById: vi.fn(),
+    getBySlug: vi.fn(),
+  },
+}));
+
+vi.mock("jose", () => ({
+  jwtVerify: vi.fn(),
+  createRemoteJWKSet: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("resend", () => ({
+  Resend: vi.fn().mockImplementation(() => ({
+    emails: { send: vi.fn().mockResolvedValue({ id: "email_1" }) },
+  })),
+}));
+
+import { reservationService } from "../services/reservation.js";
+
+const makePendingReservation = () => ({
+  id: "res_1",
+  venueId: "venue_1",
+  date: "2026-06-15",
+  startTime: "19:00",
+  endTime: "21:00",
+  partySize: 4,
+  guestName: "Jane Doe",
+  guestEmail: "jane@example.com",
+  guestPhone: null,
+  status: "PENDING",
+  notes: null,
+  cancellationReason: null,
+  cancellationNote: null,
+  guestId: null,
+  userId: null,
+  tableId: "table_1",
+  table: null,
+  createdAt: "2026-06-01T00:00:00Z",
+  updatedAt: "2026-06-01T00:00:00Z",
+});
+
+describe("PATCH /public/v1/reservations/confirm", () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.AUTH_BYPASS_IN_TESTS = "true";
+    app = await buildApp({ logger: false });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    delete process.env.AUTH_BYPASS_IN_TESTS;
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("confirms PENDING reservation and returns HTML success", async () => {
+    const token = generateManageToken("res_1", "jane@example.com");
+    vi.mocked(reservationService.getById).mockResolvedValueOnce(makePendingReservation() as never);
+    vi.mocked(reservationService.update).mockResolvedValueOnce({
+      ...makePendingReservation(),
+      status: "CONFIRMED",
+    } as never);
+
+    const response = await app.inject({
+      method: "PATCH",
+      url: `/public/v1/reservations/confirm?token=${token}`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers["content-type"]).toContain("text/html");
+    expect(response.body).toContain("confirmed");
+    expect(reservationService.update).toHaveBeenCalledWith("res_1", { status: "CONFIRMED" });
+  });
+
+  it("returns success for already-CONFIRMED reservation (idempotent)", async () => {
+    const token = generateManageToken("res_1", "jane@example.com");
+    vi.mocked(reservationService.getById).mockResolvedValueOnce({
+      ...makePendingReservation(),
+      status: "CONFIRMED",
+    } as never);
+
+    const response = await app.inject({
+      method: "PATCH",
+      url: `/public/v1/reservations/confirm?token=${token}`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers["content-type"]).toContain("text/html");
+    expect(response.body).toContain("confirmed");
+    expect(reservationService.update).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 HTML for invalid token", async () => {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/public/v1/reservations/confirm?token=garbage",
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(response.headers["content-type"]).toContain("text/html");
+  });
+
+  it("returns 410 HTML for expired token", async () => {
+    const { createHmac } = await import("crypto");
+    const secret = process.env.MANAGE_TOKEN_SECRET || "dev-secret-do-not-use-in-prod";
+    const expiry = Date.now() - 1000;
+    const payload = `res_1:jane@example.com:${expiry}`;
+    const signature = createHmac("sha256", secret).update(payload).digest("hex");
+    const expiredToken = Buffer.from(`${payload}:${signature}`).toString("base64url");
+
+    const response = await app.inject({
+      method: "PATCH",
+      url: `/public/v1/reservations/confirm?token=${expiredToken}`,
+    });
+
+    expect(response.statusCode).toBe(410);
+    expect(response.headers["content-type"]).toContain("text/html");
+  });
+});

--- a/services/reservations/src/routes/confirm-attendance.ts
+++ b/services/reservations/src/routes/confirm-attendance.ts
@@ -1,0 +1,67 @@
+import type { FastifyPluginAsync } from "fastify";
+import { verifyManageToken } from "./public-reservations.js";
+import { reservationService } from "../services/reservation.js";
+
+const successHtml = `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Attendance Confirmed</title>
+<style>body{font-family:system-ui,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;background:#f8f9fa}
+.card{text-align:center;padding:2rem;max-width:400px;background:#fff;border-radius:12px;box-shadow:0 2px 8px rgba(0,0,0,.08)}
+h1{color:#16a34a;margin:0 0 .5rem}p{color:#4b5563;margin:0}</style></head>
+<body><div class="card"><h1>Attendance confirmed</h1><p>Thanks for confirming! We look forward to seeing you.</p></div></body>
+</html>`;
+
+const invalidHtml = `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Invalid Link</title>
+<style>body{font-family:system-ui,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;background:#f8f9fa}
+.card{text-align:center;padding:2rem;max-width:400px;background:#fff;border-radius:12px;box-shadow:0 2px 8px rgba(0,0,0,.08)}
+h1{color:#dc2626;margin:0 0 .5rem}p{color:#4b5563;margin:0}</style></head>
+<body><div class="card"><h1>Invalid Link</h1><p>This confirmation link is invalid or has already been used.</p></div></body>
+</html>`;
+
+const expiredHtml = `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Link Expired</title>
+<style>body{font-family:system-ui,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;background:#f8f9fa}
+.card{text-align:center;padding:2rem;max-width:400px;background:#fff;border-radius:12px;box-shadow:0 2px 8px rgba(0,0,0,.08)}
+h1{color:#d97706;margin:0 0 .5rem}p{color:#4b5563;margin:0}</style></head>
+<body><div class="card"><h1>Link Expired</h1><p>This confirmation link has expired. Please contact the venue for assistance.</p></div></body>
+</html>`;
+
+export const confirmAttendanceRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.patch<{ Querystring: { token?: string } }>(
+    "/public/v1/reservations/confirm",
+    async (request, reply) => {
+      const { token } = request.query;
+
+      if (!token) {
+        return reply.status(401).type("text/html").send(invalidHtml);
+      }
+
+      const result = verifyManageToken(token);
+
+      if (!result.valid && result.expired) {
+        return reply.status(410).type("text/html").send(expiredHtml);
+      }
+
+      if (!result.valid) {
+        return reply.status(401).type("text/html").send(invalidHtml);
+      }
+
+      const reservation = await reservationService.getById(result.reservationId!);
+      if (!reservation) {
+        return reply.status(401).type("text/html").send(invalidHtml);
+      }
+
+      if (reservation.status === "PENDING") {
+        await reservationService.update(result.reservationId!, { status: "CONFIRMED" });
+      }
+
+      return reply.status(200).type("text/html").send(successHtml);
+    }
+  );
+};

--- a/services/reservations/src/routes/public-reservations.ts
+++ b/services/reservations/src/routes/public-reservations.ts
@@ -17,6 +17,7 @@ export function generateManageToken(reservationId: string, guestEmail: string): 
 
 export function verifyManageToken(token: string): {
   valid: boolean;
+  expired?: boolean;
   reservationId?: string;
   guestEmail?: string;
 } {
@@ -33,7 +34,7 @@ export function verifyManageToken(token: string): {
     if (signature !== expected) return { valid: false };
 
     const expiry = parseInt(expiryStr, 10);
-    if (Date.now() > expiry) return { valid: false };
+    if (Date.now() > expiry) return { valid: false, expired: true };
 
     return { valid: true, reservationId, guestEmail };
   } catch {

--- a/services/reservations/src/services/reminder.test.ts
+++ b/services/reservations/src/services/reminder.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { findReservationsNeedingReminder } from "./reminder.js";
+
+vi.mock("./database.js", () => ({
+  prisma: {
+    reservation: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "./database.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+});
+
+describe("findReservationsNeedingReminder", () => {
+  it("queries reservations 23-25h from now with PENDING/CONFIRMED status and no reminder sent", async () => {
+    vi.setSystemTime(new Date("2026-06-14T10:00:00Z"));
+    vi.mocked(prisma.reservation.findMany).mockResolvedValueOnce([]);
+
+    await findReservationsNeedingReminder();
+
+    expect(prisma.reservation.findMany).toHaveBeenCalledWith({
+      where: {
+        startTime: {
+          gte: new Date("2026-06-15T09:00:00Z"),
+          lte: new Date("2026-06-15T11:00:00Z"),
+        },
+        status: { in: ["PENDING", "CONFIRMED"] },
+        reminderSentAt: null,
+        guestEmail: { not: null },
+      },
+      include: { venue: true },
+    });
+  });
+
+  it("returns matched reservations", async () => {
+    vi.setSystemTime(new Date("2026-06-14T10:00:00Z"));
+    const mockReservations = [
+      { id: "res_1", guestEmail: "jane@example.com", startTime: new Date("2026-06-15T10:00:00Z") },
+    ];
+    vi.mocked(prisma.reservation.findMany).mockResolvedValueOnce(mockReservations as never);
+
+    const result = await findReservationsNeedingReminder();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("res_1");
+  });
+});

--- a/services/reservations/src/services/reminder.ts
+++ b/services/reservations/src/services/reminder.ts
@@ -1,0 +1,20 @@
+import { prisma } from "./database.js";
+
+export async function findReservationsNeedingReminder() {
+  const now = new Date();
+  const windowStart = new Date(now.getTime() + 23 * 60 * 60 * 1000);
+  const windowEnd = new Date(now.getTime() + 25 * 60 * 60 * 1000);
+
+  return prisma.reservation.findMany({
+    where: {
+      startTime: {
+        gte: windowStart,
+        lte: windowEnd,
+      },
+      status: { in: ["PENDING", "CONFIRMED"] },
+      reminderSentAt: null,
+      guestEmail: { not: null },
+    },
+    include: { venue: true },
+  });
+}


### PR DESCRIPTION
## Summary

- Adds `PATCH /public/v1/reservations/confirm?token=:token` — guest clicks "Confirm attendance" button in reminder email
- Returns HTML success/error pages (not JSON) since this is a guest-facing link
- Updates `verifyManageToken` to distinguish expired (410) vs invalid (401) tokens
- PENDING → CONFIRMED on valid token, idempotent for already-confirmed
- 4 tests covering happy path, idempotent, invalid, and expired cases

## Test plan

- [x] `pnpm --dir services/reservations test` — 444 tests pass
- [x] `pnpm --dir services/reservations typecheck` — clean
- [ ] Click confirm link with valid token → see "Attendance confirmed" page
- [ ] Click with expired token → see "Link Expired" page
- [ ] Click with invalid token → see "Invalid Link" page

Partial work toward #1425