### PR TITLE
fix(docker): add @mbe/sentry and @mbe/database to service Dockerfiles

### DIFF
--- a/infrastructure/worker/dep-graph.json
+++ b/infrastructure/worker/dep-graph.json
@@ -66,6 +66,11 @@
       "path": "packages/config"
     },
     {
+      "name": "@mbe/database",
+      "type": "package",
+      "path": "packages/database"
+    },
+    {
       "name": "@mbe/feature-flags",
       "type": "package",
       "path": "packages/feature-flags"
@@ -99,6 +104,11 @@
       "name": "@mbe/rialto-plugin",
       "type": "package",
       "path": "packages/rialto-plugin"
+    },
+    {
+      "name": "@mbe/sentry",
+      "type": "package",
+      "path": "packages/sentry"
     },
     {
       "name": "@mbe/types",
@@ -139,6 +149,11 @@
     },
     {
       "from": "@mbe/gen",
+      "to": "@mbe/sentry",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/gen",
       "to": "@mbe/config",
       "type": "devDependency"
     },
@@ -169,6 +184,11 @@
     },
     {
       "from": "@mbe/hospitality",
+      "to": "@mbe/sentry",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/hospitality",
       "to": "@mbe/config",
       "type": "devDependency"
     },
@@ -179,12 +199,22 @@
     },
     {
       "from": "@mbe/marketing",
+      "to": "@mbe/sentry",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/marketing",
       "to": "@mbe/config",
       "type": "devDependency"
     },
     {
       "from": "@mbe/rialto-web",
       "to": "@mbe/observability",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/rialto-web",
+      "to": "@mbe/sentry",
       "type": "dependency"
     },
     {
@@ -214,12 +244,22 @@
     },
     {
       "from": "@mbe/agent-service",
+      "to": "@mbe/sentry",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/agent-service",
       "to": "@mbe/rialto-catalog",
       "type": "dependency"
     },
     {
       "from": "@mbe/agent-service",
       "to": "@mbe/types",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/agent-service",
+      "to": "@mbe/database",
       "type": "dependency"
     },
     {
@@ -254,7 +294,17 @@
     },
     {
       "from": "@mbe/reservations-service",
+      "to": "@mbe/sentry",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/reservations-service",
       "to": "@mbe/types",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/reservations-service",
+      "to": "@mbe/database",
       "type": "dependency"
     },
     {
@@ -279,7 +329,17 @@
     },
     {
       "from": "@mbe/users-service",
+      "to": "@mbe/sentry",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/users-service",
       "to": "@mbe/types",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/users-service",
+      "to": "@mbe/database",
       "type": "dependency"
     },
     {
@@ -338,6 +398,11 @@
       "type": "devDependency"
     },
     {
+      "from": "@mbe/database",
+      "to": "@mbe/config",
+      "type": "devDependency"
+    },
+    {
       "from": "@mbe/feature-flags",
       "to": "@mbe/config",
       "type": "devDependency"
@@ -379,6 +444,16 @@
     },
     {
       "from": "@mbe/rialto-plugin",
+      "to": "@mbe/config",
+      "type": "devDependency"
+    },
+    {
+      "from": "@mbe/sentry",
+      "to": "@mbe/types",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/sentry",
       "to": "@mbe/config",
       "type": "devDependency"
     },

--- a/services/agent/Dockerfile
+++ b/services/agent/Dockerfile
@@ -18,6 +18,8 @@ COPY packages/agent-core/package.json ./packages/agent-core/
 COPY packages/observability/package.json ./packages/observability/
 COPY packages/rialto/package.json ./packages/rialto/
 COPY packages/rialto-catalog/package.json ./packages/rialto-catalog/
+COPY packages/sentry/package.json ./packages/sentry/
+COPY packages/database/package.json ./packages/database/
 COPY services/agent/package.json ./services/agent/
 
 # Install all dependencies
@@ -33,6 +35,8 @@ COPY packages/agent-core/tsconfig.json ./packages/agent-core/
 COPY packages/observability/tsconfig.json ./packages/observability/
 COPY packages/rialto/tsconfig.json packages/rialto/tsconfig.lib.json ./packages/rialto/
 COPY packages/rialto-catalog/tsconfig.json packages/rialto-catalog/tsconfig.build.json ./packages/rialto-catalog/
+COPY packages/sentry/tsconfig.json ./packages/sentry/
+COPY packages/database/tsconfig.json ./packages/database/
 COPY services/agent/tsconfig.json ./services/agent/
 
 # Copy Prisma schema (needed for db:generate)
@@ -49,6 +53,8 @@ COPY packages/rialto/src ./packages/rialto/src
 COPY packages/rialto/scripts ./packages/rialto/scripts
 COPY packages/rialto/vite.config.lib.ts ./packages/rialto/vite.config.lib.ts
 COPY packages/rialto-catalog/src ./packages/rialto-catalog/src
+COPY packages/sentry/src ./packages/sentry/src
+COPY packages/database/src ./packages/database/src
 COPY services/agent/src ./services/agent/src
 # Build workspace packages and service in a single layer
 RUN pnpm --filter @mbe/types build && \
@@ -59,6 +65,8 @@ RUN pnpm --filter @mbe/types build && \
     pnpm --filter @mbe/api-client build && \
     pnpm --filter @mattbutlerengineering/rialto build && \
     pnpm --filter @mbe/rialto-catalog build && \
+    pnpm --filter @mbe/sentry build && \
+    pnpm --filter @mbe/database build && \
     pnpm --filter @mbe/agent-service db:generate && \
     pnpm --filter @mbe/agent-service build
 
@@ -86,6 +94,8 @@ COPY packages/agent-core/package.json ./packages/agent-core/
 COPY packages/observability/package.json ./packages/observability/
 COPY packages/rialto/package.json ./packages/rialto/
 COPY packages/rialto-catalog/package.json ./packages/rialto-catalog/
+COPY packages/sentry/package.json ./packages/sentry/
+COPY packages/database/package.json ./packages/database/
 COPY services/agent/package.json ./services/agent/
 
 # Install production dependencies only (Prisma client is copied from builder)
@@ -101,6 +111,8 @@ COPY --from=builder /app/packages/agent-core/dist ./packages/agent-core/dist
 COPY --from=builder /app/packages/api-client/src ./packages/api-client/src
 COPY --from=builder /app/packages/rialto/dist ./packages/rialto/dist
 COPY --from=builder /app/packages/rialto-catalog/dist ./packages/rialto-catalog/dist
+COPY --from=builder /app/packages/sentry/dist ./packages/sentry/dist
+COPY --from=builder /app/packages/database/dist ./packages/database/dist
 
 # Copy built agent service
 COPY --from=builder /app/services/agent/dist ./services/agent/dist

--- a/services/reservations/.env.example
+++ b/services/reservations/.env.example
@@ -16,5 +16,8 @@ CORS_ORIGINS=http://localhost:3000
 AUTH_AUTHORITY=https://your-tenant.auth0.com
 AUTH_AUDIENCE=https://api.mattbutlerengineering.com
 
+# Guest self-service manage page
+# MANAGE_TOKEN_SECRET=change-me-in-production
+
 # Sentry (optional — omit to disable error tracking)
 # SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/0

--- a/services/reservations/Dockerfile
+++ b/services/reservations/Dockerfile
@@ -15,6 +15,8 @@ COPY packages/api-versioning/package.json ./packages/api-versioning/
 COPY packages/config/package.json ./packages/config/
 COPY packages/observability/package.json ./packages/observability/
 COPY packages/feature-flags/package.json ./packages/feature-flags/
+COPY packages/sentry/package.json ./packages/sentry/
+COPY packages/database/package.json ./packages/database/
 COPY services/reservations/package.json ./services/reservations/
 
 # Install all dependencies
@@ -27,6 +29,8 @@ COPY packages/api-versioning/tsconfig.json ./packages/api-versioning/
 COPY packages/config/typescript ./packages/config/typescript
 COPY packages/observability/tsconfig.json ./packages/observability/
 COPY packages/feature-flags/tsconfig.json ./packages/feature-flags/
+COPY packages/sentry/tsconfig.json ./packages/sentry/
+COPY packages/database/tsconfig.json ./packages/database/
 COPY services/reservations/tsconfig.json ./services/reservations/
 
 # Copy Prisma schema (needed for db:generate)
@@ -38,6 +42,8 @@ COPY packages/auth/src ./packages/auth/src
 COPY packages/api-versioning/src ./packages/api-versioning/src
 COPY packages/observability/src ./packages/observability/src
 COPY packages/feature-flags/src ./packages/feature-flags/src
+COPY packages/sentry/src ./packages/sentry/src
+COPY packages/database/src ./packages/database/src
 COPY services/reservations/src ./services/reservations/src
 
 # Build workspace packages and service in a single layer
@@ -46,6 +52,8 @@ RUN pnpm --filter @mbe/types build && \
     pnpm --filter @mbe/api-versioning build && \
     pnpm --filter @mbe/observability build && \
     pnpm --filter @mbe/feature-flags build && \
+    pnpm --filter @mbe/sentry build && \
+    pnpm --filter @mbe/database build && \
     pnpm --filter @mbe/reservations-service db:generate && \
     pnpm --filter @mbe/reservations-service build
 
@@ -70,6 +78,8 @@ COPY packages/api-versioning/package.json ./packages/api-versioning/
 COPY packages/config/package.json ./packages/config/
 COPY packages/observability/package.json ./packages/observability/
 COPY packages/feature-flags/package.json ./packages/feature-flags/
+COPY packages/sentry/package.json ./packages/sentry/
+COPY packages/database/package.json ./packages/database/
 COPY services/reservations/package.json ./services/reservations/
 
 # Install production dependencies only (Prisma client is copied from builder)
@@ -82,6 +92,8 @@ COPY --from=builder /app/packages/auth/dist ./packages/auth/dist
 COPY --from=builder /app/packages/api-versioning/dist ./packages/api-versioning/dist
 COPY --from=builder /app/packages/observability/dist ./packages/observability/dist
 COPY --from=builder /app/packages/feature-flags/dist ./packages/feature-flags/dist
+COPY --from=builder /app/packages/sentry/dist ./packages/sentry/dist
+COPY --from=builder /app/packages/database/dist ./packages/database/dist
 
 # Copy built reservations service
 COPY --from=builder /app/services/reservations/dist ./services/reservations/dist

--- a/services/users/Dockerfile
+++ b/services/users/Dockerfile
@@ -14,6 +14,8 @@ COPY packages/auth/package.json ./packages/auth/
 COPY packages/api-versioning/package.json ./packages/api-versioning/
 COPY packages/config/package.json ./packages/config/
 COPY packages/observability/package.json ./packages/observability/
+COPY packages/sentry/package.json ./packages/sentry/
+COPY packages/database/package.json ./packages/database/
 COPY services/users/package.json ./services/users/
 
 # Install all dependencies
@@ -25,6 +27,8 @@ COPY packages/auth/tsconfig.json ./packages/auth/
 COPY packages/api-versioning/tsconfig.json ./packages/api-versioning/
 COPY packages/config/typescript ./packages/config/typescript
 COPY packages/observability/tsconfig.json ./packages/observability/
+COPY packages/sentry/tsconfig.json ./packages/sentry/
+COPY packages/database/tsconfig.json ./packages/database/
 COPY services/users/tsconfig.json ./services/users/
 
 # Copy Prisma schema (needed for db:generate)
@@ -35,6 +39,8 @@ COPY packages/types/src ./packages/types/src
 COPY packages/auth/src ./packages/auth/src
 COPY packages/api-versioning/src ./packages/api-versioning/src
 COPY packages/observability/src ./packages/observability/src
+COPY packages/sentry/src ./packages/sentry/src
+COPY packages/database/src ./packages/database/src
 COPY services/users/src ./services/users/src
 
 # Build workspace packages and service in a single layer
@@ -42,6 +48,8 @@ RUN pnpm --filter @mbe/types build && \
     pnpm --filter @mbe/auth build && \
     pnpm --filter @mbe/api-versioning build && \
     pnpm --filter @mbe/observability build && \
+    pnpm --filter @mbe/sentry build && \
+    pnpm --filter @mbe/database build && \
     pnpm --filter @mbe/users-service db:generate && \
     pnpm --filter @mbe/users-service build
 
@@ -65,6 +73,8 @@ COPY packages/auth/package.json ./packages/auth/
 COPY packages/api-versioning/package.json ./packages/api-versioning/
 COPY packages/config/package.json ./packages/config/
 COPY packages/observability/package.json ./packages/observability/
+COPY packages/sentry/package.json ./packages/sentry/
+COPY packages/database/package.json ./packages/database/
 COPY services/users/package.json ./services/users/
 
 # Install production dependencies only (Prisma client is copied from builder)
@@ -76,6 +86,8 @@ COPY --from=builder /app/packages/types/dist ./packages/types/dist
 COPY --from=builder /app/packages/auth/dist ./packages/auth/dist
 COPY --from=builder /app/packages/api-versioning/dist ./packages/api-versioning/dist
 COPY --from=builder /app/packages/observability/dist ./packages/observability/dist
+COPY --from=builder /app/packages/sentry/dist ./packages/sentry/dist
+COPY --from=builder /app/packages/database/dist ./packages/database/dist
 
 # Copy built users service
 COPY --from=builder /app/services/users/dist ./services/users/dist


### PR DESCRIPTION
## Summary

- Add `@mbe/sentry` and `@mbe/database` COPY + build steps to all three service Dockerfiles (`users`, `reservations`, `agent`) — both packages are already in each service's `package.json` dependencies but were absent from the Docker build layers, causing `check-dockerfile-deps` to fail
- Add `MANAGE_TOKEN_SECRET` to `services/reservations/.env.example` — the variable is read in `src/routes/public-reservations.ts` but was undocumented, causing `check-env-sync` to fail

## Test plan

- [ ] `Dockerfile Lint` CI check passes
- [ ] `check-dockerfile-deps` passes in nightly compliance
- [ ] `check-env-sync` passes in nightly compliance
- [ ] Docker builds succeed for users, reservations, and agent services

Closes #1445

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tqx8FZA5PJdd1j25sLugH4)_