### PR TITLE
fix(hospitality): replace broken widget.js embed with coming-soon placeholder

### DIFF
--- a/apps/hospitality/src/pages/BookingWidgetDemoPage.test.tsx
+++ b/apps/hospitality/src/pages/BookingWidgetDemoPage.test.tsx
@@ -65,7 +65,11 @@ vi.mock("@mattbutlerengineering/rialto", () => ({
       {children}
     </button>
   ),
-  Card: ({ children }: any) => <div data-testid="card">{children}</div>,
+  Card: ({ children, "data-testid": dataTestId, ...rest }: any) => (
+    <div data-testid={dataTestId ?? "card"} {...rest}>
+      {children}
+    </div>
+  ),
   Divider: () => <hr data-testid="divider" />,
   SegmentedControl: ({ segments, value, onChange }: any) => (
     <div data-testid="segmented-control">
@@ -274,5 +278,37 @@ describe("BookingWidgetDemoPage", () => {
 
     const calledWith = writeText.mock.calls[0][0] as string;
     expect(calledWith).toContain("v-1");
+  });
+
+  it("embed code section shows a coming soon indicator", async () => {
+    render(<BookingWidgetDemoPage />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Copy")).toBeDefined();
+    });
+
+    expect(screen.getByTestId("embed-coming-soon")).toBeDefined();
+  });
+
+  it("embed code section does not reference widget.js", async () => {
+    render(<BookingWidgetDemoPage />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Copy")).toBeDefined();
+    });
+
+    expect(document.body.innerHTML).not.toContain("widget.js");
+  });
+
+  it("page renders correctly with coming soon section visible", async () => {
+    render(<BookingWidgetDemoPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("page-header")).toBeDefined();
+    });
+
+    expect(screen.getByTestId("embed-coming-soon")).toBeDefined();
+    const comingSoonTexts = screen.getAllByText(/embeddable widget/i);
+    expect(comingSoonTexts.length).toBeGreaterThan(0);
   });
 });

--- a/apps/hospitality/src/pages/BookingWidgetDemoPage.tsx
+++ b/apps/hospitality/src/pages/BookingWidgetDemoPage.tsx
@@ -149,9 +149,9 @@ export function BookingWidgetDemoPage() {
   const embedCode = useMemo(() => {
     const venueIdValue = selectedVenueId ?? "YOUR_VENUE_ID";
     const maxParty = selectedVenue?.settings?.maxPartySize ?? 8;
-    return `<!-- Add to your website -->
+    return `<!-- embeddable widget — coming soon -->
+<!-- When available, add it to your website like this: -->
 <div id="booking-widget"></div>
-<script src="https://mattbutlerengineering.com/widget.js"></script>
 <script>
   BookingWidget.init({
     container: '#booking-widget',
@@ -257,25 +257,31 @@ export function BookingWidgetDemoPage() {
             Embed Code
           </Text>
 
-          <Card variant="flat" className={styles.codeCard}>
-            <div className={styles.codeHeader}>
-              <Text variant="caption" color="tertiary">
-                HTML
-              </Text>
-              <Button variant="ghost" size="sm" onClick={handleCopy}>
-                {copied ? "Copied!" : "Copy"}
-              </Button>
-            </div>
-            <div className={styles.codeBlock}>
-              <pre className={styles.codeBlockPre}>
-                <code>{highlightEmbedCode(embedCode)}</code>
-              </pre>
-            </div>
+          <Card variant="flat" className={styles.codeCard} data-testid="embed-coming-soon">
+            <Stack gap="md">
+              <Alert variant="info">
+                The embeddable widget is currently in development. Embed code will be available
+                here once the widget is released.
+              </Alert>
+              <div className={styles.codeHeader}>
+                <Text variant="caption" color="tertiary">
+                  Preview (Coming Soon)
+                </Text>
+                <Button variant="ghost" size="sm" onClick={handleCopy}>
+                  {copied ? "Copied!" : "Copy"}
+                </Button>
+              </div>
+              <div className={styles.codeBlock}>
+                <pre className={styles.codeBlockPre}>
+                  <code>{highlightEmbedCode(embedCode)}</code>
+                </pre>
+              </div>
+            </Stack>
           </Card>
 
           <Text variant="caption" color="secondary">
-            The widget can be embedded on any website. Styles are self-contained and will not
-            conflict with your existing CSS.
+            The embeddable widget will allow guests to book directly from your website. Styles
+            will be self-contained and will not conflict with your existing CSS.
           </Text>
         </Stack>
       </section>


### PR DESCRIPTION
## Summary

- Removes the broken `widget.js` script src from the embed code snippet on BookingWidgetDemoPage
- Replaces the embed code section with a Coming Soon Alert and a preview-only snippet (no non-existent URL)
- Adds 3 new tests verifying: coming-soon indicator is present, no `widget.js` reference in DOM, and page renders correctly

Closes #1499

## Test plan

- [x] `embed code section shows a coming soon indicator` — `data-testid="embed-coming-soon"` present
- [x] `embed code section does not reference widget.js` — `widget.js` absent from rendered output
- [x] `page renders correctly with coming soon section visible` — page header + coming-soon section visible
- [x] All 13 BookingWidgetDemoPage tests pass
- [x] Full suite: 729 tests / 57 files pass
- [x] `pnpm typecheck` passes on hospitality