### PR TITLE
fix(database): increase test timeout to 15s for dynamic import tests

### DIFF
--- a/packages/database/src/index.test.ts
+++ b/packages/database/src/index.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+// Dynamic imports via `await import("./index.js")` hit a cold module load
+// on every test (vi.resetModules() runs in beforeEach). Under parallel turbo
+// load (13+ packages in CI / pre-push), the default 5s is too tight.
+vi.setConfig({ testTimeout: 15_000 });
+
 const mockPoolInstance = {
   totalCount: 5,
   activeCount: 2,


### PR DESCRIPTION
## Problem

`packages/database/src/index.test.ts` has 14 tests that all do `await import(\"./index.js\")`. Because `vi.resetModules()` runs in `beforeEach`, every test is a cold dynamic import. Under parallel turbo load (13+ packages in pre-push / CI), 5s is too tight and the first test consistently times out:

```
Error: Test timed out in 5000ms at src/index.test.ts:50:3
```

## Fix

Add `vi.setConfig({ testTimeout: 15_000 })` at the top of the file (after imports). This sets a 15s timeout for every test in this file — covering all 14 dynamic-import tests with a single line, rather than annotating each `it()` individually.

## Testing

Test passes when run in isolation and should now pass under parallel load:

```bash
pnpm --dir packages/database test
```

Closes #1617

https://claude.ai/code/session_01G4FVWgXj9RcicivMKcRx1R

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4FVWgXj9RcicivMKcRx1R)_