### PR TITLE
refactor(auth): extract isAdmin into hasPermission in @mbe/auth

### DIFF
--- a/packages/auth/src/fastify/index.ts
+++ b/packages/auth/src/fastify/index.ts
@@ -1,3 +1,9 @@
-export { authPlugin, requireAuth, optionalAuth, getAuthPluginOptionsFromEnv } from "./plugin.js";
+export {
+  authPlugin,
+  requireAuth,
+  optionalAuth,
+  getAuthPluginOptionsFromEnv,
+  hasPermission,
+} from "./plugin.js";
 export type { AuthPluginOptions } from "./plugin.js";
 export type { AuthUser } from "../types/index.js";

--- a/packages/auth/src/fastify/plugin.test.ts
+++ b/packages/auth/src/fastify/plugin.test.ts
@@ -327,6 +327,46 @@ describe("Auth Plugin", () => {
     });
   });
 
+  describe("hasPermission", () => {
+    it("returns false when user is undefined", async () => {
+      const { hasPermission } = await import("./plugin.js");
+      expect(hasPermission(undefined, "admin")).toBe(false);
+    });
+
+    it("returns false when user has no permissions array", async () => {
+      const { hasPermission } = await import("./plugin.js");
+      const user = { id: "u1", raw: { sub: "u1", iss: "", aud: "", exp: 0, iat: 0 } };
+      expect(hasPermission(user as any, "admin")).toBe(false);
+    });
+
+    it("returns false when permissions is not an array", async () => {
+      const { hasPermission } = await import("./plugin.js");
+      const user = {
+        id: "u1",
+        raw: { sub: "u1", iss: "", aud: "", exp: 0, iat: 0, permissions: "admin" },
+      };
+      expect(hasPermission(user as any, "admin")).toBe(false);
+    });
+
+    it("returns false when permission not in array", async () => {
+      const { hasPermission } = await import("./plugin.js");
+      const user = {
+        id: "u1",
+        raw: { sub: "u1", iss: "", aud: "", exp: 0, iat: 0, permissions: ["read"] },
+      };
+      expect(hasPermission(user as any, "admin")).toBe(false);
+    });
+
+    it("returns true when permission is in array", async () => {
+      const { hasPermission } = await import("./plugin.js");
+      const user = {
+        id: "u1",
+        raw: { sub: "u1", iss: "", aud: "", exp: 0, iat: 0, permissions: ["admin", "read"] },
+      };
+      expect(hasPermission(user as any, "admin")).toBe(true);
+    });
+  });
+
   describe("rate-limit registration check", () => {
     it("logs a warning when rateLimit decorator is missing", async () => {
       const warnSpy = vi.fn();

--- a/packages/auth/src/fastify/plugin.ts
+++ b/packages/auth/src/fastify/plugin.ts
@@ -161,6 +161,12 @@ export const authPlugin: FastifyPluginAsync<AuthPluginOptions> = fp(authPluginIm
   fastify: "5.x",
 });
 
+export function hasPermission(user: AuthUser | undefined, permission: string): boolean {
+  const permissions = user?.raw?.permissions;
+  if (!Array.isArray(permissions)) return false;
+  return permissions.includes(permission);
+}
+
 export async function requireAuth(request: FastifyRequest, reply: FastifyReply) {
   const isBypassed =
     process.env.AUTH_BYPASS_IN_TESTS === "true" && request.headers["x-auth-bypass"] === "true";

--- a/services/reservations/src/routes/reservations.ts
+++ b/services/reservations/src/routes/reservations.ts
@@ -10,14 +10,9 @@ import type {
   PaginatedResponse,
 } from "@mbe/types";
 import { createProblemDetails } from "@mbe/types";
-import { requireAuth, optionalAuth, type AuthUser } from "@mbe/auth/fastify";
+import { requireAuth, optionalAuth, hasPermission } from "@mbe/auth/fastify";
 import { parseFeatureFlags, isEnabled } from "@mbe/feature-flags";
 import { reservationService } from "../services/reservation.js";
-
-function isAdmin(user: AuthUser | undefined): boolean {
-  const permissions = user?.raw?.permissions;
-  return Array.isArray(permissions) && permissions.includes("admin");
-}
 import {
   emitReservationCancelled,
   emitReservationCreated,
@@ -101,7 +96,7 @@ export const reservationRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (request, reply) => {
       const authUser = request.user;
-      const adminAccess = isAdmin(authUser);
+      const adminAccess = hasPermission(authUser, "admin");
 
       if (!adminAccess) {
         reply.code(403);
@@ -328,7 +323,7 @@ export const reservationRoutes: FastifyPluginAsync = async (fastify) => {
       }
 
       const authUser = request.user;
-      const adminAccess = isAdmin(authUser);
+      const adminAccess = hasPermission(authUser, "admin");
       const isOwner = reservation.guestEmail === authUser?.email;
 
       if (!adminAccess && !isOwner) {
@@ -579,7 +574,7 @@ export const reservationRoutes: FastifyPluginAsync = async (fastify) => {
       }
 
       const authUser = request.user;
-      const adminAccess = isAdmin(authUser);
+      const adminAccess = hasPermission(authUser, "admin");
       const isOwner = authUser?.email && reservation.guestEmail === authUser.email;
 
       if (!adminAccess && !isOwner) {
@@ -693,7 +688,7 @@ export const reservationRoutes: FastifyPluginAsync = async (fastify) => {
       }
 
       const authUser = request.user;
-      const adminAccess = isAdmin(authUser);
+      const adminAccess = hasPermission(authUser, "admin");
       const isOwner = authUser?.email && reservation.guestEmail === authUser.email;
 
       if (!adminAccess && !isOwner) {

--- a/services/users/src/routes/users.ts
+++ b/services/users/src/routes/users.ts
@@ -9,13 +9,8 @@ import {
   type PaginatedResponse,
   createProblemDetails,
 } from "@mbe/types";
-import { requireAuth, type AuthUser } from "@mbe/auth/fastify";
+import { requireAuth, hasPermission } from "@mbe/auth/fastify";
 import { userService } from "../services/user.js";
-
-function isAdmin(user: AuthUser | undefined): boolean {
-  const permissions = user?.raw?.permissions;
-  return Array.isArray(permissions) && permissions.includes("admin");
-}
 
 export const userRoutes: FastifyPluginAsync = async (fastify) => {
   // List users
@@ -67,7 +62,7 @@ export const userRoutes: FastifyPluginAsync = async (fastify) => {
       },
     },
     async (request, reply) => {
-      if (!isAdmin(request.user)) {
+      if (!hasPermission(request.user, "admin")) {
         reply.code(403);
         return reply.send(
           createProblemDetails(403, "Forbidden", "Admin access required to list all users") as never
@@ -125,7 +120,7 @@ export const userRoutes: FastifyPluginAsync = async (fastify) => {
       const authUser = request.user;
       const requestedId = request.params.id;
 
-      if (!isAdmin(authUser)) {
+      if (!hasPermission(authUser, "admin")) {
         if (!authUser?.email) {
           return reply
             .code(401)
@@ -275,7 +270,7 @@ export const userRoutes: FastifyPluginAsync = async (fastify) => {
       const authUser = request.user;
       const requestedId = request.params.id;
 
-      if (!isAdmin(authUser)) {
+      if (!hasPermission(authUser, "admin")) {
         if (!authUser?.email) {
           return reply
             .code(401)
@@ -339,7 +334,7 @@ export const userRoutes: FastifyPluginAsync = async (fastify) => {
       const authUser = request.user;
       const requestedId = request.params.id;
 
-      if (!isAdmin(authUser)) {
+      if (!hasPermission(authUser, "admin")) {
         if (!authUser?.email) {
           return reply
             .code(401)


### PR DESCRIPTION
## Summary

- Add `hasPermission(user, permission)` to `@mbe/auth/fastify` — replaces the two identical private `isAdmin` fns that lived in both services
- Export `hasPermission` from `packages/auth/src/fastify/index.ts`
- Delete local `isAdmin` in `services/reservations/src/routes/reservations.ts` and `services/users/src/routes/users.ts`, import and use `hasPermission(..., "admin")` instead
- Tests written first (TDD): 5 cases covering undefined user, missing permissions array, non-array permissions, wrong permission, correct permission — all GREEN

## Test plan

- [x] `pnpm --dir packages/auth test` — 51 tests pass (includes 5 new `hasPermission` tests)
- [x] `pnpm --dir services/users test` — 149 tests pass
- [x] `pnpm --dir services/reservations test` — 239 pass (10 pre-existing failures due to baseline `@mbe/feature-flags` resolution error, confirmed same on `main`)
- [x] `pnpm --dir packages/auth typecheck` — clean
- [x] `pnpm --dir services/users typecheck` — clean
- [x] `pnpm --dir services/reservations typecheck` — only pre-existing `@mbe/feature-flags` error (baseline)
- [x] Pre-push turbo test suite — 39 tasks, all pass

Closes #1545

https://claude.ai/code/session_011vHk6osozjgT3wkk9a9o3D

---
_Generated by [Claude Code](https://claude.ai/code/session_011vHk6osozjgT3wkk9a9o3D)_