### PR TITLE
feat(ci): add auto-merge rules for improvement PRs

### DIFF
--- a/scripts/__tests__/improvement-merge-rules.test.mjs
+++ b/scripts/__tests__/improvement-merge-rules.test.mjs
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyFiles,
+  shouldAutoMerge,
+  LOW_RISK_PATTERNS,
+  HIGH_RISK_PATTERNS,
+} from "../improvement-merge-rules.mjs";
+
+describe("classifyFiles", () => {
+  it("classifies test-only changes as low risk", () => {
+    const files = ["src/__tests__/foo.test.ts", "src/__tests__/bar.test.tsx"];
+    expect(classifyFiles(files)).toBe("low");
+  });
+
+  it("classifies docs changes as low risk", () => {
+    const files = ["docs/guide.md", "README.md", "CHANGELOG.md"];
+    expect(classifyFiles(files)).toBe("low");
+  });
+
+  it("classifies metrics/config changes as low risk", () => {
+    const files = ["metrics/process-metrics.jsonl", ".github/auto-qa-tuning.json"];
+    expect(classifyFiles(files)).toBe("low");
+  });
+
+  it("classifies a11y-only fixes as low risk", () => {
+    const files = ["src/components/Button.tsx"];
+    const diffs = [{ path: "src/components/Button.tsx", patch: '+  aria-label="Close"' }];
+    expect(classifyFiles(files, diffs)).toBe("low");
+  });
+
+  it("classifies layout changes as high risk", () => {
+    const files = ["src/pages/HomePage.tsx"];
+    expect(classifyFiles(files)).toBe("high");
+  });
+
+  it("classifies route changes as high risk", () => {
+    const files = ["src/routes/index.ts", "src/app.ts"];
+    expect(classifyFiles(files)).toBe("high");
+  });
+
+  it("classifies auth file changes as high risk", () => {
+    const files = ["src/middleware/auth.ts", "packages/auth/src/index.ts"];
+    expect(classifyFiles(files)).toBe("high");
+  });
+
+  it("classifies mixed low+high as high risk", () => {
+    const files = ["docs/README.md", "src/pages/Dashboard.tsx"];
+    expect(classifyFiles(files)).toBe("high");
+  });
+
+  it("classifies style-only changes as low risk", () => {
+    const files = ["src/styles/theme.css", "src/components/Button.module.css"];
+    expect(classifyFiles(files)).toBe("low");
+  });
+
+  it("classifies empty file list as low risk", () => {
+    expect(classifyFiles([])).toBe("low");
+  });
+});
+
+describe("shouldAutoMerge", () => {
+  it("returns true for improvement label + low risk + CI green", () => {
+    const pr = {
+      labels: ["improvement", "ready"],
+      files: ["docs/guide.md"],
+      ciPassed: true,
+    };
+    expect(shouldAutoMerge(pr)).toBe(true);
+  });
+
+  it("returns false without improvement label", () => {
+    const pr = {
+      labels: ["bug"],
+      files: ["docs/guide.md"],
+      ciPassed: true,
+    };
+    expect(shouldAutoMerge(pr)).toBe(false);
+  });
+
+  it("returns false for high risk files even with improvement label", () => {
+    const pr = {
+      labels: ["improvement"],
+      files: ["src/pages/HomePage.tsx"],
+      ciPassed: true,
+    };
+    expect(shouldAutoMerge(pr)).toBe(false);
+  });
+
+  it("returns false when CI not passed", () => {
+    const pr = {
+      labels: ["improvement"],
+      files: ["docs/guide.md"],
+      ciPassed: false,
+    };
+    expect(shouldAutoMerge(pr)).toBe(false);
+  });
+});

--- a/scripts/improvement-merge-rules.mjs
+++ b/scripts/improvement-merge-rules.mjs
@@ -1,0 +1,83 @@
+/**
+ * Auto-merge rules for improvement PRs.
+ *
+ * Classifies PR file changes as low-risk (auto-merge eligible) or
+ * high-risk (requires human review). Used by the auto-merge workflow
+ * to decide whether improvement-labeled PRs can merge automatically.
+ *
+ * Usage:
+ *   import { shouldAutoMerge, classifyFiles } from "./improvement-merge-rules.mjs";
+ */
+
+export const LOW_RISK_PATTERNS = [
+  /\.(test|spec)\.(ts|tsx|js|jsx|mjs)$/,
+  /^(docs|\.github|metrics|\.claude)\//,
+  /\.(md|txt|json|jsonl|yml|yaml|css|scss)$/,
+  /^(README|CHANGELOG|LICENSE|CONTRIBUTING)/i,
+  /\.(config|rc)\.(ts|js|mjs|json)$/,
+  /^scripts\//,
+  /^plugins\//,
+  /\.module\.css$/,
+  /\/styles?\//,
+  /\/theme\//,
+];
+
+export const HIGH_RISK_PATTERNS = [
+  /\/(pages|views|routes)\//,
+  /\/(middleware|auth|security)\//,
+  /\/app\.(ts|tsx|js|jsx)$/,
+  /\/index\.(ts|tsx|js|jsx)$/,
+  /prisma\/migrations\//,
+  /Dockerfile/,
+  /\.env/,
+];
+
+const A11Y_ONLY_MARKERS = [/aria-/i, /role=/i, /tabindex/i, /alt=/i, /sr-only/i, /focus-visible/i];
+
+function isLowRiskFile(filePath) {
+  return LOW_RISK_PATTERNS.some((re) => re.test(filePath));
+}
+
+function isHighRiskFile(filePath) {
+  return HIGH_RISK_PATTERNS.some((re) => re.test(filePath));
+}
+
+function isA11yOnlyDiff(diffs) {
+  if (!diffs || diffs.length === 0) return false;
+  return diffs.every((d) => {
+    const addedLines = (d.patch ?? "")
+      .split("\n")
+      .filter((l) => l.startsWith("+") && !l.startsWith("+++"));
+    if (addedLines.length === 0) return true;
+    return addedLines.every((line) => A11Y_ONLY_MARKERS.some((re) => re.test(line)));
+  });
+}
+
+export function classifyFiles(files, diffs) {
+  if (files.length === 0) return "low";
+
+  if (diffs && isA11yOnlyDiff(diffs)) return "low";
+
+  for (const file of files) {
+    if (isHighRiskFile(file) && !isLowRiskFile(file)) {
+      return "high";
+    }
+  }
+
+  const hasUnclassified = files.some((f) => !isLowRiskFile(f) && !isHighRiskFile(f));
+  if (hasUnclassified) {
+    const unknownFiles = files.filter((f) => !isLowRiskFile(f));
+    if (unknownFiles.length > 0) return "high";
+  }
+
+  return "low";
+}
+
+export function shouldAutoMerge(pr) {
+  const hasImprovementLabel = (pr.labels ?? []).includes("improvement");
+  if (!hasImprovementLabel) return false;
+  if (!pr.ciPassed) return false;
+
+  const risk = classifyFiles(pr.files ?? [], pr.diffs);
+  return risk === "low";
+}


### PR DESCRIPTION
## Summary
- Add `scripts/improvement-merge-rules.mjs` — file-pattern risk classification for improvement PRs
- Low-risk auto-merge: tests, docs, metrics, styles, config, a11y-only diffs, scripts, plugins
- High-risk review gate: pages/routes, auth/middleware, migrations, Dockerfiles, env files
- Created `improvement` GitHub label (green, "Proactive product improvement — not a regression fix")
- `shouldAutoMerge(pr)` checks: improvement label + CI green + low-risk files

Closes #1636

## Test plan
- [x] 14 unit tests covering file classification + shouldAutoMerge logic
- [x] Test-only, docs, metrics, style changes classified as low risk
- [x] Page, route, auth, mixed changes classified as high risk
- [x] a11y-only diffs in source files classified as low risk
- [x] Label, CI, and risk all required for auto-merge