### PR TITLE
refactor(database): extract shared Fastify app bootstrap (#1564)

### DIFF
--- a/infrastructure/worker/dep-graph.json
+++ b/infrastructure/worker/dep-graph.json
@@ -409,12 +409,27 @@
     },
     {
       "from": "@mbe/database",
-      "to": "@mbe/config",
-      "type": "devDependency"
+      "to": "@mbe/api-versioning",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/database",
+      "to": "@mbe/auth",
+      "type": "dependency"
     },
     {
       "from": "@mbe/database",
       "to": "@mbe/observability",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/database",
+      "to": "@mbe/sentry",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/database",
+      "to": "@mbe/config",
       "type": "devDependency"
     },
     {

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -18,7 +18,16 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@fastify/cors": "^11.2.0",
+    "@fastify/rate-limit": "^10.3.0",
+    "@fastify/swagger": "^9.7.0",
+    "@fastify/swagger-ui": "^5.2.6",
+    "@mbe/api-versioning": "workspace:*",
+    "@mbe/auth": "workspace:*",
+    "@mbe/observability": "workspace:*",
+    "@mbe/sentry": "workspace:*",
     "@prisma/adapter-pg": "^7.8.0",
+    "@scalar/fastify-api-reference": "^1.55.3",
     "fastify-plugin": "^5.0.0",
     "pg": "^8.20.0"
   },
@@ -32,7 +41,6 @@
   },
   "devDependencies": {
     "@mbe/config": "workspace:*",
-    "@mbe/observability": "workspace:*",
     "@mbe/types": "workspace:*",
     "@types/node": "catalog:",
     "@types/pg": "^8.20.0",

--- a/packages/database/src/create-service-app.test.ts
+++ b/packages/database/src/create-service-app.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { FastifyInstance } from "fastify";
+import { createServiceApp, type ServiceAppConfig } from "./create-service-app.js";
+
+// Mock all plugin dependencies so tests don't require real servers/auth
+vi.mock("@fastify/cors", () => ({
+  default: vi.fn().mockImplementation(async () => {}),
+}));
+vi.mock("@fastify/rate-limit", () => ({
+  default: vi.fn().mockImplementation(async () => {}),
+}));
+vi.mock("@fastify/swagger", () => ({
+  default: vi.fn().mockImplementation(async (fastify: FastifyInstance) => {
+    fastify.decorate("swagger", () => ({}));
+  }),
+}));
+vi.mock("@fastify/swagger-ui", () => ({
+  default: vi.fn().mockImplementation(async () => {}),
+}));
+vi.mock("@scalar/fastify-api-reference", () => ({
+  default: vi.fn().mockImplementation(async () => {}),
+}));
+vi.mock("@mbe/auth/fastify", () => ({
+  authPlugin: vi.fn().mockImplementation(async () => {}),
+  getAuthPluginOptionsFromEnv: vi.fn().mockReturnValue({}),
+}));
+vi.mock("@mbe/observability", () => ({
+  createRequestIdMiddleware: vi.fn().mockReturnValue(vi.fn().mockImplementation(async () => {})),
+  errorRatePlugin_: vi.fn().mockImplementation(async (fastify: FastifyInstance) => {
+    fastify.decorate("getErrorRates", () => ({ endpoints: [], degraded: false }));
+  }),
+  createRateLimitMonitor: vi.fn().mockReturnValue({
+    recordHit: vi.fn(),
+    getSnapshot: vi.fn().mockReturnValue({
+      stats: { hits_last_hour: 0, blocked_ips: 0 },
+      isDegraded: false,
+    }),
+    reset: vi.fn(),
+  }),
+}));
+vi.mock("@mbe/sentry/node", () => ({
+  sentryFastifyPlugin: vi.fn().mockImplementation(async () => {}),
+}));
+vi.mock("@mbe/api-versioning/fastify", () => ({
+  apiVersioningPlugin: vi.fn().mockImplementation(async (fastify: FastifyInstance) => {
+    fastify.decorate("apiVersion", "v1");
+    fastify.decorate("sunsetDate", "2027-01-01");
+  }),
+}));
+
+/**
+ * Helper to extract the options (second arg) from a mocked Fastify plugin call.
+ * Fastify calls plugins with (fastify, opts, done), so opts is at index 1.
+ */
+function getPluginOpts(mockFn: ReturnType<typeof vi.fn>): unknown {
+  return mockFn.mock.calls[0]?.[1];
+}
+
+function createTestConfig(overrides?: Partial<ServiceAppConfig>): ServiceAppConfig {
+  return {
+    swagger: {
+      title: "Test API",
+      description: "Test API description",
+      serverUrl: "http://localhost:9999",
+    },
+    ...overrides,
+  };
+}
+
+describe("createServiceApp", () => {
+  let app: FastifyInstance;
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    // Reset env for each test
+    delete process.env.AUTH_AUTHORITY;
+    delete process.env.AUTH_AUDIENCE;
+    delete process.env.CORS_ORIGINS;
+    delete process.env.NODE_ENV;
+  });
+
+  afterEach(async () => {
+    if (app) await app.close();
+    process.env = { ...originalEnv };
+    vi.clearAllMocks();
+  });
+
+  it("returns a Fastify instance", async () => {
+    app = await createServiceApp(createTestConfig());
+    expect(app).toBeDefined();
+    expect(typeof app.inject).toBe("function");
+  });
+
+  it("disables request logging by default", async () => {
+    app = await createServiceApp(createTestConfig());
+    expect(app.initialConfig.disableRequestLogging).toBe(true);
+  });
+
+  it("uses strict false for AJV", async () => {
+    app = await createServiceApp(createTestConfig());
+    await app.ready();
+    expect(app).toBeDefined();
+  });
+
+  it("registers CORS plugin", async () => {
+    const cors = await import("@fastify/cors");
+    app = await createServiceApp(createTestConfig());
+    expect(cors.default).toHaveBeenCalled();
+  });
+
+  it("registers request-ID middleware", async () => {
+    const obs = await import("@mbe/observability");
+    app = await createServiceApp(createTestConfig());
+    expect(obs.createRequestIdMiddleware).toHaveBeenCalled();
+  });
+
+  it("registers error rate plugin", async () => {
+    const obs = await import("@mbe/observability");
+    app = await createServiceApp(createTestConfig());
+    expect(obs.errorRatePlugin_).toHaveBeenCalled();
+  });
+
+  it("decorates with rateLimitMonitor", async () => {
+    app = await createServiceApp(createTestConfig());
+    await app.ready();
+    expect(app.hasDecorator("rateLimitMonitor")).toBe(true);
+  });
+
+  it("registers rate limit plugin", async () => {
+    const rateLimit = await import("@fastify/rate-limit");
+    app = await createServiceApp(createTestConfig());
+    expect(rateLimit.default).toHaveBeenCalled();
+  });
+
+  it("registers swagger with config from ServiceAppConfig", async () => {
+    const swagger = await import("@fastify/swagger");
+    const config = createTestConfig({
+      swagger: {
+        title: "My Custom API",
+        description: "Custom description",
+        serverUrl: "http://localhost:4000",
+      },
+    });
+    app = await createServiceApp(config);
+    const opts = getPluginOpts(vi.mocked(swagger.default)) as Record<string, unknown>;
+    const openapi = (
+      opts as {
+        openapi: { info: { title: string; description: string }; servers: { url: string }[] };
+      }
+    ).openapi;
+    expect(openapi.info.title).toBe("My Custom API");
+    expect(openapi.info.description).toBe("Custom description");
+    expect(openapi.servers).toEqual([{ url: "http://localhost:4000" }]);
+  });
+
+  it("registers swagger-ui at /docs", async () => {
+    const swaggerUi = await import("@fastify/swagger-ui");
+    app = await createServiceApp(createTestConfig());
+    const opts = getPluginOpts(vi.mocked(swaggerUi.default)) as { routePrefix: string };
+    expect(opts.routePrefix).toBe("/docs");
+  });
+
+  it("registers Scalar API reference at /reference", async () => {
+    const scalar = await import("@scalar/fastify-api-reference");
+    app = await createServiceApp(createTestConfig());
+    const opts = getPluginOpts(vi.mocked(scalar.default)) as { routePrefix: string };
+    expect(opts.routePrefix).toBe("/reference");
+  });
+
+  it("registers auth plugin when AUTH_AUTHORITY and AUTH_AUDIENCE are set", async () => {
+    process.env.AUTH_AUTHORITY = "https://auth.example.com";
+    process.env.AUTH_AUDIENCE = "https://api.example.com";
+    const auth = await import("@mbe/auth/fastify");
+    app = await createServiceApp(createTestConfig());
+    expect(auth.authPlugin).toHaveBeenCalled();
+    expect(auth.getAuthPluginOptionsFromEnv).toHaveBeenCalled();
+  });
+
+  it("skips auth plugin when AUTH_AUTHORITY is not set in non-production", async () => {
+    process.env.NODE_ENV = "development";
+    const auth = await import("@mbe/auth/fastify");
+    app = await createServiceApp(createTestConfig());
+    expect(auth.authPlugin).not.toHaveBeenCalled();
+  });
+
+  it("throws in production when AUTH_AUTHORITY is not set", async () => {
+    process.env.NODE_ENV = "production";
+    await expect(createServiceApp(createTestConfig())).rejects.toThrow(
+      "Fail-closed: AUTH_AUTHORITY and AUTH_AUDIENCE are required in production"
+    );
+  });
+
+  it("registers Sentry plugin", async () => {
+    const sentry = await import("@mbe/sentry/node");
+    app = await createServiceApp(createTestConfig());
+    expect(sentry.sentryFastifyPlugin).toHaveBeenCalled();
+  });
+
+  it("registers API versioning plugin with defaults", async () => {
+    const versioning = await import("@mbe/api-versioning/fastify");
+    app = await createServiceApp(createTestConfig());
+    const opts = getPluginOpts(vi.mocked(versioning.apiVersioningPlugin)) as {
+      currentVersion: string;
+      successorVersion: string;
+      sunsetMonthsFromNow: number;
+    };
+    expect(opts.currentVersion).toBe("v1");
+    expect(opts.successorVersion).toBe("v2");
+    expect(opts.sunsetMonthsFromNow).toBe(6);
+  });
+
+  it("accepts custom logger option", async () => {
+    app = await createServiceApp(createTestConfig(), { logger: false });
+    expect(app).toBeDefined();
+  });
+
+  it("accepts custom API versioning config", async () => {
+    const versioning = await import("@mbe/api-versioning/fastify");
+    app = await createServiceApp(
+      createTestConfig({
+        apiVersioning: {
+          currentVersion: "v2",
+          successorVersion: "v3",
+          sunsetMonthsFromNow: 12,
+        },
+      })
+    );
+    const opts = getPluginOpts(vi.mocked(versioning.apiVersioningPlugin)) as {
+      currentVersion: string;
+      successorVersion: string;
+      sunsetMonthsFromNow: number;
+    };
+    expect(opts.currentVersion).toBe("v2");
+    expect(opts.successorVersion).toBe("v3");
+    expect(opts.sunsetMonthsFromNow).toBe(12);
+  });
+
+  it("validates CORS origins from CORS_ORIGINS env var", async () => {
+    process.env.CORS_ORIGINS = "https://mattbutlerengineering.com,https://evil.com";
+    const cors = await import("@fastify/cors");
+    app = await createServiceApp(createTestConfig());
+    const opts = getPluginOpts(vi.mocked(cors.default)) as { origin: string[] };
+    expect(opts.origin).toEqual(["https://mattbutlerengineering.com"]);
+  });
+
+  it("falls back to default origins when all env origins are rejected", async () => {
+    process.env.CORS_ORIGINS = "https://evil.com";
+    const cors = await import("@fastify/cors");
+    app = await createServiceApp(createTestConfig());
+    const opts = getPluginOpts(vi.mocked(cors.default)) as { origin: string[] };
+    expect(opts.origin).toContain("https://mattbutlerengineering.com");
+  });
+
+  it("includes dev origins in development mode", async () => {
+    process.env.NODE_ENV = "development";
+    const cors = await import("@fastify/cors");
+    app = await createServiceApp(createTestConfig());
+    const opts = getPluginOpts(vi.mocked(cors.default)) as { origin: string[] };
+    expect(opts.origin).toContain("http://localhost:3000");
+    expect(opts.origin).toContain("http://localhost:5173");
+  });
+
+  it("does not include dev origins in production mode", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.AUTH_AUTHORITY = "https://auth.example.com";
+    process.env.AUTH_AUDIENCE = "https://api.example.com";
+    const cors = await import("@fastify/cors");
+    app = await createServiceApp(createTestConfig());
+    const opts = getPluginOpts(vi.mocked(cors.default)) as { origin: string[] };
+    expect(opts.origin).not.toContain("http://localhost:3000");
+  });
+
+  it("calls registerSchemas hook when provided", async () => {
+    const registerSchemas = vi.fn();
+    app = await createServiceApp(createTestConfig({ registerSchemas }));
+    expect(registerSchemas).toHaveBeenCalledTimes(1);
+    // The function receives a Fastify instance (may be encapsulated)
+    const calledWith = registerSchemas.mock.calls[0]?.[0];
+    expect(calledWith).toBeDefined();
+    expect(typeof calledWith.addSchema).toBe("function");
+  });
+
+  it("does not fail when registerSchemas is not provided", async () => {
+    app = await createServiceApp(createTestConfig());
+    expect(app).toBeDefined();
+  });
+
+  it("rate limit onExceeded logs and records hit", async () => {
+    const rateLimit = await import("@fastify/rate-limit");
+    const obs = await import("@mbe/observability");
+    app = await createServiceApp(createTestConfig());
+
+    // Extract the onExceeded callback from the rate limit registration call
+    const rateLimitOpts = getPluginOpts(vi.mocked(rateLimit.default)) as {
+      onExceeded: (req: {
+        ip: string;
+        url: string;
+        log: { warn: (...args: unknown[]) => void };
+      }) => void;
+    };
+    const mockReq = {
+      ip: "127.0.0.1",
+      url: "/test",
+      log: { warn: vi.fn() },
+    };
+    rateLimitOpts.onExceeded(mockReq);
+
+    const monitor = vi.mocked(obs.createRateLimitMonitor).mock.results[0]?.value;
+    expect(monitor.recordHit).toHaveBeenCalledWith("127.0.0.1", "/test");
+    expect(mockReq.log.warn).toHaveBeenCalled();
+  });
+});

--- a/packages/database/src/create-service-app.ts
+++ b/packages/database/src/create-service-app.ts
@@ -1,0 +1,215 @@
+import Fastify, { type FastifyInstance } from "fastify";
+import cors from "@fastify/cors";
+import rateLimit from "@fastify/rate-limit";
+import swagger from "@fastify/swagger";
+import swaggerUi from "@fastify/swagger-ui";
+import ScalarApiReference from "@scalar/fastify-api-reference";
+import { authPlugin, getAuthPluginOptionsFromEnv } from "@mbe/auth/fastify";
+import {
+  createRequestIdMiddleware,
+  errorRatePlugin_,
+  createRateLimitMonitor,
+} from "@mbe/observability";
+import { sentryFastifyPlugin } from "@mbe/sentry/node";
+import { apiVersioningPlugin } from "@mbe/api-versioning/fastify";
+
+/**
+ * Swagger/OpenAPI configuration for the service.
+ */
+export interface SwaggerConfig {
+  readonly title: string;
+  readonly description: string;
+  readonly serverUrl: string;
+  readonly version?: string;
+}
+
+/**
+ * API versioning configuration.
+ */
+export interface ApiVersioningConfig {
+  readonly currentVersion: string;
+  readonly successorVersion: string;
+  readonly sunsetMonthsFromNow: number;
+}
+
+/**
+ * Configuration for createServiceApp.
+ * Services provide only the values that differ; shared bootstrap is handled internally.
+ */
+export interface ServiceAppConfig {
+  /** Swagger/OpenAPI metadata — differs per service */
+  readonly swagger: SwaggerConfig;
+  /** API versioning — defaults to v1 → v2, sunset in 6 months */
+  readonly apiVersioning?: ApiVersioningConfig;
+  /** Optional hook to register service-specific JSON schemas before plugins */
+  readonly registerSchemas?: (fastify: FastifyInstance) => void;
+}
+
+export interface AppOptions {
+  logger?: boolean | object;
+}
+
+/**
+ * Validates CORS origins from the CORS_ORIGINS env var against an allowlist.
+ * Accepts *.mattbutlerengineering.com in all environments and localhost
+ * origins only in development. Returns only the origins that pass validation.
+ */
+function validateCorsOrigins(origins: string[]): string[] {
+  const validPatterns = [
+    /^https:\/\/([a-z-]+\.)?mattbutlerengineering\.com$/,
+    ...(process.env.NODE_ENV === "development" ? [/^http:\/\/localhost:\d+$/] : []),
+  ];
+
+  const validated: string[] = [];
+  for (const origin of origins) {
+    const trimmed = origin.trim();
+    if (validPatterns.some((p) => p.test(trimmed))) {
+      validated.push(trimmed);
+    } else {
+      console.warn(`[CORS] Rejected invalid origin from CORS_ORIGINS: ${trimmed}`);
+    }
+  }
+  return validated;
+}
+
+/**
+ * Creates a Fastify application with all shared plugins pre-registered:
+ * CORS, request-ID, error-rate tracking, rate-limiting, Swagger/Scalar,
+ * Auth0, Sentry, and API versioning.
+ *
+ * Services call this instead of duplicating ~100 lines of identical bootstrap,
+ * then register their own routes on the returned instance.
+ */
+export async function createServiceApp(
+  config: ServiceAppConfig,
+  options: AppOptions = {}
+): Promise<FastifyInstance> {
+  const fastify = Fastify({
+    logger: options.logger ?? true,
+    disableRequestLogging: true,
+    ajv: { customOptions: { strict: false } },
+  });
+
+  // Register service-specific schemas (if provided)
+  if (config.registerSchemas) {
+    config.registerSchemas(fastify);
+  }
+
+  // --- CORS ---
+  const defaultDevOrigins = [
+    "http://localhost:3000",
+    "http://localhost:3002",
+    "http://localhost:3003",
+    "http://localhost:3004",
+    "http://localhost:5173",
+    "http://localhost:5174",
+  ];
+  const prodOrigins = [
+    "https://mattbutlerengineering.com",
+    "https://hospitality.mattbutlerengineering.com",
+    "https://gen.mattbutlerengineering.com",
+  ];
+
+  const defaultOrigins = [
+    ...prodOrigins,
+    ...(process.env.NODE_ENV === "development" ? defaultDevOrigins : []),
+  ];
+
+  const envOrigins = process.env.CORS_ORIGINS?.split(",");
+  const validatedEnv = envOrigins ? validateCorsOrigins(envOrigins) : null;
+
+  if (validatedEnv && validatedEnv.length === 0) {
+    console.warn("[CORS] All CORS_ORIGINS were rejected; falling back to defaults");
+  }
+
+  const corsOrigins = validatedEnv && validatedEnv.length > 0 ? validatedEnv : defaultOrigins;
+
+  await fastify.register(cors, {
+    origin: corsOrigins,
+    credentials: true,
+    allowedHeaders: ["Content-Type", "Authorization"],
+    methods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
+  });
+
+  // --- Observability ---
+  // Propagate X-Request-ID from edge router for distributed tracing
+  await fastify.register(createRequestIdMiddleware());
+
+  // Track per-endpoint error rates (exposed via health check)
+  await fastify.register(errorRatePlugin_);
+
+  const rateLimitMonitor = createRateLimitMonitor();
+  fastify.decorate("rateLimitMonitor", rateLimitMonitor);
+
+  // --- Rate limiting ---
+  await fastify.register(rateLimit, {
+    max: 100,
+    timeWindow: "1 minute",
+    onExceeded: (req) => {
+      const ip = req.ip;
+      const endpoint = req.url;
+      rateLimitMonitor.recordHit(ip, endpoint);
+      req.log.warn({ ip, endpoint, timestamp: new Date().toISOString() }, "Rate limit exceeded");
+    },
+  });
+
+  // --- Swagger / OpenAPI ---
+  const swaggerVersion = config.swagger.version ?? "1.0.0";
+  await fastify.register(swagger, {
+    openapi: {
+      info: {
+        title: config.swagger.title,
+        description: config.swagger.description,
+        version: swaggerVersion,
+      },
+      servers: [{ url: config.swagger.serverUrl }],
+      components: {
+        securitySchemes: {
+          bearerAuth: {
+            type: "http",
+            scheme: "bearer",
+            bearerFormat: "JWT",
+          },
+        },
+      },
+    },
+  });
+
+  await fastify.register(swaggerUi, {
+    routePrefix: "/docs",
+    uiConfig: {
+      docExpansion: "list",
+      deepLinking: false,
+    },
+  });
+
+  await fastify.register(ScalarApiReference, {
+    routePrefix: "/reference",
+    configuration: {
+      content: () => fastify.swagger(),
+    },
+  });
+
+  // --- Auth ---
+  if (process.env.AUTH_AUTHORITY && process.env.AUTH_AUDIENCE) {
+    await fastify.register(authPlugin, getAuthPluginOptionsFromEnv());
+  } else if (process.env.NODE_ENV === "production") {
+    throw new Error("Fail-closed: AUTH_AUTHORITY and AUTH_AUDIENCE are required in production");
+  } else {
+    fastify.log.warn("Skipping Auth0 plugin registration (dev/test mode)");
+  }
+
+  // --- Sentry ---
+  // Register Sentry error handler (no-op without SENTRY_DSN)
+  await fastify.register(sentryFastifyPlugin);
+
+  // --- API Versioning ---
+  const versioningConfig = config.apiVersioning ?? {
+    currentVersion: "v1",
+    successorVersion: "v2",
+    sunsetMonthsFromNow: 6,
+  };
+  await fastify.register(apiVersioningPlugin, versioningConfig);
+
+  return fastify;
+}

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -5,6 +5,13 @@ export { createLatencyTracker, checkAuth0 } from "./health.js";
 export type { LatencyTracker, LatencyAnomalyResult, Auth0CheckResult } from "./health.js";
 export { registerHealthRoutes } from "./health-routes.js";
 export type { HealthRoutesOptions, HealthRouteConfig } from "./health-routes.js";
+export { createServiceApp } from "./create-service-app.js";
+export type {
+  ServiceAppConfig,
+  SwaggerConfig,
+  ApiVersioningConfig,
+  AppOptions,
+} from "./create-service-app.js";
 
 const SLOW_QUERY_THRESHOLD_MS = 100;
 const SLOW_QUERY_WINDOW_MS = 5 * 60 * 1000;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -700,9 +700,36 @@ importers:
 
   packages/database:
     dependencies:
+      '@fastify/cors':
+        specifier: ^11.2.0
+        version: 11.2.0
+      '@fastify/rate-limit':
+        specifier: ^10.3.0
+        version: 10.3.0
+      '@fastify/swagger':
+        specifier: ^9.7.0
+        version: 9.7.0
+      '@fastify/swagger-ui':
+        specifier: ^5.2.6
+        version: 5.2.6
+      '@mbe/api-versioning':
+        specifier: workspace:*
+        version: link:../api-versioning
+      '@mbe/auth':
+        specifier: workspace:*
+        version: link:../auth
+      '@mbe/observability':
+        specifier: workspace:*
+        version: link:../observability
+      '@mbe/sentry':
+        specifier: workspace:*
+        version: link:../sentry
       '@prisma/adapter-pg':
         specifier: ^7.8.0
         version: 7.8.0
+      '@scalar/fastify-api-reference':
+        specifier: ^1.55.3
+        version: 1.55.3
       fastify-plugin:
         specifier: ^5.0.0
         version: 5.1.0
@@ -713,9 +740,6 @@ importers:
       '@mbe/config':
         specifier: workspace:*
         version: link:../config
-      '@mbe/observability':
-        specifier: workspace:*
-        version: link:../observability
       '@mbe/types':
         specifier: workspace:*
         version: link:../types

--- a/services/agent/src/app.ts
+++ b/services/agent/src/app.ts
@@ -1,17 +1,5 @@
-import Fastify, { type FastifyInstance } from "fastify";
-import cors from "@fastify/cors";
-import rateLimit from "@fastify/rate-limit";
-import swagger from "@fastify/swagger";
-import swaggerUi from "@fastify/swagger-ui";
-import ScalarApiReference from "@scalar/fastify-api-reference";
-import { authPlugin, getAuthPluginOptionsFromEnv } from "@mbe/auth/fastify";
-import {
-  createRequestIdMiddleware,
-  errorRatePlugin_,
-  createRateLimitMonitor,
-} from "@mbe/observability";
-import { sentryFastifyPlugin } from "@mbe/sentry/node";
-import { apiVersioningPlugin } from "@mbe/api-versioning/fastify";
+import type { FastifyInstance } from "fastify";
+import { createServiceApp, type AppOptions } from "@mbe/database";
 import { registerSchemas } from "./schemas/index.js";
 import { healthRoutes } from "./routes/health.js";
 import { readinessRoutes } from "./routes/ready.js";
@@ -25,154 +13,20 @@ import { genSpecsRoutes } from "./routes/gen-specs.js";
 import { genAgentRoutes } from "./routes/gen-agent.js";
 
 /**
- * Validates CORS origins from the CORS_ORIGINS env var against an allowlist.
- * Accepts *.mattbutlerengineering.com in all environments and localhost
- * origins only in development. Returns only the origins that pass validation.
- */
-function validateCorsOrigins(origins: string[]): string[] {
-  const validPatterns = [
-    /^https:\/\/([a-z-]+\.)?mattbutlerengineering\.com$/,
-    ...(process.env.NODE_ENV === "development" ? [/^http:\/\/localhost:\d+$/] : []),
-  ];
-
-  const validated: string[] = [];
-  for (const origin of origins) {
-    const trimmed = origin.trim();
-    if (validPatterns.some((p) => p.test(trimmed))) {
-      validated.push(trimmed);
-    } else {
-      console.warn(`[CORS] Rejected invalid origin from CORS_ORIGINS: ${trimmed}`);
-    }
-  }
-  return validated;
-}
-
-export interface AppOptions {
-  logger?: boolean | object;
-}
-
-/**
  * Creates the Fastify application instance.
  */
 export async function buildApp(options: AppOptions = {}): Promise<FastifyInstance> {
-  const fastify = Fastify({
-    logger: options.logger ?? true,
-    disableRequestLogging: true,
-    ajv: { customOptions: { strict: false } },
-  });
-
-  // Register schemas
-  registerSchemas(fastify);
-
-  // Core plugins
-  const defaultDevOrigins = [
-    "http://localhost:3000",
-    "http://localhost:3002",
-    "http://localhost:3003",
-    "http://localhost:3004",
-    "http://localhost:5173",
-    "http://localhost:5174",
-  ];
-  const prodOrigins = [
-    "https://mattbutlerengineering.com",
-    "https://hospitality.mattbutlerengineering.com",
-    "https://gen.mattbutlerengineering.com",
-  ];
-
-  const defaultOrigins = [
-    ...prodOrigins,
-    ...(process.env.NODE_ENV === "development" ? defaultDevOrigins : []),
-  ];
-
-  const envOrigins = process.env.CORS_ORIGINS?.split(",");
-  const validatedEnv = envOrigins ? validateCorsOrigins(envOrigins) : null;
-
-  if (validatedEnv && validatedEnv.length === 0) {
-    console.warn("[CORS] All CORS_ORIGINS were rejected; falling back to defaults");
-  }
-
-  const corsOrigins = validatedEnv && validatedEnv.length > 0 ? validatedEnv : defaultOrigins;
-
-  await fastify.register(cors, {
-    origin: corsOrigins,
-    credentials: true,
-    allowedHeaders: ["Content-Type", "Authorization"],
-    methods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
-  });
-
-  // Propagate X-Request-ID from edge router for distributed tracing
-  await fastify.register(createRequestIdMiddleware());
-
-  // Track per-endpoint error rates (exposed via health check)
-  await fastify.register(errorRatePlugin_);
-
-  const rateLimitMonitor = createRateLimitMonitor();
-  fastify.decorate("rateLimitMonitor", rateLimitMonitor);
-
-  await fastify.register(rateLimit, {
-    max: 100,
-    timeWindow: "1 minute",
-    onExceeded: (req) => {
-      const ip = req.ip;
-      const endpoint = req.url;
-      rateLimitMonitor.recordHit(ip, endpoint);
-      req.log.warn({ ip, endpoint, timestamp: new Date().toISOString() }, "Rate limit exceeded");
-    },
-  });
-
-  await fastify.register(swagger, {
-    openapi: {
-      info: {
+  const fastify = await createServiceApp(
+    {
+      swagger: {
         title: "MBE Agent API",
         description: "API for AI agent sessions and orchestration",
-        version: "1.0.0",
+        serverUrl: "http://localhost:3003",
       },
-      servers: [{ url: "http://localhost:3003" }],
-      components: {
-        securitySchemes: {
-          bearerAuth: {
-            type: "http",
-            scheme: "bearer",
-            bearerFormat: "JWT",
-          },
-        },
-      },
+      registerSchemas,
     },
-  });
-
-  await fastify.register(swaggerUi, {
-    routePrefix: "/docs",
-    uiConfig: {
-      docExpansion: "list",
-      deepLinking: false,
-    },
-  });
-
-  await fastify.register(ScalarApiReference, {
-    routePrefix: "/reference",
-    configuration: {
-      content: () => fastify.swagger(),
-    },
-  });
-
-  // Register Auth0 plugin
-  if (process.env.AUTH_AUTHORITY && process.env.AUTH_AUDIENCE) {
-    await fastify.register(authPlugin, getAuthPluginOptionsFromEnv());
-  } else if (process.env.NODE_ENV === "production") {
-    throw new Error("Fail-closed: AUTH_AUTHORITY and AUTH_AUDIENCE are required in production");
-  } else {
-    fastify.log.warn("Skipping Auth0 plugin registration: AUTH_AUTHORITY or AUTH_AUDIENCE not set");
-  }
-
-  // Register Sentry error handler (no-op without SENTRY_DSN)
-  await fastify.register(sentryFastifyPlugin);
-
-  // Register API versioning headers
-  await fastify.register(apiVersioningPlugin, {
-    currentVersion: "v1",
-    successorVersion: "v2",
-    sunsetMonthsFromNow: 6,
-  });
+    options
+  );
 
   // Register routes
   await fastify.register(healthRoutes);

--- a/services/reservations/src/app.ts
+++ b/services/reservations/src/app.ts
@@ -1,17 +1,5 @@
-import Fastify, { type FastifyInstance } from "fastify";
-import cors from "@fastify/cors";
-import rateLimit from "@fastify/rate-limit";
-import swagger from "@fastify/swagger";
-import swaggerUi from "@fastify/swagger-ui";
-import ScalarApiReference from "@scalar/fastify-api-reference";
-import { authPlugin, getAuthPluginOptionsFromEnv } from "@mbe/auth/fastify";
-import {
-  createRequestIdMiddleware,
-  errorRatePlugin_,
-  createRateLimitMonitor,
-} from "@mbe/observability";
-import { sentryFastifyPlugin } from "@mbe/sentry/node";
-import { apiVersioningPlugin } from "@mbe/api-versioning/fastify";
+import type { FastifyInstance } from "fastify";
+import { createServiceApp, type AppOptions } from "@mbe/database";
 import { registerSchemas } from "./schemas/index.js";
 import { healthRoutes } from "./routes/health.js";
 import { readinessRoutes } from "./routes/ready.js";
@@ -33,154 +21,20 @@ import { cancelReservationRoutes } from "./routes/cancel-reservation.js";
 import { modifyReservationRoutes } from "./routes/modify-reservation.js";
 
 /**
- * Validates CORS origins from the CORS_ORIGINS env var against an allowlist.
- * Accepts *.mattbutlerengineering.com in all environments and localhost
- * origins only in development. Returns only the origins that pass validation.
- */
-function validateCorsOrigins(origins: string[]): string[] {
-  const validPatterns = [
-    /^https:\/\/([a-z-]+\.)?mattbutlerengineering\.com$/,
-    ...(process.env.NODE_ENV === "development" ? [/^http:\/\/localhost:\d+$/] : []),
-  ];
-
-  const validated: string[] = [];
-  for (const origin of origins) {
-    const trimmed = origin.trim();
-    if (validPatterns.some((p) => p.test(trimmed))) {
-      validated.push(trimmed);
-    } else {
-      console.warn(`[CORS] Rejected invalid origin from CORS_ORIGINS: ${trimmed}`);
-    }
-  }
-  return validated;
-}
-
-export interface AppOptions {
-  logger?: boolean | object;
-}
-
-/**
  * Creates the Fastify application instance.
  */
 export async function buildApp(options: AppOptions = {}): Promise<FastifyInstance> {
-  const fastify = Fastify({
-    logger: options.logger ?? true,
-    disableRequestLogging: true,
-    ajv: { customOptions: { strict: false } },
-  });
-
-  // Register schemas
-  registerSchemas(fastify);
-
-  // Core plugins
-  const defaultDevOrigins = [
-    "http://localhost:3000",
-    "http://localhost:3002",
-    "http://localhost:3003",
-    "http://localhost:3004",
-    "http://localhost:5173",
-    "http://localhost:5174",
-  ];
-  const prodOrigins = [
-    "https://mattbutlerengineering.com",
-    "https://hospitality.mattbutlerengineering.com",
-    "https://gen.mattbutlerengineering.com",
-  ];
-
-  const defaultOrigins = [
-    ...prodOrigins,
-    ...(process.env.NODE_ENV === "development" ? defaultDevOrigins : []),
-  ];
-
-  const envOrigins = process.env.CORS_ORIGINS?.split(",");
-  const validatedEnv = envOrigins ? validateCorsOrigins(envOrigins) : null;
-
-  if (validatedEnv && validatedEnv.length === 0) {
-    console.warn("[CORS] All CORS_ORIGINS were rejected; falling back to defaults");
-  }
-
-  const corsOrigins = validatedEnv && validatedEnv.length > 0 ? validatedEnv : defaultOrigins;
-
-  await fastify.register(cors, {
-    origin: corsOrigins,
-    credentials: true,
-    allowedHeaders: ["Content-Type", "Authorization"],
-    methods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
-  });
-
-  // Propagate X-Request-ID from edge router for distributed tracing
-  await fastify.register(createRequestIdMiddleware());
-
-  // Track per-endpoint error rates (exposed via health check)
-  await fastify.register(errorRatePlugin_);
-
-  const rateLimitMonitor = createRateLimitMonitor();
-  fastify.decorate("rateLimitMonitor", rateLimitMonitor);
-
-  await fastify.register(rateLimit, {
-    max: 100,
-    timeWindow: "1 minute",
-    onExceeded: (req) => {
-      const ip = req.ip;
-      const endpoint = req.url;
-      rateLimitMonitor.recordHit(ip, endpoint);
-      req.log.warn({ ip, endpoint, timestamp: new Date().toISOString() }, "Rate limit exceeded");
-    },
-  });
-
-  await fastify.register(swagger, {
-    openapi: {
-      info: {
+  const fastify = await createServiceApp(
+    {
+      swagger: {
         title: "MBE Reservations API",
         description: "API for managing table reservations and availability",
-        version: "1.0.0",
+        serverUrl: "http://localhost:3004",
       },
-      servers: [{ url: "http://localhost:3004" }],
-      components: {
-        securitySchemes: {
-          bearerAuth: {
-            type: "http",
-            scheme: "bearer",
-            bearerFormat: "JWT",
-          },
-        },
-      },
+      registerSchemas,
     },
-  });
-
-  await fastify.register(swaggerUi, {
-    routePrefix: "/docs",
-    uiConfig: {
-      docExpansion: "list",
-      deepLinking: false,
-    },
-  });
-
-  await fastify.register(ScalarApiReference, {
-    routePrefix: "/reference",
-    configuration: {
-      content: () => fastify.swagger(),
-    },
-  });
-
-  // Register Auth0 plugin
-  if (process.env.AUTH_AUTHORITY && process.env.AUTH_AUDIENCE) {
-    await fastify.register(authPlugin, getAuthPluginOptionsFromEnv());
-  } else if (process.env.NODE_ENV === "production") {
-    throw new Error("Fail-closed: AUTH_AUTHORITY and AUTH_AUDIENCE are required in production");
-  } else {
-    fastify.log.warn("Skipping Auth0 plugin registration (dev/test mode)");
-  }
-
-  // Register Sentry error handler (no-op without SENTRY_DSN)
-  await fastify.register(sentryFastifyPlugin);
-
-  // Register API versioning headers
-  await fastify.register(apiVersioningPlugin, {
-    currentVersion: "v1",
-    successorVersion: "v2",
-    sunsetMonthsFromNow: 6,
-  });
+    options
+  );
 
   // Register routes
   await fastify.register(healthRoutes);

--- a/services/users/src/app.ts
+++ b/services/users/src/app.ts
@@ -1,169 +1,25 @@
-import Fastify, { type FastifyInstance } from "fastify";
-import cors from "@fastify/cors";
-import rateLimit from "@fastify/rate-limit";
-import swagger from "@fastify/swagger";
-import swaggerUi from "@fastify/swagger-ui";
-import ScalarApiReference from "@scalar/fastify-api-reference";
-import { authPlugin, getAuthPluginOptionsFromEnv } from "@mbe/auth/fastify";
-import {
-  createRequestIdMiddleware,
-  errorRatePlugin_,
-  createRateLimitMonitor,
-} from "@mbe/observability";
-import { sentryFastifyPlugin } from "@mbe/sentry/node";
-import { apiVersioningPlugin } from "@mbe/api-versioning/fastify";
+import type { FastifyInstance } from "fastify";
+import { createServiceApp, type AppOptions } from "@mbe/database";
 import { registerSchemas } from "./schemas/index.js";
 import { healthRoutes } from "./routes/health.js";
 import { readinessRoutes } from "./routes/ready.js";
 import { userRoutes } from "./routes/users.js";
 
 /**
- * Validates CORS origins from the CORS_ORIGINS env var against an allowlist.
- * Accepts *.mattbutlerengineering.com in all environments and localhost
- * origins only in development. Returns only the origins that pass validation.
- */
-function validateCorsOrigins(origins: string[]): string[] {
-  const validPatterns = [
-    /^https:\/\/([a-z-]+\.)?mattbutlerengineering\.com$/,
-    ...(process.env.NODE_ENV === "development" ? [/^http:\/\/localhost:\d+$/] : []),
-  ];
-
-  const validated: string[] = [];
-  for (const origin of origins) {
-    const trimmed = origin.trim();
-    if (validPatterns.some((p) => p.test(trimmed))) {
-      validated.push(trimmed);
-    } else {
-      console.warn(`[CORS] Rejected invalid origin from CORS_ORIGINS: ${trimmed}`);
-    }
-  }
-  return validated;
-}
-
-export interface AppOptions {
-  logger?: boolean | object;
-}
-
-/**
  * Creates the Fastify application instance.
  */
 export async function buildApp(options: AppOptions = {}): Promise<FastifyInstance> {
-  const fastify = Fastify({
-    logger: options.logger ?? true,
-    disableRequestLogging: true,
-    ajv: { customOptions: { strict: false } },
-  });
-
-  // Register schemas
-  registerSchemas(fastify);
-
-  // Core plugins
-  const defaultDevOrigins = [
-    "http://localhost:3000",
-    "http://localhost:3002",
-    "http://localhost:3003",
-    "http://localhost:3004",
-    "http://localhost:5173",
-    "http://localhost:5174",
-  ];
-  const prodOrigins = [
-    "https://mattbutlerengineering.com",
-    "https://hospitality.mattbutlerengineering.com",
-    "https://gen.mattbutlerengineering.com",
-  ];
-
-  const defaultOrigins = [
-    ...prodOrigins,
-    ...(process.env.NODE_ENV === "development" ? defaultDevOrigins : []),
-  ];
-
-  const envOrigins = process.env.CORS_ORIGINS?.split(",");
-  const validatedEnv = envOrigins ? validateCorsOrigins(envOrigins) : null;
-
-  if (validatedEnv && validatedEnv.length === 0) {
-    console.warn("[CORS] All CORS_ORIGINS were rejected; falling back to defaults");
-  }
-
-  const corsOrigins = validatedEnv && validatedEnv.length > 0 ? validatedEnv : defaultOrigins;
-
-  await fastify.register(cors, {
-    origin: corsOrigins,
-    credentials: true,
-    allowedHeaders: ["Content-Type", "Authorization"],
-    methods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
-  });
-
-  // Propagate X-Request-ID from edge router for distributed tracing
-  await fastify.register(createRequestIdMiddleware());
-
-  // Track per-endpoint error rates (exposed via health check)
-  await fastify.register(errorRatePlugin_);
-
-  const rateLimitMonitor = createRateLimitMonitor();
-  fastify.decorate("rateLimitMonitor", rateLimitMonitor);
-
-  await fastify.register(rateLimit, {
-    max: 100,
-    timeWindow: "1 minute",
-    onExceeded: (req) => {
-      const ip = req.ip;
-      const endpoint = req.url;
-      rateLimitMonitor.recordHit(ip, endpoint);
-      req.log.warn({ ip, endpoint, timestamp: new Date().toISOString() }, "Rate limit exceeded");
-    },
-  });
-
-  await fastify.register(swagger, {
-    openapi: {
-      info: {
+  const fastify = await createServiceApp(
+    {
+      swagger: {
         title: "MBE Users API",
         description: "API for managing users and preferences",
-        version: "1.0.0",
+        serverUrl: "http://localhost:3001",
       },
-      servers: [{ url: "http://localhost:3001" }],
-      components: {
-        securitySchemes: {
-          bearerAuth: {
-            type: "http",
-            scheme: "bearer",
-            bearerFormat: "JWT",
-          },
-        },
-      },
+      registerSchemas,
     },
-  });
-
-  await fastify.register(swaggerUi, {
-    routePrefix: "/docs",
-    uiConfig: {
-      docExpansion: "list",
-      deepLinking: false,
-    },
-  });
-
-  await fastify.register(ScalarApiReference, {
-    routePrefix: "/reference",
-    configuration: {
-      content: () => fastify.swagger(),
-    },
-  });
-
-  // Register Auth0 plugin
-  if (process.env.AUTH_AUTHORITY) {
-    await fastify.register(authPlugin, getAuthPluginOptionsFromEnv());
-  } else if (process.env.NODE_ENV === "production") {
-    throw new Error("Fail-closed: AUTH_AUTHORITY and AUTH_AUDIENCE are required in production");
-  }
-
-  // Register Sentry error handler (no-op without SENTRY_DSN)
-  await fastify.register(sentryFastifyPlugin);
-
-  // Register API versioning headers
-  await fastify.register(apiVersioningPlugin, {
-    currentVersion: "v1",
-    successorVersion: "v2",
-    sunsetMonthsFromNow: 6,
-  });
+    options
+  );
 
   // Register routes
   await fastify.register(healthRoutes);


### PR DESCRIPTION
## Summary

- Extracted ~160 lines of identical Fastify plugin registration (CORS, request-ID, error-rate, rate-limit, auth, Sentry, Swagger/Scalar, API versioning) from three services into `createServiceApp()` in `@mbe/database`
- Each service `app.ts` now provides only swagger metadata and registers its own routes (~30 lines instead of ~175)
- Normalized auth guard to check both `AUTH_AUTHORITY` and `AUTH_AUDIENCE` across all services (users previously only checked `AUTH_AUTHORITY`)

Closes #1564

## Test plan

- [x] 25 unit tests for `createServiceApp()` in `packages/database/src/create-service-app.test.ts`
- [x] All existing users service tests pass (139 tests)
- [x] All existing reservations service tests pass (457 tests)
- [x] All existing agent service tests pass (230 tests)
- [x] Typecheck passes on all affected packages
- [x] Lint passes on all affected packages
- [x] Pre-push hook passes (23/23 turbo tasks)