### PR TITLE
docs: consolidate RemoteTriggers to fit Max 5x plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,14 +84,15 @@ mbe up                                           # Start dev servers
 
 Managed at https://claude.ai/code/scheduled
 
-| Trigger                | Schedule (PT)                                                     |
-| ---------------------- | ----------------------------------------------------------------- |
-| `mbe-deep-audit`       | Mon 8:23am                                                        |
-| `mbe-light-audit`      | Tue-Sun 9:41am                                                    |
-| `mbe-issue-worker`     | Every 2h (includes CI monitoring)                                 |
-| `mbe-progress-tracker` | Daily 5:11pm                                                      |
-| `mbe-acmm-audit`       | Daily 10:00am (runs `/acmm-audit --apply --badge`)                |
-| `mbe-learning-loop`    | Daily 11:00am (sensor report → verify fixes → triage regressions) |
+| Trigger             | Schedule (PT)                                                     |
+| ------------------- | ----------------------------------------------------------------- |
+| `mbe-deep-audit`    | Mon 8:23am (weekly full site audit)                               |
+| `mbe-morning`       | Daily 9:03am (light audit + ACMM audit + issue-worker)            |
+| `mbe-midday`        | Daily 1:07pm (issue-worker + CI monitor)                          |
+| `mbe-evening`       | Daily 5:11pm (issue-worker + progress-tracker)                    |
+| `mbe-learning-loop` | Daily 11:00am (sensor report → verify fixes → triage regressions) |
+
+> **Max 5x plan**: 5 scheduled runs/day. The above fits exactly. `mbe-deep-audit` only fires Mon so Tue-Sun has 4 daily runs + headroom.
 
 ---
 


### PR DESCRIPTION
## Summary

- Consolidates 6 RemoteTriggers → 5 to fit within Max 5x plan (5 runs/day)
- Merges `mbe-light-audit` + `mbe-acmm-audit` + `mbe-issue-worker` → `mbe-morning` (daily 9:03am)
- Merges `mbe-issue-worker` + CI monitor → `mbe-midday` (daily 1:07pm)
- Merges `mbe-issue-worker` + `mbe-progress-tracker` → `mbe-evening` (daily 5:11pm)
- `mbe-deep-audit` (Mon only) and `mbe-learning-loop` (daily) unchanged

## Manual follow-up after merge

Update triggers at https://claude.ai/code/scheduled:
1. Delete: `mbe-light-audit`, `mbe-issue-worker`, `mbe-progress-tracker`, `mbe-acmm-audit`
2. Create: `mbe-morning`, `mbe-midday`, `mbe-evening` with combined prompts

## Test plan

- [x] CLAUDE.md trigger table updated
- [ ] Verify 5 triggers configured on claude.ai/code/scheduled (manual)
- [ ] Monitor for 3 days to confirm no limit hits

Closes #1433