### PR TITLE
fix(ci): add CI badge and revert-watchdog baseline filter

### DIFF
--- a/.github/workflows/revert-watchdog.yml
+++ b/.github/workflows/revert-watchdog.yml
@@ -35,7 +35,28 @@ jobs:
           PR_NUMBER=$(gh pr list --search "$SHA" --state merged --json number -q '.[0].number')
           echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
+      - name: Check for baseline failure
+        id: baseline
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ steps.culprit.outputs.culprit_sha }}
+        run: |
+          PARENT_SHA=$(git rev-parse "${SHA}^")
+          echo "parent_sha=$PARENT_SHA" >> "$GITHUB_OUTPUT"
+
+          PARENT_CONCLUSION=$(gh run list --commit "$PARENT_SHA" --workflow "CI" --json conclusion -q '.[0].conclusion' 2>/dev/null || echo "unknown")
+          echo "parent_conclusion=$PARENT_CONCLUSION" >> "$GITHUB_OUTPUT"
+
+          if [ "$PARENT_CONCLUSION" = "failure" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Parent commit $PARENT_SHA also failed CI — pre-existing baseline failure, skipping issue/revert."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Parent CI was '$PARENT_CONCLUSION' — this commit may have introduced the failure."
+          fi
+
       - name: Open Broken Main Issue
+        if: ${{ steps.baseline.outputs.skip != 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SHA: ${{ steps.culprit.outputs.culprit_sha }}
@@ -51,7 +72,7 @@ jobs:
           gh issue create --title "$TITLE" --body "$BODY" --label "priority:critical"
 
       - name: Propose Revert PR
-        if: ${{ steps.culprit.outputs.pr_number != '' }}
+        if: ${{ steps.culprit.outputs.pr_number != '' && steps.baseline.outputs.skip != 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SHA: ${{ steps.culprit.outputs.culprit_sha }}
@@ -73,7 +94,7 @@ jobs:
             --head "$BRANCH"
 
       - name: Trigger RCA
-        if: ${{ steps.culprit.outputs.pr_number != '' }}
+        if: ${{ steps.culprit.outputs.pr_number != '' && steps.baseline.outputs.skip != 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ steps.culprit.outputs.pr_number }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Matt Butler Engineering
 
+[![CI](https://github.com/mattbutlerengineering/mattbutlerengineering/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/mattbutlerengineering/mattbutlerengineering/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=flat-square)](./LICENSE)
 [![codecov](https://codecov.io/gh/mattbutlerengineering/mattbutlerengineering/graph/badge.svg?token=ANNEPED1FV)](https://codecov.io/gh/mattbutlerengineering/mattbutlerengineering)
 [![ACMM Level 3](https://img.shields.io/badge/ACMM-Level%203-7a5a36?style=flat-square)](docs/acmm.md)

--- a/packages/api-client/llms-full.txt
+++ b/packages/api-client/llms-full.txt
@@ -49,8 +49,7 @@
       }
     
       async getById(id: string): Promise<FloorPlan> {
-        const response = await this.client.get<{ data: FloorPlan }>(`/api/v1/floor-plans/${id}`);
-        return response.data;
+        return this.client.getOne<FloorPlan>(`/api/v1/floor-plans/${id}`);
       }
     
       /** Alias for getById */
@@ -59,16 +58,11 @@
       }
     
       async create(data: CreateFloorPlanRequest): Promise<FloorPlan> {
-        const response = await this.client.post<{ data: FloorPlan }>("/api/v1/floor-plans", data);
-        return response.data;
+        return this.client.postOne<FloorPlan>("/api/v1/floor-plans", data);
       }
     
       async update(id: string, data: UpdateFloorPlanRequest): Promise<FloorPlan> {
-        const response = await this.client.patch<{ data: FloorPlan }>(
-          `/api/v1/floor-plans/${id}`,
-          data
-        );
-        return response.data;
+        return this.client.patchOne<FloorPlan>(`/api/v1/floor-plans/${id}`, data);
       }
     
       async delete(id: string): Promise<void> {
@@ -76,11 +70,7 @@
       }
     
       async setActive(id: string): Promise<FloorPlan> {
-        const response = await this.client.post<{ data: FloorPlan }>(
-          `/api/v1/floor-plans/${id}/active`,
-          undefined
-        );
-        return response.data;
+        return this.client.postOne<FloorPlan>(`/api/v1/floor-plans/${id}/active`, undefined);
       }
     
       /** Alias for setActive */
@@ -92,19 +82,14 @@
         floorPlanId: string,
         positions: UpdateTablePositionRequest[]
       ): Promise<Table[]> {
-        const response = await this.client.post<{ data: Table[] }>(
+        return this.client.postOne<Table[]>(
           `/api/v1/floor-plans/${floorPlanId}/bulk-update-positions`,
           positions
         );
-        return response.data;
       }
     
       async clone(id: string): Promise<FloorPlan> {
-        const response = await this.client.post<{ data: FloorPlan }>(
-          `/api/v1/floor-plans/${id}/clone`,
-          undefined
-        );
-        return response.data;
+        return this.client.postOne<FloorPlan>(`/api/v1/floor-plans/${id}/clone`, undefined);
       }
     }
   </file>
@@ -212,34 +197,28 @@
        * Get a reservation by ID
        */
       async get(id: string): Promise<Reservation> {
-        const response = await this.client.get<ApiResponse<Reservation>>(`/api/v1/reservations/${id}`);
-        return response.data;
+        return this.client.getOne<Reservation>(`/api/v1/reservations/${id}`);
       }
     
       /**
        * Create a new reservation
        */
       async create(data: CreateReservationRequest): Promise<Reservation> {
-        const response = await this.client.post<ApiResponse<Reservation>>("/api/v1/reservations", data);
-        return response.data;
+        return this.client.postOne<Reservation>("/api/v1/reservations", data);
       }
     
       /**
        * Update a reservation
        */
       async update(id: string, data: UpdateReservationRequest): Promise<Reservation> {
-        const response = await this.client.patch<ApiResponse<Reservation>>(
-          `/api/v1/reservations/${id}`,
-          data
-        );
-        return response.data;
+        return this.client.patchOne<Reservation>(`/api/v1/reservations/${id}`, data);
       }
     
       /**
        * Cancel a reservation
        */
       async cancel(id: string): Promise<Reservation> {
-        const response = await this.client.request<ApiResponse<Reservation>>(
+        const response = await this.client.request<{ data: Reservation }>(
           `/api/v1/reservations/${id}`,
           { method: "DELETE" }
         );
@@ -269,11 +248,7 @@
         guestName?: string;
         durationMinutes?: number;
       }): Promise<Reservation> {
-        const response = await this.client.post<ApiResponse<Reservation>>(
-          "/api/v1/reservations/walk-in",
-          data
-        );
-        return response.data;
+        return this.client.postOne<Reservation>("/api/v1/reservations/walk-in", data);
       }
     }
   </file>
@@ -391,24 +366,21 @@
        * Get a table by ID
        */
       async get(id: string): Promise<Table> {
-        const response = await this.client.get<ApiResponse<Table>>(`/api/v1/tables/${id}`);
-        return response.data;
+        return this.client.getOne<Table>(`/api/v1/tables/${id}`);
       }
     
       /**
        * Create a new table
        */
       async create(data: CreateTableRequest): Promise<Table> {
-        const response = await this.client.post<ApiResponse<Table>>("/api/v1/tables", data);
-        return response.data;
+        return this.client.postOne<Table>("/api/v1/tables", data);
       }
     
       /**
        * Update a table
        */
       async update(id: string, data: UpdateTableRequest): Promise<Table> {
-        const response = await this.client.patch<ApiResponse<Table>>(`/api/v1/tables/${id}`, data);
-        return response.data;
+        return this.client.patchOne<Table>(`/api/v1/tables/${id}`, data);
       }
     
       /**
@@ -421,11 +393,10 @@
       /**
        * Update the status of a table
        */
-      async updateStatus(id: string, status: string): Promise<Table> {
-        const response = await this.client.patch<ApiResponse<Table>>(`/api/v1/tables/${id}/status`, {
-          status,
+      async updateStatus(id: string, tableStatus: string): Promise<Table> {
+        return this.client.patchOne<Table>(`/api/v1/tables/${id}/status`, {
+          status: tableStatus,
         });
-        return response.data;
       }
     }
   </file>
@@ -444,32 +415,28 @@
        * Get a user by ID
        */
       async get(id: string): Promise<User> {
-        const response = await this.client.get<ApiResponse<User>>(`/api/v1/users/${id}`);
-        return response.data;
+        return this.client.getOne<User>(`/api/v1/users/${id}`);
       }
     
       /**
        * Get the currently authenticated user
        */
       async me(): Promise<User> {
-        const response = await this.client.get<ApiResponse<User>>("/api/v1/users/me");
-        return response.data;
+        return this.client.getOne<User>("/api/v1/users/me");
       }
     
       /**
        * Create a new user
        */
       async create(data: CreateUserRequest): Promise<User> {
-        const response = await this.client.post<ApiResponse<User>>("/api/v1/users", data);
-        return response.data;
+        return this.client.postOne<User>("/api/v1/users", data);
       }
     
       /**
        * Update a user
        */
       async update(id: string, data: UpdateUserRequest): Promise<User> {
-        const response = await this.client.patch<ApiResponse<User>>(`/api/v1/users/${id}`, data);
-        return response.data;
+        return this.client.patchOne<User>(`/api/v1/users/${id}`, data);
       }
     
       /**
@@ -483,11 +450,7 @@
        * Update current user's preferences
        */
       async updatePreferences(preferences: UpdatePreferencesRequest): Promise<User> {
-        const response = await this.client.patch<ApiResponse<User>>(
-          "/api/v1/users/me/preferences",
-          preferences
-        );
-        return response.data;
+        return this.client.patchOne<User>("/api/v1/users/me/preferences", preferences);
       }
     }
   </file>
@@ -514,32 +477,28 @@
        * Get a venue by ID
        */
       async get(id: string): Promise<Venue> {
-        const response = await this.client.get<ApiResponse<Venue>>(`/api/v1/venues/${id}`);
-        return response.data;
+        return this.client.getOne<Venue>(`/api/v1/venues/${id}`);
       }
     
       /**
        * Get a venue by slug
        */
       async getBySlug(slug: string): Promise<Venue> {
-        const response = await this.client.get<ApiResponse<Venue>>(`/api/v1/venues/by-slug/${slug}`);
-        return response.data;
+        return this.client.getOne<Venue>(`/api/v1/venues/by-slug/${slug}`);
       }
     
       /**
        * Create a new venue
        */
       async create(data: CreateVenueRequest): Promise<Venue> {
-        const response = await this.client.post<ApiResponse<Venue>>("/api/v1/venues", data);
-        return response.data;
+        return this.client.postOne<Venue>("/api/v1/venues", data);
       }
     
       /**
        * Update a venue
        */
       async update(id: string, data: UpdateVenueRequest): Promise<Venue> {
-        const response = await this.client.patch<ApiResponse<Venue>>(`/api/v1/venues/${id}`, data);
-        return response.data;
+        return this.client.patchOne<Venue>(`/api/v1/venues/${id}`, data);
       }
     
       /**
@@ -565,37 +524,28 @@
        * Get a venue group by ID
        */
       async get(id: string): Promise<VenueGroup> {
-        const response = await this.client.get<ApiResponse<VenueGroup>>(`/api/v1/venues/groups/${id}`);
-        return response.data;
+        return this.client.getOne<VenueGroup>(`/api/v1/venues/groups/${id}`);
       }
     
       /**
        * Get a venue group by slug
        */
       async getBySlug(slug: string): Promise<VenueGroup> {
-        const response = await this.client.get<ApiResponse<VenueGroup>>(
-          `/api/v1/venues/groups/by-slug/${slug}`
-        );
-        return response.data;
+        return this.client.getOne<VenueGroup>(`/api/v1/venues/groups/by-slug/${slug}`);
       }
     
       /**
        * Create a new venue group
        */
       async create(data: CreateVenueGroupRequest): Promise<VenueGroup> {
-        const response = await this.client.post<ApiResponse<VenueGroup>>("/api/v1/venues/groups", data);
-        return response.data;
+        return this.client.postOne<VenueGroup>("/api/v1/venues/groups", data);
       }
     
       /**
        * Update a venue group
        */
       async update(id: string, data: UpdateVenueGroupRequest): Promise<VenueGroup> {
-        const response = await this.client.patch<ApiResponse<VenueGroup>>(
-          `/api/v1/venues/groups/${id}`,
-          data
-        );
-        return response.data;
+        return this.client.patchOne<VenueGroup>(`/api/v1/venues/groups/${id}`, data);
       }
     
       /**

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -333,7 +333,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -333,18 +333,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/services/agent/llms-full.txt
+++ b/services/agent/llms-full.txt
@@ -168,6 +168,26 @@
     }
   </file>
   </section>
+  <section priority="medium" role="prisma.config.ts">
+  <file path="prisma.config.ts">
+    function loadEnvFile(): void {
+      try {
+        const content = readFileSync(".env", "utf-8");
+        for (const line of content.split("\n")) {
+          const trimmed = line.trim();
+          if (!trimmed || trimmed.startsWith("#")) continue;
+          const eqIdx = trimmed.indexOf("=");
+          if (eqIdx === -1) continue;
+          const key = trimmed.slice(0, eqIdx);
+          const val = trimmed.slice(eqIdx + 1).replace(/^["']|["']$/g, "");
+          if (!process.env[key]) process.env[key] = val;
+        }
+      } catch {
+        // .env not present (CI, Docker) — rely on environment
+      }
+    }
+  </file>
+  </section>
   <section priority="medium" role="routes">
   <file path="src/routes/gen-agent-tools.ts">
     type ApiClient = ReturnType<typeof createApiClient>;
@@ -487,174 +507,19 @@
     };
   </file>
   <file path="src/routes/health.ts">
-    export const healthRoutes: FastifyPluginAsync = async (fastify: FastifyInstance) => {
-      const healthSchema = {
-        summary: "Service health check",
-        description: "Check agent service health and database connectivity.",
-        tags: ["Health"],
-        response: {
-          200: {
-            description: "Service health status",
-            type: "object",
-            properties: {
-              status: { type: "string", enum: ["ok", "degraded", "error"] },
-              version: { type: "string" },
-              timestamp: { type: "string", format: "date-time" },
-              checks: {
-                type: "object",
-                additionalProperties: {
-                  type: "object",
-                  additionalProperties: true,
-                  properties: {
-                    status: { type: "string", enum: ["ok", "error", "degraded"] },
-                    message: { type: "string" },
-                    latency: { type: "number" },
-                  },
-                },
-              },
-              error_rates: {
-                type: "object",
-                properties: {
-                  degraded: { type: "boolean" },
-                  endpoints: {
-                    type: "array",
-                    items: {
-                      type: "object",
-                      properties: {
-                        endpoint: { type: "string" },
-                        total: { type: "number" },
-                        errors: { type: "number" },
-                        rate: { type: "number" },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      };
-    
-      const healthHandler = async (request: FastifyRequest): Promise<HealthResponse> => {
-        const checks: Record<string, { status: string; latency?: number; message?: string }> = {};
-        const { apiVersion, successorVersion, sunsetDate } = request.server as unknown as {
-          apiVersion: string;
-          successorVersion?: string;
-          sunsetDate: string;
-        };
-    
-        const dbStart = Date.now();
-        try {
-          await prisma.$queryRaw`SELECT 1`;
-          const dbLatency = Date.now() - dbStart;
-          const anomaly = checkLatencyAnomaly(dbLatency);
-          recordDbLatency(dbLatency);
-          checks.database = {
-            status: anomaly.isAnomaly ? "error" : "ok",
-            latency: dbLatency,
-            ...(anomaly.isAnomaly && {
-              message: `Latency anomaly: ${dbLatency}ms vs rolling avg ${anomaly.rollingAvg}ms`,
-            }),
-          };
-        } catch (error) {
-          checks.database = {
-            status: "error",
-            message: error instanceof Error ? error.message : "Database connection failed",
-            latency: Date.now() - dbStart,
-          };
-        }
-    
-        const slowQueries = getSlowQueryStats();
-        const dbStatus = checks.database?.status ?? "ok";
-        const slowQueryStatus = getServiceStatus();
-    
-        checks.slow_queries = {
-          status: slowQueryStatus,
-          message: `${slowQueries.count5min} slow queries in last 5min (slowest: ${slowQueries.slowestMs}ms)`,
-          latency: slowQueries.slowestMs,
-        };
-    
-        const auth0Result = await checkAuth0();
-        checks.auth0 = {
-          status: auth0Result.status,
-          latency: auth0Result.latency,
-          ...(auth0Result.message && { message: auth0Result.message }),
-        };
-    
-        const rateLimitMonitor = (request.server as unknown as { rateLimitMonitor: RateLimitMonitor })
-          .rateLimitMonitor;
-        const rateLimitSnapshot = rateLimitMonitor.getSnapshot();
-        checks.rate_limits = {
-          status: rateLimitSnapshot.isDegraded ? "degraded" : "ok",
-          ...rateLimitSnapshot.stats,
-          ...(rateLimitSnapshot.isDegraded && {
-            message: `High rate limit activity: ${rateLimitSnapshot.stats.hits_last_hour} hits from ${rateLimitSnapshot.stats.blocked_ips} IPs`,
-          }),
-        };
-    
-        const poolMetrics = getPoolMetrics();
-        checks.pool = {
-          status: poolMetrics.isDegraded ? "degraded" : "ok",
-          ...(poolMetrics.isDegraded && {
-            message: `Pool utilization high: ${Math.round(poolMetrics.utilization * 100)}% (${poolMetrics.busy}/${poolMetrics.size} busy)`,
-          }),
-          ...{
-            active: poolMetrics.active,
-            idle: poolMetrics.idle,
-            busy: poolMetrics.busy,
-            size: poolMetrics.size,
-            utilization: poolMetrics.utilization,
-          },
-        };
-    
-        const errorRates = fastify.getErrorRates();
-        const degradedEndpoints = errorRates.endpoints.filter((e) => e.rate > 0.1 && e.total >= 5);
-    
-        const hasErrors =
-          dbStatus === "error" ||
-          slowQueryStatus === "degraded" ||
-          auth0Result.status === "degraded" ||
-          rateLimitSnapshot.isDegraded ||
-          poolMetrics.isDegraded ||
-          errorRates.degraded;
-    
-        return {
-          status: hasErrors ? "degraded" : "ok",
-          version: "1.0.0",
-          apiVersion,
-          successorVersion,
-          sunsetDate,
-          timestamp: new Date().toISOString(),
-          checks,
-          error_rates: errorRates,
-          ...(errorRates.degraded && {
-            message: `High error rate on: ${degradedEndpoints.map((e) => `${e.endpoint} (${Math.round(e.rate * 100)}%)`).join(", ")}`,
-          }),
-        };
-      };
-    
-      // /health — used by DO App Platform internal health checks (direct container access)
-      // github[js/missing-rate-limiting] — restrictive limit for DB-intensive health check
-      fastify.get<{ Reply: HealthResponse }>(
-        "/health",
-        {
-          schema: { ...healthSchema, operationId: "getAgentHealth" },
-          config: { rateLimit: { max: 10, timeWindow: "1 minute" } },
-        },
-        healthHandler
-      );
-    
-      // /api/gen/health — public path via DO ingress (preservePathPrefix: true, prefix "/api/gen")
-      // Required for synthetic monitoring hitting api.mattbutlerengineering.com/api/gen/health
-      // github[js/missing-rate-limiting] — restrictive limit for public health check
-      fastify.get<{ Reply: HealthResponse }>(
-        "/api/gen/health",
-        {
-          schema: { ...healthSchema, operationId: "getAgentHealthApiGen" },
-          config: { rateLimit: { max: 10, timeWindow: "1 minute" } },
-        },
-        healthHandler
-      );
+    export const healthRoutes: FastifyPluginAsync = async (fastify) => {
+      await fastify.register(registerHealthRoutes, {
+        prisma,
+        getSlowQueryStats,
+        getServiceStatus,
+        getPoolMetrics,
+        latencyTracker,
+        checkAuth0,
+        routes: [
+          { path: "/health", operationId: "getAgentHealth" },
+          { path: "/api/gen/health", operationId: "getAgentHealthApiGen" },
+        ],
+      });
     };
   </file>
   <file path="src/routes/orchestrate.ts">
@@ -1080,28 +945,6 @@
     export const prisma = db.prisma as unknown as PrismaClient;
     export const getSlowQueryStats = db.getSlowQueryStats;
   </file>
-  <file path="src/services/health-checks.ts">
-    export function recordDbLatency(ms: number): void {
-      dbLatencyHistory.push(ms);
-      if (dbLatencyHistory.length > LATENCY_WINDOW) {
-        dbLatencyHistory.shift();
-      }
-    }
-    export function checkLatencyAnomaly(currentMs: number): {
-      isAnomaly: boolean;
-      rollingAvg: number;
-    } {
-      if (dbLatencyHistory.length < 5) {
-        return { isAnomaly: false, rollingAvg: 0 };
-      }
-      const sum = dbLatencyHistory.reduce((a, b) => a + b, 0);
-      const rollingAvg = sum / dbLatencyHistory.length;
-      return {
-        isAnomaly: rollingAvg > 0 && currentMs > LATENCY_ANOMALY_THRESHOLD * rollingAvg,
-        rollingAvg: Math.round(rollingAvg),
-      };
-    }
-  </file>
   <file path="src/services/liveness-monitor.ts">
     async function checkStaleSessions(): Promise<void> {
       try {
@@ -1230,25 +1073,32 @@
   </section>
   <section priority="medium" role="src">
   <file path="src/app.ts">
-    function validateCorsOrigins(origins: string[]): string[] {
-      const validPatterns = [
-        /^https:\/\/([a-z-]+\.)?mattbutlerengineering\.com$/,
-        ...(process.env.NODE_ENV === "development" ? [/^http:\/\/localhost:\d+$/] : []),
-      ];
+    export async function buildApp(options: AppOptions = {}): Promise<FastifyInstance> {
+      const fastify = await createServiceApp(
+        {
+          swagger: {
+            title: "MBE Agent API",
+            description: "API for AI agent sessions and orchestration",
+            serverUrl: "http://localhost:3003",
+          },
+          registerSchemas,
+        },
+        options
+      );
     
-      const validated: string[] = [];
-      for (const origin of origins) {
-        const trimmed = origin.trim();
-        if (validPatterns.some((p) => p.test(trimmed))) {
-          validated.push(trimmed);
-        } else {
-          console.warn(`[CORS] Rejected invalid origin from CORS_ORIGINS: ${trimmed}`);
-        }
-      }
-      return validated;
-    }
-    export interface AppOptions {
-      logger?: boolean | object;
+      // Register routes
+      await fastify.register(healthRoutes);
+      await fastify.register(readinessRoutes);
+      await fastify.register(sessionRoutes, { prefix: "/v1/sessions" });
+      await fastify.register(sessionEventsRoutes, { prefix: "/v1/sessions" });
+      await fastify.register(orchestrateRoutes, { prefix: "/v1/orchestrate" });
+      await fastify.register(webhookRoutes, { prefix: "/v1/webhooks" });
+      await fastify.register(remediationRoutes, { prefix: "/v1/webhooks" });
+      await fastify.register(genChatRoutes);
+      await fastify.register(genSpecsRoutes);
+      await fastify.register(genAgentRoutes);
+    
+      return fastify;
     }
   </file>
   <file path="src/index.ts">

--- a/services/agent/llms.txt
+++ b/services/agent/llms.txt
@@ -6,6 +6,13 @@
     </item>
   </file>
   </section>
+  <section priority="medium" role="prisma.config.ts">
+  <file path="prisma.config.ts">
+    <item priority="medium">
+      function loadEnvFile(): void { /* ... */ }
+    </item>
+  </file>
+  </section>
   <section priority="medium" role="routes">
   <file path="src/routes/gen-agent-tools.ts">
     <item priority="high">
@@ -125,17 +132,6 @@
       export const getSlowQueryStats: unknown;
     </item>
   </file>
-  <file path="src/services/health-checks.ts">
-    <item priority="high">
-      export function recordDbLatency(ms: number): void { /* ... */ }
-    </item>
-    <item priority="high">
-      export function checkLatencyAnomaly(currentMs: number): {
-        isAnomaly: boolean;
-        rollingAvg: number;
-      } { /* ... */ }
-    </item>
-  </file>
   <file path="src/services/liveness-monitor.ts">
     <item priority="low">
       async function checkStaleSessions(): Promise<void> { /* ... */ }
@@ -193,13 +189,8 @@
   </section>
   <section priority="medium" role="src">
   <file path="src/app.ts">
-    <item priority="medium">
-      function validateCorsOrigins(origins: string[]): string[] { /* ... */ }
-    </item>
-    <item priority="low">
-      interface AppOptions {
-        logger?: boolean | object;
-      }
+    <item priority="high">
+      export async function buildApp(options: AppOptions = {}): Promise<FastifyInstance> { /* ... */ }
     </item>
   </file>
   <file path="src/index.ts">

--- a/services/reservations/llms-full.txt
+++ b/services/reservations/llms-full.txt
@@ -24,6 +24,26 @@
     }
   </file>
   </section>
+  <section priority="medium" role="prisma.config.ts">
+  <file path="prisma.config.ts">
+    function loadEnvFile(): void {
+      try {
+        const content = readFileSync(".env", "utf-8");
+        for (const line of content.split("\n")) {
+          const trimmed = line.trim();
+          if (!trimmed || trimmed.startsWith("#")) continue;
+          const eqIdx = trimmed.indexOf("=");
+          if (eqIdx === -1) continue;
+          const key = trimmed.slice(0, eqIdx);
+          const val = trimmed.slice(eqIdx + 1).replace(/^["']|["']$/g, "");
+          if (!process.env[key]) process.env[key] = val;
+        }
+      } catch {
+        // .env not present (CI, Docker) — rely on environment
+      }
+    }
+  </file>
+  </section>
   <section priority="medium" role="routes">
   <file path="src/routes/availability.ts">
     export const availabilityRoutes: FastifyPluginAsync = async (fastify) => {
@@ -2186,21 +2206,7 @@
             },
           },
         },
-        async (request, reply) => {
-          const authUser = request.user;
-          const adminAccess = hasPermission(authUser, "admin");
-    
-          if (!adminAccess) {
-            reply.code(403);
-            return reply.send(
-              createProblemDetails(
-                403,
-                "Forbidden",
-                "Admin access required to list all reservations"
-              ) as never
-            );
-          }
-    
+        async (request, _reply) => {
           const page = Math.max(1, parseInt(request.query.page ?? "1", 10) || 1);
           const limit = Math.max(1, Math.min(100, parseInt(request.query.limit ?? "10", 10) || 10));
           return reservationService.list({

--- a/services/reservations/llms.txt
+++ b/services/reservations/llms.txt
@@ -22,6 +22,13 @@
     </item>
   </file>
   </section>
+  <section priority="medium" role="prisma.config.ts">
+  <file path="prisma.config.ts">
+    <item priority="medium">
+      function loadEnvFile(): void { /* ... */ }
+    </item>
+  </file>
+  </section>
   <section priority="medium" role="routes">
   <file path="src/routes/availability.ts">
     <item priority="high">

--- a/services/users/llms-full.txt
+++ b/services/users/llms-full.txt
@@ -53,217 +53,41 @@
     }
   </file>
   </section>
+  <section priority="medium" role="prisma.config.ts">
+  <file path="prisma.config.ts">
+    function loadEnvFile(): void {
+      try {
+        const content = readFileSync(".env", "utf-8");
+        for (const line of content.split("\n")) {
+          const trimmed = line.trim();
+          if (!trimmed || trimmed.startsWith("#")) continue;
+          const eqIdx = trimmed.indexOf("=");
+          if (eqIdx === -1) continue;
+          const key = trimmed.slice(0, eqIdx);
+          const val = trimmed.slice(eqIdx + 1).replace(/^["']|["']$/g, "");
+          if (!process.env[key]) process.env[key] = val;
+        }
+      } catch {
+        // .env not present (CI, Docker) — rely on environment
+      }
+    }
+  </file>
+  </section>
   <section priority="medium" role="routes">
   <file path="src/routes/health.ts">
-    type HealthRouteHandler = RouteHandlerMethod<
-      RawServerDefault,
-      IncomingMessage,
-      ServerResponse,
-      { Reply: HealthResponse }
-    >;
-    export const healthRoutes: FastifyPluginAsync = async (fastify: FastifyInstance) => {
-      const healthSchema = {
-        summary: "Service health check",
-        tags: ["Health"],
-        response: {
-          200: {
-            description: "Service health status",
-            type: "object",
-            properties: {
-              status: {
-                type: "string",
-                enum: ["ok", "degraded", "error"],
-                description:
-                  "Overall service status: ok (all checks pass), degraded (some checks failing), error (critical failure)",
-                example: "ok",
-              },
-              version: {
-                type: "string",
-                description: "Service version number",
-                example: "1.0.0",
-              },
-              timestamp: {
-                type: "string",
-                format: "date-time",
-                description: "ISO 8601 timestamp of the health check",
-                example: "2024-01-15T10:30:00.000Z",
-              },
-              checks: {
-                type: "object",
-                description: "Individual health check results",
-                additionalProperties: {
-                  type: "object",
-                  additionalProperties: true,
-                  properties: {
-                    status: {
-                      type: "string",
-                      enum: ["ok", "error", "degraded"],
-                      description: "Status of this specific check",
-                    },
-                    message: {
-                      type: "string",
-                      description: "Error message if check failed",
-                    },
-                    latency: {
-                      type: "number",
-                      description: "Response time in milliseconds",
-                    },
-                  },
-                },
-              },
-              error_rates: {
-                type: "object",
-                description: "Per-endpoint error rates",
-                properties: {
-                  degraded: { type: "boolean" },
-                  endpoints: {
-                    type: "array",
-                    items: {
-                      type: "object",
-                      properties: {
-                        endpoint: { type: "string" },
-                        total: { type: "number" },
-                        errors: { type: "number" },
-                        rate: { type: "number" },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-          503: {
-            description: "Service unavailable (critical health check failed)",
-            type: "object",
-            properties: {
-              status: { type: "string", enum: ["error"] },
-              version: { type: "string" },
-              timestamp: { type: "string", format: "date-time" },
-              checks: { type: "object" },
-            },
-          },
-        },
-      };
-    
-      const healthHandler: HealthRouteHandler = async (request) => {
-        const checks: Record<string, { status: string; latency?: number; message?: string }> = {};
-        const { apiVersion, successorVersion, sunsetDate } = request.server as unknown as {
-          apiVersion: string;
-          successorVersion?: string;
-          sunsetDate: string;
-        };
-    
-        const dbStart = Date.now();
-        try {
-          await prisma.$queryRaw`SELECT 1`;
-          const dbLatency = Date.now() - dbStart;
-          const anomaly = checkLatencyAnomaly(dbLatency);
-          recordDbLatency(dbLatency);
-          checks.database = {
-            status: anomaly.isAnomaly ? "error" : "ok",
-            latency: dbLatency,
-            ...(anomaly.isAnomaly && {
-              message: `Latency anomaly: ${dbLatency}ms vs rolling avg ${anomaly.rollingAvg}ms`,
-            }),
-          };
-        } catch (error) {
-          checks.database = {
-            status: "error",
-            message: error instanceof Error ? error.message : "Database connection failed",
-            latency: Date.now() - dbStart,
-          };
-        }
-    
-        const slowQueries = getSlowQueryStats();
-        const dbStatus = checks.database?.status ?? "ok";
-        const slowQueryStatus = getServiceStatus();
-    
-        checks.slow_queries = {
-          status: slowQueryStatus,
-          message: `${slowQueries.count5min} slow queries in last 5min (slowest: ${slowQueries.slowestMs}ms)`,
-          latency: slowQueries.slowestMs,
-        };
-    
-        const auth0Result = await checkAuth0();
-        checks.auth0 = {
-          status: auth0Result.status,
-          latency: auth0Result.latency,
-          ...(auth0Result.message && { message: auth0Result.message }),
-        };
-    
-        const rateLimitMonitor = (request.server as unknown as { rateLimitMonitor: RateLimitMonitor })
-          .rateLimitMonitor;
-        const rateLimitSnapshot = rateLimitMonitor.getSnapshot();
-        checks.rate_limits = {
-          status: rateLimitSnapshot.isDegraded ? "degraded" : "ok",
-          ...rateLimitSnapshot.stats,
-          ...(rateLimitSnapshot.isDegraded && {
-            message: `High rate limit activity: ${rateLimitSnapshot.stats.hits_last_hour} hits from ${rateLimitSnapshot.stats.blocked_ips} IPs`,
-          }),
-        };
-    
-        const poolMetrics = getPoolMetrics();
-        checks.pool = {
-          status: poolMetrics.isDegraded ? "degraded" : "ok",
-          ...(poolMetrics.isDegraded && {
-            message: `Pool utilization high: ${Math.round(poolMetrics.utilization * 100)}% (${poolMetrics.busy}/${poolMetrics.size} busy)`,
-          }),
-          ...{
-            active: poolMetrics.active,
-            idle: poolMetrics.idle,
-            busy: poolMetrics.busy,
-            size: poolMetrics.size,
-            utilization: poolMetrics.utilization,
-          },
-        };
-    
-        const errorRates = fastify.getErrorRates();
-        const degradedEndpoints = errorRates.endpoints.filter((e) => e.rate > 0.1 && e.total >= 5);
-    
-        const hasErrors =
-          dbStatus === "error" ||
-          slowQueryStatus === "degraded" ||
-          auth0Result.status === "degraded" ||
-          rateLimitSnapshot.isDegraded ||
-          poolMetrics.isDegraded ||
-          errorRates.degraded;
-    
-        return {
-          status: hasErrors ? "degraded" : "ok",
-          version: "1.0.0",
-          apiVersion,
-          successorVersion,
-          sunsetDate,
-          timestamp: new Date().toISOString(),
-          checks,
-          error_rates: errorRates,
-          ...(errorRates.degraded && {
-            message: `High error rate on: ${degradedEndpoints.map((e) => `${e.endpoint} (${Math.round(e.rate * 100)}%)`).join(", ")}`,
-          }),
-        };
-      };
-    
-      // /health — used by DO App Platform internal health checks (direct container access)
-      // github[js/missing-rate-limiting] — restrictive limit for DB-intensive health check
-      fastify.get(
-        "/health",
-        {
-          schema: { ...healthSchema, operationId: "getHealth" },
-          config: { rateLimit: { max: 10, timeWindow: "1 minute" } },
-        },
-        healthHandler
-      );
-    
-      // /api/v1/users/health — public path via DO ingress (preservePathPrefix: true, prefix "/api/v1/users")
-      // github[js/missing-rate-limiting] — restrictive limit for public health check
-      fastify.get(
-        "/api/v1/users/health",
-        {
-          schema: { ...healthSchema, operationId: "getHealthApiUsers" },
-          config: { rateLimit: { max: 10, timeWindow: "1 minute" } },
-        },
-        healthHandler
-      );
+    export const healthRoutes: FastifyPluginAsync = async (fastify) => {
+      await fastify.register(registerHealthRoutes, {
+        prisma,
+        getSlowQueryStats,
+        getServiceStatus,
+        getPoolMetrics,
+        latencyTracker,
+        checkAuth0,
+        routes: [
+          { path: "/health", operationId: "getHealth" },
+          { path: "/api/v1/users/health", operationId: "getHealthApiUsers" },
+        ],
+      });
     };
   </file>
   <file path="src/routes/ready.ts">
@@ -780,28 +604,6 @@
     export const prisma = db.prisma as unknown as PrismaClient;
     export const getSlowQueryStats = db.getSlowQueryStats;
   </file>
-  <file path="src/services/health-checks.ts">
-    export function recordDbLatency(ms: number): void {
-      dbLatencyHistory.push(ms);
-      if (dbLatencyHistory.length > LATENCY_WINDOW) {
-        dbLatencyHistory.shift();
-      }
-    }
-    export function checkLatencyAnomaly(currentMs: number): {
-      isAnomaly: boolean;
-      rollingAvg: number;
-    } {
-      if (dbLatencyHistory.length < 5) {
-        return { isAnomaly: false, rollingAvg: 0 };
-      }
-      const sum = dbLatencyHistory.reduce((a, b) => a + b, 0);
-      const rollingAvg = sum / dbLatencyHistory.length;
-      return {
-        isAnomaly: rollingAvg > 0 && currentMs > LATENCY_ANOMALY_THRESHOLD * rollingAvg,
-        rollingAvg: Math.round(rollingAvg),
-      };
-    }
-  </file>
   <file path="src/services/user.ts">
     function isPrismaNotFound(err: unknown): boolean {
       return (
@@ -836,25 +638,26 @@
   </section>
   <section priority="medium" role="src">
   <file path="src/app.ts">
-    function validateCorsOrigins(origins: string[]): string[] {
-      const validPatterns = [
-        /^https:\/\/([a-z-]+\.)?mattbutlerengineering\.com$/,
-        ...(process.env.NODE_ENV === "development" ? [/^http:\/\/localhost:\d+$/] : []),
-      ];
+    export async function buildApp(options: AppOptions = {}): Promise<FastifyInstance> {
+      const fastify = await createServiceApp(
+        {
+          swagger: {
+            title: "MBE Users API",
+            description: "API for managing users and preferences",
+            serverUrl: "http://localhost:3001",
+          },
+          registerSchemas,
+        },
+        options
+      );
     
-      const validated: string[] = [];
-      for (const origin of origins) {
-        const trimmed = origin.trim();
-        if (validPatterns.some((p) => p.test(trimmed))) {
-          validated.push(trimmed);
-        } else {
-          console.warn(`[CORS] Rejected invalid origin from CORS_ORIGINS: ${trimmed}`);
-        }
-      }
-      return validated;
-    }
-    export interface AppOptions {
-      logger?: boolean | object;
+      // Register routes
+      await fastify.register(healthRoutes);
+      await fastify.register(readinessRoutes);
+      // Full path prefix — ingress forwards with preservePathPrefix: true
+      await fastify.register(userRoutes, { prefix: "/api/v1/users" });
+    
+      return fastify;
     }
   </file>
   <file path="src/index.ts">

--- a/services/users/llms.txt
+++ b/services/users/llms.txt
@@ -6,13 +6,15 @@
     </item>
   </file>
   </section>
+  <section priority="medium" role="prisma.config.ts">
+  <file path="prisma.config.ts">
+    <item priority="medium">
+      function loadEnvFile(): void { /* ... */ }
+    </item>
+  </file>
+  </section>
   <section priority="medium" role="routes">
   <file path="src/routes/health.ts">
-    <item priority="high">
-      type HealthRouteHandler = RouteHandlerMethod<
-        RawServerDefault,
-        IncomingMessage...;
-    </item>
     <item priority="high">
       export const healthRoutes: FastifyPluginAsync;
     </item>
@@ -47,17 +49,6 @@
       export const getSlowQueryStats: unknown;
     </item>
   </file>
-  <file path="src/services/health-checks.ts">
-    <item priority="high">
-      export function recordDbLatency(ms: number): void { /* ... */ }
-    </item>
-    <item priority="high">
-      export function checkLatencyAnomaly(currentMs: number): {
-        isAnomaly: boolean;
-        rollingAvg: number;
-      } { /* ... */ }
-    </item>
-  </file>
   <file path="src/services/user.ts">
     <item priority="medium">
       function isPrismaNotFound(err: unknown): boolean { /* ... */ }
@@ -78,13 +69,8 @@
   </section>
   <section priority="medium" role="src">
   <file path="src/app.ts">
-    <item priority="medium">
-      function validateCorsOrigins(origins: string[]): string[] { /* ... */ }
-    </item>
-    <item priority="low">
-      interface AppOptions {
-        logger?: boolean | object;
-      }
+    <item priority="high">
+      export async function buildApp(options: AppOptions = {}): Promise<FastifyInstance> { /* ... */ }
     </item>
   </file>
   <file path="src/index.ts">


### PR DESCRIPTION
## Summary

- Adds CI status badge to top of README.md for immediate main branch health visibility
- Adds baseline failure detection to revert-watchdog workflow — checks if parent commit's CI also failed before filing CRITICAL issues or proposing reverts

## Issues

Closes #1590
Closes #1592
Part of #1594 (Green Main tracking)

## Context

The revert-watchdog was generating 7+ false-positive CRITICAL issues per day because it had no concept of pre-existing baseline failures. Every commit to main triggered a new issue even when the parent commit also failed the same checks.

## Test plan

- [ ] Verify CI badge renders in README on GitHub
- [ ] Verify revert-watchdog YAML is valid (no syntax errors in CI)
- [ ] Manual: next CI failure on main should check parent before filing issue