### PR TITLE
docs: document claude-mem plugin for cross-session memory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,3 +167,28 @@ The Langfuse MCP server (`.mcp.json`) gives Claude Code access to:
 ## Security Scanning (Semgrep)
 
 See [AGENTS.md](./AGENTS.md#security-scanning-semgrep) for Semgrep configuration, rules, and usage. Claude Code additionally has the Semgrep MCP server (`.mcp.json`) for invoking scans via `@semgrep/mcp`.
+
+## Cross-Session Memory (claude-mem)
+
+[claude-mem](https://github.com/thedotmack/claude-mem) provides persistent cross-session memory — observations about code patterns, architecture decisions, and domain context survive between conversations.
+
+### Install
+
+```bash
+npx claude-mem install
+```
+
+### Available skills
+
+| Skill              | Purpose                                |
+| ------------------ | -------------------------------------- |
+| `/mem-search`      | Search past observations and decisions |
+| `/smart-explore`   | Token-efficient AST-based code search  |
+| `/make-plan`       | Create phased implementation plans     |
+| `/do`              | Execute plans with subagents           |
+| `/timeline-report` | Project development history analysis   |
+| `/babysit`         | Watch PR until merge-ready             |
+
+### Auto-observation
+
+claude-mem automatically records observations during sessions — code patterns discovered, architecture decisions made, debugging outcomes. These are searchable in future sessions via `/mem-search`.


### PR DESCRIPTION
## Summary

- Documents claude-mem plugin installation, available skills, and auto-observation in CLAUDE.md
- Plugin remains user-level — Claude Code's plugin architecture doesn't support project-level auto-install

## Limitation

claude-mem is fundamentally a user-level plugin. There's no mechanism to auto-install plugins for all repo contributors via project config. Each contributor needs to run `npx claude-mem install` individually. The CLAUDE.md documentation makes this discoverable.

## Acceptance criteria (from #1623)

- [x] Configuration documented in CLAUDE.md
- [x] Existing observations remain accessible (per-user, unchanged)
- [ ] All repo users pick up the skill without manual install — **not possible** with current Claude Code plugin architecture
- [ ] Auto-observation enabled — enabled per-user after install

## Test plan

- [x] CLAUDE.md renders correctly with new section
- [x] Install command `npx claude-mem install` verified working

Ref #1623