### PR TITLE
feat(hospitality): add full-page screenshots to E2E specs

### DIFF
--- a/.github/workflows/e2e-screenshots.yml
+++ b/.github/workflows/e2e-screenshots.yml
@@ -1,0 +1,42 @@
+name: E2E Screenshots
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/hospitality/**"
+  pull_request:
+    paths:
+      - "apps/hospitality/**"
+
+jobs:
+  screenshots:
+    name: Capture E2E Screenshots
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: pnpm/action-setup@a3252b7022e168dedd98d7f75d888cb28b5ea0c4 # v3
+        with:
+          version: 10
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "20"
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Install Playwright browsers
+        run: pnpm --dir apps/hospitality exec playwright install --with-deps chromium
+      - name: Build hospitality app
+        run: pnpm --dir apps/hospitality build
+      - name: Start preview server
+        run: pnpm --dir apps/hospitality preview --port 3002 &
+      - name: Wait for server
+        run: npx wait-on http://localhost:3002 --timeout 30000
+      - name: Run E2E tests
+        run: pnpm --dir apps/hospitality test:e2e
+      - name: Upload screenshots
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: e2e-screenshots
+          path: apps/hospitality/e2e/screenshots/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ test-results/
 # Playwright
 e2e/.auth/
 e2e/test-results/
+e2e/screenshots/
 .playwright-cli/
 
 # Lighthouse CI

--- a/apps/hospitality/e2e/auth.spec.ts
+++ b/apps/hospitality/e2e/auth.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "./fixtures.js";
 import { test as base } from "@playwright/test";
+// Screenshots saved to e2e/screenshots/{spec}-{state}.png on test run
 
 base.describe("Authentication — unauthenticated", () => {
   base("unauthenticated user sees login prompt", async ({ browser }) => {
@@ -11,6 +12,7 @@ base.describe("Authentication — unauthenticated", () => {
 
     await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
     await expect(page.getByTestId("dashboard-layout")).not.toBeVisible();
+    await page.screenshot({ path: "e2e/screenshots/auth-login.png", fullPage: true });
 
     await context.close();
   });
@@ -20,6 +22,7 @@ test.describe("Authentication — authenticated", () => {
   test("programmatic login loads dashboard", async ({ mockedPage }) => {
     await expect(mockedPage.getByTestId("dashboard-layout")).toBeVisible();
     await expect(mockedPage.getByRole("button", { name: "Sign In" })).not.toBeVisible();
+    await mockedPage.screenshot({ path: "e2e/screenshots/auth-dashboard.png", fullPage: true });
   });
 
   test("authenticated session persists across navigation", async ({ mockedPage }) => {

--- a/apps/hospitality/e2e/booking-widget.spec.ts
+++ b/apps/hospitality/e2e/booking-widget.spec.ts
@@ -1,10 +1,15 @@
 import { test, expect } from "./fixtures.js";
+// Screenshots saved to e2e/screenshots/{spec}-{state}.png on test run
 
 test.describe("Booking Widget demo page", () => {
   test("page loads with heading and description", async ({ mockedPage }) => {
     await mockedPage.goto("/booking-widget");
 
     await expect(mockedPage.getByRole("heading", { name: "Booking Widget" })).toBeVisible();
+    await mockedPage.screenshot({
+      path: "e2e/screenshots/booking-widget-loaded.png",
+      fullPage: true,
+    });
   });
 
   test("renders embed code section", async ({ mockedPage }) => {
@@ -15,6 +20,10 @@ test.describe("Booking Widget demo page", () => {
 
     const codeText = await codeBlock.textContent();
     expect(codeText).toContain("BookingWidget");
+    await mockedPage.screenshot({
+      path: "e2e/screenshots/booking-widget-embed.png",
+      fullPage: true,
+    });
   });
 
   test("shows venue selector or widget preview area", async ({ mockedPage }) => {

--- a/apps/hospitality/e2e/create-reservation.spec.ts
+++ b/apps/hospitality/e2e/create-reservation.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "./fixtures.js";
+// Screenshots saved to e2e/screenshots/{spec}-{state}.png on test run
 
 test.describe("CF-4: Reservation edit flow", () => {
   test("opens reservation detail sidebar", async ({ mockedPage }) => {
@@ -15,6 +16,10 @@ test.describe("CF-4: Reservation edit flow", () => {
 
     // Shows reservation info
     await expect(sidebar.getByText(/guest|party/i)).toBeVisible();
+    await mockedPage.screenshot({
+      path: "e2e/screenshots/create-reservation-sidebar.png",
+      fullPage: true,
+    });
   });
 
   test("opens edit drawer and shows current values", async ({ mockedPage }) => {
@@ -38,6 +43,10 @@ test.describe("CF-4: Reservation edit flow", () => {
     const partySizeInput = drawer.getByLabel(/party size/i);
     await expect(partySizeInput).toBeVisible();
     await expect(partySizeInput).not.toBeDisabled();
+    await mockedPage.screenshot({
+      path: "e2e/screenshots/create-reservation-drawer.png",
+      fullPage: true,
+    });
   });
 
   test("saves edited party size and verifies update", async ({ mockedPage }) => {
@@ -86,5 +95,9 @@ test.describe("CF-4: Reservation edit flow", () => {
 
     // Drawer closes without saving
     await expect(drawer).not.toBeVisible();
+    await mockedPage.screenshot({
+      path: "e2e/screenshots/create-reservation-cancelled.png",
+      fullPage: true,
+    });
   });
 });

--- a/apps/hospitality/e2e/floor-plan.spec.ts
+++ b/apps/hospitality/e2e/floor-plan.spec.ts
@@ -1,10 +1,12 @@
 import { test, expect } from "./fixtures.js";
+// Screenshots saved to e2e/screenshots/{spec}-{state}.png on test run
 
 test.describe("CF-4: Floor plan editor", () => {
   test("floor plans page shows cards", async ({ mockedPage }) => {
     await mockedPage.goto("/floor-plans");
 
     await expect(mockedPage.getByRole("heading", { name: "Floor Plans" })).toBeVisible();
+    await mockedPage.screenshot({ path: "e2e/screenshots/floor-plan-cards.png", fullPage: true });
   });
 
   test("can navigate to editor", async ({ mockedPage }) => {

--- a/apps/hospitality/e2e/guests.spec.ts
+++ b/apps/hospitality/e2e/guests.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "./fixtures.js";
+// Screenshots saved to e2e/screenshots/{spec}-{state}.png on test run
 
 test.describe("CF-7: Guest directory and search", () => {
   test("page loads with header and search input", async ({ mockedPage }) => {
@@ -8,6 +9,7 @@ test.describe("CF-7: Guest directory and search", () => {
 
     const searchInput = mockedPage.getByPlaceholder("Search guests...");
     await expect(searchInput).toBeVisible();
+    await mockedPage.screenshot({ path: "e2e/screenshots/guests-list.png", fullPage: true });
   });
 
   test("Add Guest button is visible", async ({ mockedPage }) => {
@@ -35,6 +37,10 @@ test.describe("CF-7: Guest directory and search", () => {
     await expect(
       mockedPage.getByText(/no guests found/i).or(mockedPage.getByText(/no guests yet/i))
     ).toBeVisible();
+    await mockedPage.screenshot({
+      path: "e2e/screenshots/guests-empty-search.png",
+      fullPage: true,
+    });
   });
 
   test("Add Guest dialog opens with required fields", async ({ mockedPage }) => {
@@ -47,6 +53,7 @@ test.describe("CF-7: Guest directory and search", () => {
 
     await expect(dialog.getByPlaceholder("Full name")).toBeVisible();
     await expect(dialog.getByPlaceholder("guest@example.com")).toBeVisible();
+    await mockedPage.screenshot({ path: "e2e/screenshots/guests-add-dialog.png", fullPage: true });
   });
 
   test("Add Guest dialog can be dismissed", async ({ mockedPage }) => {

--- a/apps/hospitality/e2e/onboarding.spec.ts
+++ b/apps/hospitality/e2e/onboarding.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "./fixtures.js";
+// Screenshots saved to e2e/screenshots/{spec}-{state}.png on test run
 
 test.describe("Venue onboarding wizard", () => {
   test("page loads with heading and step 1 (Basic Info)", async ({ mockedPage }) => {
@@ -7,6 +8,7 @@ test.describe("Venue onboarding wizard", () => {
     await expect(mockedPage.getByRole("heading", { name: "New Venue" })).toBeVisible();
     await expect(mockedPage.getByLabel("Venue Name")).toBeVisible();
     await expect(mockedPage.getByLabel("Slug")).toBeVisible();
+    await mockedPage.screenshot({ path: "e2e/screenshots/onboarding-step1.png", fullPage: true });
   });
 
   test("step 1 requires venue name before advancing", async ({ mockedPage }) => {
@@ -35,6 +37,7 @@ test.describe("Venue onboarding wizard", () => {
 
     await expect(mockedPage.getByLabel("Timezone")).toBeVisible();
     await expect(mockedPage.getByLabel("Currency")).toBeVisible();
+    await mockedPage.screenshot({ path: "e2e/screenshots/onboarding-step2.png", fullPage: true });
   });
 
   test("Back button returns to previous step", async ({ mockedPage }) => {
@@ -70,5 +73,9 @@ test.describe("Venue onboarding wizard", () => {
 
     await expect(mockedPage.getByRole("button", { name: /create venue/i })).toBeVisible();
     await expect(mockedPage.getByText("Basic Information")).toBeVisible();
+    await mockedPage.screenshot({
+      path: "e2e/screenshots/onboarding-complete.png",
+      fullPage: true,
+    });
   });
 });

--- a/apps/hospitality/e2e/reservations.spec.ts
+++ b/apps/hospitality/e2e/reservations.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "./fixtures.js";
+// Screenshots saved to e2e/screenshots/{spec}-{state}.png on test run
 
 test.describe("CF-6: Reservations page with filtering", () => {
   test("page loads with header and stats row", async ({ mockedPage }) => {
@@ -8,6 +9,7 @@ test.describe("CF-6: Reservations page with filtering", () => {
 
     const statsRow = mockedPage.locator('[role="status"]').first();
     await expect(statsRow).toBeVisible();
+    await mockedPage.screenshot({ path: "e2e/screenshots/reservations-list.png", fullPage: true });
   });
 
   test("displays status filter segments and search input", async ({ mockedPage }) => {
@@ -20,6 +22,10 @@ test.describe("CF-6: Reservations page with filtering", () => {
 
     const searchInput = mockedPage.getByRole("textbox");
     await expect(searchInput).toBeVisible();
+    await mockedPage.screenshot({
+      path: "e2e/screenshots/reservations-filters.png",
+      fullPage: true,
+    });
   });
 
   test("status filter updates list when Confirmed is selected", async ({ mockedPage }) => {
@@ -57,5 +63,6 @@ test.describe("CF-6: Reservations page with filtering", () => {
     await searchInput.fill("zzzzz-no-match-9999");
 
     await expect(mockedPage.getByText("No reservations")).toBeVisible();
+    await mockedPage.screenshot({ path: "e2e/screenshots/reservations-empty.png", fullPage: true });
   });
 });

--- a/apps/hospitality/e2e/settings.spec.ts
+++ b/apps/hospitality/e2e/settings.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "./fixtures.js";
+// Screenshots saved to e2e/screenshots/{spec}-{state}.png on test run
 
 test.describe("CF-10: Settings page and preferences persistence", () => {
   test("page loads with heading and appearance card", async ({ mockedPage }) => {
@@ -6,6 +7,7 @@ test.describe("CF-10: Settings page and preferences persistence", () => {
 
     await expect(mockedPage.getByRole("heading", { name: "Settings" })).toBeVisible();
     await expect(mockedPage.getByText("Appearance")).toBeVisible();
+    await mockedPage.screenshot({ path: "e2e/screenshots/settings-loaded.png", fullPage: true });
   });
 
   test("theme selector is visible with options", async ({ mockedPage }) => {
@@ -30,5 +32,9 @@ test.describe("CF-10: Settings page and preferences persistence", () => {
     await mockedPage.goto("/settings");
 
     await expect(mockedPage.getByText("Notifications")).toBeVisible();
+    await mockedPage.screenshot({
+      path: "e2e/screenshots/settings-notifications.png",
+      fullPage: true,
+    });
   });
 });

--- a/apps/hospitality/e2e/timeline-interaction.spec.ts
+++ b/apps/hospitality/e2e/timeline-interaction.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "./fixtures.js";
+// Screenshots saved to e2e/screenshots/{spec}-{state}.png on test run
 
 test.describe("CF-2: Timeline loads and displays reservations", () => {
   test("loads timeline with reservation grid", async ({ mockedPage }) => {
@@ -17,6 +18,10 @@ test.describe("CF-2: Timeline loads and displays reservations", () => {
     // Table rows are visible in the grid
     const tableRows = mockedPage.getByTestId(/^table-row-/);
     await expect(tableRows.first()).toBeVisible();
+    await mockedPage.screenshot({
+      path: "e2e/screenshots/timeline-interaction-grid.png",
+      fullPage: true,
+    });
   });
 
   test("venue selector visible for multi-venue", async ({ mockedPage }) => {
@@ -35,6 +40,10 @@ test.describe("CF-2: Timeline loads and displays reservations", () => {
     // Date navigation shows today's date
     const dateNav = mockedPage.getByTestId("date-navigation");
     await expect(dateNav).toBeVisible();
+    await mockedPage.screenshot({
+      path: "e2e/screenshots/timeline-interaction-date-nav.png",
+      fullPage: true,
+    });
   });
 
   test("reservation blocks are color-coded by status", async ({ mockedPage }) => {

--- a/apps/hospitality/e2e/timeline.spec.ts
+++ b/apps/hospitality/e2e/timeline.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "./fixtures.js";
+// Screenshots saved to e2e/screenshots/{spec}-{state}.png on test run
 
 test.describe("CF-2: Timeline loads and displays reservations", () => {
   test("timeline page loads with grid", async ({ mockedPage }) => {
@@ -6,6 +7,7 @@ test.describe("CF-2: Timeline loads and displays reservations", () => {
 
     await expect(mockedPage.getByRole("heading", { name: "Timeline" })).toBeVisible();
     await expect(mockedPage.getByText("Live")).toBeVisible();
+    await mockedPage.screenshot({ path: "e2e/screenshots/timeline-loaded.png", fullPage: true });
   });
 
   test("timeline shows date navigation", async ({ mockedPage }) => {
@@ -13,5 +15,6 @@ test.describe("CF-2: Timeline loads and displays reservations", () => {
 
     await expect(mockedPage.getByRole("button", { name: /Previous day/i })).toBeVisible();
     await expect(mockedPage.getByRole("button", { name: /Next day/i })).toBeVisible();
+    await mockedPage.screenshot({ path: "e2e/screenshots/timeline-date-nav.png", fullPage: true });
   });
 });

--- a/apps/hospitality/e2e/walkin.spec.ts
+++ b/apps/hospitality/e2e/walkin.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "./fixtures.js";
+// Screenshots saved to e2e/screenshots/{spec}-{state}.png on test run
 
 test.describe("CF-3: Walk-in creation", () => {
   test("opens walk-in dialog and lists available tables", async ({ mockedPage }) => {
@@ -19,6 +20,7 @@ test.describe("CF-3: Walk-in creation", () => {
     // Available tables are listed
     const tableList = dialog.getByTestId(/^table-list-/);
     await expect(tableList.first()).toBeVisible();
+    await mockedPage.screenshot({ path: "e2e/screenshots/walkin-dialog.png", fullPage: true });
   });
 
   test("creates walk-in and verifies timeline update", async ({ mockedPage }) => {
@@ -70,5 +72,6 @@ test.describe("CF-3: Walk-in creation", () => {
 
     // Dialog closes, no reservation created
     await expect(dialog).not.toBeVisible();
+    await mockedPage.screenshot({ path: "e2e/screenshots/walkin-cancelled.png", fullPage: true });
   });
 });


### PR DESCRIPTION
## Summary

- Add 25 `page.screenshot({ fullPage: true })` calls across all 11 E2E spec files in `apps/hospitality/e2e/`
- Gitignore `e2e/screenshots/` (added to root `.gitignore` alongside existing `e2e/.auth/` and `e2e/test-results/` entries)
- Add `.github/workflows/e2e-screenshots.yml` — triggers on hospitality path changes, builds app, starts preview server, runs E2E, uploads screenshots as 30-day artifact

## Screenshot coverage

| Spec | Count | States captured |
|------|-------|----------------|
| auth | 2 | login page, dashboard |
| onboarding | 3 | step 1, step 2, confirmation |
| timeline | 2 | loaded with grid, date nav |
| reservations | 3 | list view, filters, empty state |
| create-reservation | 3 | sidebar, edit drawer, cancelled |
| guests | 3 | list, add dialog, empty search |
| floor-plan | 1 | cards view |
| settings | 2 | loaded, notifications |
| walkin | 2 | dialog open, cancelled |
| booking-widget | 2 | loaded, embed code |
| timeline-interaction | 2 | grid, date nav |
| **Total** | **25** | |

## Test plan

- [ ] CI E2E Screenshots workflow triggers on hospitality file changes
- [ ] Screenshots artifact appears in GH Actions run summary
- [ ] 25 screenshots present in artifact
- [ ] `e2e/screenshots/` not committed to repo

Closes #1486

---
_Generated by [Claude Code](https://claude.ai/code/session_01F9dpLEgfjiSunSnaME84A6)_