### PR TITLE
fix(hospitality): UI audit fixes — scroll, spacing, and quick wins (#1487)

### DIFF
--- a/apps/hospitality/src/App.module.css
+++ b/apps/hospitality/src/App.module.css
@@ -23,7 +23,8 @@
 .unauthLayout {
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
+  height: 100%;
+  overflow-y: auto;
 }
 
 /* ── Login container ─────────────────────────── */

--- a/apps/hospitality/src/components/PageHeader.module.css
+++ b/apps/hospitality/src/components/PageHeader.module.css
@@ -1,3 +1,4 @@
 .header {
+  margin-block-start: var(--rialto-space-lg);
   margin-block-end: var(--rialto-space-lg);
 }

--- a/apps/hospitality/src/index.css
+++ b/apps/hospitality/src/index.css
@@ -10,6 +10,19 @@
   --color-foreground: var(--rialto-text-primary);
 }
 
+/* Constrain viewport so the app shell (not body/html) scrolls */
+html,
+body {
+  height: 100%;
+  overflow: hidden;
+}
+
+#root {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
 body {
   font-family: var(
     --rialto-font-sans,

--- a/apps/hospitality/src/pages/GuestsPage.module.css
+++ b/apps/hospitality/src/pages/GuestsPage.module.css
@@ -1,5 +1,5 @@
 .container {
-  padding: var(--rialto-space-lg);
+  /* Padding provided by DashboardLayout .content — no extra wrapper padding needed */
 }
 
 .header {
@@ -206,10 +206,6 @@
 }
 
 @media (max-width: 480px) {
-  .container {
-    padding: var(--rialto-space-md);
-  }
-
   .segmentsGrid {
     grid-template-columns: repeat(2, 1fr);
   }

--- a/apps/hospitality/src/pages/HomePage.module.css
+++ b/apps/hospitality/src/pages/HomePage.module.css
@@ -50,7 +50,7 @@
 .reservationTime {
   font-family: var(--rialto-font-sans);
   font-size: var(--rialto-text-sm);
-  font-weight: 500;
+  font-weight: var(--rialto-weight-medium);
   color: var(--rialto-text-primary);
   min-inline-size: 5ch;
   flex-shrink: 0;

--- a/apps/hospitality/src/pages/LoadingPage.module.css
+++ b/apps/hospitality/src/pages/LoadingPage.module.css
@@ -2,5 +2,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 100vh;
+  /* Flex-fill the parent container height rather than forcing viewport height,
+     which would break the content-only scroll arch (body/html are overflow:hidden) */
+  flex: 1;
+  min-height: 200px;
 }

--- a/apps/hospitality/src/pages/ReservationsPage.module.css
+++ b/apps/hospitality/src/pages/ReservationsPage.module.css
@@ -1,5 +1,5 @@
 .container {
-  padding: var(--rialto-space-lg);
+  /* Padding provided by DashboardLayout .content — no extra wrapper padding needed */
 }
 
 /* Live indicator */

--- a/apps/hospitality/src/pages/TimelinePage.module.css
+++ b/apps/hospitality/src/pages/TimelinePage.module.css
@@ -76,6 +76,10 @@
   background: var(--rialto-border);
 }
 
+.walkInButton {
+  margin-inline-start: var(--rialto-space-xs);
+}
+
 /* Stats row */
 .statsRow {
   display: flex;


### PR DESCRIPTION
## Summary

Closes #1487

Code-based visual audit of the hospitality app. Screenshot-based review was substituted with code inspection — E2E screenshots require a live local run. Fixes the two known concrete bugs from #1485 plus five additional quick-win issues found during the audit.

---

## Findings

| Severity | Finding | Status |
|----------|---------|--------|
| High | Whole page scrolls instead of content area | Fixed |
| High | `unauthLayout` used `min-height:100vh` with `overflow:hidden` body — login/error pages clipped | Fixed |
| High | `LoadingPage` forced `min-height:100vh` inside constrained shell | Fixed |
| Medium | Title spacing too tight below AppBar/breadcrumb (known, #1485) | Fixed |
| Medium | Double padding on ReservationsPage container | Fixed |
| Medium | Double padding on GuestsPage container (incl. 480px override) | Fixed |
| Low | Missing `.walkInButton` CSS class in TimelinePage (referenced in TSX, silently dropped) | Fixed |
| Low | Hardcoded `font-weight: 500` in HomePage — violates token contract | Fixed |
| Low | E2E screenshot review (requires local run) | Follow-up |

---

## What was fixed

1. **`index.css`** — `html, body { overflow: hidden; height: 100% }` + `#root { height: 100%; display: flex; flex-direction: column }` so only `.content` scrolls
2. **`App.module.css`** — `.unauthLayout` switched from `min-height: 100vh` → `height: 100%; overflow-y: auto`
3. **`PageHeader.module.css`** — added `margin-block-start: var(--rialto-space-lg)` for title spacing below breadcrumb bar
4. **`ReservationsPage.module.css`** — removed redundant container padding (DashboardLayout `.content` already provides it)
5. **`GuestsPage.module.css`** — same padding dedup, also removed 480px media query override
6. **`TimelinePage.module.css`** — added missing `.walkInButton` class (was referenced in TSX but undefined)
7. **`HomePage.module.css`** — `font-weight: 500` → `var(--rialto-weight-medium)`
8. **`LoadingPage.module.css`** — `min-height: 100vh` → `flex: 1; min-height: 200px` for correct behaviour in both auth and unauth contexts

## What needs follow-up

- Screenshot-based review of all pages (login, timeline, reservations, guests, floor plan, settings, walk-in, booking widget) — requires local E2E run
- Mobile timeline UX (P0 backlog — grid + sidebar leaves no room)
- Cross-page SSE data divergence on ReservationsPage (P0 backlog)
- Guest edit flow currently disabled (P1 backlog)

---

https://claude.ai/code/session_01Pfe3wiUQhiVYyq3L9Yx31o