### PR TITLE
chore: audit and fix skill descriptions and triggers

### DIFF
--- a/.claude/skills/ci-monitor/SKILL.md
+++ b/.claude/skills/ci-monitor/SKILL.md
@@ -128,16 +128,20 @@ If everything is green, exit with: "CI is healthy. All recent runs passing, no P
 
 The CI pipeline (`.github/workflows/ci.yml`) has these jobs:
 
-| Job              | What It Checks                                               |
-| ---------------- | ------------------------------------------------------------ |
-| `lint-typecheck` | ESLint, TypeScript compilation, Prisma client generation     |
-| `build`          | Full monorepo build, registry.json validation, catalog drift |
-| `test`           | Vitest test suite with coverage                              |
-| `migrations`     | Prisma migrations against test PostgreSQL database           |
+| Job                  | What It Checks                                               |
+| -------------------- | ------------------------------------------------------------ |
+| `lint`               | ESLint across all packages                                   |
+| `typecheck`          | TypeScript compilation, Prisma client generation             |
+| `architecture-audit` | ADR compliance and dependency checks via `@mbe/cli`          |
+| `build`              | Full monorepo build, registry.json validation, catalog drift |
+| `test`               | Vitest test suite with coverage                              |
+| `migrations`         | Prisma migrations against test PostgreSQL database           |
 
 Common failure patterns:
 
-- **lint-typecheck**: Usually a missing `import type`, unused variable, or formatting issue
+- **lint**: Usually a missing `import type`, unused variable, or formatting issue
+- **typecheck**: Type errors, missing imports, wrong types
+- **architecture-audit**: ADR violations or forbidden dependency patterns
 - **build**: Often a missing export, broken dependency chain, or stale generated file
 - **test**: Snapshot mismatches, assertion failures from behavior changes, mock drift
 - **migrations**: Schema drift, migration ordering issues, SQL syntax errors

--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -35,7 +35,7 @@ Push to main
 
 ### 2. API Services (`deploy-services.yml`)
 
-**Trigger paths**: `services/users/**`, `services/reservations/**`, `services/agent/**`, `packages/types/**`, `packages/auth/**`, `packages/agent-core/**`
+**Trigger paths**: `services/users/**`, `services/reservations/**`, `services/agent/**`, `packages/types/**`, `packages/auth/**`, `packages/agent-core/**`, `packages/observability/**`
 
 **Mechanism**: Installs `doctl`, finds the `mattbutlerengineering-api` app by name, triggers `doctl apps create-deployment --wait`.
 

--- a/.claude/skills/new-adr/SKILL.md
+++ b/.claude/skills/new-adr/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: true
 
 # /new-adr — create an Architecture Decision Record
 
-Scaffolds a new ADR in `docs/adr/` following the format enforced by `scripts/check-adr.js` (run by the pre-commit hook).
+Scaffolds a new ADR in `docs/adr/` following the format enforced by `pnpm --filter @mbe/cli start check-adr` (run by the pre-commit hook).
 
 ## Steps
 

--- a/.claude/skills/new-service-route/SKILL.md
+++ b/.claude/skills/new-service-route/SKILL.md
@@ -30,7 +30,7 @@ fastify.post<{
 }>(
   "/:id/clone",
   {
-    preHandler: [fastify.requireAuth],
+    preHandler: requireAuth,
     schema: {
       summary: "Clone a floor plan",
       operationId: "cloneFloorPlan",

--- a/.claude/skills/new-service/SKILL.md
+++ b/.claude/skills/new-service/SKILL.md
@@ -65,22 +65,22 @@ services/<name>/
     "db:studio": "prisma studio"
   },
   "dependencies": {
-    "@fastify/cors": "^10.0.0",
+    "@fastify/cors": "^11.0.0",
     "@fastify/swagger": "^9.0.0",
     "@mbe/types": "workspace:*",
-    "@prisma/client": "^6.0.0",
-    "@scalar/fastify-api-reference": "^1.44.1",
-    "fastify": "^5.8.1",
+    "@prisma/client": "^7.0.0",
+    "@scalar/fastify-api-reference": "^1.55.0",
+    "fastify": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {
     "@mbe/config": "workspace:*",
     "@types/node": "^22.0.0",
-    "@vitest/coverage-v8": "^4.0.18",
-    "prisma": "^6.0.0",
+    "@vitest/coverage-v8": "catalog:",
+    "prisma": "^7.0.0",
     "tsx": "^4.19.0",
     "typescript": "^5.7.3",
-    "vitest": "^4.0.18"
+    "vitest": "catalog:"
   }
 }
 ```

--- a/.claude/skills/reservations-service/SKILL.md
+++ b/.claude/skills/reservations-service/SKILL.md
@@ -13,19 +13,25 @@ This skill provides patterns and workflows for developing the Reservations Servi
 **Framework**: Fastify v5 with TypeScript
 **Database**: PostgreSQL via Prisma
 **Auth**: Auth0 JWT verification with jose
-**Port**: 3002 (API docs at http://localhost:3002/docs)
+**Port**: 3004 (API docs at http://localhost:3004/docs)
 
 ### Key Files
 
-| File                          | Purpose                                           |
-| ----------------------------- | ------------------------------------------------- |
-| `src/app.ts`                  | Fastify app setup, plugin registration            |
-| `src/routes/tables.ts`        | Table CRUD endpoints (create/update require auth) |
-| `src/routes/reservations.ts`  | Reservation CRUD endpoints                        |
-| `src/services/table.ts`       | Table business logic (Prisma operations)          |
-| `src/services/reservation.ts` | Reservation business logic                        |
-| `src/schemas/index.ts`        | OpenAPI schema definitions                        |
-| `prisma/schema.prisma`        | Database schema                                   |
+| File                               | Purpose                                           |
+| ---------------------------------- | ------------------------------------------------- |
+| `src/app.ts`                       | Fastify app setup, plugin registration            |
+| `src/routes/tables.ts`             | Table CRUD endpoints (create/update require auth) |
+| `src/routes/reservations.ts`       | Reservation CRUD endpoints                        |
+| `src/routes/venues.ts`             | Venue CRUD endpoints                              |
+| `src/routes/floor-plans.ts`        | Floor plan CRUD endpoints                         |
+| `src/routes/guests.ts`             | Guest management endpoints                        |
+| `src/routes/availability.ts`       | Availability check endpoints                      |
+| `src/routes/holds.ts`              | Reservation hold endpoints                        |
+| `src/routes/cancel-reservation.ts` | Self-service cancellation endpoint                |
+| `src/services/table.ts`            | Table business logic (Prisma operations)          |
+| `src/services/reservation.ts`      | Reservation business logic                        |
+| `src/schemas/index.ts`             | OpenAPI schema definitions                        |
+| `prisma/schema.prisma`             | Database schema                                   |
 
 ## Adding New Endpoints
 
@@ -42,7 +48,7 @@ fastify.get<{
 }>(
   "/endpoint-path",
   {
-    preHandler: verifyAuth, // Add for protected routes
+    preHandler: requireAuth, // Add for protected routes
     schema: {
       summary: "Short action description",
       operationId: "uniqueOperationName",
@@ -83,7 +89,7 @@ This service uses two auth patterns:
 fastify.post<{ Body: CreateTableRequest; Reply: ApiResponse<Table> | ApiError }>(
   "/",
   {
-    preHandler: verifyAuth, // Requires valid JWT
+    preHandler: requireAuth, // Requires valid JWT
     schema: {
       security: [{ bearerAuth: [] }],
       // ...
@@ -166,7 +172,7 @@ pnpm test                              # Run all tests
 pnpm test:watch                        # Watch mode
 pnpm test:coverage                     # Coverage report
 npx vitest run src/routes/tables.test.ts  # Single file
-npx vitest --grep "POST /v1/tables"    # Match pattern
+npx vitest --grep "POST /api/v1/tables"    # Match pattern
 ```
 
 ### Test Structure Pattern
@@ -249,7 +255,7 @@ describe("Table Routes", () => {
 
     const response = await app.inject({
       method: "POST",
-      url: "/v1/tables",
+      url: "/api/v1/tables",
       headers: { authorization: "Bearer valid-token" },
       payload: { name: "Table 1", capacity: 4 },
     });
@@ -312,24 +318,24 @@ For schema changes, use the `prisma-migrations` skill.
 
 ### Tables
 
-| Method | Path             | Auth | Description                                   |
-| ------ | ---------------- | ---- | --------------------------------------------- |
-| GET    | `/v1/tables`     | No   | List tables (paginated, filter by activeOnly) |
-| GET    | `/v1/tables/:id` | No   | Get table by ID                               |
-| POST   | `/v1/tables`     | Yes  | Create table                                  |
-| PATCH  | `/v1/tables/:id` | Yes  | Update table                                  |
-| DELETE | `/v1/tables/:id` | Yes  | Delete table                                  |
+| Method | Path                 | Auth | Description                                   |
+| ------ | -------------------- | ---- | --------------------------------------------- |
+| GET    | `/api/v1/tables`     | No   | List tables (paginated, filter by activeOnly) |
+| GET    | `/api/v1/tables/:id` | No   | Get table by ID                               |
+| POST   | `/api/v1/tables`     | Yes  | Create table                                  |
+| PATCH  | `/api/v1/tables/:id` | Yes  | Update table                                  |
+| DELETE | `/api/v1/tables/:id` | Yes  | Delete table                                  |
 
 ### Reservations
 
-| Method | Path                   | Auth     | Description                                               |
-| ------ | ---------------------- | -------- | --------------------------------------------------------- |
-| GET    | `/v1/reservations`     | No       | List reservations (filter by date/status/tableId/venueId) |
-| GET    | `/v1/reservations/me`  | Yes      | Get current user's reservations                           |
-| GET    | `/v1/reservations/:id` | No       | Get reservation by ID                                     |
-| POST   | `/v1/reservations`     | Optional | Create reservation (guest or user)                        |
-| PATCH  | `/v1/reservations/:id` | No       | Update reservation                                        |
-| DELETE | `/v1/reservations/:id` | No       | Cancel reservation (sets status to CANCELLED)             |
+| Method | Path                       | Auth     | Description                                               |
+| ------ | -------------------------- | -------- | --------------------------------------------------------- |
+| GET    | `/api/v1/reservations`     | No       | List reservations (filter by date/status/tableId/venueId) |
+| GET    | `/api/v1/reservations/me`  | Yes      | Get current user's reservations                           |
+| GET    | `/api/v1/reservations/:id` | No       | Get reservation by ID                                     |
+| POST   | `/api/v1/reservations`     | Optional | Create reservation (guest or user)                        |
+| PATCH  | `/api/v1/reservations/:id` | No       | Update reservation                                        |
+| DELETE | `/api/v1/reservations/:id` | No       | Cancel reservation (sets status to CANCELLED)             |
 
 ### Health
 
@@ -355,7 +361,7 @@ pnpm typecheck # TypeScript
 
 ### Open API Docs
 
-Navigate to http://localhost:3002/docs for interactive Scalar API documentation.
+Navigate to http://localhost:3004/docs for interactive Scalar API documentation.
 
 ### Database Operations
 
@@ -415,7 +421,7 @@ All errors follow this structure:
 
 1. [ ] Add TypeScript types for Params/Body/Reply
 2. [ ] Include OpenAPI schema with summary, description, tags
-3. [ ] Add `preHandler: verifyAuth` or `optionalAuth` as needed
+3. [ ] Add `preHandler: requireAuth` or `optionalAuth` as needed
 4. [ ] Add `security: [{ bearerAuth: [] }]` if auth required
 5. [ ] Handle all error cases (400, 401, 404, 500)
 6. [ ] Add service method if new business logic needed

--- a/.claude/skills/users-service/SKILL.md
+++ b/.claude/skills/users-service/SKILL.md
@@ -40,7 +40,7 @@ fastify.get<{
 }>(
   "/endpoint-path",
   {
-    preHandler: verifyAuth, // Add for protected routes
+    preHandler: requireAuth, // Add for protected routes
     schema: {
       summary: "Short action description",
       operationId: "uniqueOperationName",
@@ -73,13 +73,13 @@ fastify.get<{
 
 ### Adding a Protected Endpoint
 
-Protected endpoints require JWT authentication. Add `preHandler: verifyAuth` and `security` schema:
+Protected endpoints require JWT authentication. Add `preHandler: requireAuth` and `security` schema:
 
 ```typescript
 fastify.get<{ Reply: ApiResponse<User> }>(
   "/me/profile",
   {
-    preHandler: verifyAuth, // JWT verification
+    preHandler: requireAuth, // JWT verification
     schema: {
       summary: "Get extended profile",
       operationId: "getExtendedProfile",
@@ -146,7 +146,7 @@ pnpm test                          # Run all tests
 pnpm test:watch                    # Watch mode
 pnpm test:coverage                 # Coverage report
 npx vitest run src/routes/users.test.ts  # Single file
-npx vitest --grep "GET /v1/users"  # Match pattern
+npx vitest --grep "GET /api/v1/users"  # Match pattern
 ```
 
 ### Test Structure Pattern
@@ -181,7 +181,7 @@ describe("User Routes", () => {
     vi.clearAllMocks();
   });
 
-  describe("GET /v1/users", () => {
+  describe("GET /api/v1/users", () => {
     it("should return paginated users", async () => {
       const mockUsers = [{ id: "1", email: "test@example.com" /* ... */ }];
 
@@ -192,7 +192,7 @@ describe("User Routes", () => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/v1/users",
+        url: "/api/v1/users",
       });
 
       expect(response.statusCode).toBe(200);
@@ -213,7 +213,7 @@ Mock the auth layer or test 401 responses:
 it("should return 401 without auth header", async () => {
   const response = await app.inject({
     method: "GET",
-    url: "/v1/users/me",
+    url: "/api/v1/users/me",
   });
 
   expect(response.statusCode).toBe(401);
@@ -233,7 +233,7 @@ AUTH_AUDIENCE=https://api.mattbutlerengineering.com
 
 1. Client gets JWT from Auth0
 2. Client sends `Authorization: Bearer <token>` header
-3. `verifyAuth` preHandler validates token via JWKS
+3. `requireAuth` preHandler validates token via JWKS
 4. `request.user` populated with user info from JWT claims
 
 ### JWT Payload Structure
@@ -281,16 +281,16 @@ For schema changes, use the `prisma-migrations` skill.
 
 ## API Endpoints Reference
 
-| Method | Path                       | Auth | Description                     |
-| ------ | -------------------------- | ---- | ------------------------------- |
-| GET    | `/v1/users`                | No   | List users (paginated)          |
-| GET    | `/v1/users/:id`            | No   | Get user by ID                  |
-| POST   | `/v1/users`                | No   | Create user                     |
-| PATCH  | `/v1/users/:id`            | No   | Update user                     |
-| DELETE | `/v1/users/:id`            | No   | Delete user                     |
-| GET    | `/v1/users/me`             | Yes  | Get current user (auto-creates) |
-| PATCH  | `/v1/users/me/preferences` | Yes  | Update preferences              |
-| GET    | `/health`                  | No   | Health check                    |
+| Method | Path                           | Auth | Description                     |
+| ------ | ------------------------------ | ---- | ------------------------------- |
+| GET    | `/api/v1/users`                | No   | List users (paginated)          |
+| GET    | `/api/v1/users/:id`            | No   | Get user by ID                  |
+| POST   | `/api/v1/users`                | No   | Create user                     |
+| PATCH  | `/api/v1/users/:id`            | No   | Update user                     |
+| DELETE | `/api/v1/users/:id`            | No   | Delete user                     |
+| GET    | `/api/v1/users/me`             | Yes  | Get current user (auto-creates) |
+| PATCH  | `/api/v1/users/me/preferences` | Yes  | Update preferences              |
+| GET    | `/health`                      | No   | Health check                    |
 
 ## Common Development Tasks
 
@@ -336,7 +336,7 @@ All errors follow this structure:
 
 1. [ ] Add TypeScript types for Params/Body/Reply
 2. [ ] Include OpenAPI schema with summary, description, tags
-3. [ ] Add `preHandler: verifyAuth` if protected
+3. [ ] Add `preHandler: requireAuth` if protected
 4. [ ] Add `security: [{ bearerAuth: [] }]` if protected
 5. [ ] Handle all error cases (400, 401, 404, 500)
 6. [ ] Add service method if new business logic needed


### PR DESCRIPTION
## Summary

Audited 45 skills (32 project + 13 global). Fixed 7 skills with stale references:

- **ci-monitor** — CI job names corrected
- **deploy** — missing trigger path added
- **new-adr** — stale script path → CLI command
- **new-service-route** — wrong auth preHandler pattern
- **new-service** — package versions updated (Prisma 6→7, cors 10→11, catalog entries)
- **reservations-service** — wrong port, stale auth patterns, API paths
- **users-service** — stale auth patterns, API paths

38 skills passed with no issues.

## Test plan

- [x] All file path references verified
- [x] All command references verified
- [x] No stale package names

Closes #1481