### PR TITLE
feat(metrics): add threshold auto-tuner with guard rails

### DIFF
--- a/scripts/__tests__/threshold-tuner.test.mjs
+++ b/scripts/__tests__/threshold-tuner.test.mjs
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  computeAdjustments,
+  applyAdjustments,
+  loadThresholdHistory,
+  isWithinWeeklyLimit,
+  HARD_FLOORS,
+} from "../threshold-tuner.mjs";
+
+function makeTmpDir() {
+  return mkdtempSync(join(tmpdir(), "tuner-test-"));
+}
+
+describe("computeAdjustments", () => {
+  it("loosens threshold by 5% when FP rate > 30%", () => {
+    const metrics = { fp_rate: 35, agent_success_rate: 70 };
+    const current = { acceptanceRateFloor: 0.85 };
+    const result = computeAdjustments(metrics, current, []);
+    const adj = result.find((a) => a.threshold === "acceptanceRateFloor");
+    expect(adj).toBeTruthy();
+    expect(adj.direction).toBe("loosen");
+    expect(adj.newValue).toBeLessThan(current.acceptanceRateFloor);
+  });
+
+  it("tightens threshold by 5% when effectiveness < 50%", () => {
+    const metrics = { fp_rate: 15, agent_success_rate: 40 };
+    const current = { acceptanceRateFloor: 0.85 };
+    const result = computeAdjustments(metrics, current, []);
+    const adj = result.find((a) => a.threshold === "acceptanceRateFloor");
+    expect(adj).toBeTruthy();
+    expect(adj.direction).toBe("tighten");
+    expect(adj.newValue).toBeGreaterThan(current.acceptanceRateFloor);
+  });
+
+  it("tightens by 3% when FP < 10% and effectiveness > 80%", () => {
+    const metrics = { fp_rate: 5, agent_success_rate: 90 };
+    const current = { acceptanceRateFloor: 0.85 };
+    const result = computeAdjustments(metrics, current, []);
+    const adj = result.find((a) => a.threshold === "acceptanceRateFloor");
+    expect(adj).toBeTruthy();
+    expect(adj.direction).toBe("tighten");
+    expect(adj.newValue - current.acceptanceRateFloor).toBeCloseTo(0.03, 2);
+  });
+
+  it("returns empty when metrics in normal range", () => {
+    const metrics = { fp_rate: 20, agent_success_rate: 65 };
+    const current = { acceptanceRateFloor: 0.85 };
+    const result = computeAdjustments(metrics, current, []);
+    expect(result.length).toBe(0);
+  });
+
+  it("returns empty when metrics are null", () => {
+    const metrics = { fp_rate: null, agent_success_rate: null };
+    const current = { acceptanceRateFloor: 0.85 };
+    const result = computeAdjustments(metrics, current, []);
+    expect(result.length).toBe(0);
+  });
+});
+
+describe("guard rails", () => {
+  it("never drops below hard floor", () => {
+    const metrics = { fp_rate: 50, agent_success_rate: 70 };
+    const current = { acceptanceRateFloor: HARD_FLOORS.acceptanceRateFloor + 0.01 };
+    const result = computeAdjustments(metrics, current, []);
+    const adj = result.find((a) => a.threshold === "acceptanceRateFloor");
+    if (adj) {
+      expect(adj.newValue).toBeGreaterThanOrEqual(HARD_FLOORS.acceptanceRateFloor);
+    }
+  });
+
+  it("never exceeds ceiling", () => {
+    const metrics = { fp_rate: 5, agent_success_rate: 95 };
+    const current = { acceptanceRateFloor: 0.98 };
+    const result = computeAdjustments(metrics, current, []);
+    const adj = result.find((a) => a.threshold === "acceptanceRateFloor");
+    if (adj) {
+      expect(adj.newValue).toBeLessThanOrEqual(1.0);
+    }
+  });
+
+  it("enforces max 10% weekly change", () => {
+    const recentChanges = [
+      {
+        date: new Date().toISOString().split("T")[0],
+        threshold: "acceptanceRateFloor",
+        oldValue: 0.85,
+        newValue: 0.77,
+      },
+    ];
+    const result = isWithinWeeklyLimit("acceptanceRateFloor", 0.77, 0.7, recentChanges);
+    expect(result).toBe(false);
+  });
+
+  it("allows change within 10% weekly limit", () => {
+    const result = isWithinWeeklyLimit("acceptanceRateFloor", 0.85, 0.8, []);
+    expect(result).toBe(true);
+  });
+});
+
+describe("applyAdjustments", () => {
+  let dir;
+
+  beforeEach(() => {
+    dir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true });
+  });
+
+  it("writes adjusted threshold to tuning config", () => {
+    const configPath = join(dir, "auto-qa-tuning.json");
+    const changesPath = join(dir, "threshold-changes.jsonl");
+    const config = {
+      version: 1,
+      thresholds: { acceptanceRateFloor: 0.85 },
+      history: [],
+    };
+    writeFileSync(configPath, JSON.stringify(config));
+
+    const adjustments = [
+      {
+        threshold: "acceptanceRateFloor",
+        oldValue: 0.85,
+        newValue: 0.8,
+        direction: "loosen",
+        trigger: "fp_rate > 30%",
+        evidence: "FP rate: 35%",
+      },
+    ];
+
+    applyAdjustments(adjustments, configPath, changesPath);
+
+    const updated = JSON.parse(readFileSync(configPath, "utf-8"));
+    expect(updated.thresholds.acceptanceRateFloor).toBe(0.8);
+    expect(updated.history.length).toBe(1);
+    expect(updated.history[0].trigger).toBe("threshold-auto-tuner");
+  });
+
+  it("appends to threshold-changes.jsonl", () => {
+    const configPath = join(dir, "auto-qa-tuning.json");
+    const changesPath = join(dir, "threshold-changes.jsonl");
+    writeFileSync(
+      configPath,
+      JSON.stringify({ version: 1, thresholds: { acceptanceRateFloor: 0.85 }, history: [] })
+    );
+
+    const adjustments = [
+      {
+        threshold: "acceptanceRateFloor",
+        oldValue: 0.85,
+        newValue: 0.8,
+        direction: "loosen",
+        trigger: "fp_rate > 30%",
+        evidence: "FP rate: 35%",
+      },
+    ];
+
+    applyAdjustments(adjustments, configPath, changesPath);
+
+    const lines = readFileSync(changesPath, "utf-8").trim().split("\n");
+    expect(lines.length).toBe(1);
+    const entry = JSON.parse(lines[0]);
+    expect(entry.threshold).toBe("acceptanceRateFloor");
+    expect(entry.oldValue).toBe(0.85);
+    expect(entry.newValue).toBe(0.8);
+  });
+
+  it("does nothing when adjustments array is empty", () => {
+    const configPath = join(dir, "auto-qa-tuning.json");
+    const changesPath = join(dir, "threshold-changes.jsonl");
+    writeFileSync(
+      configPath,
+      JSON.stringify({ version: 1, thresholds: { acceptanceRateFloor: 0.85 }, history: [] })
+    );
+
+    applyAdjustments([], configPath, changesPath);
+
+    const updated = JSON.parse(readFileSync(configPath, "utf-8"));
+    expect(updated.thresholds.acceptanceRateFloor).toBe(0.85);
+    expect(updated.history.length).toBe(0);
+  });
+});
+
+describe("loadThresholdHistory", () => {
+  it("returns empty array when file doesn't exist", () => {
+    const result = loadThresholdHistory("/nonexistent/path.jsonl");
+    expect(result).toEqual([]);
+  });
+
+  it("parses JSONL entries", () => {
+    const dir = makeTmpDir();
+    const path = join(dir, "changes.jsonl");
+    writeFileSync(
+      path,
+      '{"date":"2026-05-22","threshold":"acceptanceRateFloor","oldValue":0.85,"newValue":0.80}\n'
+    );
+    const result = loadThresholdHistory(path);
+    expect(result.length).toBe(1);
+    expect(result[0].threshold).toBe("acceptanceRateFloor");
+    rmSync(dir, { recursive: true });
+  });
+});

--- a/scripts/threshold-tuner.mjs
+++ b/scripts/threshold-tuner.mjs
@@ -1,0 +1,248 @@
+/**
+ * Threshold auto-tuner for the improvement flywheel.
+ *
+ * Reads process metrics (FP rate, effectiveness) and adjusts
+ * .github/auto-qa-tuning.json thresholds with guard rails.
+ *
+ * Called by verify-fixes.mjs after computing verification results.
+ *
+ * Usage:
+ *   node scripts/threshold-tuner.mjs              # tune from latest metrics
+ *   node scripts/threshold-tuner.mjs --dry-run    # show adjustments without writing
+ */
+
+import { readFileSync, writeFileSync, existsSync, appendFileSync, mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+const TUNING_PATH = resolve(ROOT, ".github", "auto-qa-tuning.json");
+const METRICS_PATH = resolve(ROOT, "metrics", "process-metrics.jsonl");
+const CHANGES_PATH = resolve(ROOT, "metrics", "threshold-changes.jsonl");
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes("--dry-run");
+
+export const HARD_FLOORS = {
+  acceptanceRateFloor: 0.5,
+  maxBudgetUSD: 0.25,
+  maxRetries: 1,
+  stuckTurnsThreshold: 3,
+  meanCloseHoursTarget: 4,
+};
+
+const HARD_CEILINGS = {
+  acceptanceRateFloor: 1.0,
+  maxBudgetUSD: 10.0,
+  maxRetries: 5,
+  stuckTurnsThreshold: 20,
+  meanCloseHoursTarget: 168,
+};
+
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+export function loadThresholdHistory(changesPath) {
+  if (!existsSync(changesPath)) return [];
+  try {
+    return readFileSync(changesPath, "utf-8")
+      .split("\n")
+      .filter((l) => l.trim())
+      .map((l) => {
+        try {
+          return JSON.parse(l);
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function getLatestMetrics(metricsPath) {
+  if (!existsSync(metricsPath)) return null;
+  try {
+    const lines = readFileSync(metricsPath, "utf-8")
+      .split("\n")
+      .filter((l) => l.trim());
+    if (lines.length === 0) return null;
+    return JSON.parse(lines[lines.length - 1]);
+  } catch {
+    return null;
+  }
+}
+
+export function isWithinWeeklyLimit(thresholdName, currentValue, proposedValue, recentChanges) {
+  const sevenDaysAgo = new Date(Date.now() - SEVEN_DAYS_MS);
+  const weekChanges = recentChanges.filter(
+    (c) => c.threshold === thresholdName && new Date(c.date) >= sevenDaysAgo
+  );
+
+  let totalChange = Math.abs(proposedValue - currentValue);
+  for (const c of weekChanges) {
+    totalChange += Math.abs(c.newValue - c.oldValue);
+  }
+
+  const maxChange = Math.abs(currentValue) * 0.1;
+  return totalChange <= maxChange;
+}
+
+function clamp(value, thresholdName) {
+  const floor = HARD_FLOORS[thresholdName] ?? 0;
+  const ceiling = HARD_CEILINGS[thresholdName] ?? Infinity;
+  return Math.max(floor, Math.min(ceiling, value));
+}
+
+function round(value, decimals = 4) {
+  return Math.round(value * 10 ** decimals) / 10 ** decimals;
+}
+
+export function computeAdjustments(metrics, currentThresholds, recentChanges) {
+  if (!metrics || metrics.fp_rate === null || metrics.agent_success_rate === null) {
+    return [];
+  }
+
+  const adjustments = [];
+  const fpRate = metrics.fp_rate;
+  const effectiveness = metrics.agent_success_rate;
+
+  if (fpRate > 30) {
+    const oldValue = currentThresholds.acceptanceRateFloor;
+    let newValue = round(oldValue * 0.95);
+    newValue = clamp(newValue, "acceptanceRateFloor");
+    if (
+      newValue !== oldValue &&
+      isWithinWeeklyLimit("acceptanceRateFloor", oldValue, newValue, recentChanges)
+    ) {
+      adjustments.push({
+        threshold: "acceptanceRateFloor",
+        oldValue,
+        newValue,
+        direction: "loosen",
+        trigger: "fp_rate > 30%",
+        evidence: `FP rate: ${fpRate}%`,
+      });
+    }
+  } else if (effectiveness < 50) {
+    const oldValue = currentThresholds.acceptanceRateFloor;
+    let newValue = round(oldValue * 1.05);
+    newValue = clamp(newValue, "acceptanceRateFloor");
+    if (
+      newValue !== oldValue &&
+      isWithinWeeklyLimit("acceptanceRateFloor", oldValue, newValue, recentChanges)
+    ) {
+      adjustments.push({
+        threshold: "acceptanceRateFloor",
+        oldValue,
+        newValue,
+        direction: "tighten",
+        trigger: "effectiveness < 50%",
+        evidence: `Agent success rate: ${effectiveness}%`,
+      });
+    }
+  } else if (fpRate < 10 && effectiveness > 80) {
+    const oldValue = currentThresholds.acceptanceRateFloor;
+    let newValue = round(oldValue + 0.03);
+    newValue = clamp(newValue, "acceptanceRateFloor");
+    if (
+      newValue !== oldValue &&
+      isWithinWeeklyLimit("acceptanceRateFloor", oldValue, newValue, recentChanges)
+    ) {
+      adjustments.push({
+        threshold: "acceptanceRateFloor",
+        oldValue,
+        newValue,
+        direction: "tighten",
+        trigger: "headroom (fp < 10% && effectiveness > 80%)",
+        evidence: `FP rate: ${fpRate}%, effectiveness: ${effectiveness}%`,
+      });
+    }
+  }
+
+  return adjustments;
+}
+
+export function applyAdjustments(adjustments, configPath, changesPath) {
+  if (adjustments.length === 0) return;
+
+  const config = JSON.parse(readFileSync(configPath, "utf-8"));
+  const today = new Date().toISOString().split("T")[0];
+
+  for (const adj of adjustments) {
+    config.thresholds[adj.threshold] = adj.newValue;
+
+    mkdirSync(dirname(changesPath), { recursive: true });
+    appendFileSync(
+      changesPath,
+      JSON.stringify({
+        date: today,
+        threshold: adj.threshold,
+        oldValue: adj.oldValue,
+        newValue: adj.newValue,
+        trigger: adj.trigger,
+        evidence: adj.evidence,
+      }) + "\n"
+    );
+  }
+
+  config.lastTunedAt = today;
+  config.history = config.history ?? [];
+  config.history.push({
+    date: today,
+    trigger: "threshold-auto-tuner",
+    adjustments: adjustments.map(
+      (a) => `${a.threshold}: ${a.oldValue} → ${a.newValue} (${a.direction}, ${a.trigger})`
+    ),
+    note: `Auto-tuned ${adjustments.length} threshold(s) from process metrics.`,
+  });
+
+  writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+}
+
+/* ── Main ────────────────────────────────────────────── */
+
+function main() {
+  const metrics = getLatestMetrics(METRICS_PATH);
+  if (!metrics) {
+    console.log("threshold-tuner: no process metrics available, skipping");
+    return;
+  }
+
+  if (!existsSync(TUNING_PATH)) {
+    console.log("threshold-tuner: no auto-qa-tuning.json found, skipping");
+    return;
+  }
+
+  const config = JSON.parse(readFileSync(TUNING_PATH, "utf-8"));
+  const recentChanges = loadThresholdHistory(CHANGES_PATH);
+  const adjustments = computeAdjustments(metrics, config.thresholds, recentChanges);
+
+  if (adjustments.length === 0) {
+    console.log("threshold-tuner: metrics in normal range, no adjustments needed");
+    return;
+  }
+
+  if (DRY_RUN) {
+    console.log("threshold-tuner (dry-run): would apply:");
+    for (const a of adjustments) {
+      console.log(`  ${a.threshold}: ${a.oldValue} → ${a.newValue} (${a.direction})`);
+    }
+    return;
+  }
+
+  applyAdjustments(adjustments, TUNING_PATH, CHANGES_PATH);
+
+  console.log(`threshold-tuner: applied ${adjustments.length} adjustment(s)`);
+  for (const a of adjustments) {
+    console.log(`  ${a.threshold}: ${a.oldValue} → ${a.newValue} (${a.direction}, ${a.trigger})`);
+  }
+}
+
+const isMain =
+  process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+
+if (isMain) {
+  main();
+}


### PR DESCRIPTION
## Summary
- Add `scripts/threshold-tuner.mjs` — reads process metrics and auto-adjusts `.github/auto-qa-tuning.json` thresholds
- Three decision rules: loosen on high FP rate (>30%), tighten on low effectiveness (<50%), tighten with headroom (FP<10% + eff>80%)
- Three guard rails: max 10% weekly change, hard floors per threshold, no sensor fully disabled
- All adjustments logged to `metrics/threshold-changes.jsonl` with full audit trail
- Graceful fallback when metrics file doesn't exist

Closes #1633

## Test plan
- [x] 14 unit tests covering all 3 decision rules + guard rails
- [x] Edge cases: null metrics, at-floor values, weekly limit exceeded
- [x] JSONL append and config write verified with temp dirs
- [x] Empty adjustments produce no file changes