### PR TITLE
fix(health): expose subsystem status rollup in coarse /health/system response

### DIFF
--- a/.github/workflows/synthetic-monitoring.yml
+++ b/.github/workflows/synthetic-monitoring.yml
@@ -227,7 +227,10 @@ jobs:
           TIMELINE: ${{ steps.timeline.outputs.timeline }}
         run: |
           # Build a concise summary of what's wrong
-          # Health endpoint may return flat {status,timestamp} or full {subsystems:{...}} response
+          # Unauthenticated /health/system returns {status, timestamp, requestId,
+          # subsystems:{services,static_sites,ci,deploys}} where each subsystem
+          # has only a {status} field (no sensitive details). Authenticated callers
+          # also get per-check breakdowns, latencies, commit SHAs, etc.
           FAILED_SERVICES=$(echo "$HEALTH_RESPONSE" | jq -r '
             [(.subsystems // {}).services // {} | (.checks // {}) | to_entries[] | select(.value.status != "ok") | .key] | join(", ")' 2>/dev/null || echo "")
           FAILED_SITES=$(echo "$HEALTH_RESPONSE" | jq -r '

--- a/infrastructure/worker/edge-router.js
+++ b/infrastructure/worker/edge-router.js
@@ -282,12 +282,7 @@ const SERVICE_ENDPOINTS = {
   agent: "/api/gen/health",
 };
 
-const STATIC_SITE_BINDINGS = [
-  "MARKETING",
-  "HOSPITALITY",
-  "RIALTO",
-  "GEN",
-];
+const STATIC_SITE_BINDINGS = ["MARKETING", "HOSPITALITY", "RIALTO", "GEN"];
 
 const KV_KEYS = {
   ci: "ci/latest",
@@ -506,11 +501,24 @@ function isHealthAuthorized(request, env) {
 }
 
 /**
- * Return a coarse health response with no infrastructure details.
+ * Return a coarse health response with per-subsystem STATUS rollup but no
+ * sensitive infrastructure details (no commit SHAs, latencies, service names,
+ * pipeline identifiers, or KV data).  This lets unauthenticated callers — e.g.
+ * the synthetic monitoring workflow — determine WHY the system is degraded
+ * without exposing internal topology.
  */
-function coarseHealthResponse(status, timestamp, requestId, request) {
+function coarseHealthResponse(status, timestamp, requestId, request, subsystemStatuses) {
   const corsOrigin = corsOriginFor(request);
-  return new Response(JSON.stringify({ status, timestamp, requestId }), {
+  const body = { status, timestamp, requestId };
+  if (subsystemStatuses) {
+    body.subsystems = {
+      services: { status: subsystemStatuses.services },
+      static_sites: { status: subsystemStatuses.static_sites },
+      ci: { status: subsystemStatuses.ci },
+      deploys: { status: subsystemStatuses.deploys },
+    };
+  }
+  return new Response(JSON.stringify(body), {
     status: 200,
     headers: {
       "Content-Type": "application/json",
@@ -579,9 +587,17 @@ async function handleHealthSystem(request, env, requestId) {
   const status = computeSystemStatus(services, staticSites, ci, deploys);
   const timestamp = new Date(now).toISOString();
 
-  // Gate detailed output behind token auth (safe by default)
+  // Gate detailed output behind token auth (safe by default).
+  // Unauthenticated callers get per-subsystem STATUS rollup only — enough
+  // for monitoring scripts to know WHY the system is degraded without
+  // exposing commit SHAs, latencies, pipeline names, or service topology.
   if (!isHealthAuthorized(request, env)) {
-    return coarseHealthResponse(status, timestamp, requestId, request);
+    return coarseHealthResponse(status, timestamp, requestId, request, {
+      services: services.status,
+      static_sites: staticSites.status,
+      ci: ci.status,
+      deploys: deploys.status,
+    });
   }
 
   const corsOrigin = corsOriginFor(request);

--- a/infrastructure/worker/edge-router.test.js
+++ b/infrastructure/worker/edge-router.test.js
@@ -392,8 +392,17 @@ describe("Edge Router", () => {
       const body = await response.json();
       expect(body).toHaveProperty("status");
       expect(body).toHaveProperty("timestamp");
-      // Should NOT have detailed subsystem info without auth
-      expect(body).not.toHaveProperty("subsystems");
+      // Coarse response includes per-subsystem STATUS rollup so monitoring
+      // scripts can determine WHY the system is degraded — but no sensitive
+      // details (commit SHAs, latencies, pipeline names, service topology).
+      expect(body).toHaveProperty("subsystems.services.status");
+      expect(body).toHaveProperty("subsystems.static_sites.status");
+      expect(body).toHaveProperty("subsystems.ci.status");
+      expect(body).toHaveProperty("subsystems.deploys.status");
+      // Verify no sensitive fields leak through
+      expect(body.subsystems.ci).not.toHaveProperty("last_run");
+      expect(body.subsystems.deploys).not.toHaveProperty("pipelines");
+      expect(body.subsystems.services).not.toHaveProperty("checks");
     });
 
     it("omits CORS header when no Origin is sent", async () => {


### PR DESCRIPTION
## Problem

`HEALTH_TOKEN` is not set in the Cloudflare Worker env, so **all callers** of `/health/system` — including the synthetic monitoring workflow — receive the coarse `{ status, timestamp }` response. The monitoring script extracts `.subsystems.ci.status` and `.subsystems.deploys.status` but both are `null` (no `subsystems` key in coarse response), so every health issue is titled **"CI: unknown. Deploys: unknown."** regardless of the actual cause.

This made health alert issues completely non-actionable: we knew the system was degraded, but not why.

## Fix

Include a **per-subsystem STATUS rollup** in the unauthenticated coarse response — enough for monitoring scripts to determine why the system is degraded, without leaking sensitive infrastructure details:

```json
{
  "status": "degraded",
  "timestamp": "...",
  "requestId": "...",
  "subsystems": {
    "services":    { "status": "ok" },
    "static_sites": { "status": "ok" },
    "ci":          { "status": "stale" },
    "deploys":     { "status": "degraded" }
  }
}
```

No sensitive fields exposed: no commit SHAs, latencies, pipeline names, service names, or KV data.

The existing monitoring jq expressions (`(.subsystems // {}).ci.status`) already handle this shape, so issue titles will now accurately reflect the cause (e.g. **"CI: stale. Deploys: degraded."**).

## Changes

- `infrastructure/worker/edge-router.js` — `coarseHealthResponse()` accepts optional `subsystemStatuses` and includes `{ services, static_sites, ci, deploys }` each with just `{ status }` field; call site passes rollup from computed subsystem objects
- `infrastructure/worker/edge-router.test.js` — update test to assert subsystem statuses ARE present in coarse response and sensitive fields are NOT (no `last_run`, `pipelines`, `checks`)
- `.github/workflows/synthetic-monitoring.yml` — update stale comment to document actual response shape

## Testing

```bash
cd infrastructure/worker && npx vitest@4.1.6 run edge-router.test.js
# 45 passed, 1 pre-existing failure in /health/deps (unrelated)
```

Closes #1611

https://claude.ai/code/session_01WB7qaHfmkVYq3bfyt9Mkib

---
_Generated by [Claude Code](https://claude.ai/code/session_01WB7qaHfmkVYq3bfyt9Mkib)_