### PR TITLE
refactor(agent-core): extract PostCommitGateway to consolidate post-commit validation locality

### DIFF
--- a/packages/agent-core/llms-full.txt
+++ b/packages/agent-core/llms-full.txt
@@ -290,6 +290,19 @@
       readonly errors: readonly string[];
     }
   </file>
+  <file path="src/post-commit-gateway.ts">
+    export type GatewayOutcome = "merge-direct" | "create-pr" | "create-draft-pr";
+    export interface GatewayVerdict {
+      outcome: GatewayOutcome;
+      passed: boolean;
+      /** Names of gates that failed, e.g. ["verification", "static-analysis"] */
+      gateFailures: string[];
+      /** Human-readable failure messages collected from verification + quality gates */
+      errors: string[];
+      /** LLM evaluation result — undefined when evaluation was skipped or not run */
+      evaluation?: EvaluationResult;
+    }
+  </file>
   <file path="src/pr-creator.ts">
     export async function createPullRequest(options: PrOptions): Promise<PrResult> {
       const { title, body, baseBranch, branchName, repoPath, draft } = options;

--- a/packages/agent-core/llms-full.txt
+++ b/packages/agent-core/llms-full.txt
@@ -1108,7 +1108,7 @@
                   let prUrl: string | null = null;
                   const changed = worktree ? await hasChanges(worktree.path) : false;
     
-                  let qualityResult: QualityGatesResult | undefined;
+                  let gatewayEvaluation: EvaluationResult | undefined;
     
                   if (changed && worktree) {
                     // Capture narrowed worktree for use in closures (TS loses narrowing in callbacks)
@@ -1117,145 +1117,123 @@
                     const commitMsg = `${prefix}: ${sanitizeForCommitMessage(config.taskDescription)}`;
                     await commitChanges(wt.path, commitMsg);
     
-                    // 6a. Run lint + typecheck + test verification before pushing
-                    let verificationPassed = true;
-                    if (isSuccess) {
-                      const verification = await orchestrateVerification(wt.path, onEvent);
-                      verificationPassed = verification.passed;
-                      if (verification.error) errors.push(verification.error);
-                    }
-    
                     // Push with retry for transient network failures
                     await withRetry(() => pushBranch(wt.path, wt.branchName), { maxRetries: 3 });
     
-                    // 6b, 6c, 6d. Run Quality Gates (LLM Success Eval, Static Analysis, Security Review)
-                    if (isSuccess && verificationPassed) {
+                    // 6a–6d. Run post-commit gateway (verification + quality gates)
+                    let verdict;
+                    if (isSuccess) {
                       const diff = await getCachedDiff(wt.path);
-                      qualityResult = await runQualityGates(
-                        config.taskDescription,
-                        diff,
-                        commitMsg,
+                      verdict = await runPostCommitGateway(
                         {
-                          evaluateSuccess: config.evaluateSuccess,
-                          runSecurityReview: true,
-                          runStaticAnalysis: true,
+                          worktreePath: wt.path,
+                          diff,
+                          commitMsg,
+                          taskDescription: config.taskDescription,
+                          config: {
+                            evaluateSuccess: config.evaluateSuccess,
+                            runSecurityReview: true,
+                            runStaticAnalysis: true,
+                          },
                         },
                         onEvent
                       );
-                      errors.push(...qualityResult.errors);
+                      errors.push(...verdict.errors);
+                      gatewayEvaluation = verdict.evaluation;
                     }
     
-                    const allGatesPass =
-                      verificationPassed &&
-                      (!qualityResult ||
-                        (qualityResult.evaluation?.passed !== false &&
-                          qualityResult.staticAnalysisClean &&
-                          qualityResult.securityReview?.approved !== false));
-    
                     if (config.createPr) {
-                      // Fast-path: trivial dependency bumps that passed tests are merged
-                      // directly without waiting for PR review.
-                      if (allGatesPass) {
-                        const depBumpCheck = isTrivialDepBump(await getCachedDiff(wt.path));
-                        if (depBumpCheck.isTrivial) {
-                          const commitTitle = buildPrTitle(config.taskDescription);
-                          prUrl = await mergeDirectly({
-                            branchName: wt.branchName,
-                            baseBranch: config.baseBranch,
-                            repoPath: wt.path,
-                            commitTitle,
-                          });
-                          emitEvent(onEvent, "session:result", {
-                            message: `Trivial dep bump — direct-merged: ${prUrl}`,
-                          });
-                        } else {
-                          const title = buildPrTitle(config.taskDescription);
-                          const body = resultMessage
-                            ? buildPrBody(
-                                config.taskDescription,
-                                resultMessage.session_id,
-                                resultMessage.total_cost_usd,
-                                resultMessage.num_turns
-                              )
-                            : buildFailurePrBody(config.taskDescription, errors, stuckReason?.type);
+                      if (verdict?.outcome === "merge-direct") {
+                        // Fast-path: trivial dep bump — direct-merge
+                        const commitTitle = buildPrTitle(config.taskDescription);
+                        prUrl = await mergeDirectly({
+                          branchName: wt.branchName,
+                          baseBranch: config.baseBranch,
+                          repoPath: wt.path,
+                          commitTitle,
+                        });
+                        emitEvent(onEvent, "session:result", {
+                          message: `Trivial dep bump — direct-merged: ${prUrl}`,
+                        });
+                      } else if (!verdict || verdict.outcome === "create-pr") {
+                        // All gates passed — create normal PR
+                        const title = buildPrTitle(config.taskDescription);
+                        const body = resultMessage
+                          ? buildPrBody(
+                              config.taskDescription,
+                              resultMessage.session_id,
+                              resultMessage.total_cost_usd,
+                              resultMessage.num_turns
+                            )
+                          : buildFailurePrBody(config.taskDescription, errors, stuckReason?.type);
     
-                          const prSpan = tracer.startSpan("agent_core.create_pr");
-                          let pr;
+                        const prSpan = tracer.startSpan("agent_core.create_pr");
+                        let pr;
+                        try {
+                          // Retry PR creation for transient GitHub API failures
+                          const { value: prResult } = await withRetry(
+                            () =>
+                              createPullRequest({
+                                title,
+                                body,
+                                baseBranch: config.baseBranch,
+                                branchName: wt.branchName,
+                                repoPath: wt.path,
+                                draft: false,
+                              }),
+                            { maxRetries: 3 }
+                          );
+                          pr = prResult;
+                          prSpan.setAttribute("pr.url", pr.url);
+                          prSpan.setAttribute("pr.number", pr.number);
+                          prSpan.setAttribute("pr.draft", false);
+                        } finally {
+                          prSpan.end();
+                        }
+    
+                        prUrl = pr.url;
+                        emitEvent(onEvent, "session:result", {
+                          message: `PR created: ${pr.url}`,
+                        });
+    
+                        // Run feedback loop if enabled (poll for review comments / CI failures)
+                        if (config.feedbackLoop?.enabled) {
+                          // Use remaining budget instead of fixed 50% ratio
+                          const sessionCost = resultMessage?.total_cost_usd ?? 0;
+                          const remainingBudget = Math.max(
+                            0,
+                            effectiveConfig.maxBudgetUsd - sessionCost
+                          );
+    
+                          const fbSpan = tracer.startSpan("agent_core.feedback_loop");
+                          let feedbackResult;
                           try {
-                            // Retry PR creation for transient GitHub API failures
-                            const { value: prResult } = await withRetry(
-                              () =>
-                                createPullRequest({
-                                  title,
-                                  body,
-                                  baseBranch: config.baseBranch,
-                                  branchName: wt.branchName,
-                                  repoPath: wt.path,
-                                  draft: false,
-                                }),
-                              { maxRetries: 3 }
+                            feedbackResult = await runFeedbackLoop(
+                              {
+                                prNumber: pr.number,
+                                branchName: wt.branchName,
+                                repoPath: wt.path,
+                                model: getFeedbackLoopModel(config.model),
+                                maxRetries: config.feedbackLoop.maxRetries ?? 2,
+                                pollIntervalMs: config.feedbackLoop.pollIntervalMs ?? 30_000,
+                                pollTimeoutMs: config.feedbackLoop.pollTimeoutMs ?? 300_000,
+                                maxBudgetUsd: remainingBudget,
+                                allowedTools: config.allowedTools,
+                              },
+                              onEvent
                             );
-                            pr = prResult;
-                            prSpan.setAttribute("pr.url", pr.url);
-                            prSpan.setAttribute("pr.number", pr.number);
-                            prSpan.setAttribute("pr.draft", false);
+                            fbSpan.setAttribute("feedback.retries_used", feedbackResult.retriesUsed);
+                            fbSpan.setAttribute("feedback.resolved", feedbackResult.resolved);
                           } finally {
-                            prSpan.end();
+                            fbSpan.end();
                           }
     
-                          prUrl = pr.url;
                           emitEvent(onEvent, "session:result", {
-                            message: `PR created: ${pr.url}`,
+                            message: `Feedback loop: ${feedbackResult.resolved ? "resolved" : "escalated"} after ${feedbackResult.retriesUsed} retries`,
                           });
-    
-                          // Run feedback loop if enabled (poll for review comments / CI failures)
-                          if (config.feedbackLoop?.enabled) {
-                            // Use remaining budget instead of fixed 50% ratio
-                            const sessionCost = resultMessage?.total_cost_usd ?? 0;
-                            const remainingBudget = Math.max(
-                              0,
-                              effectiveConfig.maxBudgetUsd - sessionCost
-                            );
-    
-                            const fbSpan = tracer.startSpan("agent_core.feedback_loop");
-                            let feedbackResult;
-                            try {
-                              feedbackResult = await runFeedbackLoop(
-                                {
-                                  prNumber: pr.number,
-                                  branchName: wt.branchName,
-                                  repoPath: wt.path,
-                                  model: getFeedbackLoopModel(config.model),
-                                  maxRetries: config.feedbackLoop.maxRetries ?? 2,
-                                  pollIntervalMs: config.feedbackLoop.pollIntervalMs ?? 30_000,
-                                  pollTimeoutMs: config.feedbackLoop.pollTimeoutMs ?? 300_000,
-                                  maxBudgetUsd: remainingBudget,
-                                  allowedTools: config.allowedTools,
-                                },
-                                onEvent
-                              );
-                              fbSpan.setAttribute("feedback.retries_used", feedbackResult.retriesUsed);
-                              fbSpan.setAttribute("feedback.resolved", feedbackResult.resolved);
-                            } finally {
-                              fbSpan.end();
-                            }
-    
-                            emitEvent(onEvent, "session:result", {
-                              message: `Feedback loop: ${feedbackResult.resolved ? "resolved" : "escalated"} after ${feedbackResult.retriesUsed} retries`,
-                            });
-                          }
                         }
                       } else {
-                        // Quality gates failed — create draft PR so humans can review
-                        const gateFailures: string[] = [];
-                        if (!verificationPassed) gateFailures.push("verification");
-                        if (qualityResult && !qualityResult.staticAnalysisClean)
-                          gateFailures.push("static-analysis");
-                        if (qualityResult && qualityResult.evaluation?.passed === false)
-                          gateFailures.push("evaluation");
-                        if (qualityResult && qualityResult.securityReview?.approved === false)
-                          gateFailures.push("security-review");
-    
+                        // verdict.outcome === "create-draft-pr" — quality gates failed
                         const title = `wip: ${config.taskDescription.slice(0, 57)}`;
                         const body = buildFailurePrBody(
                           config.taskDescription,
@@ -1279,7 +1257,7 @@
     
                         prUrl = pr.url;
                         emitEvent(onEvent, "session:result", {
-                          message: `Draft PR created (failed gates: ${gateFailures.join(", ")}): ${pr.url}`,
+                          message: `Draft PR created (failed gates: ${verdict.gateFailures.join(", ")}): ${pr.url}`,
                         });
                       }
                     }
@@ -1290,11 +1268,11 @@
                   }
     
                   // 7. Build final result
-                  const evalSummary = qualityResult?.evaluation
+                  const evalSummary = gatewayEvaluation
                     ? {
-                        passed: qualityResult.evaluation.passed,
-                        confidence: qualityResult.evaluation.confidence,
-                        reasoning: qualityResult.evaluation.reasoning,
+                        passed: gatewayEvaluation.passed,
+                        confidence: gatewayEvaluation.confidence,
+                        reasoning: gatewayEvaluation.reasoning,
                       }
                     : undefined;
     

--- a/packages/agent-core/llms.txt
+++ b/packages/agent-core/llms.txt
@@ -280,6 +280,20 @@
       }
     </item>
   </file>
+  <file path="src/post-commit-gateway.ts">
+    <item priority="low">
+      type GatewayOutcome = "merge-direct" | "create-pr" | "create-draft-pr";
+    </item>
+    <item priority="low">
+      interface GatewayVerdict {
+        outcome: GatewayOutcome;
+        passed: boolean;
+        gateFailures: string[];
+        errors: string[];
+        evaluation?: EvaluationResult;
+      }
+    </item>
+  </file>
   <file path="src/pr-creator.ts">
     <item priority="high">
       export async function createPullRequest(options: PrOptions): Promise<PrResult> { /* ... */ }

--- a/packages/agent-core/src/__tests__/post-commit-gateway.test.ts
+++ b/packages/agent-core/src/__tests__/post-commit-gateway.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock orchestrateVerification
+vi.mock("../verification-orchestrator.js", () => ({
+  orchestrateVerification: vi.fn(),
+}));
+
+// Mock runQualityGates
+vi.mock("../quality-gates.js", () => ({
+  runQualityGates: vi.fn(),
+}));
+
+// Mock isTrivialDepBump
+vi.mock("../dep-bump-merger.js", () => ({
+  isTrivialDepBump: vi.fn(),
+  mergeDirectly: vi.fn(),
+}));
+
+import { orchestrateVerification } from "../verification-orchestrator.js";
+import { runQualityGates } from "../quality-gates.js";
+import { isTrivialDepBump } from "../dep-bump-merger.js";
+import { runPostCommitGateway } from "../post-commit-gateway.js";
+
+const VALID_INPUT = {
+  worktreePath: "/repo/.agent-worktrees/branch-abc",
+  diff: "diff --git a/src/index.ts\n+const x = 1;",
+  commitMsg: "feat: add feature",
+  taskDescription: "Add a new feature",
+  config: {
+    evaluateSuccess: true,
+    runSecurityReview: true,
+    runStaticAnalysis: true,
+  },
+};
+
+describe("runPostCommitGateway", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default: all gates pass
+    vi.mocked(orchestrateVerification).mockResolvedValue({ passed: true });
+    vi.mocked(runQualityGates).mockResolvedValue({
+      staticAnalysisClean: true,
+      errors: [],
+      evaluation: { passed: true, confidence: 0.9, reasoning: "Good", issues: [] },
+      securityReview: { approved: true, issues: [] },
+    });
+    vi.mocked(isTrivialDepBump).mockReturnValue({ isTrivial: false });
+  });
+
+  // ── Outcome: merge-direct ──────────────────────────────────────────
+
+  it("returns merge-direct outcome when all gates pass and diff is a trivial dep bump", async () => {
+    vi.mocked(isTrivialDepBump).mockReturnValue({ isTrivial: true });
+
+    const verdict = await runPostCommitGateway(VALID_INPUT);
+
+    expect(verdict.outcome).toBe("merge-direct");
+    expect(verdict.passed).toBe(true);
+    expect(verdict.gateFailures).toEqual([]);
+    expect(verdict.errors).toEqual([]);
+  });
+
+  // ── Outcome: create-pr ─────────────────────────────────────────────
+
+  it("returns create-pr outcome when all gates pass and diff is not trivial", async () => {
+    vi.mocked(isTrivialDepBump).mockReturnValue({ isTrivial: false });
+
+    const verdict = await runPostCommitGateway(VALID_INPUT);
+
+    expect(verdict.outcome).toBe("create-pr");
+    expect(verdict.passed).toBe(true);
+    expect(verdict.gateFailures).toEqual([]);
+    expect(verdict.errors).toEqual([]);
+  });
+
+  it("returns create-pr when evaluateSuccess is false but everything else passes", async () => {
+    const input = {
+      ...VALID_INPUT,
+      config: { ...VALID_INPUT.config, evaluateSuccess: false },
+    };
+    vi.mocked(runQualityGates).mockResolvedValue({
+      staticAnalysisClean: true,
+      errors: [],
+      securityReview: { approved: true, issues: [] },
+      // No evaluation result since it was skipped
+    });
+
+    const verdict = await runPostCommitGateway(input);
+
+    expect(verdict.outcome).toBe("create-pr");
+    expect(verdict.passed).toBe(true);
+  });
+
+  // ── Outcome: create-draft-pr ───────────────────────────────────────
+
+  it("returns create-draft-pr when verification fails", async () => {
+    vi.mocked(orchestrateVerification).mockResolvedValue({
+      passed: false,
+      error: "Verification failed: typecheck: Type error in src/foo.ts",
+    });
+
+    const verdict = await runPostCommitGateway(VALID_INPUT);
+
+    expect(verdict.outcome).toBe("create-draft-pr");
+    expect(verdict.passed).toBe(false);
+    expect(verdict.gateFailures).toContain("verification");
+  });
+
+  it("returns create-draft-pr when static analysis fails", async () => {
+    vi.mocked(runQualityGates).mockResolvedValue({
+      staticAnalysisClean: false,
+      errors: ["Static analysis errors: src/foo.ts:10 [no-console] console.log detected"],
+      evaluation: { passed: true, confidence: 0.9, reasoning: "Good", issues: [] },
+      securityReview: { approved: true, issues: [] },
+    });
+
+    const verdict = await runPostCommitGateway(VALID_INPUT);
+
+    expect(verdict.outcome).toBe("create-draft-pr");
+    expect(verdict.passed).toBe(false);
+    expect(verdict.gateFailures).toContain("static-analysis");
+  });
+
+  it("returns create-draft-pr when LLM evaluation fails", async () => {
+    vi.mocked(runQualityGates).mockResolvedValue({
+      staticAnalysisClean: true,
+      errors: ["Evaluation failed: Task not addressed"],
+      evaluation: { passed: false, confidence: 0.3, reasoning: "Task not addressed", issues: [] },
+      securityReview: { approved: true, issues: [] },
+    });
+
+    const verdict = await runPostCommitGateway(VALID_INPUT);
+
+    expect(verdict.outcome).toBe("create-draft-pr");
+    expect(verdict.passed).toBe(false);
+    expect(verdict.gateFailures).toContain("evaluation");
+  });
+
+  it("returns create-draft-pr when security review fails", async () => {
+    vi.mocked(runQualityGates).mockResolvedValue({
+      staticAnalysisClean: true,
+      errors: ["Security review failed: Hardcoded secret detected"],
+      evaluation: { passed: true, confidence: 0.9, reasoning: "Good", issues: [] },
+      securityReview: { approved: false, issues: ["Hardcoded secret detected"] },
+    });
+
+    const verdict = await runPostCommitGateway(VALID_INPUT);
+
+    expect(verdict.outcome).toBe("create-draft-pr");
+    expect(verdict.passed).toBe(false);
+    expect(verdict.gateFailures).toContain("security-review");
+  });
+
+  // ── gateFailures combinations ──────────────────────────────────────
+
+  it("collects multiple gate failures when verification and static analysis both fail", async () => {
+    vi.mocked(orchestrateVerification).mockResolvedValue({
+      passed: false,
+      error: "Lint failed",
+    });
+    vi.mocked(runQualityGates).mockResolvedValue({
+      staticAnalysisClean: false,
+      errors: ["Static analysis errors: ..."],
+      evaluation: { passed: true, confidence: 0.9, reasoning: "Good", issues: [] },
+      securityReview: { approved: true, issues: [] },
+    });
+
+    const verdict = await runPostCommitGateway(VALID_INPUT);
+
+    expect(verdict.outcome).toBe("create-draft-pr");
+    expect(verdict.passed).toBe(false);
+    // Verification failed → quality gates not run; only verification in gateFailures
+    expect(verdict.gateFailures).toContain("verification");
+  });
+
+  it("collects evaluation and security-review failures when both fail", async () => {
+    vi.mocked(runQualityGates).mockResolvedValue({
+      staticAnalysisClean: true,
+      errors: [
+        "Evaluation failed: Not addressed",
+        "Security review failed: SQL injection detected",
+      ],
+      evaluation: { passed: false, confidence: 0.2, reasoning: "Not addressed", issues: [] },
+      securityReview: { approved: false, issues: ["SQL injection detected"] },
+    });
+
+    const verdict = await runPostCommitGateway(VALID_INPUT);
+
+    expect(verdict.outcome).toBe("create-draft-pr");
+    expect(verdict.passed).toBe(false);
+    expect(verdict.gateFailures).toContain("evaluation");
+    expect(verdict.gateFailures).toContain("security-review");
+  });
+
+  // ── errors propagation ─────────────────────────────────────────────
+
+  it("propagates verification error into verdict errors", async () => {
+    vi.mocked(orchestrateVerification).mockResolvedValue({
+      passed: false,
+      error: "Verification failed: tests: 2 failing",
+    });
+
+    const verdict = await runPostCommitGateway(VALID_INPUT);
+
+    expect(verdict.errors).toContain("Verification failed: tests: 2 failing");
+  });
+
+  it("propagates quality gate errors into verdict errors", async () => {
+    vi.mocked(runQualityGates).mockResolvedValue({
+      staticAnalysisClean: true,
+      errors: ["Evaluation failed: diff does not address task"],
+      evaluation: { passed: false, confidence: 0.2, reasoning: "...", issues: [] },
+      securityReview: { approved: true, issues: [] },
+    });
+
+    const verdict = await runPostCommitGateway(VALID_INPUT);
+
+    expect(verdict.errors).toContain("Evaluation failed: diff does not address task");
+  });
+
+  // ── Config passthrough ─────────────────────────────────────────────
+
+  it("passes config options to runQualityGates", async () => {
+    const input = {
+      ...VALID_INPUT,
+      config: {
+        evaluateSuccess: false,
+        runSecurityReview: false,
+        runStaticAnalysis: true,
+      },
+    };
+    vi.mocked(runQualityGates).mockResolvedValue({
+      staticAnalysisClean: true,
+      errors: [],
+    });
+
+    await runPostCommitGateway(input);
+
+    expect(runQualityGates).toHaveBeenCalledWith(
+      input.taskDescription,
+      input.diff,
+      input.commitMsg,
+      expect.objectContaining({
+        evaluateSuccess: false,
+        runSecurityReview: false,
+        runStaticAnalysis: true,
+      }),
+      undefined // no onEvent
+    );
+  });
+
+  it("skips quality gates when verification fails", async () => {
+    vi.mocked(orchestrateVerification).mockResolvedValue({
+      passed: false,
+      error: "Typecheck failed",
+    });
+
+    await runPostCommitGateway(VALID_INPUT);
+
+    // Quality gates should NOT be called if verification failed
+    expect(runQualityGates).not.toHaveBeenCalled();
+  });
+
+  it("passes worktreePath to orchestrateVerification", async () => {
+    await runPostCommitGateway(VALID_INPUT);
+
+    expect(orchestrateVerification).toHaveBeenCalledWith(
+      VALID_INPUT.worktreePath,
+      undefined // no onEvent
+    );
+  });
+
+  it("passes onEvent callback to orchestrateVerification and runQualityGates", async () => {
+    const onEvent = vi.fn();
+
+    await runPostCommitGateway(VALID_INPUT, onEvent);
+
+    expect(orchestrateVerification).toHaveBeenCalledWith(VALID_INPUT.worktreePath, onEvent);
+    expect(runQualityGates).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.any(String),
+      expect.any(Object),
+      onEvent
+    );
+  });
+});

--- a/packages/agent-core/src/__tests__/session-runner.test.ts
+++ b/packages/agent-core/src/__tests__/session-runner.test.ts
@@ -12,7 +12,6 @@ vi.mock("../worktree-manager.js", () => ({
   pushBranch: vi.fn(),
   hasChanges: vi.fn(),
   removeWorktree: vi.fn(),
-  runVerification: vi.fn(),
 }));
 
 vi.mock("../pr-creator.js", () => ({
@@ -23,17 +22,11 @@ vi.mock("../pr-creator.js", () => ({
 }));
 
 vi.mock("../success-evaluator.js", () => ({
-  evaluateSuccess: vi.fn(),
   getGitDiff: vi.fn(),
-  shouldEvaluate: vi.fn().mockReturnValue(true),
 }));
 
-vi.mock("../diff-reviewer.js", () => ({
-  reviewDiff: vi.fn(),
-}));
-
-vi.mock("../diff-static-analyzer.js", () => ({
-  analyzeDiff: vi.fn(),
+vi.mock("../post-commit-gateway.js", () => ({
+  runPostCommitGateway: vi.fn(),
 }));
 
 vi.mock("../feedback-loop.js", () => ({
@@ -103,12 +96,10 @@ import {
   pushBranch,
   hasChanges,
   removeWorktree,
-  runVerification,
 } from "../worktree-manager.js";
 import { createPullRequest, buildPrTitle, buildPrBody } from "../pr-creator.js";
-import { evaluateSuccess, getGitDiff } from "../success-evaluator.js";
-import { reviewDiff } from "../diff-reviewer.js";
-import { analyzeDiff } from "../diff-static-analyzer.js";
+import { getGitDiff } from "../success-evaluator.js";
+import { runPostCommitGateway } from "../post-commit-gateway.js";
 import { runFeedbackLoop } from "../feedback-loop.js";
 import { loadMemory, queryPastFailures, buildFailureContext } from "../failure-memory.js";
 import { buildSystemPrompt } from "../prompt-builder.js";
@@ -188,24 +179,16 @@ describe("runSession", () => {
     vi.mocked(queryPastFailures).mockReturnValue([]);
     vi.mocked(buildFailureContext).mockReturnValue("");
 
-    vi.mocked(runVerification).mockResolvedValue({
+    vi.mocked(runPostCommitGateway).mockResolvedValue({
+      outcome: "create-pr",
       passed: true,
-      lintOk: true,
-      typecheckOk: true,
-      testsOk: true,
+      gateFailures: [],
+      errors: [],
     });
 
-    vi.mocked(reviewDiff).mockResolvedValue({ approved: true, issues: [] });
-    vi.mocked(analyzeDiff).mockReturnValue({ clean: true, violations: [], durationMs: 1 });
     vi.mocked(runFeedbackLoop).mockResolvedValue({ resolved: false, retriesUsed: 0 });
 
     vi.mocked(getGitDiff).mockResolvedValue("diff --git a/file.ts\n+change");
-    vi.mocked(evaluateSuccess).mockResolvedValue({
-      passed: true,
-      confidence: 0.95,
-      reasoning: "Changes address the task",
-      issues: [],
-    });
   });
 
   it("runs a successful session with PR creation", async () => {
@@ -428,11 +411,11 @@ describe("runSession", () => {
     vi.mocked(hasChanges).mockResolvedValue(true);
     vi.mocked(commitChanges).mockResolvedValue("abc123");
     vi.mocked(pushBranch).mockResolvedValue(undefined);
-    vi.mocked(runVerification).mockResolvedValue({
+    vi.mocked(runPostCommitGateway).mockResolvedValue({
+      outcome: "create-draft-pr",
       passed: false,
-      lintOk: true,
-      typecheckOk: false,
-      testsOk: true,
+      gateFailures: ["verification"],
+      errors: ["Verification failed: typecheck errors"],
     });
     vi.mocked(buildPrTitle).mockReturnValue("wip: Fix the login bug");
     vi.mocked(buildPrBody).mockReturnValue("body");

--- a/packages/agent-core/src/post-commit-gateway.ts
+++ b/packages/agent-core/src/post-commit-gateway.ts
@@ -1,0 +1,98 @@
+import { orchestrateVerification } from "./verification-orchestrator.js";
+import { runQualityGates } from "./quality-gates.js";
+import { isTrivialDepBump } from "./dep-bump-merger.js";
+import type { SessionEventCallback } from "./types.js";
+import type { EvaluationResult } from "./success-evaluator.js";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type GatewayOutcome = "merge-direct" | "create-pr" | "create-draft-pr";
+
+export interface GatewayVerdict {
+  outcome: GatewayOutcome;
+  passed: boolean;
+  /** Names of gates that failed, e.g. ["verification", "static-analysis"] */
+  gateFailures: string[];
+  /** Human-readable failure messages collected from verification + quality gates */
+  errors: string[];
+  /** LLM evaluation result — undefined when evaluation was skipped or not run */
+  evaluation?: EvaluationResult;
+}
+
+export interface PostCommitGatewayConfig {
+  evaluateSuccess?: boolean;
+  runSecurityReview?: boolean;
+  runStaticAnalysis?: boolean;
+}
+
+export interface PostCommitGatewayInput {
+  worktreePath: string;
+  diff: string;
+  commitMsg: string;
+  taskDescription: string;
+  config: PostCommitGatewayConfig;
+}
+
+// ── Implementation ────────────────────────────────────────────────────────────
+
+/**
+ * Run all post-commit validation gates and determine the PR outcome.
+ *
+ * Returns a GatewayVerdict with:
+ *   - `outcome`: "merge-direct" | "create-pr" | "create-draft-pr"
+ *   - `passed`: true when all gates passed
+ *   - `gateFailures`: names of gates that failed
+ *   - `errors`: human-readable messages collected from all gates
+ */
+export async function runPostCommitGateway(
+  input: PostCommitGatewayInput,
+  onEvent?: SessionEventCallback
+): Promise<GatewayVerdict> {
+  const { worktreePath, diff, commitMsg, taskDescription, config } = input;
+  const errors: string[] = [];
+  const gateFailures: string[] = [];
+
+  // 1. Verification (lint + typecheck + tests)
+  const verification = await orchestrateVerification(worktreePath, onEvent);
+  if (!verification.passed) {
+    gateFailures.push("verification");
+    if (verification.error) errors.push(verification.error);
+  }
+
+  // 2. Quality gates — only run when verification passed
+  let evaluation: EvaluationResult | undefined;
+  if (verification.passed) {
+    const qualityResult = await runQualityGates(
+      taskDescription,
+      diff,
+      commitMsg,
+      {
+        evaluateSuccess: config.evaluateSuccess,
+        runSecurityReview: config.runSecurityReview,
+        runStaticAnalysis: config.runStaticAnalysis,
+      },
+      onEvent
+    );
+
+    errors.push(...qualityResult.errors);
+    evaluation = qualityResult.evaluation;
+
+    if (!qualityResult.staticAnalysisClean) gateFailures.push("static-analysis");
+    if (qualityResult.evaluation?.passed === false) gateFailures.push("evaluation");
+    if (qualityResult.securityReview?.approved === false) gateFailures.push("security-review");
+  }
+
+  const allGatesPass = gateFailures.length === 0;
+
+  if (!allGatesPass) {
+    return { outcome: "create-draft-pr", passed: false, gateFailures, errors, evaluation };
+  }
+
+  // 3. Determine merge strategy — trivial dep bumps bypass PR review
+  const depBumpCheck = isTrivialDepBump(diff);
+  if (depBumpCheck.isTrivial) {
+    return { outcome: "merge-direct", passed: true, gateFailures: [], errors: [], evaluation };
+  }
+
+  return { outcome: "create-pr", passed: true, gateFailures: [], errors: [], evaluation };
+}

--- a/packages/agent-core/src/session-runner.ts
+++ b/packages/agent-core/src/session-runner.ts
@@ -16,8 +16,9 @@ import {
   removeWorktree,
 } from "./worktree-manager.js";
 import { createPullRequest, buildPrTitle, buildPrBody, buildFailurePrBody } from "./pr-creator.js";
-import { isTrivialDepBump, mergeDirectly } from "./dep-bump-merger.js";
+import { mergeDirectly } from "./dep-bump-merger.js";
 import { getGitDiff } from "./success-evaluator.js";
+import type { EvaluationResult } from "./success-evaluator.js";
 import { mapSdkMessage } from "./event-mapper.js";
 import type { TurnMetricsEvent } from "./event-mapper.js";
 import { sanitizeStreamChunk } from "./sanitize-output.js";
@@ -45,9 +46,7 @@ import {
 
 // New modularized sub-phases
 import { emitEvent, sanitizeForCommitMessage } from "./utils.js";
-import { orchestrateVerification } from "./verification-orchestrator.js";
-import { runQualityGates } from "./quality-gates.js";
-import type { QualityGatesResult } from "./quality-gates.js";
+import { runPostCommitGateway } from "./post-commit-gateway.js";
 
 // QA tuning — adaptive thresholds from .github/auto-qa-tuning.json
 import { loadQaTuning, applyTuningDefaults } from "./qa-tuning-loader.js";
@@ -542,7 +541,7 @@ export async function runSession(
               let prUrl: string | null = null;
               const changed = worktree ? await hasChanges(worktree.path) : false;
 
-              let qualityResult: QualityGatesResult | undefined;
+              let gatewayEvaluation: EvaluationResult | undefined;
 
               if (changed && worktree) {
                 // Capture narrowed worktree for use in closures (TS loses narrowing in callbacks)
@@ -551,145 +550,123 @@ export async function runSession(
                 const commitMsg = `${prefix}: ${sanitizeForCommitMessage(config.taskDescription)}`;
                 await commitChanges(wt.path, commitMsg);
 
-                // 6a. Run lint + typecheck + test verification before pushing
-                let verificationPassed = true;
-                if (isSuccess) {
-                  const verification = await orchestrateVerification(wt.path, onEvent);
-                  verificationPassed = verification.passed;
-                  if (verification.error) errors.push(verification.error);
-                }
-
                 // Push with retry for transient network failures
                 await withRetry(() => pushBranch(wt.path, wt.branchName), { maxRetries: 3 });
 
-                // 6b, 6c, 6d. Run Quality Gates (LLM Success Eval, Static Analysis, Security Review)
-                if (isSuccess && verificationPassed) {
+                // 6a–6d. Run post-commit gateway (verification + quality gates)
+                let verdict;
+                if (isSuccess) {
                   const diff = await getCachedDiff(wt.path);
-                  qualityResult = await runQualityGates(
-                    config.taskDescription,
-                    diff,
-                    commitMsg,
+                  verdict = await runPostCommitGateway(
                     {
-                      evaluateSuccess: config.evaluateSuccess,
-                      runSecurityReview: true,
-                      runStaticAnalysis: true,
+                      worktreePath: wt.path,
+                      diff,
+                      commitMsg,
+                      taskDescription: config.taskDescription,
+                      config: {
+                        evaluateSuccess: config.evaluateSuccess,
+                        runSecurityReview: true,
+                        runStaticAnalysis: true,
+                      },
                     },
                     onEvent
                   );
-                  errors.push(...qualityResult.errors);
+                  errors.push(...verdict.errors);
+                  gatewayEvaluation = verdict.evaluation;
                 }
 
-                const allGatesPass =
-                  verificationPassed &&
-                  (!qualityResult ||
-                    (qualityResult.evaluation?.passed !== false &&
-                      qualityResult.staticAnalysisClean &&
-                      qualityResult.securityReview?.approved !== false));
-
                 if (config.createPr) {
-                  // Fast-path: trivial dependency bumps that passed tests are merged
-                  // directly without waiting for PR review.
-                  if (allGatesPass) {
-                    const depBumpCheck = isTrivialDepBump(await getCachedDiff(wt.path));
-                    if (depBumpCheck.isTrivial) {
-                      const commitTitle = buildPrTitle(config.taskDescription);
-                      prUrl = await mergeDirectly({
-                        branchName: wt.branchName,
-                        baseBranch: config.baseBranch,
-                        repoPath: wt.path,
-                        commitTitle,
-                      });
-                      emitEvent(onEvent, "session:result", {
-                        message: `Trivial dep bump — direct-merged: ${prUrl}`,
-                      });
-                    } else {
-                      const title = buildPrTitle(config.taskDescription);
-                      const body = resultMessage
-                        ? buildPrBody(
-                            config.taskDescription,
-                            resultMessage.session_id,
-                            resultMessage.total_cost_usd,
-                            resultMessage.num_turns
-                          )
-                        : buildFailurePrBody(config.taskDescription, errors, stuckReason?.type);
+                  if (verdict?.outcome === "merge-direct") {
+                    // Fast-path: trivial dep bump — direct-merge
+                    const commitTitle = buildPrTitle(config.taskDescription);
+                    prUrl = await mergeDirectly({
+                      branchName: wt.branchName,
+                      baseBranch: config.baseBranch,
+                      repoPath: wt.path,
+                      commitTitle,
+                    });
+                    emitEvent(onEvent, "session:result", {
+                      message: `Trivial dep bump — direct-merged: ${prUrl}`,
+                    });
+                  } else if (!verdict || verdict.outcome === "create-pr") {
+                    // All gates passed — create normal PR
+                    const title = buildPrTitle(config.taskDescription);
+                    const body = resultMessage
+                      ? buildPrBody(
+                          config.taskDescription,
+                          resultMessage.session_id,
+                          resultMessage.total_cost_usd,
+                          resultMessage.num_turns
+                        )
+                      : buildFailurePrBody(config.taskDescription, errors, stuckReason?.type);
 
-                      const prSpan = tracer.startSpan("agent_core.create_pr");
-                      let pr;
+                    const prSpan = tracer.startSpan("agent_core.create_pr");
+                    let pr;
+                    try {
+                      // Retry PR creation for transient GitHub API failures
+                      const { value: prResult } = await withRetry(
+                        () =>
+                          createPullRequest({
+                            title,
+                            body,
+                            baseBranch: config.baseBranch,
+                            branchName: wt.branchName,
+                            repoPath: wt.path,
+                            draft: false,
+                          }),
+                        { maxRetries: 3 }
+                      );
+                      pr = prResult;
+                      prSpan.setAttribute("pr.url", pr.url);
+                      prSpan.setAttribute("pr.number", pr.number);
+                      prSpan.setAttribute("pr.draft", false);
+                    } finally {
+                      prSpan.end();
+                    }
+
+                    prUrl = pr.url;
+                    emitEvent(onEvent, "session:result", {
+                      message: `PR created: ${pr.url}`,
+                    });
+
+                    // Run feedback loop if enabled (poll for review comments / CI failures)
+                    if (config.feedbackLoop?.enabled) {
+                      // Use remaining budget instead of fixed 50% ratio
+                      const sessionCost = resultMessage?.total_cost_usd ?? 0;
+                      const remainingBudget = Math.max(
+                        0,
+                        effectiveConfig.maxBudgetUsd - sessionCost
+                      );
+
+                      const fbSpan = tracer.startSpan("agent_core.feedback_loop");
+                      let feedbackResult;
                       try {
-                        // Retry PR creation for transient GitHub API failures
-                        const { value: prResult } = await withRetry(
-                          () =>
-                            createPullRequest({
-                              title,
-                              body,
-                              baseBranch: config.baseBranch,
-                              branchName: wt.branchName,
-                              repoPath: wt.path,
-                              draft: false,
-                            }),
-                          { maxRetries: 3 }
+                        feedbackResult = await runFeedbackLoop(
+                          {
+                            prNumber: pr.number,
+                            branchName: wt.branchName,
+                            repoPath: wt.path,
+                            model: getFeedbackLoopModel(config.model),
+                            maxRetries: config.feedbackLoop.maxRetries ?? 2,
+                            pollIntervalMs: config.feedbackLoop.pollIntervalMs ?? 30_000,
+                            pollTimeoutMs: config.feedbackLoop.pollTimeoutMs ?? 300_000,
+                            maxBudgetUsd: remainingBudget,
+                            allowedTools: config.allowedTools,
+                          },
+                          onEvent
                         );
-                        pr = prResult;
-                        prSpan.setAttribute("pr.url", pr.url);
-                        prSpan.setAttribute("pr.number", pr.number);
-                        prSpan.setAttribute("pr.draft", false);
+                        fbSpan.setAttribute("feedback.retries_used", feedbackResult.retriesUsed);
+                        fbSpan.setAttribute("feedback.resolved", feedbackResult.resolved);
                       } finally {
-                        prSpan.end();
+                        fbSpan.end();
                       }
 
-                      prUrl = pr.url;
                       emitEvent(onEvent, "session:result", {
-                        message: `PR created: ${pr.url}`,
+                        message: `Feedback loop: ${feedbackResult.resolved ? "resolved" : "escalated"} after ${feedbackResult.retriesUsed} retries`,
                       });
-
-                      // Run feedback loop if enabled (poll for review comments / CI failures)
-                      if (config.feedbackLoop?.enabled) {
-                        // Use remaining budget instead of fixed 50% ratio
-                        const sessionCost = resultMessage?.total_cost_usd ?? 0;
-                        const remainingBudget = Math.max(
-                          0,
-                          effectiveConfig.maxBudgetUsd - sessionCost
-                        );
-
-                        const fbSpan = tracer.startSpan("agent_core.feedback_loop");
-                        let feedbackResult;
-                        try {
-                          feedbackResult = await runFeedbackLoop(
-                            {
-                              prNumber: pr.number,
-                              branchName: wt.branchName,
-                              repoPath: wt.path,
-                              model: getFeedbackLoopModel(config.model),
-                              maxRetries: config.feedbackLoop.maxRetries ?? 2,
-                              pollIntervalMs: config.feedbackLoop.pollIntervalMs ?? 30_000,
-                              pollTimeoutMs: config.feedbackLoop.pollTimeoutMs ?? 300_000,
-                              maxBudgetUsd: remainingBudget,
-                              allowedTools: config.allowedTools,
-                            },
-                            onEvent
-                          );
-                          fbSpan.setAttribute("feedback.retries_used", feedbackResult.retriesUsed);
-                          fbSpan.setAttribute("feedback.resolved", feedbackResult.resolved);
-                        } finally {
-                          fbSpan.end();
-                        }
-
-                        emitEvent(onEvent, "session:result", {
-                          message: `Feedback loop: ${feedbackResult.resolved ? "resolved" : "escalated"} after ${feedbackResult.retriesUsed} retries`,
-                        });
-                      }
                     }
                   } else {
-                    // Quality gates failed — create draft PR so humans can review
-                    const gateFailures: string[] = [];
-                    if (!verificationPassed) gateFailures.push("verification");
-                    if (qualityResult && !qualityResult.staticAnalysisClean)
-                      gateFailures.push("static-analysis");
-                    if (qualityResult && qualityResult.evaluation?.passed === false)
-                      gateFailures.push("evaluation");
-                    if (qualityResult && qualityResult.securityReview?.approved === false)
-                      gateFailures.push("security-review");
-
+                    // verdict.outcome === "create-draft-pr" — quality gates failed
                     const title = `wip: ${config.taskDescription.slice(0, 57)}`;
                     const body = buildFailurePrBody(
                       config.taskDescription,
@@ -713,7 +690,7 @@ export async function runSession(
 
                     prUrl = pr.url;
                     emitEvent(onEvent, "session:result", {
-                      message: `Draft PR created (failed gates: ${gateFailures.join(", ")}): ${pr.url}`,
+                      message: `Draft PR created (failed gates: ${verdict.gateFailures.join(", ")}): ${pr.url}`,
                     });
                   }
                 }
@@ -724,11 +701,11 @@ export async function runSession(
               }
 
               // 7. Build final result
-              const evalSummary = qualityResult?.evaluation
+              const evalSummary = gatewayEvaluation
                 ? {
-                    passed: qualityResult.evaluation.passed,
-                    confidence: qualityResult.evaluation.confidence,
-                    reasoning: qualityResult.evaluation.reasoning,
+                    passed: gatewayEvaluation.passed,
+                    confidence: gatewayEvaluation.confidence,
+                    reasoning: gatewayEvaluation.reasoning,
                   }
                 : undefined;
 


### PR DESCRIPTION
## Summary

Extracts the inline post-commit validation pipeline from `session-runner.ts` into a dedicated `post-commit-gateway.ts` module.

## Changes

### New: `packages/agent-core/src/post-commit-gateway.ts`
- `GatewayOutcome` type: `"merge-direct" | "create-pr" | "create-draft-pr"`
- `GatewayVerdict` interface with `outcome`, `passed`, `gateFailures`, `errors`, `evaluation`
- `runPostCommitGateway()` composes `orchestrateVerification` + `runQualityGates` + `isTrivialDepBump`
- All gate failure logic (`allGatesPass`, `gateFailures` array) lives here, not in session orchestration

### New: `packages/agent-core/src/__tests__/post-commit-gateway.test.ts`
- 15 tests covering all 3 outcome types and all 4 failure modes (verification, static-analysis, evaluation, security-review)

### Updated: `session-runner.ts`
- Replaces ~80-line inline post-commit block with single `runPostCommitGateway()` call
- Branches on `verdict.outcome` (`merge-direct` | `create-pr` | `create-draft-pr`)
- Removes `verificationPassed`, `qualityResult`, `allGatesPass`, `gateFailures` variables

### Updated: `session-runner.test.ts`
- Replaces 4 separate post-commit mocks (`runVerification`, `evaluateSuccess`, `reviewDiff`, `analyzeDiff`) with single `runPostCommitGateway` mock
- Reduces mock seam count for post-commit path testing

## Test Results

- 905 tests pass (44 test files)
- `pnpm typecheck` clean

Closes #1615

https://claude.ai/code/session_01NA3kGi2h9kt16Y6taNsb69

---
_Generated by [Claude Code](https://claude.ai/code/session_01NA3kGi2h9kt16Y6taNsb69)_