### PR TITLE
fix(health): remove dead canary service bindings

### DIFF
--- a/docs/architecture/dependency-graph.md
+++ b/docs/architecture/dependency-graph.md
@@ -150,9 +150,9 @@ flowchart TD
 
 ## Legend
 
-| Color | Category |
-|-------|----------|
-| Blue | Frontend Apps (`apps/*`) |
-| Amber | Backend Services (`services/*`) |
-| Indigo | Shared Packages (`packages/*`) |
-| Green | Developer Tools (`tools/*`) |
+| Color  | Category                        |
+| ------ | ------------------------------- |
+| Blue   | Frontend Apps (`apps/*`)        |
+| Amber  | Backend Services (`services/*`) |
+| Indigo | Shared Packages (`packages/*`)  |
+| Green  | Developer Tools (`tools/*`)     |

--- a/infrastructure/worker/edge-router.js
+++ b/infrastructure/worker/edge-router.js
@@ -289,16 +289,7 @@ const SERVICE_ENDPOINTS = {
   agent: "/api/gen/health",
 };
 
-const STATIC_SITE_BINDINGS = [
-  "MARKETING",
-  "HOSPITALITY",
-  "RIALTO",
-  "GEN",
-  "MARKETING_CANARY",
-  "HOSPITALITY_CANARY",
-  "RIALTO_CANARY",
-  "GEN_CANARY",
-];
+const STATIC_SITE_BINDINGS = ["MARKETING", "HOSPITALITY", "RIALTO", "GEN"];
 
 const KV_KEYS = {
   ci: "ci/latest",

--- a/infrastructure/worker/wrangler.toml
+++ b/infrastructure/worker/wrangler.toml
@@ -31,23 +31,6 @@ service = "mattbutlerengineering-rialto-web"
 binding = "GEN"
 service = "mattbutlerengineering-gen"
 
-# Canary Workers — serve at /canary/<app>/* for pre-promotion verification
-[[services]]
-binding = "MARKETING_CANARY"
-service = "mattbutlerengineering-marketing-canary"
-
-[[services]]
-binding = "HOSPITALITY_CANARY"
-service = "mattbutlerengineering-hospitality-canary"
-
-[[services]]
-binding = "RIALTO_CANARY"
-service = "mattbutlerengineering-rialto-web-canary"
-
-[[services]]
-binding = "GEN_CANARY"
-service = "mattbutlerengineering-gen-canary"
-
 # Health state KV — stores CI/deploy status written by GitHub Actions.
 # ID comes from: cd infrastructure/pulumi && pulumi stack output healthKvNamespaceId
 [[kv_namespaces]]

--- a/packages/database/src/health.test.ts
+++ b/packages/database/src/health.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import {
-  createLatencyTracker,
-  checkAuth0,
-  type LatencyTracker,
-} from "./health.js";
+import { createLatencyTracker, checkAuth0, type LatencyTracker } from "./health.js";
 
 describe("createLatencyTracker", () => {
   let tracker: LatencyTracker;

--- a/packages/rialto/registry.json
+++ b/packages/rialto/registry.json
@@ -89,9 +89,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "title",
@@ -1668,9 +1666,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "AuthMascot",
@@ -3306,9 +3302,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "AutocompleteOption",
@@ -4858,9 +4852,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "children",
@@ -6338,9 +6330,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "title",
@@ -7911,9 +7901,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "children",
@@ -9384,9 +9372,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "title",
@@ -10864,9 +10850,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "ChalkboardItem",
@@ -12349,9 +12333,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "CharsetName",
@@ -12522,9 +12504,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "label",
@@ -14162,9 +14142,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "DataListItem",
@@ -14210,9 +14188,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "title",
@@ -14241,9 +14217,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "Divider",
@@ -14339,9 +14313,7 @@
           "description": "Panel width/height"
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "title",
@@ -15857,9 +15829,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "title",
@@ -15891,9 +15861,7 @@
           "description": "Optional callback invoked when an error is caught. Use to report errors to external services."
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "Ferrofluid",
@@ -17359,9 +17327,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "FlipDot",
@@ -18867,9 +18833,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "FlipDotAnimationMode",
@@ -20345,9 +20309,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "FooterColumn",
@@ -21884,9 +21846,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "HeadingLevel",
@@ -23376,9 +23336,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "HoverCard",
@@ -25139,9 +25097,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "label",
@@ -26605,9 +26561,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "Kbd",
@@ -28228,9 +28182,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "label",
@@ -29712,9 +29664,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "NavbarLink",
@@ -31173,9 +31123,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "NavItem",
@@ -31300,9 +31248,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "PageHeader",
@@ -32768,9 +32714,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "Pagination",
@@ -32936,9 +32880,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "Progress",
@@ -34407,9 +34349,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "Radio",
@@ -34507,9 +34447,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "label",
@@ -34542,9 +34480,7 @@
           "description": "Theme mode. `'system'` follows the OS color scheme. Defaults to `'system'`."
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "ScrollArea",
@@ -35997,9 +35933,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "Segment",
@@ -37470,9 +37404,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "segments[].label",
@@ -39026,9 +38958,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "SidebarItem",
@@ -39098,9 +39028,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "Slider",
@@ -40640,9 +40568,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "SplitFlap",
@@ -42125,9 +42051,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "SplitScreenExit",
@@ -42158,9 +42082,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "Stack",
@@ -43643,9 +43565,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "StaggerDirection",
@@ -45128,9 +45048,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "label",
@@ -46837,9 +46755,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "TapeChart",
@@ -48519,9 +48435,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "TextArea",
@@ -50068,9 +49982,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "label",
@@ -51753,9 +51665,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "label",
@@ -51798,9 +51708,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "content",
@@ -53293,9 +53201,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "TreeNode",

--- a/services/agent/src/routes/contract.test.ts
+++ b/services/agent/src/routes/contract.test.ts
@@ -25,7 +25,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/agent/src/routes/gen-agent.test.ts
+++ b/services/agent/src/routes/gen-agent.test.ts
@@ -50,7 +50,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/agent/src/routes/gen-chat.test.ts
+++ b/services/agent/src/routes/gen-chat.test.ts
@@ -49,7 +49,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/agent/src/routes/gen-specs.test.ts
+++ b/services/agent/src/routes/gen-specs.test.ts
@@ -50,7 +50,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/agent/src/routes/health.ts
+++ b/services/agent/src/routes/health.ts
@@ -1,9 +1,5 @@
 import type { FastifyPluginAsync } from "fastify";
-import {
-  registerHealthRoutes,
-  createLatencyTracker,
-  checkAuth0,
-} from "@mbe/database";
+import { registerHealthRoutes, createLatencyTracker, checkAuth0 } from "@mbe/database";
 import {
   prisma,
   getSlowQueryStats,

--- a/services/agent/src/routes/orchestrate.test.ts
+++ b/services/agent/src/routes/orchestrate.test.ts
@@ -28,7 +28,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/agent/src/routes/ready.test.ts
+++ b/services/agent/src/routes/ready.test.ts
@@ -13,7 +13,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/agent/src/routes/session-events.integration.test.ts
+++ b/services/agent/src/routes/session-events.integration.test.ts
@@ -44,7 +44,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/agent/src/routes/sessions.test.ts
+++ b/services/agent/src/routes/sessions.test.ts
@@ -27,7 +27,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/agent/src/routes/webhooks.test.ts
+++ b/services/agent/src/routes/webhooks.test.ts
@@ -28,7 +28,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/reservations/src/routes/availability.test.ts
+++ b/services/reservations/src/routes/availability.test.ts
@@ -108,7 +108,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/reservations/src/routes/contract.test.ts
+++ b/services/reservations/src/routes/contract.test.ts
@@ -17,7 +17,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/reservations/src/routes/events.integration.test.ts
+++ b/services/reservations/src/routes/events.integration.test.ts
@@ -29,7 +29,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/reservations/src/routes/floor-plans.test.ts
+++ b/services/reservations/src/routes/floor-plans.test.ts
@@ -85,7 +85,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/reservations/src/routes/guests.test.ts
+++ b/services/reservations/src/routes/guests.test.ts
@@ -87,7 +87,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/reservations/src/routes/health.ts
+++ b/services/reservations/src/routes/health.ts
@@ -1,9 +1,5 @@
 import type { FastifyPluginAsync } from "fastify";
-import {
-  registerHealthRoutes,
-  createLatencyTracker,
-  checkAuth0,
-} from "@mbe/database";
+import { registerHealthRoutes, createLatencyTracker, checkAuth0 } from "@mbe/database";
 import {
   prisma,
   getSlowQueryStats,

--- a/services/reservations/src/routes/public-availability.test.ts
+++ b/services/reservations/src/routes/public-availability.test.ts
@@ -77,7 +77,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 vi.mock("jose", () => ({

--- a/services/reservations/src/routes/public-holds.test.ts
+++ b/services/reservations/src/routes/public-holds.test.ts
@@ -75,7 +75,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 vi.mock("jose", () => ({

--- a/services/reservations/src/routes/public-venues.test.ts
+++ b/services/reservations/src/routes/public-venues.test.ts
@@ -76,7 +76,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/reservations/src/routes/reservations.test.ts
+++ b/services/reservations/src/routes/reservations.test.ts
@@ -106,7 +106,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/reservations/src/routes/tables.test.ts
+++ b/services/reservations/src/routes/tables.test.ts
@@ -97,7 +97,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/reservations/src/routes/venues.test.ts
+++ b/services/reservations/src/routes/venues.test.ts
@@ -84,7 +84,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/users/src/app.test.ts
+++ b/services/users/src/app.test.ts
@@ -22,7 +22,12 @@ vi.mock("./services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/users/src/routes/contract.test.ts
+++ b/services/users/src/routes/contract.test.ts
@@ -22,7 +22,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/users/src/routes/health.ts
+++ b/services/users/src/routes/health.ts
@@ -1,9 +1,5 @@
 import type { FastifyPluginAsync } from "fastify";
-import {
-  registerHealthRoutes,
-  createLatencyTracker,
-  checkAuth0,
-} from "@mbe/database";
+import { registerHealthRoutes, createLatencyTracker, checkAuth0 } from "@mbe/database";
 import {
   prisma,
   getSlowQueryStats,

--- a/services/users/src/routes/users-auth.test.ts
+++ b/services/users/src/routes/users-auth.test.ts
@@ -27,7 +27,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/users/src/routes/users-edge-cases.test.ts
+++ b/services/users/src/routes/users-edge-cases.test.ts
@@ -20,7 +20,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/users/src/routes/users.test.ts
+++ b/services/users/src/routes/users.test.ts
@@ -23,7 +23,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 


### PR DESCRIPTION
## Summary

- Canary Workers removed from Pulumi IaC in fc8ef43 but `STATIC_SITE_BINDINGS` in `edge-router.js` and `[[services]]` in `wrangler.toml` were not updated — causing two cascading failures
- Removes 4 dead canary bindings from both files so all 3 sources agree (passes `check-service-bindings.js`)
- Canary routing code already null-checks bindings before use (falls through to 404), so no routing changes needed

## Root cause

Two failures from the same stale bindings:

1. **Build red on every PR** — `check-service-bindings.js` compares wrangler.toml / edge-router.js / pulumi/index.ts and exits 1 on mismatch (Pulumi had 4, the other two had 8)
2. **`/health/system` unhealthy since May 18** — health check probes all 8 `STATIC_SITE_BINDINGS`; the 4 missing canary Workers returned `status: timeout`, pushing `staticSites` to `"unhealthy"` (≥2 non-ok checks)

## Test plan

- [ ] `check-service-bindings.js` passes locally (verified: all 3 sources now have `[GEN, HOSPITALITY, MARKETING, RIALTO]`)
- [ ] CI Build job passes
- [ ] `/health/system` returns `staticSites.status: healthy` after deploy

Closes #1602

---
_Generated by [Claude Code](https://claude.ai/code/session_01KrjYSzaK2tmDdsDS7ZvJ51)_