### PR TITLE
feat: tracer bullet — check availability via staff chat

### DIFF
--- a/apps/hospitality/src/components/DashboardLayout.test.tsx
+++ b/apps/hospitality/src/components/DashboardLayout.test.tsx
@@ -32,6 +32,7 @@ vi.mock("@mattbutlerengineering/rialto", () => ({
   CommandPalette: () => <div data-testid="command-palette" />,
   ErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   GenCopilot: () => <div data-testid="copilot" />,
+  ChatPanel: () => <div data-testid="chat-panel" />,
   Kbd: () => <div />,
   Button: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
     <button onClick={onClick}>{children}</button>

--- a/apps/hospitality/src/components/DashboardLayout.tsx
+++ b/apps/hospitality/src/components/DashboardLayout.tsx
@@ -6,6 +6,7 @@ import {
   CommandPalette,
   ErrorBoundary,
   GenCopilot,
+  ChatPanel,
   Kbd,
   Button,
   Stack,
@@ -58,6 +59,7 @@ function DashboardLayoutInner() {
   const readiness = useVenueReadiness();
 
   const [copilotOpen, setCopilotOpen] = useState(false);
+  const [chatOpen, setChatOpen] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
   // Readiness-based redirect guard
@@ -128,7 +130,7 @@ function DashboardLayoutInner() {
     [navigate, signOut]
   );
 
-  // Build dynamic nav sections from readiness state + copilot tool
+  // Build dynamic nav sections from readiness state + copilot + chat tools
   const sectionsWithCopilot = useMemo(
     () => [
       ...buildNavSections(readiness),
@@ -139,6 +141,11 @@ function DashboardLayoutInner() {
             id: "copilot",
             label: "Copilot",
             path: "/__copilot__",
+          },
+          {
+            id: "chat",
+            label: "Staff Chat",
+            path: "/__chat__",
           },
         ],
       },
@@ -154,11 +161,15 @@ function DashboardLayoutInner() {
     groups: paletteGroups,
   } = useCommandPalette({ sections: sectionsWithCopilot, navigate, toggleTheme, signOut });
 
-  // Custom navigate that handles copilot toggle
+  // Custom navigate that handles copilot + chat toggle
   const handleNavigateWithCopilot = useCallback(
     (path: string) => {
       if (path === "/__copilot__") {
         setCopilotOpen((prev) => !prev);
+        return;
+      }
+      if (path === "/__chat__") {
+        setChatOpen((prev) => !prev);
         return;
       }
       handleNavigate(path);
@@ -217,7 +228,7 @@ function DashboardLayoutInner() {
       />
 
       {/* ── Mobile sidebar toggle (visible < 768px only) ── */}
-      <button
+      <Button
         className={styles.mobileSidebarToggle}
         onClick={handleMobileToggle}
         aria-label={isMobileMenuOpen ? "Close sidebar" : "Open sidebar"}
@@ -239,7 +250,7 @@ function DashboardLayoutInner() {
           <line x1="3" y1="12" x2="21" y2="12" />
           <line x1="3" y1="18" x2="21" y2="18" />
         </svg>
-      </button>
+      </Button>
 
       <div className={styles.body}>
         <div className={styles.sidebarColumn}>
@@ -252,7 +263,7 @@ function DashboardLayoutInner() {
             onMobileClose={handleMobileClose}
             headerSlot={<VenueSwitcher onNavigate={handleNavigate} />}
           />
-          <button
+          <Button
             type="button"
             className={styles.commandHint}
             onClick={() => setPaletteOpen(true)}
@@ -260,8 +271,8 @@ function DashboardLayoutInner() {
           >
             <Kbd>{navigator.platform?.includes("Mac") ? "\u2318" : "Ctrl"}</Kbd>
             <Kbd>K</Kbd>
-            <span className={styles.commandHintLabel}>Search</span>
-          </button>
+            <Text className={styles.commandHintLabel}>Search</Text>
+          </Button>
         </div>
 
         <main
@@ -307,6 +318,15 @@ function DashboardLayoutInner() {
           domainContext={HOSPITALITY_DOMAIN_CONTEXT}
           getAccessToken={getAccessToken}
           registry={registry}
+        />
+      )}
+
+      {/* Conditionally mount ChatPanel — destroying it on close resets chat history */}
+      {chatOpen && (
+        <ChatPanel
+          onClose={() => setChatOpen(false)}
+          api="/api/gen/agent"
+          getAccessToken={getAccessToken}
         />
       )}
     </div>

--- a/packages/rialto/package.json
+++ b/packages/rialto/package.json
@@ -74,6 +74,10 @@
       "types": "./dist/lib/components/Chalkboard/index.d.ts",
       "import": "./dist/lib/components/Chalkboard/index.js"
     },
+    "./ChatPanel": {
+      "types": "./dist/lib/components/ChatPanel/index.d.ts",
+      "import": "./dist/lib/components/ChatPanel/index.js"
+    },
     "./Checkbox": {
       "types": "./dist/lib/components/Checkbox/index.d.ts",
       "import": "./dist/lib/components/Checkbox/index.js"

--- a/packages/rialto/registry.json
+++ b/packages/rialto/registry.json
@@ -89,9 +89,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "title",
@@ -1668,9 +1666,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "AuthMascot",
@@ -3306,9 +3302,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "AutocompleteOption",
@@ -4858,9 +4852,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "children",
@@ -6338,9 +6330,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "title",
@@ -7911,9 +7901,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "children",
@@ -9384,9 +9372,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "title",
@@ -10864,9 +10850,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "ChalkboardItem",
@@ -12349,9 +12333,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "CharsetName",
@@ -12473,9 +12455,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "label",
@@ -14107,9 +14087,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "DataListItem",
@@ -14155,9 +14133,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "title",
@@ -14186,9 +14162,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "Divider",
@@ -14285,9 +14259,7 @@
           "description": "Panel width/height"
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "title",
@@ -15803,9 +15775,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "title",
@@ -15837,9 +15807,7 @@
           "description": "Optional callback invoked when an error is caught. Use to report errors to external services."
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "Ferrofluid",
@@ -17305,9 +17273,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "FlipDot",
@@ -18813,9 +18779,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "FlipDotAnimationMode",
@@ -20291,9 +20255,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "FooterColumn",
@@ -21868,9 +21830,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "HeadingLevel",
@@ -23360,9 +23320,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "HoverCard",
@@ -25123,9 +25081,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "label",
@@ -26589,9 +26545,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "Kbd",
@@ -28212,9 +28166,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "label",
@@ -29696,9 +29648,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "NavbarLink",
@@ -31157,9 +31107,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "NavItem",
@@ -31284,9 +31232,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "PageHeader",
@@ -32752,9 +32698,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "Pagination",
@@ -32914,9 +32858,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "Progress",
@@ -34385,9 +34327,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "Radio",
@@ -34485,9 +34425,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "label",
@@ -34520,9 +34458,7 @@
           "description": "Theme mode. `'system'` follows the OS color scheme. Defaults to `'system'`."
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "ScrollArea",
@@ -35975,9 +35911,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "Segment",
@@ -37448,9 +37382,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "segments[].label",
@@ -39004,9 +38936,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "SidebarItem",
@@ -39076,9 +39006,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "Slider",
@@ -40618,9 +40546,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "SplitFlap",
@@ -42103,9 +42029,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "SplitScreenExit",
@@ -42136,9 +42060,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "Stack",
@@ -43621,9 +43543,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "StaggerDirection",
@@ -45106,9 +45026,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "label",
@@ -46815,9 +46733,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "TapeChart",
@@ -48497,9 +48413,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "TextArea",
@@ -50046,9 +49960,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "label",
@@ -51731,9 +51643,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "label",
@@ -51776,9 +51686,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "content",
@@ -53271,9 +53179,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "TreeNode",

--- a/packages/rialto/src/components/ChatPanel/ChatPanel.module.css
+++ b/packages/rialto/src/components/ChatPanel/ChatPanel.module.css
@@ -1,0 +1,78 @@
+.body {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--rialto-space-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--rialto-space-sm);
+}
+
+.emptyState {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--rialto-space-xl);
+  text-align: center;
+}
+
+.userMessage {
+  align-self: flex-end;
+  background: var(--rialto-accent);
+  color: #fff;
+  padding: var(--rialto-space-sm) var(--rialto-space-md);
+  border-radius: var(--rialto-radius-soft);
+  max-width: 80%;
+}
+
+.assistantMessage {
+  align-self: flex-start;
+  background: var(--rialto-surface-elevated);
+  padding: var(--rialto-space-sm) var(--rialto-space-md);
+  border-radius: var(--rialto-radius-soft);
+  max-width: 80%;
+}
+
+.loadingIndicator {
+  align-self: flex-start;
+  padding: var(--rialto-space-sm) var(--rialto-space-md);
+}
+
+.inputBar {
+  display: flex;
+  gap: var(--rialto-space-sm);
+  padding: var(--rialto-space-md);
+  border-block-start: 1px solid var(--rialto-border);
+  align-items: flex-end;
+}
+
+.input {
+  flex: 1;
+  font-family: var(--rialto-font-sans);
+  font-size: var(--rialto-text-sm);
+  color: var(--rialto-text-primary);
+  background: var(--rialto-surface-recessed);
+  border: 1px solid var(--rialto-border);
+  border-radius: var(--rialto-radius-default);
+  padding: var(--rialto-space-sm);
+  resize: none;
+  outline: none;
+  transition: border-color 150ms var(--rialto-ease-precision);
+}
+
+.input:focus {
+  border-color: var(--rialto-accent);
+  box-shadow: var(--rialto-shadow-focus);
+}
+
+.input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/packages/rialto/src/components/ChatPanel/ChatPanel.test.tsx
+++ b/packages/rialto/src/components/ChatPanel/ChatPanel.test.tsx
@@ -1,0 +1,162 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { axe } from "vitest-axe";
+import { vi } from "vitest";
+
+// Mock the streaming hook so tests don't make network calls
+vi.mock("./useChatStream", () => ({
+  useChatStream: vi.fn(() => ({
+    messages: [],
+    isStreaming: false,
+    error: null,
+    send: vi.fn(),
+    stop: vi.fn(),
+  })),
+}));
+
+import { ChatPanel } from "./ChatPanel.js";
+import { useChatStream } from "./useChatStream.js";
+
+const mockGetAccessToken = () => "test-token";
+
+describe("ChatPanel", () => {
+  describe("rendering", () => {
+    it("renders empty state message", () => {
+      render(
+        <ChatPanel onClose={() => {}} api="/api/gen/agent" getAccessToken={mockGetAccessToken} />
+      );
+      expect(
+        screen.getByText(/ask me anything about availability, reservations, or guests/i)
+      ).toBeInTheDocument();
+    });
+
+    it("renders as a dialog (drawer)", () => {
+      render(
+        <ChatPanel onClose={() => {}} api="/api/gen/agent" getAccessToken={mockGetAccessToken} />
+      );
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    it("renders the send button", () => {
+      render(
+        <ChatPanel onClose={() => {}} api="/api/gen/agent" getAccessToken={mockGetAccessToken} />
+      );
+      expect(screen.getByRole("button", { name: /send/i })).toBeInTheDocument();
+    });
+
+    it("renders user message after send", () => {
+      vi.mocked(useChatStream).mockReturnValueOnce({
+        messages: [{ id: "1", role: "user", content: "Check availability" }],
+        isStreaming: false,
+        error: null,
+        send: vi.fn(),
+        stop: vi.fn(),
+      });
+
+      render(
+        <ChatPanel onClose={() => {}} api="/api/gen/agent" getAccessToken={mockGetAccessToken} />
+      );
+
+      expect(screen.getByText("Check availability")).toBeInTheDocument();
+    });
+
+    it("renders assistant response", () => {
+      vi.mocked(useChatStream).mockReturnValueOnce({
+        messages: [
+          { id: "1", role: "user", content: "Check availability" },
+          { id: "2", role: "assistant", content: "I found 3 available slots." },
+        ],
+        isStreaming: false,
+        error: null,
+        send: vi.fn(),
+        stop: vi.fn(),
+      });
+
+      render(
+        <ChatPanel onClose={() => {}} api="/api/gen/agent" getAccessToken={mockGetAccessToken} />
+      );
+
+      expect(screen.getByText("I found 3 available slots.")).toBeInTheDocument();
+    });
+
+    it("shows loading indicator while streaming", () => {
+      vi.mocked(useChatStream).mockReturnValueOnce({
+        messages: [{ id: "1", role: "user", content: "Check" }],
+        isStreaming: true,
+        error: null,
+        send: vi.fn(),
+        stop: vi.fn(),
+      });
+
+      render(
+        <ChatPanel onClose={() => {}} api="/api/gen/agent" getAccessToken={mockGetAccessToken} />
+      );
+
+      expect(screen.getByTestId("chat-loading-indicator")).toBeInTheDocument();
+    });
+
+    it("send button disabled while streaming", () => {
+      vi.mocked(useChatStream).mockReturnValueOnce({
+        messages: [],
+        isStreaming: true,
+        error: null,
+        send: vi.fn(),
+        stop: vi.fn(),
+      });
+
+      render(
+        <ChatPanel onClose={() => {}} api="/api/gen/agent" getAccessToken={mockGetAccessToken} />
+      );
+
+      expect(screen.getByRole("button", { name: /send/i })).toBeDisabled();
+    });
+  });
+
+  describe("interactions", () => {
+    it("calls onClose when close button clicked", async () => {
+      const user = userEvent.setup();
+      const onClose = vi.fn();
+
+      render(
+        <ChatPanel onClose={onClose} api="/api/gen/agent" getAccessToken={mockGetAccessToken} />
+      );
+
+      await user.click(screen.getByRole("button", { name: /close/i }));
+      expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it("calls send with input text when form submitted", async () => {
+      const user = userEvent.setup();
+      const mockSend = vi.fn();
+      // Use mockReturnValue (not Once) so subsequent re-renders also get mockSend
+      vi.mocked(useChatStream).mockReturnValue({
+        messages: [],
+        isStreaming: false,
+        error: null,
+        send: mockSend,
+        stop: vi.fn(),
+      });
+
+      render(
+        <ChatPanel onClose={() => {}} api="/api/gen/agent" getAccessToken={mockGetAccessToken} />
+      );
+
+      await user.type(screen.getByRole("textbox"), "check availability tonight");
+      await user.click(screen.getByRole("button", { name: /send/i }));
+
+      expect(mockSend).toHaveBeenCalledWith("check availability tonight");
+    });
+  });
+
+  describe("accessibility", () => {
+    it("passes axe", async () => {
+      const { container } = render(
+        <ChatPanel onClose={() => {}} api="/api/gen/agent" getAccessToken={mockGetAccessToken} />
+      );
+      const results = await axe(container, {
+        rules: { "color-contrast": { enabled: false } },
+      });
+      expect(results).toHaveNoViolations();
+    });
+  });
+});

--- a/packages/rialto/src/components/ChatPanel/ChatPanel.tsx
+++ b/packages/rialto/src/components/ChatPanel/ChatPanel.tsx
@@ -1,0 +1,125 @@
+import { useState, useRef, useEffect, type KeyboardEvent } from "react";
+import { Drawer } from "../Drawer/Drawer.js";
+import { Button } from "../Button/Button.js";
+import { Text } from "../Text/Text.js";
+import { useChatStream } from "./useChatStream.js";
+import type { ChatMessage } from "./useChatStream.js";
+import styles from "./ChatPanel.module.css";
+
+export interface ChatPanelProps {
+  /** Called when the user closes the panel — consumer should unmount ChatPanel */
+  onClose: () => void;
+  /** API endpoint for the agent stream (e.g. "/api/gen/agent") */
+  api: string;
+  /**
+   * Callback that returns the current auth token (or null if unauthenticated).
+   */
+  getAccessToken: () => string | null | undefined;
+  /** Optional domain context hint shown in empty state */
+  domainContext?: string;
+}
+
+/**
+ * ChatPanel is a slide-over panel (Drawer) providing a multi-turn AI chat
+ * interface for hospitality staff to check availability, reservations, and guests.
+ *
+ * @example
+ * ```tsx
+ * {chatOpen && (
+ *   <ChatPanel
+ *     onClose={() => setChatOpen(false)}
+ *     api="/api/gen/agent"
+ *     getAccessToken={getAccessToken}
+ *   />
+ * )}
+ * ```
+ */
+export function ChatPanel({ onClose, api, getAccessToken }: ChatPanelProps) {
+  const [inputValue, setInputValue] = useState("");
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  const { messages, isStreaming, send } = useChatStream({ api, getAccessToken });
+
+  // Auto-scroll to latest message (guard for jsdom which lacks scrollIntoView)
+  useEffect(() => {
+    if (typeof messagesEndRef.current?.scrollIntoView === "function") {
+      messagesEndRef.current.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [messages]);
+
+  function handleSubmit() {
+    const trimmed = inputValue.trim();
+    if (!trimmed || isStreaming) return;
+    void send(trimmed);
+    setInputValue("");
+  }
+
+  function handleKeyDown(e: KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit();
+    }
+  }
+
+  const isEmpty = messages.length === 0;
+
+  return (
+    <Drawer open={true} onClose={onClose} title="Staff Assistant" side="right">
+      <div className={styles.body}>
+        {/* Message list */}
+        <div className={styles.messages} role="log" aria-live="polite" aria-label="Chat messages">
+          {isEmpty ? (
+            <div className={styles.emptyState}>
+              <Text color="secondary">
+                Ask me anything about availability, reservations, or guests.
+              </Text>
+            </div>
+          ) : (
+            messages.map((msg: ChatMessage) => (
+              <div
+                key={msg.id}
+                className={msg.role === "user" ? styles.userMessage : styles.assistantMessage}
+              >
+                <Text>{msg.content}</Text>
+              </div>
+            ))
+          )}
+
+          {/* Loading indicator while streaming */}
+          {isStreaming && (
+            <div className={styles.loadingIndicator} data-testid="chat-loading-indicator">
+              <Text color="secondary">...</Text>
+            </div>
+          )}
+
+          <div ref={messagesEndRef} />
+        </div>
+
+        {/* Input bar */}
+        <div className={styles.inputBar}>
+          <textarea
+            className={styles.input}
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Type a message..."
+            rows={2}
+            aria-label="Chat message input"
+            disabled={isStreaming}
+          />
+          <Button
+            variant="primary"
+            size="md"
+            onClick={handleSubmit}
+            disabled={isStreaming || inputValue.trim().length === 0}
+            aria-label="Send"
+          >
+            Send
+          </Button>
+        </div>
+      </div>
+    </Drawer>
+  );
+}
+
+ChatPanel.displayName = "ChatPanel";

--- a/packages/rialto/src/components/ChatPanel/index.ts
+++ b/packages/rialto/src/components/ChatPanel/index.ts
@@ -1,0 +1,4 @@
+export { ChatPanel } from "./ChatPanel.js";
+export type { ChatPanelProps } from "./ChatPanel.js";
+export { useChatStream } from "./useChatStream.js";
+export type { ChatMessage, UseChatStreamOptions, UseChatStreamReturn } from "./useChatStream.js";

--- a/packages/rialto/src/components/ChatPanel/useChatStream.test.ts
+++ b/packages/rialto/src/components/ChatPanel/useChatStream.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+// Mock streamNDJSON from api-client
+vi.mock("@mbe/api-client/streaming", () => ({
+  streamNDJSON: vi.fn(),
+}));
+
+import { streamNDJSON } from "@mbe/api-client/streaming";
+import { useChatStream } from "./useChatStream.js";
+
+describe("useChatStream", () => {
+  const mockGetAccessToken = vi.fn(() => "test-token");
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("initial state: empty messages, not streaming, no error", () => {
+    const { result } = renderHook(() =>
+      useChatStream({ api: "/api/gen/agent", getAccessToken: mockGetAccessToken })
+    );
+
+    expect(result.current.messages).toEqual([]);
+    expect(result.current.isStreaming).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("send() appends user message immediately", async () => {
+    vi.mocked(streamNDJSON).mockImplementation(async function* () {
+      // yield nothing — simulates empty stream
+    });
+
+    const { result } = renderHook(() =>
+      useChatStream({ api: "/api/gen/agent", getAccessToken: mockGetAccessToken })
+    );
+
+    await act(async () => {
+      await result.current.send("check availability");
+    });
+
+    expect(result.current.messages).toContainEqual(
+      expect.objectContaining({ role: "user", content: "check availability" })
+    );
+  });
+
+  it("NDJSON text chunks accumulate into assistant message", async () => {
+    vi.mocked(streamNDJSON).mockImplementation(async function* () {
+      yield { type: "text", content: "Hello " };
+      yield { type: "text", content: "there!" };
+    });
+
+    const { result } = renderHook(() =>
+      useChatStream({ api: "/api/gen/agent", getAccessToken: mockGetAccessToken })
+    );
+
+    await act(async () => {
+      await result.current.send("hi");
+    });
+
+    const assistantMsg = result.current.messages.find((m) => m.role === "assistant");
+    expect(assistantMsg).toBeDefined();
+    expect(assistantMsg?.content).toBe("Hello there!");
+  });
+
+  it("isStreaming is true during stream, false after completion", async () => {
+    let resolveStream!: () => void;
+    const streamPromise = new Promise<void>((res) => {
+      resolveStream = res;
+    });
+
+    vi.mocked(streamNDJSON).mockImplementation(async function* () {
+      await streamPromise;
+      yield { type: "text", content: "done" };
+    });
+
+    const { result } = renderHook(() =>
+      useChatStream({ api: "/api/gen/agent", getAccessToken: mockGetAccessToken })
+    );
+
+    let sendPromise: Promise<void>;
+    act(() => {
+      sendPromise = result.current.send("test");
+    });
+
+    expect(result.current.isStreaming).toBe(true);
+
+    await act(async () => {
+      resolveStream();
+      await sendPromise;
+    });
+
+    expect(result.current.isStreaming).toBe(false);
+  });
+
+  it("stop() aborts stream and sets isStreaming to false", async () => {
+    let aborted = false;
+    vi.mocked(streamNDJSON).mockImplementation(async function* (config) {
+      config.signal?.addEventListener("abort", () => {
+        aborted = true;
+      });
+      // Simulate long stream
+      await new Promise<void>((_, reject) => {
+        config.signal?.addEventListener("abort", () => {
+          reject(new DOMException("Aborted", "AbortError"));
+        });
+      });
+      yield { type: "text", content: "never reached" };
+    });
+
+    const { result } = renderHook(() =>
+      useChatStream({ api: "/api/gen/agent", getAccessToken: mockGetAccessToken })
+    );
+
+    act(() => {
+      void result.current.send("test");
+    });
+
+    await act(async () => {
+      result.current.stop();
+    });
+
+    expect(result.current.isStreaming).toBe(false);
+    expect(aborted).toBe(true);
+  });
+
+  it("non-text chunk types are ignored", async () => {
+    vi.mocked(streamNDJSON).mockImplementation(async function* () {
+      yield { type: "tool_call", content: "ignored" };
+      yield { type: "text", content: "Hello" };
+    });
+
+    const { result } = renderHook(() =>
+      useChatStream({ api: "/api/gen/agent", getAccessToken: mockGetAccessToken })
+    );
+
+    await act(async () => {
+      await result.current.send("hi");
+    });
+
+    const assistantMsg = result.current.messages.find((m) => m.role === "assistant");
+    expect(assistantMsg?.content).toBe("Hello");
+  });
+
+  it("posts full message history to api", async () => {
+    vi.mocked(streamNDJSON).mockImplementation(async function* () {
+      yield { type: "text", content: "first response" };
+    });
+
+    const { result } = renderHook(() =>
+      useChatStream({ api: "/api/gen/agent", getAccessToken: mockGetAccessToken })
+    );
+
+    await act(async () => {
+      await result.current.send("first message");
+    });
+
+    vi.mocked(streamNDJSON).mockImplementation(async function* () {
+      yield { type: "text", content: "second response" };
+    });
+
+    await act(async () => {
+      await result.current.send("second message");
+    });
+
+    // Second call should have included history
+    const calls = vi.mocked(streamNDJSON).mock.calls;
+    const secondCall = calls[1]?.[0];
+    expect(secondCall?.body).toMatchObject({
+      messages: expect.arrayContaining([
+        expect.objectContaining({ role: "user", content: "first message" }),
+        expect.objectContaining({ role: "assistant", content: "first response" }),
+        expect.objectContaining({ role: "user", content: "second message" }),
+      ]),
+    });
+  });
+});

--- a/packages/rialto/src/components/ChatPanel/useChatStream.ts
+++ b/packages/rialto/src/components/ChatPanel/useChatStream.ts
@@ -1,0 +1,142 @@
+import { useState, useRef, useCallback, useEffect } from "react";
+import { streamNDJSON } from "@mbe/api-client/streaming";
+
+export interface ChatMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+}
+
+export interface UseChatStreamOptions {
+  api: string;
+  getAccessToken: () => string | null | undefined;
+  onComplete?: () => void;
+  onError?: (error: Error) => void;
+}
+
+export interface UseChatStreamReturn {
+  messages: ChatMessage[];
+  isStreaming: boolean;
+  error: Error | null;
+  send: (content: string) => Promise<void>;
+  stop: () => void;
+}
+
+/**
+ * Hook for multi-turn chat streaming with NDJSON protocol.
+ * Manages message history and streams assistant responses chunk by chunk.
+ */
+export function useChatStream({
+  api,
+  getAccessToken,
+  onComplete,
+  onError,
+}: UseChatStreamOptions): UseChatStreamReturn {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  // Stable refs for callbacks
+  const onCompleteRef = useRef(onComplete);
+  const onErrorRef = useRef(onError);
+  const getAccessTokenRef = useRef(getAccessToken);
+
+  useEffect(() => {
+    onCompleteRef.current = onComplete;
+  }, [onComplete]);
+
+  useEffect(() => {
+    onErrorRef.current = onError;
+  }, [onError]);
+
+  useEffect(() => {
+    getAccessTokenRef.current = getAccessToken;
+  }, [getAccessToken]);
+
+  // Keep a ref to messages for use inside send without stale closure
+  const messagesRef = useRef<ChatMessage[]>([]);
+  useEffect(() => {
+    messagesRef.current = messages;
+  }, [messages]);
+
+  const send = useCallback(
+    async (content: string): Promise<void> => {
+      // Abort any in-flight request
+      abortControllerRef.current?.abort();
+
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+
+      const userMsg: ChatMessage = {
+        id: crypto.randomUUID(),
+        role: "user",
+        content,
+      };
+
+      // Append user message and start streaming
+      const historyWithUser = [...messagesRef.current, userMsg];
+      setMessages(historyWithUser);
+      setIsStreaming(true);
+      setError(null);
+
+      // Build assistant placeholder
+      const assistantId = crypto.randomUUID();
+      let accumulatedContent = "";
+
+      try {
+        const token = getAccessTokenRef.current();
+
+        const stream = streamNDJSON<{ type: string; content: string }>({
+          url: api,
+          body: {
+            messages: historyWithUser.map((m) => ({ role: m.role, content: m.content })),
+          },
+          headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+          signal: controller.signal,
+        });
+
+        for await (const chunk of stream) {
+          if (chunk.type !== "text") continue;
+
+          accumulatedContent += chunk.content;
+
+          setMessages((prev) => {
+            const existing = prev.find((m) => m.id === assistantId);
+            if (existing) {
+              return prev.map((m) =>
+                m.id === assistantId ? { ...m, content: accumulatedContent } : m
+              );
+            }
+            return [
+              ...prev,
+              { id: assistantId, role: "assistant" as const, content: accumulatedContent },
+            ];
+          });
+        }
+
+        setIsStreaming(false);
+        onCompleteRef.current?.();
+      } catch (err) {
+        if (err instanceof Error && err.name === "AbortError") {
+          setIsStreaming(false);
+          return;
+        }
+
+        const caughtError = err instanceof Error ? err : new Error(String(err));
+        setError(caughtError);
+        setIsStreaming(false);
+        onErrorRef.current?.(caughtError);
+      }
+    },
+    [api]
+  );
+
+  const stop = useCallback(() => {
+    abortControllerRef.current?.abort();
+    setIsStreaming(false);
+  }, []);
+
+  return { messages, isStreaming, error, send, stop };
+}

--- a/packages/rialto/src/components/index.ts
+++ b/packages/rialto/src/components/index.ts
@@ -70,6 +70,7 @@ export * from "./Text";
 
 // ── Generative AI ───────────────────────────────
 export * from "./GenCopilot";
+export * from "./ChatPanel";
 
 // ── Media ──────────────────────────────────────
 export * from "./ImageUpload";

--- a/services/agent/src/app.ts
+++ b/services/agent/src/app.ts
@@ -23,6 +23,7 @@ import { webhookRoutes } from "./routes/webhooks.js";
 import { genUiRoutes } from "./routes/gen-ui.js";
 import { genChatRoutes } from "./routes/gen-chat.js";
 import { genSpecsRoutes } from "./routes/gen-specs.js";
+import { genAgentRoutes } from "./routes/gen-agent.js";
 
 /**
  * Validates CORS origins from the CORS_ORIGINS env var against an allowlist.
@@ -185,6 +186,7 @@ export async function buildApp(options: AppOptions = {}): Promise<FastifyInstanc
   await fastify.register(genUiRoutes);
   await fastify.register(genChatRoutes);
   await fastify.register(genSpecsRoutes);
+  await fastify.register(genAgentRoutes);
 
   return fastify;
 }

--- a/services/agent/src/routes/gen-agent.test.ts
+++ b/services/agent/src/routes/gen-agent.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { FastifyInstance } from "fastify";
+
+// Must mock before importing buildApp
+vi.mock("ai", () => ({
+  streamText: vi.fn(),
+  tool: vi.fn((config) => config),
+  Output: {
+    object: vi.fn(),
+  },
+}));
+
+vi.mock("@mbe/rialto-catalog/catalog", () => ({
+  catalog: {
+    prompt: vi.fn(() => "mock system prompt"),
+  },
+}));
+
+vi.mock("@mbe/auth/fastify", () => ({
+  authPlugin: vi.fn(async (_f: unknown, _o: unknown) => {}),
+  getAuthPluginOptionsFromEnv: vi.fn(() => ({})),
+  requireAuth: vi.fn(async (req: { user?: { id: string } }) => {
+    req.user = { id: "test-user" };
+  }),
+}));
+
+// Mock database and other service deps pulled in by app.ts → sessions route
+vi.mock("../services/session.js", () => ({
+  sessionService: {
+    list: vi.fn(),
+    getById: vi.fn(),
+    create: vi.fn(),
+    updateStatus: vi.fn(),
+    delete: vi.fn(),
+    addEvent: vi.fn(),
+    listEvents: vi.fn(),
+  },
+}));
+
+vi.mock("../services/session-executor.js", () => ({
+  executeSession: vi.fn().mockResolvedValue(undefined),
+  cancelSession: vi.fn(),
+  getActiveSessionCount: vi.fn().mockReturnValue(0),
+}));
+
+vi.mock("../services/database.js", () => ({
+  prisma: {
+    $queryRaw: vi.fn(),
+  },
+}));
+
+vi.mock("../services/orchestrator.js", () => ({
+  orchestratorService: {
+    decompose: vi.fn(),
+  },
+}));
+
+// Mock global fetch for tool execution tests
+vi.stubGlobal(
+  "fetch",
+  vi.fn().mockResolvedValue({
+    ok: true,
+    json: vi.fn().mockResolvedValue({
+      data: [
+        { time: "18:00", available: true, partySize: 4 },
+        { time: "18:30", available: true, partySize: 4 },
+      ],
+    }),
+  })
+);
+
+import { streamText } from "ai";
+import { buildApp } from "../app.js";
+
+describe("POST /api/gen/agent", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    app = await buildApp({ logger: false });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 without auth", async () => {
+    const { requireAuth } = await import("@mbe/auth/fastify");
+    vi.mocked(requireAuth).mockImplementationOnce(async (_req, reply) => {
+      reply.code(401).send({
+        type: "https://mattbutlerengineering.com/errors/unauthorized",
+        title: "Unauthorized",
+        status: 401,
+        detail: "Authentication required",
+      });
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/gen/agent",
+      payload: { messages: [{ role: "user", content: "check availability" }] },
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  it("returns 400 for missing messages", async () => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/gen/agent",
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it("returns 400 for invalid message role", async () => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/gen/agent",
+      payload: { messages: [{ role: "system", content: "bad role" }] },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it("calls streamText with system prompt and user messages", async () => {
+    const closedStream = new ReadableStream({
+      start(controller) {
+        controller.close();
+      },
+    });
+    const mockStream = {
+      textStream: closedStream,
+      toUIMessageStream: vi.fn(() => closedStream),
+    };
+    vi.mocked(streamText).mockReturnValueOnce(mockStream as never);
+
+    await app.inject({
+      method: "POST",
+      url: "/api/gen/agent",
+      payload: { messages: [{ role: "user", content: "check availability" }] },
+    });
+
+    expect(streamText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            role: "system",
+            content: expect.stringContaining("mock system prompt"),
+          }),
+          expect.objectContaining({
+            role: "user",
+            content: "check availability",
+          }),
+        ]),
+      })
+    );
+  });
+
+  it("includes check_availability tool in streamText call", async () => {
+    const closedStream = new ReadableStream({
+      start(controller) {
+        controller.close();
+      },
+    });
+    const mockStream = {
+      textStream: closedStream,
+      toUIMessageStream: vi.fn(() => closedStream),
+    };
+    vi.mocked(streamText).mockReturnValueOnce(mockStream as never);
+
+    await app.inject({
+      method: "POST",
+      url: "/api/gen/agent",
+      payload: { messages: [{ role: "user", content: "check availability" }] },
+    });
+
+    expect(streamText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tools: expect.objectContaining({
+          check_availability: expect.anything(),
+        }),
+      })
+    );
+  });
+
+  it("applies rate limit of 30 req/hour per user", async () => {
+    const closedStream = new ReadableStream({
+      start(controller) {
+        controller.close();
+      },
+    });
+    const mockStream = {
+      textStream: closedStream,
+      toUIMessageStream: vi.fn(() => closedStream),
+    };
+    vi.mocked(streamText).mockReturnValueOnce(mockStream as never);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/gen/agent",
+      payload: { messages: [{ role: "user", content: "check availability" }] },
+    });
+
+    // Rate limit headers should be present
+    expect(response.headers["x-ratelimit-limit"]).toBeDefined();
+  });
+
+  it("applies prompt caching on system message", async () => {
+    const closedStream = new ReadableStream({
+      start(controller) {
+        controller.close();
+      },
+    });
+    const mockStream = {
+      textStream: closedStream,
+      toUIMessageStream: vi.fn(() => closedStream),
+    };
+    vi.mocked(streamText).mockReturnValueOnce(mockStream as never);
+
+    await app.inject({
+      method: "POST",
+      url: "/api/gen/agent",
+      payload: { messages: [{ role: "user", content: "check availability" }] },
+    });
+
+    expect(streamText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            role: "system",
+            providerOptions: {
+              anthropic: { cacheControl: { type: "ephemeral" } },
+            },
+          }),
+        ]),
+      })
+    );
+  });
+});

--- a/services/agent/src/routes/gen-agent.ts
+++ b/services/agent/src/routes/gen-agent.ts
@@ -1,0 +1,152 @@
+/// <reference types="@fastify/rate-limit" />
+// AI SDK routes "provider/model" strings through Vercel AI Gateway when
+// AI_GATEWAY_API_KEY is set in the environment. No @ai-sdk/anthropic import needed.
+import { streamText, tool } from "ai";
+import type { FastifyRequest } from "fastify";
+import type { FastifyPluginAsync } from "fastify";
+import { requireAuth } from "@mbe/auth/fastify";
+import { createProblemDetails } from "@mbe/types";
+// Import directly from catalog (not index) to avoid pulling in registry.tsx (browser-only)
+import { catalog } from "@mbe/rialto-catalog/catalog";
+import { z } from "zod";
+
+// Memoize catalog prompt at module load — avoid re-generating per request
+const CATALOG_PROMPT = catalog.prompt();
+const STAFF_SUFFIX =
+  "\n\nYou are a hospitality staff assistant. Help staff check availability, answer questions about reservations and guests.";
+const SYSTEM_PROMPT = CATALOG_PROMPT + STAFF_SUFFIX;
+
+const GenAgentBodySchema = z.object({
+  messages: z.array(
+    z.object({
+      role: z.enum(["user", "assistant"]),
+      content: z.string(),
+    })
+  ),
+});
+
+export const genAgentRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.post(
+    "/api/gen/agent",
+    {
+      preHandler: [requireAuth],
+      config: {
+        // 30 req/hour per user (more conservative than gen-chat's 50)
+        rateLimit: {
+          max: 30,
+          timeWindow: "1 hour",
+          keyGenerator: (request: FastifyRequest) => request.user?.id ?? request.ip,
+        },
+      },
+    },
+    async (request, reply) => {
+      // Validate request body
+      const parseResult = GenAgentBodySchema.safeParse(request.body);
+      if (!parseResult.success) {
+        return reply
+          .code(400)
+          .send(
+            createProblemDetails(
+              400,
+              "Bad Request",
+              parseResult.error.issues.map((i) => i.message).join(", ")
+            )
+          );
+      }
+
+      const { messages } = parseResult.data;
+
+      // Capture token for tool execution — extract from Authorization header
+      const authHeader = request.headers.authorization ?? "";
+      const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : null;
+
+      const modelId = "anthropic/claude-haiku-4-5-20251001";
+
+      const result = streamText({
+        model: modelId,
+        // GEN-05: prompt caching via providerOptions on the system message
+        messages: [
+          {
+            role: "system",
+            content: SYSTEM_PROMPT,
+            providerOptions: {
+              anthropic: { cacheControl: { type: "ephemeral" } },
+            },
+          },
+          ...messages,
+        ],
+        tools: {
+          check_availability: tool({
+            description: "Check available time slots for a venue on a specific date",
+            inputSchema: z.object({
+              venueId: z.string().describe("The venue ID to check availability for"),
+              date: z.string().describe("ISO date YYYY-MM-DD"),
+              partySize: z.number().int().positive().describe("Number of guests"),
+            }),
+            execute: async ({ venueId, date, partySize }) => {
+              const apiBase = process.env.API_URL ?? "http://localhost:3001";
+              const params = new URLSearchParams({
+                date,
+                partySize: String(partySize),
+              });
+              const url = `${apiBase}/api/v1/availability/${venueId}?${params.toString()}`;
+              const headers: Record<string, string> = {
+                "Content-Type": "application/json",
+              };
+              if (token) {
+                headers["Authorization"] = `Bearer ${token}`;
+              }
+              const response = await fetch(url, { headers });
+              if (!response.ok) {
+                throw new Error(`Availability API error: ${response.status}`);
+              }
+              const body = (await response.json()) as { data: unknown };
+              return body.data;
+            },
+          }),
+        },
+        onFinish: async ({ usage, providerMetadata }) => {
+          const anthropicMeta = providerMetadata?.anthropic as
+            | { cacheCreationInputTokens?: number; cacheReadInputTokens?: number }
+            | undefined;
+          request.log.info(
+            {
+              userId: request.user?.id,
+              modelId,
+              inputTokens: usage.inputTokens,
+              outputTokens: usage.outputTokens,
+              cacheReadInputTokens: anthropicMeta?.cacheReadInputTokens ?? 0,
+              cacheCreationInputTokens: anthropicMeta?.cacheCreationInputTokens ?? 0,
+            },
+            "gen-agent cost log"
+          );
+        },
+      });
+
+      // NDJSON streaming — each chunk as { type: "text", content: "..." }
+      reply.header("Content-Type", "application/x-ndjson; charset=utf-8");
+      reply.header("Cache-Control", "no-cache");
+      reply.header("Connection", "keep-alive");
+      reply.header("X-Accel-Buffering", "no");
+
+      const encoder = new TextEncoder();
+
+      const ndjsonStream = new ReadableStream({
+        async start(controller) {
+          try {
+            for await (const chunk of result.textStream) {
+              const line = JSON.stringify({ type: "text", content: chunk }) + "\n";
+              controller.enqueue(encoder.encode(line));
+            }
+          } catch {
+            // Stream ended or aborted
+          } finally {
+            controller.close();
+          }
+        },
+      });
+
+      return reply.send(ndjsonStream);
+    }
+  );
+};


### PR DESCRIPTION
## Summary

- **Backend**: New `POST /api/gen/agent` route in `services/agent` — streaming agentic endpoint with `check_availability` tool (calls reservations API via native fetch, returns NDJSON `{ type, content }` chunks). Rate limited to 30 req/hour per user. Prompt cached on system message.
- **Frontend**: New `ChatPanel` component + `useChatStream` hook in `packages/rialto`. Multi-turn NDJSON chat with message history, streaming accumulation, AbortController cancellation, empty state, loading indicator.
- **Integration**: `DashboardLayout` in `apps/hospitality` mounts `ChatPanel` via a new "Staff Chat" nav item in the Tools section.

## What was built

- `services/agent/src/routes/gen-agent.ts` — Fastify route mirroring `gen-chat.ts`, using Vercel AI SDK `streamText()` with AI SDK v6 `tool()` helper (`inputSchema` not `parameters`)
- `packages/rialto/src/components/ChatPanel/ChatPanel.tsx` — Drawer-based chat UI
- `packages/rialto/src/components/ChatPanel/useChatStream.ts` — NDJSON streaming hook
- All exports wired: rialto barrel, package.json exports map

## Test plan

- [x] `pnpm --dir services/agent test` — 215/215 pass (7 new gen-agent tests)
- [x] `pnpm --dir packages/rialto test` — 1615/1615 pass (17 new ChatPanel/useChatStream tests)
- [x] `pnpm --dir apps/hospitality test` — 731/731 pass
- [x] `pnpm --dir services/agent typecheck` — zero errors
- [x] `pnpm --dir packages/rialto typecheck` — zero errors
- [x] `pnpm --dir apps/hospitality typecheck` — zero errors
- [x] `pnpm lint` from repo root — zero errors (0 errors, pre-existing warnings only)
- [x] TDD: tests written first, verified failing, then implementation

Closes #1503

https://claude.ai/code/session_01NTMmsVBCmuU4f397a1MZUT

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTMmsVBCmuU4f397a1MZUT)_