### PR TITLE
feat(learning-loop): add sensor correlator for cross-sensor root cause grouping

### DIFF
--- a/scripts/__tests__/sensor-correlator.test.mjs
+++ b/scripts/__tests__/sensor-correlator.test.mjs
@@ -1,0 +1,309 @@
+import { describe, it, expect } from "vitest";
+import { correlate } from "../sensor-correlator.mjs";
+
+const now = new Date().toISOString();
+const hourAgo = new Date(Date.now() - 3600_000).toISOString();
+const twoDaysAgo = new Date(Date.now() - 2 * 86400_000).toISOString();
+
+describe("correlate", () => {
+  it("returns empty array for empty regressions", () => {
+    const result = correlate({ regressions: [] }, []);
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array for undefined regressions", () => {
+    const result = correlate({}, []);
+    expect(result).toEqual([]);
+  });
+
+  it("groups perf-related signals in same timeframe", () => {
+    const report = {
+      regressions: [
+        {
+          sensor: "lighthouse",
+          metric: "performance",
+          current: 0.7,
+          previous: 0.9,
+          delta: -0.2,
+          severity: "high",
+          timestamp: now,
+        },
+        {
+          sensor: "sentry",
+          metric: "timeout_rate",
+          current: 15,
+          previous: 2,
+          delta: 13,
+          severity: "high",
+          timestamp: hourAgo,
+        },
+      ],
+    };
+    const result = correlate(report, []);
+    expect(result.length).toBe(1);
+    expect(result[0].signals.length).toBe(2);
+    expect(result[0].rootCause.length).toBeGreaterThan(0);
+  });
+
+  it("groups availability-related signals together", () => {
+    const report = {
+      regressions: [
+        {
+          sensor: "sentry",
+          metric: "error_rate",
+          current: 50,
+          previous: 5,
+          delta: 45,
+          severity: "critical",
+          timestamp: now,
+        },
+        {
+          sensor: "ci",
+          metric: "pass_rate",
+          current: 60,
+          previous: 100,
+          delta: -40,
+          severity: "high",
+          timestamp: hourAgo,
+        },
+      ],
+    };
+    const result = correlate(report, []);
+    expect(result.length).toBe(1);
+    expect(result[0].signals.length).toBe(2);
+    expect(result[0].severity).toBe("critical");
+  });
+
+  it("keeps non-overlapping signals independent", () => {
+    const report = {
+      regressions: [
+        {
+          sensor: "lighthouse",
+          metric: "performance",
+          current: 0.7,
+          previous: 0.9,
+          delta: -0.2,
+          severity: "high",
+          timestamp: now,
+        },
+        {
+          sensor: "acmm",
+          metric: "criteria_count",
+          current: 50,
+          previous: 55,
+          delta: -5,
+          severity: "medium",
+          timestamp: twoDaysAgo,
+        },
+      ],
+    };
+    const result = correlate(report, []);
+    expect(result.length).toBe(2);
+    expect(result[0].signals.length).toBe(1);
+    expect(result[1].signals.length).toBe(1);
+  });
+
+  it("deduplicates against open issues by sensor+metric", () => {
+    const report = {
+      regressions: [
+        {
+          sensor: "lighthouse",
+          metric: "performance",
+          current: 0.7,
+          previous: 0.9,
+          delta: -0.2,
+          severity: "high",
+          timestamp: now,
+        },
+        {
+          sensor: "ci",
+          metric: "pass_rate",
+          current: 80,
+          previous: 100,
+          delta: -20,
+          severity: "high",
+          timestamp: now,
+        },
+      ],
+    };
+    const openIssues = [
+      {
+        number: 100,
+        title: "fix(lighthouse): performance regressed (-0.15)",
+        labels: [{ name: "audit" }],
+      },
+    ];
+    const result = correlate(report, openIssues);
+    expect(result.length).toBe(1);
+    expect(result[0].signals[0].sensor).toBe("ci");
+  });
+
+  it("ranks severity: critical > high > medium > low", () => {
+    const report = {
+      regressions: [
+        {
+          sensor: "acmm",
+          metric: "level",
+          current: 4,
+          previous: 5,
+          delta: -1,
+          severity: "medium",
+          timestamp: now,
+        },
+        {
+          sensor: "sentry",
+          metric: "error_rate",
+          current: 100,
+          previous: 5,
+          delta: 95,
+          severity: "critical",
+          timestamp: twoDaysAgo,
+        },
+        {
+          sensor: "lighthouse",
+          metric: "a11y",
+          current: 0.6,
+          previous: 0.9,
+          delta: -0.3,
+          severity: "high",
+          timestamp: twoDaysAgo,
+        },
+      ],
+    };
+    const result = correlate(report, []);
+    expect(result[0].severity).toBe("critical");
+    expect(result[1].severity).toBe("high");
+    expect(result[2].severity).toBe("medium");
+  });
+
+  it("uses signal count as tiebreaker within same severity", () => {
+    const report = {
+      regressions: [
+        {
+          sensor: "lighthouse",
+          metric: "performance",
+          current: 0.7,
+          previous: 0.9,
+          delta: -0.2,
+          severity: "high",
+          timestamp: now,
+        },
+        {
+          sensor: "sentry",
+          metric: "timeout_rate",
+          current: 15,
+          previous: 2,
+          delta: 13,
+          severity: "high",
+          timestamp: hourAgo,
+        },
+        {
+          sensor: "acmm",
+          metric: "level",
+          current: 4,
+          previous: 5,
+          delta: -1,
+          severity: "high",
+          timestamp: twoDaysAgo,
+        },
+      ],
+    };
+    const result = correlate(report, []);
+    expect(result[0].signals.length).toBeGreaterThanOrEqual(
+      result[result.length - 1].signals.length
+    );
+  });
+
+  it("caps output at 3 root causes", () => {
+    const report = {
+      regressions: [
+        { sensor: "lighthouse", metric: "performance", severity: "high", timestamp: now },
+        { sensor: "ci", metric: "pass_rate", severity: "high", timestamp: twoDaysAgo },
+        {
+          sensor: "acmm",
+          metric: "level",
+          severity: "medium",
+          timestamp: new Date(Date.now() - 4 * 86400_000).toISOString(),
+        },
+        {
+          sensor: "sentry",
+          metric: "error_count",
+          severity: "low",
+          timestamp: new Date(Date.now() - 6 * 86400_000).toISOString(),
+        },
+        {
+          sensor: "lighthouse",
+          metric: "seo",
+          severity: "low",
+          timestamp: new Date(Date.now() - 8 * 86400_000).toISOString(),
+        },
+      ],
+    };
+    const result = correlate(report, []);
+    expect(result.length).toBeLessThanOrEqual(3);
+  });
+
+  it("includes suggestedLabel in output", () => {
+    const report = {
+      regressions: [
+        { sensor: "lighthouse", metric: "performance", severity: "high", timestamp: now },
+      ],
+    };
+    const result = correlate(report, []);
+    expect(result[0].suggestedLabel).toBeTruthy();
+    expect(typeof result[0].suggestedLabel).toBe("string");
+  });
+
+  it("produces correct output shape", () => {
+    const report = {
+      regressions: [
+        {
+          sensor: "ci",
+          metric: "pass_rate",
+          current: 80,
+          previous: 100,
+          delta: -20,
+          severity: "high",
+          timestamp: now,
+        },
+      ],
+    };
+    const result = correlate(report, []);
+    expect(result.length).toBe(1);
+    const group = result[0];
+    expect(typeof group.rootCause).toBe("string");
+    expect(Array.isArray(group.signals)).toBe(true);
+    expect(["critical", "high", "medium", "low"]).toContain(group.severity);
+    expect(typeof group.suggestedLabel).toBe("string");
+  });
+
+  it("handles single signal as standalone group", () => {
+    const report = {
+      regressions: [
+        {
+          sensor: "ci",
+          metric: "duration",
+          current: 300,
+          previous: 120,
+          delta: 180,
+          severity: "medium",
+          timestamp: now,
+        },
+      ],
+    };
+    const result = correlate(report, []);
+    expect(result.length).toBe(1);
+    expect(result[0].signals.length).toBe(1);
+  });
+
+  it("handles signals without timestamps gracefully", () => {
+    const report = {
+      regressions: [
+        { sensor: "lighthouse", metric: "performance", severity: "high" },
+        { sensor: "sentry", metric: "timeout_rate", severity: "high" },
+      ],
+    };
+    const result = correlate(report, []);
+    expect(result.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/scripts/sensor-correlator.mjs
+++ b/scripts/sensor-correlator.mjs
@@ -1,0 +1,147 @@
+/**
+ * Sensor correlator for the learning loop.
+ *
+ * Groups related regression signals into single root-cause issues,
+ * preventing duplicate issues across sensors.
+ *
+ * Called by the learning-loop after sensor collection and before issue creation.
+ * The output replaces the raw `regressions[]` as input to the issue creation step.
+ */
+
+const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
+const MAX_GROUPS = 3;
+
+const SEVERITY_ORDER = { critical: 0, high: 1, medium: 2, low: 3 };
+
+const CATEGORY_MAP = {
+  performance: [
+    "lighthouse:performance",
+    "lighthouse:speed-index",
+    "sentry:timeout_rate",
+    "ci:duration",
+  ],
+  availability: ["sentry:error_rate", "sentry:error_count", "ci:pass_rate", "ci:failures"],
+  quality: ["acmm:level", "acmm:criteria_count", "lighthouse:a11y", "lighthouse:best-practices"],
+};
+
+const LABEL_MAP = {
+  lighthouse: "audit",
+  ci: "ci-fix",
+  sentry: "sentry",
+  acmm: "acmm",
+};
+
+function classifySignal(signal) {
+  const key = `${signal.sensor}:${signal.metric}`;
+  for (const [category, keys] of Object.entries(CATEGORY_MAP)) {
+    if (keys.includes(key)) return category;
+  }
+  if (signal.sensor === "lighthouse") return "performance";
+  if (signal.sensor === "sentry") return "availability";
+  if (signal.sensor === "ci") return "availability";
+  if (signal.sensor === "acmm") return "quality";
+  return "quality";
+}
+
+function getTimestamp(signal) {
+  if (signal.timestamp) return new Date(signal.timestamp).getTime();
+  return Date.now();
+}
+
+function withinTimeWindow(tsA, tsB) {
+  return Math.abs(tsA - tsB) <= TWENTY_FOUR_HOURS_MS;
+}
+
+function isDuplicate(signal, openIssues) {
+  const sensorLower = signal.sensor.toLowerCase();
+  const metricLower = signal.metric.toLowerCase();
+  return openIssues.some((issue) => {
+    const title = (issue.title ?? "").toLowerCase();
+    return title.includes(sensorLower) && title.includes(metricLower);
+  });
+}
+
+function highestSeverity(signals) {
+  let best = "low";
+  for (const s of signals) {
+    const sev = s.severity ?? "low";
+    if ((SEVERITY_ORDER[sev] ?? 3) < (SEVERITY_ORDER[best] ?? 3)) {
+      best = sev;
+    }
+  }
+  return best;
+}
+
+function primaryLabel(signals) {
+  const counts = {};
+  for (const s of signals) {
+    const label = LABEL_MAP[s.sensor] ?? "bug";
+    counts[label] = (counts[label] ?? 0) + 1;
+  }
+  return Object.entries(counts).sort((a, b) => b[1] - a[1])[0]?.[0] ?? "bug";
+}
+
+function buildRootCause(signals) {
+  const sensors = [...new Set(signals.map((s) => s.sensor))];
+  const metrics = [...new Set(signals.map((s) => s.metric))];
+  if (sensors.length === 1) {
+    return `${sensors[0]} ${metrics.join(" + ")} regression`;
+  }
+  return `cross-sensor regression: ${sensors.join(" + ")} (${metrics.join(", ")})`;
+}
+
+/**
+ * @param {Object} sensorReport - The sensor-report.json contents (has `regressions[]` array)
+ * @param {Array} openIssues - Currently open GitHub issues (from `gh issue list`)
+ * @returns {Array<{rootCause: string, signals: Array, severity: string, suggestedLabel: string}>}
+ */
+export function correlate(sensorReport, openIssues) {
+  const regressions = sensorReport?.regressions;
+  if (!regressions || regressions.length === 0) return [];
+
+  const deduplicated = regressions.filter((s) => !isDuplicate(s, openIssues));
+  if (deduplicated.length === 0) return [];
+
+  const classified = deduplicated.map((s) => ({
+    signal: s,
+    category: classifySignal(s),
+    ts: getTimestamp(s),
+  }));
+
+  const groups = [];
+  const used = new Set();
+
+  for (let i = 0; i < classified.length; i++) {
+    if (used.has(i)) continue;
+
+    const group = [classified[i]];
+    used.add(i);
+
+    for (let j = i + 1; j < classified.length; j++) {
+      if (used.has(j)) continue;
+      if (
+        classified[j].category === classified[i].category &&
+        withinTimeWindow(classified[j].ts, classified[i].ts)
+      ) {
+        group.push(classified[j]);
+        used.add(j);
+      }
+    }
+
+    const signals = group.map((g) => g.signal);
+    groups.push({
+      rootCause: buildRootCause(signals),
+      signals,
+      severity: highestSeverity(signals),
+      suggestedLabel: primaryLabel(signals),
+    });
+  }
+
+  groups.sort((a, b) => {
+    const sevDiff = (SEVERITY_ORDER[a.severity] ?? 3) - (SEVERITY_ORDER[b.severity] ?? 3);
+    if (sevDiff !== 0) return sevDiff;
+    return b.signals.length - a.signals.length;
+  });
+
+  return groups.slice(0, MAX_GROUPS);
+}


### PR DESCRIPTION
## Summary
- Add `scripts/sensor-correlator.mjs` — groups related regression signals into single root-cause issues
- Correlation by category (perf/availability/quality) + 24h temporal window
- Cross-sensor dedup against open GitHub issues prevents duplicate filing
- Severity ranking: critical > availability > performance > quality, signal count tiebreaker
- Max 3 correlated groups per run (replaces raw regressions as input to issue creation)

Closes #1632

## Test plan
- [x] 13 unit tests covering all correlation scenarios
- [x] Grouping: perf signals merged, availability signals merged, non-overlapping kept independent
- [x] Dedup: signals matching open issue titles filtered out
- [x] Ranking: severity order verified, signal count tiebreaker verified
- [x] Edge cases: empty regressions, missing timestamps, single signal, 3-cap enforced