### PR TITLE
fix(auth): use canonical createProblemDetails from @mbe/types (ADR-002)

### DIFF
--- a/packages/auth/src/fastify/plugin.test.ts
+++ b/packages/auth/src/fastify/plugin.test.ts
@@ -116,6 +116,22 @@ describe("Auth Plugin", () => {
       expect(mockJwtVerify).not.toHaveBeenCalled();
     });
 
+    it("returns RFC 9457 problem details with about:blank type on 401", async () => {
+      mockJwtVerify.mockRejectedValueOnce(new Error("Invalid token"));
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/protected",
+        headers: {
+          authorization: "Bearer invalid-token",
+        },
+      });
+
+      expect(response.statusCode).toBe(401);
+      const body = JSON.parse(response.body);
+      expect(body.type).toBe("about:blank");
+    });
+
     it("returns 401 for invalid/malformed token", async () => {
       mockJwtVerify.mockRejectedValueOnce(new Error("Invalid token"));
 

--- a/packages/auth/src/fastify/plugin.ts
+++ b/packages/auth/src/fastify/plugin.ts
@@ -2,6 +2,7 @@ import { createRemoteJWKSet, jwtVerify } from "jose";
 import fp from "fastify-plugin";
 import type { FastifyInstance, FastifyRequest, FastifyReply, FastifyPluginAsync } from "fastify";
 import type { JWTPayload, AuthUser } from "../types/index.js";
+import { createProblemDetails } from "@mbe/types";
 
 declare module "fastify" {
   interface FastifyRequest {
@@ -16,18 +17,6 @@ export interface AuthPluginOptions {
   audience: string;
   /** Routes to exclude from token verification (e.g., ["/health"]) */
   excludePaths?: string[];
-}
-
-function createProblemDetails(status: number, title: string, detail: string) {
-  return {
-    type: `https://httpstatuses.com/${status}`,
-    title,
-    status,
-    detail,
-    error: title,
-    message: detail,
-    statusCode: status,
-  };
 }
 
 /**


### PR DESCRIPTION
## Summary

- Delete local `createProblemDetails` from `packages/auth/src/fastify/plugin.ts` that diverged from canonical version (set non-standard `type: https://httpstatuses.com/${status}` instead of RFC 7807 `about:blank`)
- Import `createProblemDetails` from `@mbe/types` — package already had the dependency
- Auth error responses now match all other services' error shape (ADR-002 compliance)

## Test plan

- [x] TDD: wrote test asserting 401 response `type` field = `"about:blank"` (RED — failed with `https://httpstatuses.com/401`)
- [x] Swapped to canonical import (GREEN — 52 tests pass)
- [x] `pnpm --dir packages/auth typecheck` clean
- [x] Pre-push turbo test suite — 21 tasks all pass

Closes #1546