### PR TITLE
feat(reservations): self-service modify flow (time/date/party size)

### DIFF
--- a/services/reservations/llms-full.txt
+++ b/services/reservations/llms-full.txt
@@ -395,9 +395,7 @@
           }
     
           if (reservation.status === "PENDING") {
-            await reservationService.update(result.reservationId!, {
-              status: "CONFIRMED",
-            });
+            await reservationService.update(result.reservationId!, { status: "CONFIRMED" });
           }
     
           return reply.status(200).type("text/html").send(successHtml);
@@ -474,10 +472,7 @@
         }
       );
     
-      fastify.get<{
-        Params: { venueId: string };
-        Reply: ApiResponse<FloorPlan> | ApiError;
-      }>(
+      fastify.get<{ Params: { venueId: string }; Reply: ApiResponse<FloorPlan> | ApiError }>(
         "/venue/:venueId/active",
         {
           schema: {
@@ -501,10 +496,7 @@
         }
       );
     
-      fastify.get<{
-        Params: { id: string };
-        Reply: ApiResponse<FloorPlan> | ApiError;
-      }>(
+      fastify.get<{ Params: { id: string }; Reply: ApiResponse<FloorPlan> | ApiError }>(
         "/:id",
         {
           schema: {
@@ -526,10 +518,7 @@
         }
       );
     
-      fastify.post<{
-        Body: CreateFloorPlanRequest;
-        Reply: ApiResponse<FloorPlan> | ApiError;
-      }>(
+      fastify.post<{ Body: CreateFloorPlanRequest; Reply: ApiResponse<FloorPlan> | ApiError }>(
         "/",
         {
           preHandler: requireAuth,
@@ -553,10 +542,7 @@
         }
       );
     
-      fastify.post<{
-        Params: { id: string };
-        Reply: ApiResponse<FloorPlan> | ApiError;
-      }>(
+      fastify.post<{ Params: { id: string }; Reply: ApiResponse<FloorPlan> | ApiError }>(
         "/:id/clone",
         {
           preHandler: requireAuth,
@@ -615,10 +601,7 @@
         }
       );
     
-      fastify.post<{
-        Params: { id: string };
-        Reply: ApiResponse<FloorPlan> | ApiError;
-      }>(
+      fastify.post<{ Params: { id: string }; Reply: ApiResponse<FloorPlan> | ApiError }>(
         "/:id/activate",
         {
           preHandler: requireAuth,
@@ -723,10 +706,7 @@
         }
       );
     
-      fastify.post<{
-        Params: { tableId: string };
-        Reply: { data: Table } | ApiError;
-      }>(
+      fastify.post<{ Params: { tableId: string }; Reply: { data: Table } | ApiError }>(
         "/tables/:tableId/remove",
         {
           preHandler: requireAuth,
@@ -1170,11 +1150,7 @@
               .code(400)
               .send(createProblemDetails(400, "Bad Request", "Either email or phone is required"));
           }
-          const guest = await guestService.findOrCreate(venueId, {
-            email,
-            phone,
-            name,
-          });
+          const guest = await guestService.findOrCreate(venueId, { email, phone, name });
           return { data: guest };
         }
       );
@@ -1724,13 +1700,174 @@
                 notes: reservation.notes,
               },
               venue: venue
-                ? {
-                    id: venue.id,
-                    name: venue.name,
-                    slug: venue.slug,
-                    ianaTimezone: venue.ianaTimezone,
-                  }
+                ? { id: venue.id, name: venue.name, slug: venue.slug, ianaTimezone: venue.ianaTimezone }
                 : null,
+            },
+          });
+        }
+      );
+    };
+  </file>
+  <file path="src/routes/modify-reservation.ts">
+    interface ModifyBody {
+      date?: string;
+      startTime?: string;
+      endTime?: string;
+      partySize?: number;
+      specialRequests?: string;
+    }
+    export const modifyReservationRoutes: FastifyPluginAsync = async (fastify) => {
+      fastify.patch<{ Querystring: { token?: string }; Body: ModifyBody }>(
+        "/public/v1/reservations/manage",
+        {
+          config: {
+            rateLimit: { max: 10, timeWindow: "1 minute" },
+          },
+        },
+        async (request, reply) => {
+          const { token } = request.query;
+    
+          if (!token) {
+            return reply.status(400).send({
+              type: "about:blank",
+              title: "Missing Token",
+              status: 400,
+              detail: "Token query parameter is required",
+            });
+          }
+    
+          const result = verifyManageToken(token);
+    
+          if (!result.valid && result.expired) {
+            return reply.status(410).send({
+              type: "about:blank",
+              title: "Token Expired",
+              status: 410,
+              detail: "This manage link has expired",
+            });
+          }
+    
+          if (!result.valid) {
+            return reply.status(401).send({
+              type: "about:blank",
+              title: "Invalid Token",
+              status: 401,
+              detail: "Invalid or malformed token",
+            });
+          }
+    
+          const reservation = await reservationService.getById(result.reservationId!);
+          if (!reservation) {
+            return reply.status(404).send({
+              type: "about:blank",
+              title: "Reservation Not Found",
+              status: 404,
+              detail: "Reservation not found",
+            });
+          }
+    
+          if (reservation.status === "CANCELLED") {
+            return reply.status(409).send({
+              type: "about:blank",
+              title: "Cannot Modify",
+              status: 409,
+              detail: "Cannot modify a cancelled reservation",
+            });
+          }
+    
+          if (reservation.status === "COMPLETED") {
+            return reply.status(409).send({
+              type: "about:blank",
+              title: "Cannot Modify",
+              status: 409,
+              detail: "Cannot modify a completed reservation",
+            });
+          }
+    
+          const body = request.body ?? {};
+          const { date, startTime, endTime, partySize, specialRequests } = body;
+    
+          const hasChanges =
+            date !== undefined ||
+            startTime !== undefined ||
+            endTime !== undefined ||
+            partySize !== undefined ||
+            specialRequests !== undefined;
+    
+          if (!hasChanges) {
+            return reply.status(400).send({
+              type: "about:blank",
+              title: "No Changes",
+              status: 400,
+              detail: "At least one field must be provided to modify",
+            });
+          }
+    
+          const updateData = {
+            ...(date !== undefined && { date }),
+            ...(startTime !== undefined && { startTime }),
+            ...(endTime !== undefined && { endTime }),
+            ...(partySize !== undefined && { partySize }),
+            ...(specialRequests !== undefined && { notes: specialRequests }),
+          };
+    
+          const updateResult = await reservationService.updateWithConflictCheck(
+            reservation.id,
+            updateData
+          );
+    
+          if (!updateResult.success) {
+            if (updateResult.conflict) {
+              return reply.status(409).send({
+                type: "about:blank",
+                title: "Slot Unavailable",
+                status: 409,
+                detail: updateResult.error,
+              });
+            }
+            return reply.status(500).send({
+              type: "about:blank",
+              title: "Update Failed",
+              status: 500,
+              detail: updateResult.error ?? "Failed to modify reservation",
+            });
+          }
+    
+          const updated = updateResult.reservation!;
+          const venue = updated.venueId ? await venueService.getById(updated.venueId) : null;
+    
+          if (updated.guestEmail && venue) {
+            await notificationAdapter.sendBookingModified({
+              reservationId: updated.id,
+              date: updated.date,
+              startTime: updated.startTime,
+              endTime: updated.endTime,
+              partySize: updated.partySize,
+              guestName: updated.guestName,
+              guestEmail: updated.guestEmail,
+              guestPhone: updated.guestPhone ?? null,
+              specialRequests: updated.notes ?? null,
+              venueName: venue.name,
+              venueTimezone: venue.ianaTimezone,
+              venueAddress: null,
+              manageToken: token,
+              sequence: 2,
+            });
+          }
+    
+          return reply.status(200).send({
+            data: {
+              reservation: {
+                id: updated.id,
+                date: updated.date,
+                startTime: updated.startTime,
+                endTime: updated.endTime,
+                partySize: updated.partySize,
+                guestName: updated.guestName,
+                guestEmail: updated.guestEmail,
+                status: updated.status,
+                notes: updated.notes,
+              },
             },
           });
         }
@@ -1801,12 +1938,7 @@
     export const publicHoldRoutes: FastifyPluginAsync = async (fastify) => {
       fastify.post<{
         Params: { slug: string };
-        Body: {
-          date: string;
-          startTime: string;
-          endTime: string;
-          partySize: number;
-        };
+        Body: { date: string; startTime: string; endTime: string; partySize: number };
         Reply: ApiResponse<ReservationHold>;
       }>(
         "/:slug/holds",

--- a/services/reservations/llms.txt
+++ b/services/reservations/llms.txt
@@ -84,6 +84,20 @@
       export const manageReservationRoutes: FastifyPluginAsync;
     </item>
   </file>
+  <file path="src/routes/modify-reservation.ts">
+    <item priority="high">
+      interface ModifyBody {
+        date?: string;
+        startTime?: string;
+        endTime?: string;
+        partySize?: number;
+        specialRequests?: string;
+      }
+    </item>
+    <item priority="high">
+      export const modifyReservationRoutes: FastifyPluginAsync;
+    </item>
+  </file>
   <file path="src/routes/public-availability.ts">
     <item priority="high">
       export const publicAvailabilityRoutes: FastifyPluginAsync;

--- a/services/reservations/src/app.ts
+++ b/services/reservations/src/app.ts
@@ -30,6 +30,7 @@ import { publicReservationRoutes } from "./routes/public-reservations.js";
 import { confirmAttendanceRoutes } from "./routes/confirm-attendance.js";
 import { manageReservationRoutes } from "./routes/manage-reservation.js";
 import { cancelReservationRoutes } from "./routes/cancel-reservation.js";
+import { modifyReservationRoutes } from "./routes/modify-reservation.js";
 
 /**
  * Validates CORS origins from the CORS_ORIGINS env var against an allowlist.
@@ -39,9 +40,7 @@ import { cancelReservationRoutes } from "./routes/cancel-reservation.js";
 function validateCorsOrigins(origins: string[]): string[] {
   const validPatterns = [
     /^https:\/\/([a-z-]+\.)?mattbutlerengineering\.com$/,
-    ...(process.env.NODE_ENV === "development"
-      ? [/^http:\/\/localhost:\d+$/]
-      : []),
+    ...(process.env.NODE_ENV === "development" ? [/^http:\/\/localhost:\d+$/] : []),
   ];
 
   const validated: string[] = [];
@@ -50,9 +49,7 @@ function validateCorsOrigins(origins: string[]): string[] {
     if (validPatterns.some((p) => p.test(trimmed))) {
       validated.push(trimmed);
     } else {
-      console.warn(
-        `[CORS] Rejected invalid origin from CORS_ORIGINS: ${trimmed}`
-      );
+      console.warn(`[CORS] Rejected invalid origin from CORS_ORIGINS: ${trimmed}`);
     }
   }
   return validated;
@@ -65,9 +62,7 @@ export interface AppOptions {
 /**
  * Creates the Fastify application instance.
  */
-export async function buildApp(
-  options: AppOptions = {}
-): Promise<FastifyInstance> {
+export async function buildApp(options: AppOptions = {}): Promise<FastifyInstance> {
   const fastify = Fastify({
     logger: options.logger ?? true,
     disableRequestLogging: true,
@@ -101,13 +96,10 @@ export async function buildApp(
   const validatedEnv = envOrigins ? validateCorsOrigins(envOrigins) : null;
 
   if (validatedEnv && validatedEnv.length === 0) {
-    console.warn(
-      "[CORS] All CORS_ORIGINS were rejected; falling back to defaults"
-    );
+    console.warn("[CORS] All CORS_ORIGINS were rejected; falling back to defaults");
   }
 
-  const corsOrigins =
-    validatedEnv && validatedEnv.length > 0 ? validatedEnv : defaultOrigins;
+  const corsOrigins = validatedEnv && validatedEnv.length > 0 ? validatedEnv : defaultOrigins;
 
   await fastify.register(cors, {
     origin: corsOrigins,
@@ -132,10 +124,7 @@ export async function buildApp(
       const ip = req.ip;
       const endpoint = req.url;
       rateLimitMonitor.recordHit(ip, endpoint);
-      req.log.warn(
-        { ip, endpoint, timestamp: new Date().toISOString() },
-        "Rate limit exceeded"
-      );
+      req.log.warn({ ip, endpoint, timestamp: new Date().toISOString() }, "Rate limit exceeded");
     },
   });
 
@@ -178,9 +167,7 @@ export async function buildApp(
   if (process.env.AUTH_AUTHORITY && process.env.AUTH_AUDIENCE) {
     await fastify.register(authPlugin, getAuthPluginOptionsFromEnv());
   } else if (process.env.NODE_ENV === "production") {
-    throw new Error(
-      "Fail-closed: AUTH_AUTHORITY and AUTH_AUDIENCE are required in production"
-    );
+    throw new Error("Fail-closed: AUTH_AUTHORITY and AUTH_AUDIENCE are required in production");
   } else {
     fastify.log.warn("Skipping Auth0 plugin registration (dev/test mode)");
   }
@@ -221,6 +208,7 @@ export async function buildApp(
   await fastify.register(confirmAttendanceRoutes);
   await fastify.register(manageReservationRoutes);
   await fastify.register(cancelReservationRoutes);
+  await fastify.register(modifyReservationRoutes);
 
   return fastify;
 }

--- a/services/reservations/src/routes/modify-reservation.test.ts
+++ b/services/reservations/src/routes/modify-reservation.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import { buildApp } from "../app.js";
+import type { FastifyInstance } from "fastify";
+import { generateManageToken } from "./public-reservations.js";
+
+const { mockSendBookingModified } = vi.hoisted(() => ({
+  mockSendBookingModified: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@mbe/notifications", () => {
+  class MockResendNotificationAdapter {
+    sendBookingConfirmation = vi.fn().mockResolvedValue(undefined);
+    sendBookingReminder = vi.fn().mockResolvedValue(undefined);
+    sendBookingModified = mockSendBookingModified;
+    sendBookingCancelled = vi.fn().mockResolvedValue(undefined);
+  }
+  return { ResendNotificationAdapter: MockResendNotificationAdapter };
+});
+
+vi.mock("../services/reservation.js", () => ({
+  reservationService: {
+    getById: vi.fn(),
+    list: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    cancel: vi.fn(),
+    updateWithConflictCheck: vi.fn(),
+  },
+}));
+
+vi.mock("../services/venue.js", () => ({
+  venueService: {
+    list: vi.fn(),
+    getById: vi.fn(),
+    getBySlug: vi.fn(),
+  },
+}));
+
+vi.mock("jose", () => ({
+  jwtVerify: vi.fn(),
+  createRemoteJWKSet: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("resend", () => ({
+  Resend: vi.fn().mockImplementation(() => ({
+    emails: { send: vi.fn().mockResolvedValue({ id: "email_1" }) },
+  })),
+}));
+
+import { reservationService } from "../services/reservation.js";
+import { venueService } from "../services/venue.js";
+
+const mockReservation = {
+  id: "res_1",
+  venueId: "venue_1",
+  date: "2026-06-15",
+  startTime: "19:00",
+  endTime: "21:00",
+  partySize: 4,
+  guestName: "Jane Doe",
+  guestEmail: "jane@example.com",
+  guestPhone: "+1555000111",
+  status: "PENDING",
+  notes: "Window seat please",
+  cancellationReason: null,
+  cancellationNote: null,
+  guestId: null,
+  userId: null,
+  tableId: "table_1",
+  table: null,
+  createdAt: "2026-06-01T00:00:00Z",
+  updatedAt: "2026-06-01T00:00:00Z",
+};
+
+const mockVenue = {
+  id: "venue_1",
+  name: "The Oak Table",
+  slug: "the-oak-table",
+  ianaTimezone: "America/Los_Angeles",
+  address: "123 Oak St, Portland OR",
+};
+
+describe("PATCH /public/v1/reservations/manage", () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.AUTH_BYPASS_IN_TESTS = "true";
+    app = await buildApp({ logger: false });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    delete process.env.AUTH_BYPASS_IN_TESTS;
+  });
+
+  it("modifies reservation and returns 200 with updated data", async () => {
+    const token = generateManageToken("res_1", "jane@example.com");
+    const updatedReservation = {
+      ...mockReservation,
+      partySize: 6,
+      startTime: "20:00",
+    };
+
+    vi.mocked(reservationService.getById).mockResolvedValueOnce(mockReservation as never);
+    vi.mocked(reservationService.updateWithConflictCheck).mockResolvedValueOnce({
+      success: true,
+      reservation: updatedReservation,
+    } as never);
+    vi.mocked(venueService.getById).mockResolvedValueOnce(mockVenue as never);
+
+    const response = await app.inject({
+      method: "PATCH",
+      url: `/public/v1/reservations/manage?token=${token}`,
+      payload: { partySize: 6, startTime: "20:00" },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.data.reservation.partySize).toBe(6);
+    expect(body.data.reservation.startTime).toBe("20:00");
+  });
+
+  it("sends modified email with iCal sequence number", async () => {
+    const token = generateManageToken("res_1", "jane@example.com");
+    const updatedReservation = { ...mockReservation, partySize: 2 };
+
+    vi.mocked(reservationService.getById).mockResolvedValueOnce(mockReservation as never);
+    vi.mocked(reservationService.updateWithConflictCheck).mockResolvedValueOnce({
+      success: true,
+      reservation: updatedReservation,
+    } as never);
+    vi.mocked(venueService.getById).mockResolvedValueOnce(mockVenue as never);
+
+    await app.inject({
+      method: "PATCH",
+      url: `/public/v1/reservations/manage?token=${token}`,
+      payload: { partySize: 2 },
+    });
+
+    expect(mockSendBookingModified).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reservationId: "res_1",
+        guestEmail: "jane@example.com",
+        venueName: "The Oak Table",
+        sequence: 2,
+      })
+    );
+  });
+
+  it("returns 409 when time slot has conflict", async () => {
+    const token = generateManageToken("res_1", "jane@example.com");
+
+    vi.mocked(reservationService.getById).mockResolvedValueOnce(mockReservation as never);
+    vi.mocked(reservationService.updateWithConflictCheck).mockResolvedValueOnce({
+      success: false,
+      error: "Time slot has a conflict with an existing reservation or hold",
+      conflict: { hasConflict: true },
+    } as never);
+
+    const response = await app.inject({
+      method: "PATCH",
+      url: `/public/v1/reservations/manage?token=${token}`,
+      payload: { startTime: "18:00" },
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json().title).toBe("Slot Unavailable");
+  });
+
+  it("returns 409 for cancelled reservation", async () => {
+    const token = generateManageToken("res_1", "jane@example.com");
+
+    vi.mocked(reservationService.getById).mockResolvedValueOnce({
+      ...mockReservation,
+      status: "CANCELLED",
+    } as never);
+
+    const response = await app.inject({
+      method: "PATCH",
+      url: `/public/v1/reservations/manage?token=${token}`,
+      payload: { partySize: 2 },
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json().detail).toContain("cancelled");
+  });
+
+  it("returns 409 for completed reservation", async () => {
+    const token = generateManageToken("res_1", "jane@example.com");
+
+    vi.mocked(reservationService.getById).mockResolvedValueOnce({
+      ...mockReservation,
+      status: "COMPLETED",
+    } as never);
+
+    const response = await app.inject({
+      method: "PATCH",
+      url: `/public/v1/reservations/manage?token=${token}`,
+      payload: { partySize: 2 },
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json().detail).toContain("completed");
+  });
+
+  it("returns 400 when no fields provided", async () => {
+    const token = generateManageToken("res_1", "jane@example.com");
+
+    vi.mocked(reservationService.getById).mockResolvedValueOnce(mockReservation as never);
+
+    const response = await app.inject({
+      method: "PATCH",
+      url: `/public/v1/reservations/manage?token=${token}`,
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().detail).toContain("At least one field");
+  });
+
+  it("returns 400 when token is missing", async () => {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/public/v1/reservations/manage",
+      payload: { partySize: 2 },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it("returns 401 for invalid token", async () => {
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/public/v1/reservations/manage?token=garbage-token",
+      payload: { partySize: 2 },
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  it("returns 404 when reservation not found", async () => {
+    const token = generateManageToken("res_nonexistent", "jane@example.com");
+
+    vi.mocked(reservationService.getById).mockResolvedValueOnce(null as never);
+
+    const response = await app.inject({
+      method: "PATCH",
+      url: `/public/v1/reservations/manage?token=${token}`,
+      payload: { partySize: 2 },
+    });
+
+    expect(response.statusCode).toBe(404);
+  });
+
+  it("allows modifying special requests only", async () => {
+    const token = generateManageToken("res_1", "jane@example.com");
+    const updatedReservation = {
+      ...mockReservation,
+      notes: "No peanuts please",
+    };
+
+    vi.mocked(reservationService.getById).mockResolvedValueOnce(mockReservation as never);
+    vi.mocked(reservationService.updateWithConflictCheck).mockResolvedValueOnce({
+      success: true,
+      reservation: updatedReservation,
+    } as never);
+    vi.mocked(venueService.getById).mockResolvedValueOnce(mockVenue as never);
+
+    const response = await app.inject({
+      method: "PATCH",
+      url: `/public/v1/reservations/manage?token=${token}`,
+      payload: { specialRequests: "No peanuts please" },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().data.reservation.notes).toBe("No peanuts please");
+  });
+});

--- a/services/reservations/src/routes/modify-reservation.ts
+++ b/services/reservations/src/routes/modify-reservation.ts
@@ -1,0 +1,186 @@
+import type { FastifyPluginAsync } from "fastify";
+import { Resend } from "resend";
+import { verifyManageToken } from "./public-reservations.js";
+import { reservationService } from "../services/reservation.js";
+import { venueService } from "../services/venue.js";
+import { ResendNotificationAdapter } from "@mbe/notifications";
+
+const resendClient = process.env.RESEND_API_KEY
+  ? (new Resend(process.env.RESEND_API_KEY) as unknown as {
+      emails: {
+        send(payload: Record<string, unknown>): Promise<{ id: string }>;
+      };
+    })
+  : null;
+
+const notificationAdapter = new ResendNotificationAdapter({
+  resend: resendClient,
+  fromAddress: process.env.EMAIL_FROM ?? "reservations@mattbutlerengineering.com",
+  manageBaseUrl: process.env.MANAGE_BASE_URL ?? "https://mattbutlerengineering.com",
+});
+
+interface ModifyBody {
+  date?: string;
+  startTime?: string;
+  endTime?: string;
+  partySize?: number;
+  specialRequests?: string;
+}
+
+export const modifyReservationRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.patch<{ Querystring: { token?: string }; Body: ModifyBody }>(
+    "/public/v1/reservations/manage",
+    {
+      config: {
+        rateLimit: { max: 10, timeWindow: "1 minute" },
+      },
+    },
+    async (request, reply) => {
+      const { token } = request.query;
+
+      if (!token) {
+        return reply.status(400).send({
+          type: "about:blank",
+          title: "Missing Token",
+          status: 400,
+          detail: "Token query parameter is required",
+        });
+      }
+
+      const result = verifyManageToken(token);
+
+      if (!result.valid && result.expired) {
+        return reply.status(410).send({
+          type: "about:blank",
+          title: "Token Expired",
+          status: 410,
+          detail: "This manage link has expired",
+        });
+      }
+
+      if (!result.valid) {
+        return reply.status(401).send({
+          type: "about:blank",
+          title: "Invalid Token",
+          status: 401,
+          detail: "Invalid or malformed token",
+        });
+      }
+
+      const reservation = await reservationService.getById(result.reservationId!);
+      if (!reservation) {
+        return reply.status(404).send({
+          type: "about:blank",
+          title: "Reservation Not Found",
+          status: 404,
+          detail: "Reservation not found",
+        });
+      }
+
+      if (reservation.status === "CANCELLED") {
+        return reply.status(409).send({
+          type: "about:blank",
+          title: "Cannot Modify",
+          status: 409,
+          detail: "Cannot modify a cancelled reservation",
+        });
+      }
+
+      if (reservation.status === "COMPLETED") {
+        return reply.status(409).send({
+          type: "about:blank",
+          title: "Cannot Modify",
+          status: 409,
+          detail: "Cannot modify a completed reservation",
+        });
+      }
+
+      const body = request.body ?? {};
+      const { date, startTime, endTime, partySize, specialRequests } = body;
+
+      const hasChanges =
+        date !== undefined ||
+        startTime !== undefined ||
+        endTime !== undefined ||
+        partySize !== undefined ||
+        specialRequests !== undefined;
+
+      if (!hasChanges) {
+        return reply.status(400).send({
+          type: "about:blank",
+          title: "No Changes",
+          status: 400,
+          detail: "At least one field must be provided to modify",
+        });
+      }
+
+      const updateData = {
+        ...(date !== undefined && { date }),
+        ...(startTime !== undefined && { startTime }),
+        ...(endTime !== undefined && { endTime }),
+        ...(partySize !== undefined && { partySize }),
+        ...(specialRequests !== undefined && { notes: specialRequests }),
+      };
+
+      const updateResult = await reservationService.updateWithConflictCheck(
+        reservation.id,
+        updateData
+      );
+
+      if (!updateResult.success) {
+        if (updateResult.conflict) {
+          return reply.status(409).send({
+            type: "about:blank",
+            title: "Slot Unavailable",
+            status: 409,
+            detail: updateResult.error,
+          });
+        }
+        return reply.status(500).send({
+          type: "about:blank",
+          title: "Update Failed",
+          status: 500,
+          detail: updateResult.error ?? "Failed to modify reservation",
+        });
+      }
+
+      const updated = updateResult.reservation!;
+      const venue = updated.venueId ? await venueService.getById(updated.venueId) : null;
+
+      if (updated.guestEmail && venue) {
+        await notificationAdapter.sendBookingModified({
+          reservationId: updated.id,
+          date: updated.date,
+          startTime: updated.startTime,
+          endTime: updated.endTime,
+          partySize: updated.partySize,
+          guestName: updated.guestName,
+          guestEmail: updated.guestEmail,
+          guestPhone: updated.guestPhone ?? null,
+          specialRequests: updated.notes ?? null,
+          venueName: venue.name,
+          venueTimezone: venue.ianaTimezone,
+          venueAddress: null,
+          manageToken: token,
+          sequence: 2,
+        });
+      }
+
+      return reply.status(200).send({
+        data: {
+          reservation: {
+            id: updated.id,
+            date: updated.date,
+            startTime: updated.startTime,
+            endTime: updated.endTime,
+            partySize: updated.partySize,
+            guestName: updated.guestName,
+            guestEmail: updated.guestEmail,
+            status: updated.status,
+            notes: updated.notes,
+          },
+        },
+      });
+    }
+  );
+};


### PR DESCRIPTION
## Summary

- Adds `PATCH /public/v1/reservations/manage?token=:token` endpoint for guest self-service modification
- Accepts `date`, `startTime`, `endTime`, `partySize`, `specialRequests` in request body
- Uses `updateWithConflictCheck` to validate availability before updating
- Sends iCal `METHOD:REQUEST` email with `SEQUENCE:2` via `sendBookingModified`
- Per-route rate limit (10 req/min)
- 10 integration tests covering happy path, conflict detection, status guards, auth, and edge cases

## Test plan

- [x] Valid token + body → 200 with updated reservation data
- [x] Modified email sent with iCal sequence number
- [x] Conflicting time slot → 409 Slot Unavailable
- [x] Cancelled reservation → 409
- [x] Completed reservation → 409
- [x] Empty body → 400
- [x] Missing token → 400
- [x] Invalid token → 401
- [x] Reservation not found → 404
- [x] Special requests only modification → 200

Closes #1423