### PR TITLE
fix(health): raise staleness threshold 1h → 24h to stop false-positive alerts

### DIFF
--- a/infrastructure/worker/edge-router.js
+++ b/infrastructure/worker/edge-router.js
@@ -281,7 +281,7 @@ function brandedErrorPage(statusCode, message, requestId, nonce = "") {
 // status is read from KV (written by GitHub Actions).
 
 const HEALTH_TIMEOUT_MS = 5_000;
-const STALENESS_THRESHOLD_MS = 60 * 60 * 1_000; // 1 hour
+const STALENESS_THRESHOLD_MS = 24 * 60 * 60 * 1_000; // 24 hours
 
 const SERVICE_ENDPOINTS = {
   users: "/health",


### PR DESCRIPTION
## Summary

- `STALENESS_THRESHOLD_MS` was `1 hour` — CI/deploy KV data expires after any quiet period (overnight, weekend)
- `computeSystemStatus` treats stale CI as `degraded`, so `/health/system` returns `degraded` during normal off-hours
- Synthetic monitoring runs twice daily, sees degraded, auto-creates noise issues (pattern: #1512)
- Fix: raise threshold to **24 hours** — matches realistic CI/deploy cadence, eliminates false-positive alerts

## Test plan

- [ ] `STALENESS_THRESHOLD_MS` changed from `60 * 60 * 1_000` to `24 * 60 * 60 * 1_000` in `edge-router.js`
- [ ] No other logic changed

Closes #1512

https://claude.ai/code/session_01K1uUwDy9P8y6tLkSPvEwmw

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1uUwDy9P8y6tLkSPvEwmw)_