### PR TITLE
feat(acmm): add substance checkers for Tier 2 artifact validation

### DIFF
--- a/plugins/acmm/scripts/__tests__/substance.test.js
+++ b/plugins/acmm/scripts/__tests__/substance.test.js
@@ -1,0 +1,277 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { substanceCheckers, runSubstanceChecks } from "../substance.js";
+
+function makeTmpDir() {
+  return mkdtempSync(join(tmpdir(), "substance-test-"));
+}
+
+describe("reflection substance checker", () => {
+  const checker = substanceCheckers["acmm:correction-capture"];
+
+  test("passes when frontmatter has feeds_back_into and body > 50 chars", () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "reflection.md");
+    writeFileSync(
+      filePath,
+      [
+        "---",
+        "feeds_back_into: CLAUDE.md",
+        "---",
+        "",
+        "This is a substantive reflection body that contains enough content to pass the minimum character threshold for validation.",
+      ].join("\n")
+    );
+    const result = checker([filePath], dir);
+    assert.equal(result.passed, true);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("fails when frontmatter missing feeds_back_into", () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "reflection.md");
+    writeFileSync(
+      filePath,
+      [
+        "---",
+        "title: some reflection",
+        "---",
+        "",
+        "This is a substantive reflection body that contains enough content to pass the minimum character threshold for validation.",
+      ].join("\n")
+    );
+    const result = checker([filePath], dir);
+    assert.equal(result.passed, false);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("fails when body is too short", () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "reflection.md");
+    writeFileSync(filePath, ["---", "feeds_back_into: CLAUDE.md", "---", "", "Short."].join("\n"));
+    const result = checker([filePath], dir);
+    assert.equal(result.passed, false);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("fails for empty file", () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "reflection.md");
+    writeFileSync(filePath, "");
+    const result = checker([filePath], dir);
+    assert.equal(result.passed, false);
+    rmSync(dir, { recursive: true });
+  });
+});
+
+describe("skill substance checker", () => {
+  const checker = substanceCheckers["acmm:simple-skills"];
+
+  test("passes for non-stub skill with trigger and >100 chars instruction", () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "SKILL.md");
+    writeFileSync(
+      filePath,
+      [
+        "---",
+        "name: my-skill",
+        "description: Does something useful when triggered by user request",
+        "---",
+        "",
+        "# My Skill",
+        "",
+        "This skill provides a detailed workflow for completing a common task. It includes multiple steps that guide the agent through the process from start to finish with clear checkpoints.",
+      ].join("\n")
+    );
+    const result = checker([filePath], dir);
+    assert.equal(result.passed, true);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("fails for stub skill with <100 chars instruction", () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "SKILL.md");
+    writeFileSync(
+      filePath,
+      ["---", "name: stub-skill", "description: placeholder", "---", "", "# TODO", "", "TBD"].join(
+        "\n"
+      )
+    );
+    const result = checker([filePath], dir);
+    assert.equal(result.passed, false);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("fails for empty skill file", () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "SKILL.md");
+    writeFileSync(filePath, "");
+    const result = checker([filePath], dir);
+    assert.equal(result.passed, false);
+    rmSync(dir, { recursive: true });
+  });
+});
+
+describe("feedback loop substance checker", () => {
+  const checker = substanceCheckers["acmm:feedback-loops"];
+
+  test("passes when log has entries from last 30 days", () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "log.md");
+    const recentDate = new Date().toISOString().split("T")[0];
+    writeFileSync(filePath, `## ${recentDate}\n\nSome feedback loop entry with content.\n`);
+    const result = checker([filePath], dir);
+    assert.equal(result.passed, true);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("fails when log entries are stale (>30 days)", () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "log.md");
+    writeFileSync(filePath, "## 2024-01-01\n\nOld entry.\n");
+    const result = checker([filePath], dir);
+    assert.equal(result.passed, false);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("fails for empty log file", () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "log.md");
+    writeFileSync(filePath, "");
+    const result = checker([filePath], dir);
+    assert.equal(result.passed, false);
+    rmSync(dir, { recursive: true });
+  });
+});
+
+describe("test coverage substance checker", () => {
+  const checker = substanceCheckers["fullsend:test-coverage"];
+
+  test("passes when coverage config has recognizable threshold", () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "vitest.config.ts");
+    writeFileSync(
+      filePath,
+      "export default { test: { coverage: { thresholds: { lines: 80, branches: 70 } } } }"
+    );
+    const result = checker([filePath], dir);
+    assert.equal(result.passed, true);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("fails when file has no threshold values", () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "vitest.config.ts");
+    writeFileSync(filePath, "export default { test: {} }");
+    const result = checker([filePath], dir);
+    assert.equal(result.passed, false);
+    rmSync(dir, { recursive: true });
+  });
+});
+
+describe("runbook substance checker", () => {
+  const checker = substanceCheckers["fullsend:observability-runbook"];
+
+  test("passes when runbook references real service names", () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "runbook.md");
+    writeFileSync(
+      filePath,
+      "# Runbook\n\nCheck the /api/v1/users/health endpoint.\nRestart the users-service pod.\nMonitor Grafana dashboard.\n"
+    );
+    const result = checker([filePath], dir);
+    assert.equal(result.passed, true);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("fails when runbook is a stub without operational references", () => {
+    const dir = makeTmpDir();
+    const filePath = join(dir, "runbook.md");
+    writeFileSync(filePath, "# Runbook\n\nTODO: fill in later\n");
+    const result = checker([filePath], dir);
+    assert.equal(result.passed, false);
+    rmSync(dir, { recursive: true });
+  });
+});
+
+describe("runSubstanceChecks", () => {
+  test("returns substantive=true for criteria with passing checker", () => {
+    const dir = makeTmpDir();
+    const skillDir = join(dir, "skills", "test");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      [
+        "---",
+        "name: test-skill",
+        "description: A well-described skill for testing purposes",
+        "---",
+        "",
+        "# Test Skill",
+        "",
+        "This skill provides a comprehensive workflow for testing. It includes validation steps, error handling guidance, and detailed instructions that go well beyond a simple stub.",
+      ].join("\n")
+    );
+
+    const detectedIds = new Set(["acmm:simple-skills"]);
+    const criteria = [
+      {
+        id: "acmm:simple-skills",
+        detection: { type: "any-of", pattern: [join(skillDir, "SKILL.md")] },
+      },
+    ];
+
+    const results = runSubstanceChecks(detectedIds, criteria, dir);
+    assert.equal(results["acmm:simple-skills"].substantive, true);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("returns substantive=false for criteria with failing checker", () => {
+    const dir = makeTmpDir();
+    const skillDir = join(dir, "skills", "test");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "stub");
+
+    const detectedIds = new Set(["acmm:simple-skills"]);
+    const criteria = [
+      {
+        id: "acmm:simple-skills",
+        detection: { type: "any-of", pattern: [join(skillDir, "SKILL.md")] },
+      },
+    ];
+
+    const results = runSubstanceChecks(detectedIds, criteria, dir);
+    assert.equal(results["acmm:simple-skills"].substantive, false);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("returns substantive=null for criteria without checker", () => {
+    const detectedIds = new Set(["acmm:some-other-criterion"]);
+    const criteria = [
+      {
+        id: "acmm:some-other-criterion",
+        detection: { type: "path", pattern: "some/file" },
+      },
+    ];
+
+    const results = runSubstanceChecks(detectedIds, criteria, "/tmp");
+    assert.equal(results["acmm:some-other-criterion"].substantive, null);
+  });
+
+  test("skips substance check for undetected criteria", () => {
+    const detectedIds = new Set();
+    const criteria = [
+      {
+        id: "acmm:simple-skills",
+        detection: { type: "any-of", pattern: ["skills/"] },
+      },
+    ];
+
+    const results = runSubstanceChecks(detectedIds, criteria, "/tmp");
+    assert.equal(results["acmm:simple-skills"], undefined);
+  });
+});

--- a/plugins/acmm/scripts/audit.js
+++ b/plugins/acmm/scripts/audit.js
@@ -26,6 +26,7 @@ import { applyIssuesForFailures, ensureAcmmLabel } from "./outputs/issues.js";
 import { measureFlakeRate } from "./flake-rate.js";
 import { measurePrOutcomes } from "./pr-outcomes.js";
 import { measureEvals } from "./evals.js";
+import { runSubstanceChecks } from "./substance.js";
 import path from "node:path";
 import fs from "node:fs";
 
@@ -233,6 +234,18 @@ for (const c of ALL_CRITERIA) {
   results[c.id] = { passed, evidence };
 }
 
+/* ── Tier 2: Substance checks (additive — only for detected criteria) ── */
+const substanceResults = runSubstanceChecks(detectedIds, ALL_CRITERIA, cwd);
+for (const [id, sub] of Object.entries(substanceResults)) {
+  if (results[id]) {
+    results[id] = {
+      ...results[id],
+      substantive: sub.substantive,
+      substanceEvidence: sub.substanceEvidence,
+    };
+  }
+}
+
 const nextState = recordHistory(
   {
     ...prior,
@@ -344,6 +357,22 @@ console.log(
 console.log(
   `Cross-cutting traceability: ${computation.crossCutting.traceability.met}/${computation.crossCutting.traceability.total}`
 );
+
+const substEntries = Object.values(substanceResults).filter((s) => s.substantive !== null);
+const substChecked = substEntries.length;
+const substPassed = substEntries.filter((s) => s.substantive === true).length;
+const substFailed = substEntries.filter((s) => s.substantive === false).length;
+if (substChecked > 0) {
+  console.log(
+    `Substance (Tier 2): ${substPassed}/${substChecked} substantive${substFailed > 0 ? ` (${substFailed} partially met)` : ""}`
+  );
+  for (const [id, sub] of Object.entries(substanceResults)) {
+    if (sub.substantive === false) {
+      console.log(`  ◐ ${id}: ${sub.substanceEvidence}`);
+    }
+  }
+  console.log("");
+}
 
 if (computation.behavioralGates.length > 0) {
   console.log("");

--- a/plugins/acmm/scripts/substance.js
+++ b/plugins/acmm/scripts/substance.js
@@ -1,0 +1,170 @@
+import { readFileSync, existsSync, readdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+function readFileSafe(filePath) {
+  try {
+    return existsSync(filePath) ? readFileSync(filePath, "utf-8") : "";
+  } catch {
+    return "";
+  }
+}
+
+function parseFrontmatter(content) {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return { frontmatter: "", body: "" };
+  const fmEnd = content.indexOf("---", 4);
+  const body = content.slice(fmEnd + 3).trim();
+  return { frontmatter: match[1], body };
+}
+
+function extractISODates(text) {
+  return [...text.matchAll(/\b(\d{4}-\d{2}-\d{2})\b/g)].map((m) => m[1]);
+}
+
+function checkReflection(filePaths, _cwd) {
+  for (const fp of filePaths) {
+    const content = readFileSafe(fp);
+    if (!content) continue;
+    const { frontmatter, body } = parseFrontmatter(content);
+    if (frontmatter.includes("feeds_back_into:") && body.length > 50) {
+      return { passed: true, evidence: `has feeds_back_into + body ${body.length} chars` };
+    }
+  }
+  return { passed: false, evidence: "missing feeds_back_into frontmatter or body too short" };
+}
+
+function checkSkill(filePaths, _cwd) {
+  for (const fp of filePaths) {
+    const content = readFileSafe(fp);
+    if (!content) continue;
+    const { body } = parseFrontmatter(content);
+    const instructionContent = body
+      .replace(/^#+\s+.*$/gm, "")
+      .replace(/\s+/g, " ")
+      .trim();
+    if (instructionContent.length > 100) {
+      return {
+        passed: true,
+        evidence: `${instructionContent.length} chars of instruction content`,
+      };
+    }
+  }
+  return { passed: false, evidence: "stub or insufficient instruction content (<100 chars)" };
+}
+
+function checkFeedbackLoop(filePaths, _cwd) {
+  const now = Date.now();
+  for (const fp of filePaths) {
+    const content = readFileSafe(fp);
+    if (!content.trim()) continue;
+    const dates = extractISODates(content);
+    for (const d of dates) {
+      const ts = new Date(d).getTime();
+      if (!isNaN(ts) && now - ts <= THIRTY_DAYS_MS) {
+        return { passed: true, evidence: `recent entry dated ${d}` };
+      }
+    }
+  }
+  return { passed: false, evidence: "no entries from last 30 days" };
+}
+
+function checkTestCoverage(filePaths, _cwd) {
+  for (const fp of filePaths) {
+    const content = readFileSafe(fp);
+    if (!content) continue;
+    if (/(?:threshold|coverage|lines|branches|functions|statements)\s*[:=]\s*\d+/i.test(content)) {
+      return { passed: true, evidence: "coverage threshold configured" };
+    }
+  }
+  return { passed: false, evidence: "no recognizable coverage threshold" };
+}
+
+function checkRunbook(filePaths, _cwd) {
+  const indicators = [
+    /\/api\/v\d+\//,
+    /(?:service|pod|container|deployment|instance)/i,
+    /(?:grafana|datadog|sentry|prometheus|pagerduty|opsgenie)/i,
+    /(?:kubectl|docker|doctl|wrangler|pulumi|terraform)/i,
+    /(?:restart|rollback|scale|deploy|health)/i,
+    /(?:endpoint|dashboard|alert|monitor)/i,
+  ];
+
+  for (const fp of filePaths) {
+    const content = readFileSafe(fp);
+    if (!content) continue;
+    const matches = indicators.filter((re) => re.test(content));
+    if (matches.length >= 2) {
+      return { passed: true, evidence: `${matches.length} operational indicators found` };
+    }
+  }
+  return { passed: false, evidence: "fewer than 2 operational indicators" };
+}
+
+export const substanceCheckers = {
+  "acmm:correction-capture": checkReflection,
+  "acmm:simple-skills": checkSkill,
+  "acmm:feedback-loops": checkFeedbackLoop,
+  "fullsend:test-coverage": checkTestCoverage,
+  "fullsend:observability-runbook": checkRunbook,
+};
+
+export function runSubstanceChecks(detectedIds, criteria, cwd) {
+  const results = {};
+
+  for (const c of criteria) {
+    if (!detectedIds.has(c.id)) continue;
+
+    const checker = substanceCheckers[c.id];
+    if (!checker) {
+      results[c.id] = { substantive: null, substanceEvidence: null };
+      continue;
+    }
+
+    const patterns = Array.isArray(c.detection.pattern)
+      ? c.detection.pattern
+      : [c.detection.pattern];
+    const filePaths = patterns
+      .map((p) => {
+        const resolved = typeof p === "string" ? p : (p.file ?? "");
+        return resolve(cwd, resolved);
+      })
+      .filter((p) => existsSync(p));
+
+    if (filePaths.length === 0) {
+      const dirPaths = patterns
+        .map((p) => resolve(cwd, typeof p === "string" ? p : ""))
+        .filter((p) => existsSync(p));
+
+      const expanded = [];
+      for (const dp of dirPaths) {
+        try {
+          const files = readdirSync(dp, { recursive: true });
+          for (const f of files) {
+            const full = join(dp, f);
+            expanded.push(full);
+          }
+        } catch {
+          // skip
+        }
+      }
+      if (expanded.length > 0) {
+        const result = checker(expanded, cwd);
+        results[c.id] = { substantive: result.passed, substanceEvidence: result.evidence };
+        continue;
+      }
+
+      results[c.id] = {
+        substantive: false,
+        substanceEvidence: "no files found for substance check",
+      };
+      continue;
+    }
+
+    const result = checker(filePaths, cwd);
+    results[c.id] = { substantive: result.passed, substanceEvidence: result.evidence };
+  }
+
+  return results;
+}


### PR DESCRIPTION
## Summary
- Add `plugins/acmm/scripts/substance.js` — 5 substance checkers keyed by criterion ID
- Checkers: reflections (frontmatter+body), skills (non-stub), feedback loops (30-day recency), test coverage (thresholds), runbooks (operational indicators)
- Integrate into `audit.js` — runs after Tier 1 detection, adds `substantive` + `substanceEvidence` fields to results
- Console output shows "Substance (Tier 2)" summary with partially-met criteria listed
- Backwards-compatible: `passed` still means Tier 1 file presence

Closes #1631

## Test plan
- [x] 18 unit tests covering all 5 checker types with valid/invalid/empty fixtures
- [x] Integration tests for `runSubstanceChecks` with detected/undetected/no-checker cases
- [x] Full audit run verified — correctly reports 1/5 substantive, 4 partially met
- [x] Existing detection tests unchanged (42/42 pass)