### PR TITLE
fix(database): guard shutdown() against duplicate pool.end() calls

### DIFF
--- a/packages/database/src/index.test.ts
+++ b/packages/database/src/index.test.ts
@@ -247,6 +247,23 @@ describe("createDatabase", () => {
     expect(stats.utilization).toBe(0);
   });
 
+  it("shutdown is idempotent — calling it twice does not call pool.end() twice", async () => {
+    const { createDatabase } = await import("./index.js");
+    const MockPrisma = createMockPrismaClient();
+    const db = createDatabase(MockPrisma as never);
+
+    // Clear any calls from prior tests or beforeExit registrations
+    mockPoolInstance.end.mockClear();
+
+    // First shutdown should call pool.end() exactly once
+    await db.shutdown();
+    expect(mockPoolInstance.end).toHaveBeenCalledTimes(1);
+
+    // Second shutdown should be a no-op (idempotent guard)
+    await db.shutdown();
+    expect(mockPoolInstance.end).toHaveBeenCalledTimes(1);
+  });
+
   it("$allOperations handles undefined model and operation in slow query", async () => {
     const { createDatabase } = await import("./index.js");
     createDatabase(createMockPrismaClient() as never);

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -122,6 +122,8 @@ export function createDatabase<T extends PrismaLike>(
     return "ok";
   }
 
+  let isShutDown = false;
+
   const adapter = new PrismaPg(pool);
   const basePrisma = new PrismaClient({ adapter });
 
@@ -183,6 +185,8 @@ export function createDatabase<T extends PrismaLike>(
   }) as T;
 
   async function shutdown() {
+    if (isShutDown) return;
+    isShutDown = true;
     await basePrisma.$disconnect();
     await pool.end();
   }


### PR DESCRIPTION
## Summary

- Add `isShutDown` guard to `shutdown()` in `createDatabase()` factory — prevents duplicate `pool.end()` calls when `beforeExit` fires multiple times during async shutdown
- Root cause: `process.on("beforeExit", shutdown)` can fire multiple times because `shutdown()` is async, and SIGTERM handler calls `process.exit(0)` which triggers `beforeExit`

## Test plan

- [x] TDD: wrote test calling `shutdown()` twice, asserting `pool.end()` called only once (RED → GREEN)
- [x] All 14 database package tests pass
- [x] `pnpm --dir packages/database typecheck` clean

Closes #1550