### PR TITLE
fix(agent-core): replace hardcoded model IDs with resolveModelId() registry

### DIFF
--- a/packages/agent-core/src/__tests__/success-evaluator.test.ts
+++ b/packages/agent-core/src/__tests__/success-evaluator.test.ts
@@ -184,7 +184,7 @@ describe("evaluateSuccess", () => {
     expect(query).toHaveBeenCalledWith(
       expect.objectContaining({
         options: expect.objectContaining({
-          model: "claude-haiku-4-5-20250929",
+          model: "claude-haiku-4-5-20251001",
         }),
       })
     );

--- a/packages/agent-core/src/diff-reviewer.ts
+++ b/packages/agent-core/src/diff-reviewer.ts
@@ -1,5 +1,6 @@
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import type { SDKResultMessage } from "@anthropic-ai/claude-agent-sdk";
+import { resolveModelId } from "./model-router.js";
 
 // ── Types ───────────────────────────────────────────────────────────
 
@@ -14,7 +15,7 @@ export interface ReviewConfig {
 }
 
 export const DEFAULT_REVIEW_CONFIG: ReviewConfig = {
-  model: "claude-haiku-4-5-20250929",
+  model: resolveModelId("haiku"),
   maxBudgetUsd: 0.05,
 };
 

--- a/packages/agent-core/src/intent-extractor.ts
+++ b/packages/agent-core/src/intent-extractor.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { trace } from "@opentelemetry/api";
+import { resolveModelId } from "./model-router.js";
 
 const tracer = trace.getTracer("@mbe/agent-core");
 
@@ -122,7 +123,7 @@ export async function extractIssueIntent(
     const client = new sdkModule.default();
 
     const response = await client.messages.create({
-      model: "claude-haiku-4-5-20251001",
+      model: resolveModelId("haiku"),
       max_tokens: 1024,
       system:
         "You extract structured task intent from GitHub issues for an autonomous coding agent. " +

--- a/packages/agent-core/src/model-ids-registry.test.ts
+++ b/packages/agent-core/src/model-ids-registry.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { resolveModelId } from "./model-router.js";
+import { DEFAULT_EVALUATION_CONFIG } from "./success-evaluator.js";
+import { DEFAULT_REVIEW_CONFIG } from "./diff-reviewer.js";
+import { DEFAULT_SESSION_CONFIG } from "./types.js";
+import { DEFAULT_ORCHESTRATOR_CONFIG } from "./task-decomposer.js";
+
+describe("model ID registry consistency", () => {
+  describe("stale haiku IDs (active bug)", () => {
+    it("success-evaluator default config uses the canonical haiku ID", () => {
+      expect(DEFAULT_EVALUATION_CONFIG.model).toBe(resolveModelId("haiku"));
+    });
+
+    it("diff-reviewer default config uses the canonical haiku ID", () => {
+      expect(DEFAULT_REVIEW_CONFIG.model).toBe(resolveModelId("haiku"));
+    });
+  });
+
+  describe("hardcoded but correct IDs (should use registry)", () => {
+    it("types.ts default session config uses the canonical sonnet ID", () => {
+      expect(DEFAULT_SESSION_CONFIG.model).toBe(resolveModelId("sonnet"));
+    });
+
+    it("task-decomposer orchestrator model uses the canonical sonnet ID", () => {
+      expect(DEFAULT_ORCHESTRATOR_CONFIG.model).toBe(resolveModelId("sonnet"));
+    });
+
+    it("task-decomposer session model uses the canonical sonnet ID", () => {
+      expect(DEFAULT_ORCHESTRATOR_CONFIG.sessionModel).toBe(resolveModelId("sonnet"));
+    });
+  });
+});

--- a/packages/agent-core/src/success-evaluator.ts
+++ b/packages/agent-core/src/success-evaluator.ts
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import type { SDKResultMessage } from "@anthropic-ai/claude-agent-sdk";
+import { resolveModelId } from "./model-router.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -20,7 +21,7 @@ export interface EvaluationConfig {
 }
 
 export const DEFAULT_EVALUATION_CONFIG: EvaluationConfig = {
-  model: "claude-haiku-4-5-20250929",
+  model: resolveModelId("haiku"),
   maxBudgetUsd: 0.05,
 };
 

--- a/packages/agent-core/src/task-decomposer.ts
+++ b/packages/agent-core/src/task-decomposer.ts
@@ -6,6 +6,8 @@
  * instructs the orchestrator on how to decompose tasks effectively.
  */
 
+import { resolveModelId } from "./model-router.js";
+
 export interface OrchestratorConfig {
   readonly taskDescription: string;
   readonly apiBaseUrl: string;
@@ -20,8 +22,8 @@ export interface OrchestratorConfig {
 
 export const DEFAULT_ORCHESTRATOR_CONFIG: Omit<OrchestratorConfig, "taskDescription"> = {
   apiBaseUrl: "http://localhost:3003",
-  model: "claude-sonnet-4-6",
-  sessionModel: "claude-sonnet-4-6",
+  model: resolveModelId("sonnet"),
+  sessionModel: resolveModelId("sonnet"),
   maxBudgetPerSession: 1.0,
   maxTurnsPerSession: 50,
   baseBranch: "main",

--- a/packages/agent-core/src/task-intelligence.ts
+++ b/packages/agent-core/src/task-intelligence.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { existsSync } from "node:fs";
+import { resolveModelId } from "./model-router.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -135,10 +136,10 @@ export function resolveBudget(taskDescription: string): BudgetConfig {
 // Choose the right model based on task type.
 
 const MODEL_MAP = {
-  simple: "claude-haiku-4-5-20251001",
-  standard: "claude-sonnet-4-6",
-  complex: "claude-sonnet-4-6",
-} as const;
+  simple: resolveModelId("haiku"),
+  standard: resolveModelId("sonnet"),
+  complex: resolveModelId("sonnet"),
+};
 
 /**
  * Select model based on task complexity.

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -1,5 +1,6 @@
 import type { SDKMessage, SDKResultMessage } from "@anthropic-ai/claude-agent-sdk";
 import type { StuckDetectorConfig } from "./stuck-detector.js";
+import { resolveModelId } from "./model-router.js";
 
 // ── Failure categorization ───────────────────────────────────────────
 
@@ -88,7 +89,7 @@ export interface SessionConfig {
 
 export const DEFAULT_SESSION_CONFIG: Omit<SessionConfig, "taskDescription" | "repoPath"> = {
   baseBranch: "main",
-  model: "claude-sonnet-4-6",
+  model: resolveModelId("sonnet"),
   maxTurns: 50,
   maxBudgetUsd: 1.0,
   allowedTools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash", "NotebookEdit"],


### PR DESCRIPTION
## Summary

- Fix 2 stale haiku IDs in `success-evaluator.ts` and `diff-reviewer.ts` (`"claude-haiku-4-5-20250929"` → `resolveModelId("haiku")`)
- Centralize all 6 files with hardcoded model IDs to use `resolveModelId(tier)` from the canonical registry in `model-router.ts`
- Model upgrade now requires exactly one edit in `MODEL_IDS`

## Test plan

- [x] TDD: wrote `model-ids-registry.test.ts` with 5 assertions verifying defaults match registry (RED — stale IDs exposed)
- [x] Fixed stale assertion in `success-evaluator.test.ts` that encoded the bug
- [x] All 890 agent-core tests pass (GREEN)
- [x] `pnpm --dir packages/agent-core typecheck` clean
- [x] Grep confirms no remaining hardcoded model IDs in non-test source files

Closes #1547