### PR TITLE
feat(infra): add Cloudflare Analytics Engine to edge router

### DIFF
--- a/infrastructure/worker/edge-router.js
+++ b/infrastructure/worker/edge-router.js
@@ -282,12 +282,7 @@ const SERVICE_ENDPOINTS = {
   agent: "/api/gen/health",
 };
 
-const STATIC_SITE_BINDINGS = [
-  "MARKETING",
-  "HOSPITALITY",
-  "RIALTO",
-  "GEN",
-];
+const STATIC_SITE_BINDINGS = ["MARKETING", "HOSPITALITY", "RIALTO", "GEN"];
 
 const KV_KEYS = {
   ci: "ci/latest",
@@ -951,8 +946,20 @@ async function handleFeatureFlags(request, env, url) {
   });
 }
 
+function writeAnalytics(env, request, route, statusCode, startTime) {
+  if (!env.ANALYTICS) return;
+  const country = request.headers.get("CF-IPCountry") || "unknown";
+  const elapsed = Date.now() - startTime;
+  env.ANALYTICS.writeDataPoint({
+    blobs: [route, request.method, country, new URL(request.url).pathname],
+    doubles: [statusCode, elapsed],
+    indexes: [route],
+  });
+}
+
 export default {
   async fetch(request, env) {
+    const startTime = Date.now();
     const url = new URL(request.url);
 
     // Generate or preserve request ID
@@ -1081,6 +1088,7 @@ export default {
       }
 
       // Pass through the response (including 4xx which should show app error pages)
+      writeAnalytics(env, request, "api", apiResponse.status, startTime);
       return apiResponse;
     }
 
@@ -1107,18 +1115,23 @@ export default {
     let prefix = "";
     let bindingOrigin = "";
 
+    let routeName = "marketing";
+
     if (url.pathname.startsWith("/hospitality")) {
       binding = env.HOSPITALITY;
       prefix = "/hospitality";
       bindingOrigin = "https://mattbutlerengineering-hospitality.workers.dev";
+      routeName = "hospitality";
     } else if (url.pathname.startsWith("/rialto")) {
       binding = env.RIALTO;
       prefix = "/rialto";
       bindingOrigin = "https://mattbutlerengineering-rialto-web.workers.dev";
+      routeName = "rialto";
     } else if (url.pathname.startsWith("/gen")) {
       binding = env.GEN;
       prefix = "/gen";
       bindingOrigin = "https://mattbutlerengineering-gen.workers.dev";
+      routeName = "gen";
     } else {
       binding = env.MARKETING;
       bindingOrigin = "https://mattbutlerengineering-marketing.workers.dev";
@@ -1174,6 +1187,7 @@ export default {
       }
     }
 
+    writeAnalytics(env, request, routeName, response.status, startTime);
     return addHeaders(response, url.pathname, nonce);
   },
 };

--- a/infrastructure/worker/edge-router.test.js
+++ b/infrastructure/worker/edge-router.test.js
@@ -94,6 +94,12 @@ function createMockKv() {
   };
 }
 
+function createMockAnalytics() {
+  return {
+    writeDataPoint: vi.fn(),
+  };
+}
+
 function createEnv() {
   return {
     API_ORIGIN: "https://api.mattbutlerengineering.com",
@@ -102,6 +108,7 @@ function createEnv() {
     RIALTO: createMockBinding("RIALTO"),
     GEN: createMockBinding("GEN"),
     HEALTH_STATE: createMockKv(),
+    ANALYTICS: createMockAnalytics(),
   };
 }
 
@@ -630,6 +637,32 @@ describe("Edge Router", () => {
       );
       expect(response.status).toBe(200);
       expect(env.MARKETING.fetch).toHaveBeenCalled();
+    });
+  });
+
+  describe("Analytics Engine", () => {
+    it("writes analytics data point on static site request", async () => {
+      await edgeRouter.fetch(makeRequest("/"), env);
+
+      expect(env.ANALYTICS.writeDataPoint).toHaveBeenCalledTimes(1);
+      const call = env.ANALYTICS.writeDataPoint.mock.calls[0][0];
+      expect(call.blobs).toContain("marketing");
+      expect(call.doubles[0]).toBe(200);
+    });
+
+    it("records correct route target for each binding", async () => {
+      await edgeRouter.fetch(makeRequest("/hospitality/dashboard"), env);
+
+      const call = env.ANALYTICS.writeDataPoint.mock.calls[0][0];
+      expect(call.blobs).toContain("hospitality");
+    });
+
+    it("does not fail when ANALYTICS binding is absent", async () => {
+      const envWithoutAnalytics = { ...env };
+      delete envWithoutAnalytics.ANALYTICS;
+
+      const response = await edgeRouter.fetch(makeRequest("/"), envWithoutAnalytics);
+      expect(response.status).toBe(200);
     });
   });
 });

--- a/infrastructure/worker/wrangler.toml
+++ b/infrastructure/worker/wrangler.toml
@@ -36,3 +36,9 @@ service = "mattbutlerengineering-gen"
 [[kv_namespaces]]
 binding = "HEALTH_STATE"
 id = "dda61075cc654b0a849046ae563d8d45"
+
+# Analytics Engine — custom request metrics (free tier, non-blocking writes)
+# Query via SQL API: https://developers.cloudflare.com/analytics/analytics-engine/sql-api/
+[[analytics_engine_datasets]]
+binding = "ANALYTICS"
+dataset = "edge_requests"


### PR DESCRIPTION
## Summary

- Adds Workers Analytics Engine binding to edge router for custom request metrics (free tier)
- Tracks: route target, HTTP method, country, path, status code, response time
- Non-blocking writes — zero impact on request latency
- Gracefully degrades when ANALYTICS binding is absent (backward compatible)
- 3 new tests covering analytics writes, route labeling, and missing binding

## What this enables

- Query request patterns via CF Analytics Engine SQL API
- Build dashboards per route (marketing vs hospitality vs api)
- Track response times and error rates by country
- Can be used as a sensor input for the learning loop

## Next steps (follow-up issues)

- [ ] Create a `/cf-analytics` skill or script to query the SQL API
- [ ] Integrate as a sensor in the learning loop
- [ ] Enable CF Web Analytics beacon on static sites for Core Web Vitals

## Test plan

- [x] 3 new analytics tests pass
- [x] 46 existing edge-router tests pass (1 pre-existing failure in deps endpoint)
- [ ] Deploy to CF and verify data points appear in Analytics Engine dashboard

Ref #1574