### PR TITLE
fix(hospitality): replace raw fetch with @mbe/api-client in SystemHealthBadge

### DIFF
--- a/apps/hospitality/src/components/SystemHealthBadge.test.tsx
+++ b/apps/hospitality/src/components/SystemHealthBadge.test.tsx
@@ -1,12 +1,17 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { render, screen, waitFor, act } from "@testing-library/react";
 import { SystemHealthBadge } from "./SystemHealthBadge.js";
 import { useAuth } from "@mbe/auth/react";
+import { useApiClient } from "../hooks/useApiClient.js";
 import React from "react";
 
 vi.mock("@mbe/auth/react", () => ({
   useAuth: vi.fn(),
+}));
+
+vi.mock("../hooks/useApiClient.js", () => ({
+  useApiClient: vi.fn(),
 }));
 
 vi.mock("@mattbutlerengineering/rialto", () => ({
@@ -15,13 +20,31 @@ vi.mock("@mattbutlerengineering/rialto", () => ({
       {children}
     </span>
   ),
+  Button: ({
+    children,
+    ...props
+  }: { children: React.ReactNode } & React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
   Popover: ({ trigger, children }: { trigger: React.ReactNode; children: React.ReactNode }) => (
     <div data-testid="popover">
       {trigger}
       <div data-testid="popover-content">{children}</div>
     </div>
   ),
+  Text: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <span className={className}>{children}</span>
+  ),
 }));
+
+function makeApiClient(overrides: Record<string, unknown> = {}) {
+  return {
+    health: {
+      getSystemHealth: vi.fn(),
+    },
+    ...overrides,
+  };
+}
 
 describe("SystemHealthBadge", () => {
   afterEach(() => {
@@ -32,6 +55,7 @@ describe("SystemHealthBadge", () => {
     vi.mocked(useAuth).mockReturnValue({
       user: { raw: { permissions: [] } },
     } as any);
+    vi.mocked(useApiClient).mockReturnValue(makeApiClient() as any);
 
     const { container } = render(<SystemHealthBadge />);
     expect(container.innerHTML).toBe("");
@@ -41,6 +65,7 @@ describe("SystemHealthBadge", () => {
     vi.mocked(useAuth).mockReturnValue({
       user: { raw: {} },
     } as any);
+    vi.mocked(useApiClient).mockReturnValue(makeApiClient() as any);
 
     const { container } = render(<SystemHealthBadge />);
     expect(container.innerHTML).toBe("");
@@ -50,9 +75,35 @@ describe("SystemHealthBadge", () => {
     vi.mocked(useAuth).mockReturnValue({
       user: null,
     } as any);
+    vi.mocked(useApiClient).mockReturnValue(makeApiClient() as any);
 
     const { container } = render(<SystemHealthBadge />);
     expect(container.innerHTML).toBe("");
+  });
+
+  it("uses useApiClient hook instead of raw fetch", async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: { raw: { permissions: ["admin"] } },
+    } as any);
+
+    const mockGetSystemHealth = vi.fn().mockResolvedValue({
+      status: "healthy",
+      timestamp: "2026-01-15T12:00:00Z",
+    });
+    vi.mocked(useApiClient).mockReturnValue(
+      makeApiClient({ health: { getSystemHealth: mockGetSystemHealth } }) as any
+    );
+
+    await act(async () => {
+      render(<SystemHealthBadge />);
+    });
+
+    await waitFor(() => {
+      expect(mockGetSystemHealth).toHaveBeenCalled();
+    });
+
+    // Verify useApiClient hook was called (not raw fetch)
+    expect(useApiClient).toHaveBeenCalled();
   });
 
   it("fetches health data for admin users and renders badge", async () => {
@@ -71,10 +122,10 @@ describe("SystemHealthBadge", () => {
       deploy: { status: "healthy" },
     };
 
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve(healthData),
-    });
+    const mockGetSystemHealth = vi.fn().mockResolvedValue(healthData);
+    vi.mocked(useApiClient).mockReturnValue(
+      makeApiClient({ health: { getSystemHealth: mockGetSystemHealth } }) as any
+    );
 
     await act(async () => {
       render(<SystemHealthBadge />);
@@ -100,7 +151,10 @@ describe("SystemHealthBadge", () => {
       user: { raw: { permissions: ["admin"] } },
     } as any);
 
-    global.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+    const mockGetSystemHealth = vi.fn().mockRejectedValue(new Error("Network error"));
+    vi.mocked(useApiClient).mockReturnValue(
+      makeApiClient({ health: { getSystemHealth: mockGetSystemHealth } }) as any
+    );
 
     await act(async () => {
       render(<SystemHealthBadge />);
@@ -110,15 +164,17 @@ describe("SystemHealthBadge", () => {
     expect(screen.queryByTestId("popover")).toBeNull();
   });
 
-  it("handles non-ok response silently", async () => {
+  it("handles API error silently", async () => {
     vi.mocked(useAuth).mockReturnValue({
       user: { raw: { permissions: ["admin"] } },
     } as any);
 
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: false,
-      status: 500,
-    });
+    const mockGetSystemHealth = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error("500 Service Unavailable"), { statusCode: 500 }));
+    vi.mocked(useApiClient).mockReturnValue(
+      makeApiClient({ health: { getSystemHealth: mockGetSystemHealth } }) as any
+    );
 
     await act(async () => {
       render(<SystemHealthBadge />);
@@ -137,10 +193,10 @@ describe("SystemHealthBadge", () => {
       timestamp: "2026-01-15T12:00:00Z",
     };
 
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve(healthData),
-    });
+    const mockGetSystemHealth = vi.fn().mockResolvedValue(healthData);
+    vi.mocked(useApiClient).mockReturnValue(
+      makeApiClient({ health: { getSystemHealth: mockGetSystemHealth } }) as any
+    );
 
     await act(async () => {
       render(<SystemHealthBadge />);
@@ -152,5 +208,42 @@ describe("SystemHealthBadge", () => {
 
     expect(screen.queryByText("CI")).toBeNull();
     expect(screen.queryByText("Deploys")).toBeNull();
+  });
+});
+
+describe("SystemHealthBadge — polling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("polls health every 60 seconds", async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: { raw: { permissions: ["admin"] } },
+    } as any);
+
+    const mockGetSystemHealth = vi.fn().mockResolvedValue({
+      status: "healthy",
+      timestamp: "2026-01-15T12:00:00Z",
+    });
+    vi.mocked(useApiClient).mockReturnValue(
+      makeApiClient({ health: { getSystemHealth: mockGetSystemHealth } }) as any
+    );
+
+    await act(async () => {
+      render(<SystemHealthBadge />);
+    });
+
+    const initialCalls = mockGetSystemHealth.mock.calls.length;
+
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+    });
+
+    expect(mockGetSystemHealth.mock.calls.length).toBeGreaterThan(initialCalls);
   });
 });

--- a/apps/hospitality/src/components/SystemHealthBadge.tsx
+++ b/apps/hospitality/src/components/SystemHealthBadge.tsx
@@ -1,22 +1,9 @@
 import { useState, useEffect, useCallback } from "react";
-import { Badge, Popover } from "@mattbutlerengineering/rialto";
+import { Badge, Button, Popover, Text } from "@mattbutlerengineering/rialto";
 import { useAuth } from "@mbe/auth/react";
+import type { SystemHealth } from "@mbe/api-client";
+import { useApiClient } from "../hooks/useApiClient.js";
 import styles from "./SystemHealthBadge.module.css";
-
-interface ServiceHealth {
-  readonly status: string;
-  readonly version?: string;
-  readonly latency?: number;
-}
-
-interface SystemHealth {
-  readonly status: string;
-  readonly timestamp: string;
-  readonly services?: Record<string, ServiceHealth>;
-  readonly staticSites?: Record<string, { status: string }>;
-  readonly ci?: { status: string };
-  readonly deploy?: { status: string };
-}
 
 const POLL_INTERVAL_MS = 60_000;
 
@@ -46,7 +33,7 @@ function StatusDot({ status }: { readonly status: string }) {
   const color = colorMap[status] ?? "var(--rialto-text-tertiary)";
 
   return (
-    <span
+    <Text
       className={styles.dot}
       style={{ backgroundColor: color }}
       aria-label={`System ${status}`}
@@ -56,6 +43,7 @@ function StatusDot({ status }: { readonly status: string }) {
 
 export function SystemHealthBadge() {
   const { user } = useAuth();
+  const api = useApiClient();
   const [health, setHealth] = useState<SystemHealth | null>(null);
 
   // Only show to admin users — permissions live in the raw JWT claims
@@ -64,16 +52,12 @@ export function SystemHealthBadge() {
 
   const fetchHealth = useCallback(async () => {
     try {
-      const response = await fetch("/api/health/system", {
-        signal: AbortSignal.timeout(10_000),
-      });
-      if (response.ok) {
-        setHealth(await response.json());
-      }
+      const data = await api.health.getSystemHealth();
+      setHealth(data);
     } catch {
       // Silent failure — badge just shows stale data
     }
-  }, []);
+  }, [api]);
 
   useEffect(() => {
     if (!isAdmin) return;
@@ -86,16 +70,16 @@ export function SystemHealthBadge() {
   if (!isAdmin || !health) return null;
 
   const trigger = (
-    <button type="button" className={styles.trigger} aria-label={`System health: ${health.status}`}>
+    <Button type="button" className={styles.trigger} aria-label={`System health: ${health.status}`}>
       <StatusDot status={health.status} />
-    </button>
+    </Button>
   );
 
   return (
     <Popover trigger={trigger} placement="bottom">
       <div className={styles.panel}>
         <div className={styles.header}>
-          <span className={styles.title}>System Health</span>
+          <Text className={styles.title}>System Health</Text>
           <Badge color={statusColor(health.status)} size="sm">
             {health.status}
           </Badge>
@@ -103,12 +87,12 @@ export function SystemHealthBadge() {
 
         {health.services && (
           <div className={styles.section}>
-            <span className={styles.sectionLabel}>Services</span>
+            <Text className={styles.sectionLabel}>Services</Text>
             {Object.entries(health.services).map(([name, svc]) => (
               <div key={name} className={styles.row}>
                 <StatusDot status={svc.status} />
-                <span className={styles.name}>{name}</span>
-                {svc.latency != null && <span className={styles.meta}>{svc.latency}ms</span>}
+                <Text className={styles.name}>{name}</Text>
+                {svc.latency != null && <Text className={styles.meta}>{svc.latency}ms</Text>}
               </div>
             ))}
           </div>
@@ -117,21 +101,21 @@ export function SystemHealthBadge() {
         {health.ci && (
           <div className={styles.row}>
             <StatusDot status={health.ci.status} />
-            <span className={styles.name}>CI</span>
+            <Text className={styles.name}>CI</Text>
           </div>
         )}
 
         {health.deploy && (
           <div className={styles.row}>
             <StatusDot status={health.deploy.status} />
-            <span className={styles.name}>Deploys</span>
+            <Text className={styles.name}>Deploys</Text>
           </div>
         )}
 
         <div className={styles.footer}>
-          <span className={styles.meta}>
+          <Text className={styles.meta}>
             Updated {new Date(health.timestamp).toLocaleTimeString()}
-          </span>
+          </Text>
         </div>
       </div>
     </Popover>

--- a/packages/api-client/src/health.test.ts
+++ b/packages/api-client/src/health.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ApiClient } from "./client.js";
+import { HealthClient } from "./health.js";
+
+const mockFetch = vi.fn<typeof fetch>();
+vi.stubGlobal("fetch", mockFetch);
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeClient() {
+  const apiClient = new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 0 });
+  return new HealthClient(apiClient);
+}
+
+describe("HealthClient", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  describe("getSystemHealth", () => {
+    it("requests GET /api/health/system", async () => {
+      const healthData = {
+        status: "healthy",
+        timestamp: "2026-01-15T12:00:00Z",
+      };
+      mockFetch.mockResolvedValueOnce(jsonResponse(healthData));
+
+      await makeClient().getSystemHealth();
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/health/system");
+      expect(options?.method ?? "GET").toBe("GET");
+    });
+
+    it("returns system health data", async () => {
+      const healthData = {
+        status: "healthy",
+        timestamp: "2026-01-15T12:00:00Z",
+        services: {
+          "users-api": { status: "healthy", latency: 42 },
+          "reservations-api": { status: "degraded", latency: 150 },
+        },
+        ci: { status: "healthy" },
+        deploy: { status: "healthy" },
+      };
+      mockFetch.mockResolvedValueOnce(jsonResponse(healthData));
+
+      const result = await makeClient().getSystemHealth();
+      expect(result).toEqual(healthData);
+    });
+
+    it("returns minimal health data without optional fields", async () => {
+      const healthData = {
+        status: "healthy",
+        timestamp: "2026-01-15T12:00:00Z",
+      };
+      mockFetch.mockResolvedValueOnce(jsonResponse(healthData));
+
+      const result = await makeClient().getSystemHealth();
+      expect(result).toEqual(healthData);
+      expect(result.services).toBeUndefined();
+      expect(result.ci).toBeUndefined();
+      expect(result.deploy).toBeUndefined();
+    });
+
+    it("propagates errors from the API client", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse(
+          { error: "Internal Server Error", message: "Service unavailable", statusCode: 500 },
+          500
+        )
+      );
+
+      await expect(makeClient().getSystemHealth()).rejects.toThrow();
+    });
+
+    it("propagates network errors", async () => {
+      mockFetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+
+      await expect(makeClient().getSystemHealth()).rejects.toThrow(TypeError);
+    });
+  });
+});

--- a/packages/api-client/src/health.ts
+++ b/packages/api-client/src/health.ts
@@ -1,0 +1,27 @@
+import type { ApiClient } from "./client.js";
+
+export interface ServiceHealth {
+  readonly status: string;
+  readonly version?: string;
+  readonly latency?: number;
+}
+
+export interface SystemHealth {
+  readonly status: string;
+  readonly timestamp: string;
+  readonly services?: Record<string, ServiceHealth>;
+  readonly staticSites?: Record<string, { status: string }>;
+  readonly ci?: { status: string };
+  readonly deploy?: { status: string };
+}
+
+export class HealthClient {
+  constructor(private client: ApiClient) {}
+
+  /**
+   * Get system-wide health status (admin only)
+   */
+  async getSystemHealth(): Promise<SystemHealth> {
+    return this.client.get<SystemHealth>("/api/health/system");
+  }
+}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -19,6 +19,7 @@ export {
   type GetDatesParams,
 } from "./availability.js";
 export { streamNDJSON, type StreamConfig } from "./streaming.js";
+export { HealthClient, type SystemHealth, type ServiceHealth } from "./health.js";
 
 import { ApiClient } from "./client.js";
 import type { ApiClientError } from "./client.js";
@@ -29,6 +30,7 @@ import { TablesClient } from "./tables.js";
 import { GuestsClient } from "./guests.js";
 import { FloorPlansClient } from "./floor-plans.js";
 import { AvailabilityClient, HoldsClient } from "./availability.js";
+import { HealthClient } from "./health.js";
 
 /**
  * Create a configured API client for the MBE platform
@@ -59,5 +61,6 @@ export function createApiClient(config: {
     floorPlans: new FloorPlansClient(client),
     availability: new AvailabilityClient(client),
     holds: new HoldsClient(client),
+    health: new HealthClient(client),
   };
 }


### PR DESCRIPTION
## Summary

- Adds `HealthClient` to `@mbe/api-client` with a `getSystemHealth()` method for `GET /api/health/system`
- Refactors `SystemHealthBadge` to use `useApiClient` hook instead of raw `fetch()`, consistent with all other data-fetching in the app
- Updates `SystemHealthBadge` to use Rialto `Button` and `Text` components instead of bare HTML elements (enforced by ESLint)

Fixes #1498.

## Test plan

- [x] New `packages/api-client/src/health.test.ts` — covers `HealthClient.getSystemHealth()`, success/error/network failure paths
- [x] Updated `SystemHealthBadge.test.tsx` — verifies `useApiClient` hook is called (not raw fetch), all render paths covered, polling behaviour covered
- [x] `pnpm test` passes in both `packages/api-client` and `apps/hospitality` (728 tests)
- [x] `pnpm typecheck` passes in both packages