### PR TITLE
fix(hospitality): pin AppBar/sidebar, scroll only content area

### DIFF
--- a/apps/hospitality/src/App.module.css
+++ b/apps/hospitality/src/App.module.css
@@ -36,6 +36,15 @@
   outline: none;
 }
 
+/* ── Authenticated layout (nav pinned, content scrolls) ── */
+
+.authLayout {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+}
+
 /* ── Footer ──────────────────────────────────── */
 
 .footer {

--- a/apps/hospitality/src/App.test.tsx
+++ b/apps/hospitality/src/App.test.tsx
@@ -79,4 +79,15 @@ describe("App", () => {
     const { container } = renderApp();
     expect(container.querySelector("footer")).toBeNull();
   });
+
+  it("wraps authenticated view in a flex column layout for scroll containment", () => {
+    vi.mocked(useAuth).mockReturnValue({
+      isLoading: false,
+      isAuthenticated: true,
+    } as any);
+    renderApp();
+    const wrapper = screen.getByTestId("auth-layout");
+    expect(wrapper).toBeDefined();
+    expect(wrapper.className).toContain("authLayout");
+  });
 });

--- a/apps/hospitality/src/App.tsx
+++ b/apps/hospitality/src/App.tsx
@@ -106,12 +106,12 @@ export function App() {
   }
 
   return (
-    <>
+    <div className={styles.authLayout} data-testid="auth-layout">
       {nav}
       <Suspense fallback={<LoadingPage />}>
         <Outlet />
       </Suspense>
-    </>
+    </div>
   );
 }
 

--- a/apps/hospitality/src/components/DashboardLayout.module.css
+++ b/apps/hospitality/src/components/DashboardLayout.module.css
@@ -23,7 +23,8 @@
 .root {
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  flex: 1;
+  min-height: 0;
   overflow: hidden;
   background: var(--rialto-surface);
   color: var(--rialto-text-primary);
@@ -130,8 +131,10 @@
 .content {
   flex: 1;
   min-width: 0;
+  min-height: 0;
   overflow-y: auto;
   padding: var(--rialto-space-lg);
+  padding-block-start: var(--rialto-space-xl);
   outline: none;
 }
 


### PR DESCRIPTION
## Summary

- Wraps authenticated view in `authLayout` (flex column, 100vh, overflow hidden) so GlobalNav stays fixed
- Changes DashboardLayout `.root` from `height: 100vh` to `flex: 1` to fill remaining space without double-viewport
- Adds `padding-block-start: xl` to `.content` for more breathing room below AppBar/breadcrumb
- Adds `min-height: 0` to flex children for proper overflow containment

## Before

Whole page scrolled — AppBar, sidebar, and content all moved together.

## After

AppBar pinned at top, sidebar pinned at left, only content area scrolls.

## Test plan

- [x] New test: authenticated view wrapped in `authLayout` class
- [x] All 726 hospitality tests pass
- [x] Typecheck clean
- [ ] Visual verification in browser (dev server)

Closes #1485