### PR TITLE
fix(ci): regenerate dependency-graph.md — agent service gained api-client dep

### DIFF
--- a/docs/architecture/dependency-graph.md
+++ b/docs/architecture/dependency-graph.md
@@ -60,13 +60,14 @@ flowchart TD
   rialto_web --> sentry
   rialto_web --> config
   agent_service --> agent_core
+  agent_service --> api_client
   agent_service --> api_versioning
   agent_service --> auth
-  agent_service --> observability
-  agent_service --> sentry
-  agent_service --> rialto_catalog
-  agent_service --> types
   agent_service --> database
+  agent_service --> observability
+  agent_service --> rialto_catalog
+  agent_service --> sentry
+  agent_service --> types
   agent_service --> agent_test_utils
   agent_service --> config
   reservations_service --> api_versioning
@@ -144,9 +145,9 @@ flowchart TD
 
 ## Legend
 
-| Color  | Category                        |
-| ------ | ------------------------------- |
-| Blue   | Frontend Apps (`apps/*`)        |
-| Amber  | Backend Services (`services/*`) |
-| Indigo | Shared Packages (`packages/*`)  |
-| Green  | Developer Tools (`tools/*`)     |
+| Color | Category |
+|-------|----------|
+| Blue | Frontend Apps (`apps/*`) |
+| Amber | Backend Services (`services/*`) |
+| Indigo | Shared Packages (`packages/*`) |
+| Green | Developer Tools (`tools/*`) |


### PR DESCRIPTION
## Summary

- `dependency-graph.md` was stale — agent service recently gained `@mbe/api-client` as a dependency but the graph wasn't regenerated
- This caused the Build job's "Check dependency graph drift" step to fail on every PR (baseline failure)
- Also updates table formatting (script output changed from padded columns to minimal markdown)

## Root Cause

The `pnpm graph` step in CI runs `node scripts/generate-dep-graph.js` and diffs `docs/architecture/dependency-graph.md`. The committed file didn't reflect the `@mbe/api-client` edge added to `services/agent` in recent commits.

## Fix

Ran `pnpm graph` locally and committed the result.

---
*Fixes baseline Build failure affecting all open PRs (#1528, #1531, #1532, #1534, etc.)*

https://claude.ai/code/session_01Wia32okyosGxsYz4c38jMS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wia32okyosGxsYz4c38jMS)_