### PR TITLE
fix(infrastructure): restore e2e user and add password-realm grant type (#1671)

### DIFF
--- a/infrastructure/pulumi/auth0.ts
+++ b/infrastructure/pulumi/auth0.ts
@@ -58,7 +58,12 @@ export const hospitalityApp = new auth0.Client("mattbutlerengineering-hospitalit
     alg: "RS256",
     lifetimeInSeconds: 36000,
   },
-  grantTypes: ["authorization_code", "refresh_token", "password"],
+  grantTypes: [
+    "authorization_code",
+    "refresh_token",
+    "password",
+    "http://auth0.com/oauth/grant-type/password-realm",
+  ],
   refreshToken: {
     rotationType: "rotating",
     expirationType: "expiring",
@@ -80,8 +85,20 @@ export const hospitalityApiGrant = new auth0.ClientGrant(
   }
 );
 
+// Dedicated E2E test user (ROPC auth, no MFA)
+const e2ePassword = config.requireSecret("e2eUserPassword");
+
+export const e2eUser = new auth0.User("e2e-test-user", {
+  connectionName: "Username-Password-Authentication",
+  email: "e2e-test@mattbutlerengineering.com",
+  password: e2ePassword,
+  emailVerified: true,
+  name: "E2E Test User",
+});
+
 // Exports for use in other files and .env generation
 export const auth0Outputs = {
   apiIdentifier: api.identifier,
   hospitalityClientId: hospitalityApp.clientId,
+  e2eUserEmail: e2eUser.email,
 };

--- a/infrastructure/pulumi/index.test.ts
+++ b/infrastructure/pulumi/index.test.ts
@@ -69,6 +69,7 @@ const configEntries: Record<string, string> = {
   otelHeaders: "Authorization=Basic abc123",
   aiGatewayApiKey: "gw-key-123",
   remediationWebhookSecret: "webhook-secret-123",
+  e2eUserPassword: "test-password-123",
 };
 
 for (const [key, value] of Object.entries(configEntries)) {


### PR DESCRIPTION
## Summary

E2E tests have been failing since May 19 with `Auth0 token request failed (401): access_denied`. Two root causes:

1. **E2E test user removed** — commit `0104ff14` deleted the `auth0.User("e2e-test-user")` Pulumi resource because the M2M app lacked `create:users` scope. This likely deleted the user from Auth0.
2. **Missing `password-realm` grant type** — the Pulumi config only had `"password"` but `auth-helpers.ts` uses `grant_type: "http://auth0.com/oauth/grant-type/password-realm"` which is a separate Auth0 grant type.

This PR:
- Adds `"http://auth0.com/oauth/grant-type/password-realm"` to the hospitality app's `grantTypes`
- Restores the `e2eUser` Pulumi resource and re-exports `e2eUserEmail`
- Adds `e2eUserPassword` to the test config entries

**After merge, manual steps required:**
1. `pulumi config set --secret e2eUserPassword <password>`
2. `pulumi up --stack prod`
3. `gh secret set E2E_AUTH_PASSWORD --body <same-password>`

Closes #1671

## Test plan

- [x] Pulumi typecheck passes
- [x] Test config updated with `e2eUserPassword`
- [ ] `pulumi up` applies changes (requires R2 credentials)
- [ ] E2E tests pass after user is recreated