### PR TITLE
feat(acmm): implement meta:product-improvements check function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ test.txt
 playwright-report/
 test-results/
 /metrics/
+!/metrics/improvement-activity.jsonl
 
 # Playwright
 e2e/.auth/

--- a/docs/architecture/dependency-graph.md
+++ b/docs/architecture/dependency-graph.md
@@ -143,9 +143,9 @@ flowchart TD
 
 ## Legend
 
-| Color  | Category                        |
-| ------ | ------------------------------- |
-| Blue   | Frontend Apps (`apps/*`)        |
-| Amber  | Backend Services (`services/*`) |
-| Indigo | Shared Packages (`packages/*`)  |
-| Green  | Developer Tools (`tools/*`)     |
+| Color | Category |
+|-------|----------|
+| Blue | Frontend Apps (`apps/*`) |
+| Amber | Backend Services (`services/*`) |
+| Indigo | Shared Packages (`packages/*`) |
+| Green | Developer Tools (`tools/*`) |

--- a/docs/architecture/dependency-graph.md
+++ b/docs/architecture/dependency-graph.md
@@ -143,9 +143,9 @@ flowchart TD
 
 ## Legend
 
-| Color | Category |
-|-------|----------|
-| Blue | Frontend Apps (`apps/*`) |
-| Amber | Backend Services (`services/*`) |
-| Indigo | Shared Packages (`packages/*`) |
-| Green | Developer Tools (`tools/*`) |
+| Color  | Category                        |
+| ------ | ------------------------------- |
+| Blue   | Frontend Apps (`apps/*`)        |
+| Amber  | Backend Services (`services/*`) |
+| Indigo | Shared Packages (`packages/*`)  |
+| Green  | Developer Tools (`tools/*`)     |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1378,13 +1378,6 @@
       partySize: number;
     }
   </file>
-  <file path="packages/api-versioning/src/fastify.ts">
-    export interface ApiVersioningOptions {
-      currentVersion: string;
-      successorVersion?: string;
-      sunsetMonthsFromNow?: number;
-    }
-  </file>
   <file path="packages/agent-test-utils/src/worktree-simulator.ts">
     export type RepoState = "clean" | "dirty" | "conflicted";
     export interface SimulatedFile {

--- a/llms.txt
+++ b/llms.txt
@@ -519,15 +519,6 @@
       }
     </item>
   </file>
-  <file path="packages/api-versioning/src/fastify.ts">
-    <item priority="low">
-      interface ApiVersioningOptions {
-        currentVersion: string;
-        successorVersion?: string | undefined;
-        sunsetMonthsFromNow?: number | undefined;
-      }
-    </item>
-  </file>
   <file path="packages/agent-test-utils/src/worktree-simulator.ts">
     <item priority="low">
       type RepoState = "clean" | "dirty" | "conflicted";

--- a/metrics/improvement-activity.jsonl
+++ b/metrics/improvement-activity.jsonl
@@ -1,0 +1,2 @@
+{"number":1652,"title":"feat(learning-loop): product improvement discoverer","mergedAt":"2026-05-22T00:00:00Z","url":"https://github.com/mattbutlerengineering/mattbutlerengineering/pull/1652","type":"pr"}
+{"number":1654,"title":"feat(ci): add auto-merge rules for improvement PRs","mergedAt":"2026-05-23T00:42:39Z","url":"https://github.com/mattbutlerengineering/mattbutlerengineering/pull/1654","type":"pr"}

--- a/packages/agent-core/llms-full.txt
+++ b/packages/agent-core/llms-full.txt
@@ -12,22 +12,223 @@
       return false;
     }
   </file>
-  <file path="src/adapters/gemini-adapter.ts">
-    function truncateTask(task: string, maxLength: number = MAX_TASK_LENGTH): string {
-      if (task.length <= maxLength) return task;
-      return task.slice(0, maxLength - 3) + "...";
+  <file path="src/adapters/cli-adapter-base.ts">
+    export abstract class CliAdapterBase implements AgentAdapter {
+      /** Unique adapter name matching AgentAdapter.name. */
+      abstract readonly name: string;
+    
+      /** CLI binary to invoke and to check availability with `which`. */
+      abstract readonly cliBinary: string;
+    
+      /**
+       * Human-readable display name used in error messages (e.g. "Gemini", "OpenCode").
+       * Defaults to `name` — override in subclasses if display casing differs.
+       */
+      protected get displayName(): string {
+        return this.name;
+      }
+    
+      /**
+       * Build the argument list for the CLI subprocess.
+       * The task description passed here is already truncated.
+       */
+      protected abstract buildArgs(config: AdapterConfig): string[];
+    
+      /**
+       * Extract structured information from CLI stdout/stderr.
+       * Used to determine `hasChanges` when the CLI itself reports changes
+       * (subclasses may override; default implementation always returns false
+       * and defers to the git-status check in `run`).
+       */
+      protected abstract parseOutput(
+        stdout: string,
+        stderr: string
+      ): { hasChanges: boolean; summary?: string };
+    
+      // ── Public AgentAdapter implementation ──────────────────────────
+    
+      /**
+       * Check whether the CLI binary is available on PATH.
+       */
+      async isAvailable(): Promise<boolean> {
+        try {
+          await execFileAsync("which", [this.cliBinary]);
+          return true;
+        } catch {
+          return false;
+        }
+      }
+    
+      /**
+       * Execute the shared CLI adapter lifecycle:
+       *   1. Truncate task description
+       *   2. Spawn the CLI subprocess via buildArgs
+       *   3. Detect rate limiting in combined output
+       *   4. Check for git changes; commit if present
+       *   5. Return normalized AdapterResult
+       */
+      async run(config: AdapterConfig): Promise<AdapterResult> {
+        const startTime = Date.now();
+        const timeout = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+        const truncatedConfig = {
+          ...config,
+          taskDescription: this.truncateTask(config.taskDescription),
+        };
+        const args = this.buildArgs(truncatedConfig);
+    
+        const { stdout, stderr, exitedSuccessfully } = await this.spawnCli(
+          args,
+          config.worktreePath,
+          timeout
+        );
+    
+        const combinedOutput = `${stdout}\n${stderr}`;
+        const rateLimited = this.detectRateLimiting(combinedOutput);
+    
+        const hasChanges = await this.checkForChanges(config.worktreePath);
+    
+        if (hasChanges) {
+          await this.commitChanges(config.worktreePath, config.taskDescription);
+        }
+    
+        const durationMs = Date.now() - startTime;
+    
+        return {
+          success: exitedSuccessfully,
+          hasChanges,
+          durationMs,
+          rateLimited,
+          ...(exitedSuccessfully
+            ? {}
+            : { error: stderr || `${this.displayName} CLI exited with non-zero status` }),
+        };
+      }
+    
+      // ── Protected shared utilities ───────────────────────────────────
+    
+      /**
+       * Truncate a task description to a safe length for CLI arguments.
+       */
+      protected truncateTask(task: string, maxLength: number = MAX_TASK_LENGTH): string {
+        if (task.length <= maxLength) return task;
+        return task.slice(0, maxLength - 3) + "...";
+      }
+    
+      /**
+       * Scan combined CLI output for rate-limit indicators.
+       */
+      protected detectRateLimiting(output: string): boolean {
+        return RATE_LIMIT_PATTERNS.some((pattern) => pattern.test(output));
+      }
+    
+      /**
+       * Build a short conventional commit message from the task description.
+       */
+      protected buildCommitMessage(task: string): string {
+        const maxSubject = 72;
+        const prefix = "feat: ";
+        const available = maxSubject - prefix.length;
+        const subject = task.length > available ? task.slice(0, available - 3) + "..." : task;
+        return `${prefix}${subject}`;
+      }
+    
+      // ── Private helpers ──────────────────────────────────────────────
+    
+      /**
+       * Spawn the CLI binary and capture stdout/stderr.
+       * Returns a structured result regardless of exit code.
+       */
+      private async spawnCli(
+        args: readonly string[],
+        cwd: string,
+        timeout: number
+      ): Promise<{ stdout: string; stderr: string; exitedSuccessfully: boolean }> {
+        try {
+          const result = await execFileAsync(this.cliBinary, [...args], {
+            cwd,
+            timeout,
+            maxBuffer: 10 * 1024 * 1024, // 10 MB
+          });
+          return { stdout: result.stdout, stderr: result.stderr, exitedSuccessfully: true };
+        } catch (err: unknown) {
+          const execError = err as {
+            stdout?: string;
+            stderr?: string;
+            code?: string | number;
+            killed?: boolean;
+          };
+          return {
+            stdout: execError.stdout ?? "",
+            stderr: execError.stderr ?? "",
+            exitedSuccessfully: false,
+          };
+        }
+      }
+    
+      /**
+       * Check if the worktree has uncommitted changes via `git status --porcelain`.
+       */
+      private async checkForChanges(worktreePath: string): Promise<boolean> {
+        try {
+          const { stdout } = await execFileAsync("git", ["-C", worktreePath, "status", "--porcelain"]);
+          return stdout.trim().length > 0;
+        } catch {
+          return false;
+        }
+      }
+    
+      /**
+       * Stage all changes and commit with a descriptive message.
+       */
+      private async commitChanges(worktreePath: string, task: string): Promise<void> {
+        const gitOpts = { cwd: worktreePath };
+        await execFileAsync("git", ["-C", worktreePath, "add", "-A"], gitOpts);
+        await execFileAsync(
+          "git",
+          ["-C", worktreePath, "commit", "-m", this.buildCommitMessage(task)],
+          gitOpts
+        );
+      }
     }
-    function detectRateLimiting(output: string): boolean {
-      return RATE_LIMIT_PATTERNS.some((pattern) => pattern.test(output));
+  </file>
+  <file path="src/adapters/gemini-adapter.ts">
+    export class GeminiCliAdapter extends CliAdapterBase {
+      readonly name = "gemini";
+      readonly cliBinary = "gemini";
+      protected override get displayName(): string {
+        return "Gemini";
+      }
+    
+      protected buildArgs(config: AdapterConfig): string[] {
+        return ["-p", config.taskDescription, "--yolo"];
+      }
+    
+      protected parseOutput(
+        _stdout: string,
+        stderr: string
+      ): { hasChanges: boolean; summary?: string } {
+        return { hasChanges: false, summary: stderr || undefined };
+      }
     }
   </file>
   <file path="src/adapters/opencode-adapter.ts">
-    function truncateTask(task: string, maxLength: number = MAX_TASK_LENGTH): string {
-      if (task.length <= maxLength) return task;
-      return task.slice(0, maxLength - 3) + "...";
-    }
-    function detectRateLimiting(output: string): boolean {
-      return RATE_LIMIT_PATTERNS.some((pattern) => pattern.test(output));
+    export class OpenCodeAdapter extends CliAdapterBase {
+      readonly name = "opencode";
+      readonly cliBinary = "opencode";
+      protected override get displayName(): string {
+        return "OpenCode";
+      }
+    
+      protected buildArgs(config: AdapterConfig): string[] {
+        return ["run", config.taskDescription];
+      }
+    
+      protected parseOutput(
+        _stdout: string,
+        stderr: string
+      ): { hasChanges: boolean; summary?: string } {
+        return { hasChanges: false, summary: stderr || undefined };
+      }
     }
   </file>
   </section>

--- a/packages/agent-core/llms.txt
+++ b/packages/agent-core/llms.txt
@@ -8,20 +8,34 @@
       function deriveHasChanges(result: SessionResult): boolean { /* ... */ }
     </item>
   </file>
-  <file path="src/adapters/gemini-adapter.ts">
-    <item priority="medium">
-      function truncateTask(task: string, maxLength: number = MAX_TASK_LENGTH): string { /* ... */ }
+  <file path="src/adapters/cli-adapter-base.ts">
+    <item priority="low">
+      class CliAdapterBase {
+        name: string;
+        cliBinary: string;
+        async buildArgs(): Promise<unknown>;
+        async parseOutput(): Promise<unknown>;
+      }
     </item>
-    <item priority="medium">
-      function detectRateLimiting(output: string): boolean { /* ... */ }
+  </file>
+  <file path="src/adapters/gemini-adapter.ts">
+    <item priority="high">
+      class GeminiCliAdapter {
+        name: unknown;
+        cliBinary: unknown;
+        async buildArgs(): Promise<unknown>;
+        async parseOutput(): Promise<unknown>;
+      }
     </item>
   </file>
   <file path="src/adapters/opencode-adapter.ts">
-    <item priority="medium">
-      function truncateTask(task: string, maxLength: number = MAX_TASK_LENGTH): string { /* ... */ }
-    </item>
-    <item priority="medium">
-      function detectRateLimiting(output: string): boolean { /* ... */ }
+    <item priority="high">
+      class OpenCodeAdapter {
+        name: unknown;
+        cliBinary: unknown;
+        async buildArgs(): Promise<unknown>;
+        async parseOutput(): Promise<unknown>;
+      }
     </item>
   </file>
   </section>

--- a/packages/database/llms-full.txt
+++ b/packages/database/llms-full.txt
@@ -57,5 +57,71 @@
       slowestMs: number;
     }
   </file>
+  <file path="src/list-utils.ts">
+    export function parseListQuery(query: { page?: string; limit?: string }): {
+      page: number;
+      limit: number;
+    } {
+      const rawPage = parseInt(query.page ?? "1", 10);
+      const rawLimit = parseInt(query.limit ?? "10", 10);
+      const page = Math.max(1, isNaN(rawPage) ? 1 : rawPage);
+      const limit = Math.max(1, Math.min(100, isNaN(rawLimit) ? 10 : rawLimit));
+      return { page, limit };
+    }
+    export function createListResponseSchema(entityRef: string) {
+      return {
+        type: "object" as const,
+        properties: {
+          data: { type: "array" as const, items: { $ref: entityRef } },
+          pagination: {
+            type: "object" as const,
+            properties: {
+              page: { type: "number" as const },
+              limit: { type: "number" as const },
+              total: { type: "number" as const },
+            },
+          },
+        },
+      };
+    }
+  </file>
+  <file path="src/start-service-server.ts">
+    export interface StartServiceServerOptions {
+      serviceName: string;
+      port: number;
+      buildApp: () => Promise<FastifyInstance>;
+      beforeShutdown?: () => void | Promise<void>;
+    }
+    export async function startServiceServer(options: StartServiceServerOptions): Promise<void> {
+      const { initTelemetry } = await import("@mbe/observability");
+      const { initSentry } = await import("@mbe/sentry/node");
+    
+      const sdk = initTelemetry({ serviceName: options.serviceName });
+      sdk.start();
+      initSentry({ serviceName: options.serviceName });
+    
+      const host = process.env.HOST ?? "0.0.0.0";
+    
+      try {
+        const fastify = await options.buildApp();
+        await fastify.listen({ port: options.port, host });
+        fastify.log.info(`Server running at http://${host}:${options.port}`);
+        fastify.log.info(`API docs at http://${host}:${options.port}/docs`);
+    
+        const shutdown = async () => {
+          await options.beforeShutdown?.();
+          await sdk.shutdown();
+          await fastify.close();
+        };
+    
+        process.on("SIGTERM", () => {
+          shutdown().then(() => process.exit(0));
+        });
+      } catch (err) {
+        console.error(err);
+        process.exit(1);
+      }
+    }
+  </file>
   </section>
 </codebase>

--- a/packages/database/llms.txt
+++ b/packages/database/llms.txt
@@ -64,5 +64,29 @@
       }
     </item>
   </file>
+  <file path="src/list-utils.ts">
+    <item priority="high">
+      export function parseListQuery(query: { page?: string; limit?: string }): {
+        page: number;
+        limit: number;
+      } { /* ... */ }
+    </item>
+    <item priority="high">
+      export function createListResponseSchema(entityRef: string) { /* ... */ }
+    </item>
+  </file>
+  <file path="src/start-service-server.ts">
+    <item priority="low">
+      interface StartServiceServerOptions {
+        serviceName: string;
+        port: number;
+        buildApp: () => Promise<FastifyInstance>;
+        beforeShutdown?: () => void | Promise<void>;
+      }
+    </item>
+    <item priority="high">
+      export async function startServiceServer(options: StartServiceServerOptions): Promise<void> { /* ... */ }
+    </item>
+  </file>
   </section>
 </codebase>

--- a/packages/database/src/health.test.ts
+++ b/packages/database/src/health.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import {
-  createLatencyTracker,
-  checkAuth0,
-  type LatencyTracker,
-} from "./health.js";
+import { createLatencyTracker, checkAuth0, type LatencyTracker } from "./health.js";
 
 describe("createLatencyTracker", () => {
   let tracker: LatencyTracker;

--- a/packages/rialto/registry.json
+++ b/packages/rialto/registry.json
@@ -89,9 +89,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "title",
@@ -1668,9 +1666,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "AuthMascot",
@@ -3306,9 +3302,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "AutocompleteOption",
@@ -4858,9 +4852,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "children",
@@ -6338,9 +6330,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "title",
@@ -7911,9 +7901,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "children",
@@ -9384,9 +9372,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "title",
@@ -10864,9 +10850,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "ChalkboardItem",
@@ -12349,9 +12333,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "CharsetName",
@@ -12522,9 +12504,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "label",
@@ -14162,9 +14142,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "DataListItem",
@@ -14210,9 +14188,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "title",
@@ -14241,9 +14217,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "Divider",
@@ -14339,9 +14313,7 @@
           "description": "Panel width/height"
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "title",
@@ -15857,9 +15829,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "title",
@@ -15891,9 +15861,7 @@
           "description": "Optional callback invoked when an error is caught. Use to report errors to external services."
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "Ferrofluid",
@@ -17359,9 +17327,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "FlipDot",
@@ -18867,9 +18833,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "FlipDotAnimationMode",
@@ -20345,9 +20309,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "FooterColumn",
@@ -21884,9 +21846,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "HeadingLevel",
@@ -23376,9 +23336,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "HoverCard",
@@ -25139,9 +25097,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "label",
@@ -26605,9 +26561,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "Kbd",
@@ -28228,9 +28182,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "label",
@@ -29712,9 +29664,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "NavbarLink",
@@ -31173,9 +31123,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "NavItem",
@@ -31300,9 +31248,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "PageHeader",
@@ -32768,9 +32714,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "Pagination",
@@ -32936,9 +32880,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "Progress",
@@ -34407,9 +34349,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "Radio",
@@ -34507,9 +34447,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "label",
@@ -34542,9 +34480,7 @@
           "description": "Theme mode. `'system'` follows the OS color scheme. Defaults to `'system'`."
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "ScrollArea",
@@ -35997,9 +35933,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "Segment",
@@ -37470,9 +37404,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "segments[].label",
@@ -39026,9 +38958,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "SidebarItem",
@@ -39098,9 +39028,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "Slider",
@@ -40640,9 +40568,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "SplitFlap",
@@ -42125,9 +42051,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "SplitScreenExit",
@@ -42158,9 +42082,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "Stack",
@@ -43643,9 +43565,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "StaggerDirection",
@@ -45128,9 +45048,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "label",
@@ -46837,9 +46755,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "TapeChart",
@@ -48519,9 +48435,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "TextArea",
@@ -50068,9 +49982,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "label",
@@ -51753,9 +51665,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "label",
@@ -51798,9 +51708,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ],
+      "slots": ["children"],
       "characterLimits": [
         {
           "prop": "content",
@@ -53293,9 +53201,7 @@
           "required": false
         }
       ],
-      "slots": [
-        "children"
-      ]
+      "slots": ["children"]
     },
     {
       "name": "TreeNode",

--- a/plugins/acmm/scripts/__tests__/meta-criteria.test.js
+++ b/plugins/acmm/scripts/__tests__/meta-criteria.test.js
@@ -8,6 +8,7 @@ import {
   checkInstructionEvolution,
   checkProcessMetrics,
   checkFpRate,
+  checkProductImprovements,
   META_CRITERIA,
 } from "../meta-criteria.js";
 
@@ -158,6 +159,108 @@ describe("checkFpRate", () => {
   });
 });
 
+describe("checkProductImprovements", () => {
+  test("passes when improvement-activity.jsonl has recent closed issue", () => {
+    const dir = makeTmpDir();
+    const metricsDir = join(dir, "metrics");
+    mkdirSync(metricsDir, { recursive: true });
+    writeFileSync(
+      join(metricsDir, "improvement-activity.jsonl"),
+      `{"number":100,"title":"Fix login flow","closedAt":"${new Date().toISOString()}","url":"https://github.com/x/y/issues/100","type":"issue"}\n`
+    );
+    const result = checkProductImprovements(dir);
+    assert.equal(result.passed, true);
+    assert.ok(
+      result.evidence.includes("1 improvement"),
+      `expected count in evidence, got: ${result.evidence}`
+    );
+    rmSync(dir, { recursive: true });
+  });
+
+  test("passes when file has recent merged PR entry", () => {
+    const dir = makeTmpDir();
+    const metricsDir = join(dir, "metrics");
+    mkdirSync(metricsDir, { recursive: true });
+    writeFileSync(
+      join(metricsDir, "improvement-activity.jsonl"),
+      `{"number":200,"title":"Add activity audit","mergedAt":"${new Date().toISOString()}","url":"https://github.com/x/y/pull/200","type":"pr"}\n`
+    );
+    const result = checkProductImprovements(dir);
+    assert.equal(result.passed, true);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("fails when file exists but all entries are stale (>30 days)", () => {
+    const dir = makeTmpDir();
+    const metricsDir = join(dir, "metrics");
+    mkdirSync(metricsDir, { recursive: true });
+    writeFileSync(
+      join(metricsDir, "improvement-activity.jsonl"),
+      `{"number":50,"title":"Old fix","closedAt":"${staleDate}","url":"https://github.com/x/y/issues/50","type":"issue"}\n`
+    );
+    const result = checkProductImprovements(dir);
+    assert.equal(result.passed, false);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("falls back to gh CLI when metrics file absent — passes when gh returns recent items", () => {
+    const dir = makeTmpDir();
+    const recentTs = new Date().toISOString();
+    const mockExecFileSync = (_cmd, args) => {
+      if (args.includes("issue")) {
+        return JSON.stringify([
+          {
+            number: 10,
+            title: "Improve onboarding",
+            closedAt: recentTs,
+            url: "https://g/issues/10",
+          },
+        ]);
+      }
+      return JSON.stringify([]);
+    };
+    const result = checkProductImprovements(dir, { execFileSyncFn: mockExecFileSync });
+    assert.equal(result.passed, true);
+    assert.ok(result.evidence.includes("1 improvement"), `evidence: ${result.evidence}`);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("falls back to gh CLI — fails when all items are stale", () => {
+    const dir = makeTmpDir();
+    const oldTs = "2024-01-15T00:00:00Z";
+    const mockExecFileSync = (_cmd, args) => {
+      if (args.includes("issue")) {
+        return JSON.stringify([
+          { number: 10, title: "Old improvement", closedAt: oldTs, url: "https://g/issues/10" },
+        ]);
+      }
+      return JSON.stringify([]);
+    };
+    const result = checkProductImprovements(dir, { execFileSyncFn: mockExecFileSync });
+    assert.equal(result.passed, false);
+    assert.ok(result.evidence.includes("none closed"), `evidence: ${result.evidence}`);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("falls back to gh CLI — fails when gh returns no items", () => {
+    const dir = makeTmpDir();
+    const mockExecFileSync = () => JSON.stringify([]);
+    const result = checkProductImprovements(dir, { execFileSyncFn: mockExecFileSync });
+    assert.equal(result.passed, false);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("falls back to gh CLI — fails gracefully when gh unavailable", () => {
+    const dir = makeTmpDir();
+    const mockExecFileSync = () => {
+      throw new Error("gh not found");
+    };
+    const result = checkProductImprovements(dir, { execFileSyncFn: mockExecFileSync });
+    assert.equal(result.passed, false);
+    rmSync(dir, { recursive: true });
+  });
+});
+
 describe("META_CRITERIA", () => {
   test("exports 5 criteria", () => {
     assert.equal(META_CRITERIA.length, 5);
@@ -171,5 +274,20 @@ describe("META_CRITERIA", () => {
       assert.equal(c.level, 6, `${c.id} should be level 6`);
       assert.ok(c.detection, `${c.id} missing detection`);
     }
+  });
+
+  test("meta:product-improvements has a non-null check function", () => {
+    const criterion = META_CRITERIA.find((c) => c.id === "meta:product-improvements");
+    assert.ok(criterion, "meta:product-improvements criterion must exist");
+    assert.equal(typeof criterion.check, "function", "check must be a function, not null");
+  });
+
+  test("meta:product-improvements detection uses file-based pattern", () => {
+    const criterion = META_CRITERIA.find((c) => c.id === "meta:product-improvements");
+    assert.ok(
+      typeof criterion.detection.pattern === "string" &&
+        criterion.detection.pattern.includes("improvement"),
+      `detection.pattern should reference improvement metrics, got: ${criterion.detection.pattern}`
+    );
   });
 });

--- a/plugins/acmm/scripts/meta-criteria.js
+++ b/plugins/acmm/scripts/meta-criteria.js
@@ -1,4 +1,5 @@
 import { readFileSync, existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
@@ -80,6 +81,106 @@ export function checkFpRate(root) {
   return { passed: true, evidence: `FP rate ${latest.fp_rate}% < 30%` };
 }
 
+/**
+ * Check whether at least one improvement-labeled issue or PR was closed/merged
+ * in the last 30 days. Reads from `metrics/improvement-activity.jsonl` (populated
+ * by `scripts/collect-improvement-activity.mjs`); falls back to querying the `gh`
+ * CLI directly when the file is absent.
+ *
+ * @param {string} root - repo root
+ * @param {{ execFileSyncFn?: Function }} [opts] - injectable for testing
+ * @returns {{ passed: boolean, evidence: string }}
+ */
+export function checkProductImprovements(root, opts = {}) {
+  // Fast path: read from pre-collected metrics file
+  const metricsFile = join(root, "metrics", "improvement-activity.jsonl");
+  const entries = loadJsonl(metricsFile);
+  if (entries !== null) {
+    const cutoff = Date.now() - THIRTY_DAYS_MS;
+    const recent = entries.filter((e) => {
+      const ts = e.closedAt ?? e.mergedAt ?? e.date ?? e.timestamp;
+      return ts && new Date(ts).getTime() >= cutoff;
+    });
+    if (recent.length === 0) {
+      return {
+        passed: false,
+        evidence: `${entries.length} improvement entries found but none in last 30 days`,
+      };
+    }
+    return {
+      passed: true,
+      evidence: `${recent.length} improvement(s) shipped in last 30 days`,
+    };
+  }
+
+  // Fallback: query gh CLI directly
+  const fn = opts.execFileSyncFn ?? execFileSync;
+  const cutoff = Date.now() - THIRTY_DAYS_MS;
+  const allItems = [];
+
+  for (const [cmd, args] of [
+    [
+      "gh",
+      [
+        "issue",
+        "list",
+        "--label",
+        "improvement",
+        "--state",
+        "closed",
+        "--limit",
+        "50",
+        "--json",
+        "number,title,closedAt,url",
+      ],
+    ],
+    [
+      "gh",
+      [
+        "pr",
+        "list",
+        "--label",
+        "improvement",
+        "--state",
+        "merged",
+        "--limit",
+        "50",
+        "--json",
+        "number,title,mergedAt,url",
+      ],
+    ],
+  ]) {
+    try {
+      const out = fn(cmd, args, { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] });
+      const parsed = JSON.parse(out);
+      if (Array.isArray(parsed)) allItems.push(...parsed);
+    } catch {
+      // gh unavailable or label not found — skip
+    }
+  }
+
+  if (allItems.length === 0) {
+    return { passed: false, evidence: "no improvement-labeled issues or PRs found via gh CLI" };
+  }
+
+  const recent = allItems.filter((item) => {
+    const ts = item.closedAt ?? item.mergedAt;
+    return ts && new Date(ts).getTime() >= cutoff;
+  });
+
+  if (recent.length === 0) {
+    return {
+      passed: false,
+      evidence: `${allItems.length} improvement items found but none closed/merged in last 30 days`,
+    };
+  }
+
+  return {
+    passed: true,
+    evidence: `${recent.length} improvement(s) shipped in last 30 days`,
+  };
+}
+
 export const META_CRITERIA = [
   {
     id: "meta:threshold-tuning",
@@ -133,7 +234,7 @@ export const META_CRITERIA = [
     name: "Proactive product improvements shipped",
     description: "At least one improvement-labeled issue merged in last 30 days",
     scannable: false,
-    detection: { type: "active", pattern: "github:improvement-label" },
-    check: null,
+    detection: { type: "active", pattern: "metrics/improvement-activity.jsonl" },
+    check: checkProductImprovements,
   },
 ];

--- a/scripts/collect-improvement-activity.mjs
+++ b/scripts/collect-improvement-activity.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/**
+ * Collect improvement-labeled issues and PRs from GitHub and write to
+ * metrics/improvement-activity.jsonl.
+ *
+ * Supports --dry-run to preview without writing.
+ * Idempotent: deduplicates on re-run by number+type.
+ *
+ * Usage:
+ *   node scripts/collect-improvement-activity.mjs
+ *   node scripts/collect-improvement-activity.mjs --dry-run
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, appendFileSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const METRICS_DIR = join(REPO_ROOT, "metrics");
+const OUTPUT_FILE = join(METRICS_DIR, "improvement-activity.jsonl");
+const DRY_RUN = process.argv.includes("--dry-run");
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+function loadExisting() {
+  if (!existsSync(OUTPUT_FILE)) return new Map();
+  const existing = new Map();
+  readFileSync(OUTPUT_FILE, "utf-8")
+    .split("\n")
+    .filter((l) => l.trim())
+    .forEach((l) => {
+      try {
+        const e = JSON.parse(l);
+        if (e.number && e.type) existing.set(`${e.type}:${e.number}`, true);
+      } catch {
+        // skip malformed
+      }
+    });
+  return existing;
+}
+
+function queryGh(args, label = "") {
+  try {
+    const out = execFileSync("gh", args, {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return JSON.parse(out);
+  } catch {
+    console.warn(`  Warning: gh query failed${label ? ` (${label})` : ""} — skipping`);
+    return [];
+  }
+}
+
+const existing = loadExisting();
+const cutoff = Date.now() - THIRTY_DAYS_MS;
+const newEntries = [];
+
+// Query closed issues
+const issues = queryGh(
+  [
+    "issue",
+    "list",
+    "--label",
+    "improvement",
+    "--state",
+    "closed",
+    "--limit",
+    "100",
+    "--json",
+    "number,title,closedAt,url",
+  ],
+  "issues"
+);
+for (const issue of issues) {
+  if (!issue.closedAt) continue;
+  const closedAt = new Date(issue.closedAt).getTime();
+  if (closedAt < cutoff) continue;
+  const key = `issue:${issue.number}`;
+  if (existing.has(key)) continue;
+  newEntries.push({
+    number: issue.number,
+    title: issue.title,
+    closedAt: issue.closedAt,
+    url: issue.url,
+    type: "issue",
+  });
+}
+
+// Query merged PRs
+const prs = queryGh(
+  [
+    "pr",
+    "list",
+    "--label",
+    "improvement",
+    "--state",
+    "merged",
+    "--limit",
+    "100",
+    "--json",
+    "number,title,mergedAt,url",
+  ],
+  "prs"
+);
+for (const pr of prs) {
+  if (!pr.mergedAt) continue;
+  const mergedAt = new Date(pr.mergedAt).getTime();
+  if (mergedAt < cutoff) continue;
+  const key = `pr:${pr.number}`;
+  if (existing.has(key)) continue;
+  newEntries.push({
+    number: pr.number,
+    title: pr.title,
+    mergedAt: pr.mergedAt,
+    url: pr.url,
+    type: "pr",
+  });
+}
+
+if (newEntries.length === 0) {
+  console.log("collect-improvement-activity: no new entries found.");
+  process.exit(0);
+}
+
+if (DRY_RUN) {
+  console.log(`collect-improvement-activity: dry run — ${newEntries.length} new entries:`);
+  for (const e of newEntries) console.log(" ", JSON.stringify(e));
+  process.exit(0);
+}
+
+mkdirSync(METRICS_DIR, { recursive: true });
+for (const e of newEntries) {
+  appendFileSync(OUTPUT_FILE, JSON.stringify(e) + "\n");
+}
+console.log(
+  `collect-improvement-activity: appended ${newEntries.length} new entries to ${OUTPUT_FILE}`
+);

--- a/services/agent/llms-full.txt
+++ b/services/agent/llms-full.txt
@@ -776,8 +776,7 @@
           },
         },
         async (request) => {
-          const page = Math.max(1, parseInt(request.query.page ?? "1", 10) || 1);
-          const limit = Math.max(1, Math.min(100, parseInt(request.query.limit ?? "10", 10) || 10));
+          const { page, limit } = parseListQuery(request.query);
           const status = request.query.status as AgentSessionStatus | undefined;
     
           const prismaStatus = status?.toUpperCase() as
@@ -1099,22 +1098,6 @@
       await fastify.register(genAgentRoutes);
     
       return fastify;
-    }
-  </file>
-  <file path="src/index.ts">
-    async function main() {
-      const fastify = await buildApp();
-    
-      try {
-        await fastify.listen({ port: PORT, host: HOST });
-        fastify.log.info(`Server running at http://${HOST}:${PORT}`);
-        fastify.log.info(`API docs at http://${HOST}:${PORT}/docs`);
-    
-        startLivenessMonitor();
-      } catch (err) {
-        fastify.log.error(err);
-        process.exit(1);
-      }
     }
   </file>
   </section>

--- a/services/agent/llms.txt
+++ b/services/agent/llms.txt
@@ -193,10 +193,5 @@
       export async function buildApp(options: AppOptions = {}): Promise<FastifyInstance> { /* ... */ }
     </item>
   </file>
-  <file path="src/index.ts">
-    <item priority="low">
-      async function main() { /* ... */ }
-    </item>
-  </file>
   </section>
 </codebase>

--- a/services/agent/src/routes/contract.test.ts
+++ b/services/agent/src/routes/contract.test.ts
@@ -25,7 +25,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/agent/src/routes/gen-agent.test.ts
+++ b/services/agent/src/routes/gen-agent.test.ts
@@ -50,7 +50,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/agent/src/routes/gen-chat.test.ts
+++ b/services/agent/src/routes/gen-chat.test.ts
@@ -49,7 +49,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/agent/src/routes/gen-specs.test.ts
+++ b/services/agent/src/routes/gen-specs.test.ts
@@ -50,7 +50,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/agent/src/routes/health.ts
+++ b/services/agent/src/routes/health.ts
@@ -1,9 +1,5 @@
 import type { FastifyPluginAsync } from "fastify";
-import {
-  registerHealthRoutes,
-  createLatencyTracker,
-  checkAuth0,
-} from "@mbe/database";
+import { registerHealthRoutes, createLatencyTracker, checkAuth0 } from "@mbe/database";
 import {
   prisma,
   getSlowQueryStats,

--- a/services/agent/src/routes/orchestrate.test.ts
+++ b/services/agent/src/routes/orchestrate.test.ts
@@ -28,7 +28,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/agent/src/routes/ready.test.ts
+++ b/services/agent/src/routes/ready.test.ts
@@ -13,7 +13,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/agent/src/routes/session-events.integration.test.ts
+++ b/services/agent/src/routes/session-events.integration.test.ts
@@ -44,7 +44,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/agent/src/routes/sessions.test.ts
+++ b/services/agent/src/routes/sessions.test.ts
@@ -27,7 +27,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/agent/src/routes/webhooks.test.ts
+++ b/services/agent/src/routes/webhooks.test.ts
@@ -28,7 +28,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/reservations/llms-full.txt
+++ b/services/reservations/llms-full.txt
@@ -486,8 +486,7 @@
           },
         },
         async (request) => {
-          const page = parseInt(request.query.page || "1", 10);
-          const limit = parseInt(request.query.limit || "10", 10);
+          const { page, limit } = parseListQuery(request.query);
           return floorPlanService.list(page, limit, request.query.venueId);
         }
       );
@@ -2220,8 +2219,7 @@
             );
           }
     
-          const page = Math.max(1, parseInt(request.query.page ?? "1", 10) || 1);
-          const limit = Math.max(1, Math.min(100, parseInt(request.query.limit ?? "10", 10) || 10));
+          const { page, limit } = parseListQuery(request.query);
           return reservationService.list({
             page,
             limit,
@@ -2293,8 +2291,7 @@
               .send(createProblemDetails(401, "Unauthorized", "Authentication required"));
           }
     
-          const page = Math.max(1, parseInt(request.query.page ?? "1", 10) || 1);
-          const limit = Math.max(1, Math.min(100, parseInt(request.query.limit ?? "10", 10) || 10));
+          const { page, limit } = parseListQuery(request.query);
           return reservationService.listByUserId(authUser.id, page, limit);
         }
       );
@@ -2881,8 +2878,7 @@
           },
         },
         async (request) => {
-          const page = Math.max(1, parseInt(request.query.page ?? "1", 10) || 1);
-          const limit = Math.max(1, Math.min(100, parseInt(request.query.limit ?? "10", 10) || 10));
+          const { page, limit } = parseListQuery(request.query);
           const activeOnly = request.query.activeOnly === "true";
           return tableService.list(page, limit, activeOnly);
         }
@@ -3281,8 +3277,7 @@
           },
         },
         async (request) => {
-          const page = Math.max(1, parseInt(request.query.page ?? "1", 10) || 1);
-          const limit = Math.max(1, Math.min(100, parseInt(request.query.limit ?? "10", 10) || 10));
+          const { page, limit } = parseListQuery(request.query);
           return venueGroupService.list(page, limit);
         }
       );
@@ -3581,8 +3576,7 @@
           },
         },
         async (request) => {
-          const page = Math.max(1, parseInt(request.query.page ?? "1", 10) || 1);
-          const limit = Math.max(1, Math.min(100, parseInt(request.query.limit ?? "10", 10) || 10));
+          const { page, limit } = parseListQuery(request.query);
           return venueService.list(page, limit, request.query.venueGroupId);
         }
       );
@@ -4203,20 +4197,6 @@
       await fastify.register(modifyReservationRoutes);
     
       return fastify;
-    }
-  </file>
-  <file path="src/index.ts">
-    async function main() {
-      const fastify = await buildApp();
-    
-      try {
-        await fastify.listen({ port: PORT, host: HOST });
-        fastify.log.info(`Server running at http://${HOST}:${PORT}`);
-        fastify.log.info(`API docs at http://${HOST}:${PORT}/docs`);
-      } catch (err) {
-        fastify.log.error(err);
-        process.exit(1);
-      }
     }
   </file>
   </section>

--- a/services/reservations/llms.txt
+++ b/services/reservations/llms.txt
@@ -335,11 +335,6 @@
       export async function buildApp(options: AppOptions = {}): Promise<FastifyInstance> { /* ... */ }
     </item>
   </file>
-  <file path="src/index.ts">
-    <item priority="low">
-      async function main() { /* ... */ }
-    </item>
-  </file>
   </section>
   <section priority="medium" role="test">
   <file path="src/test/mocks.ts">

--- a/services/reservations/src/routes/availability.test.ts
+++ b/services/reservations/src/routes/availability.test.ts
@@ -108,7 +108,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/reservations/src/routes/contract.test.ts
+++ b/services/reservations/src/routes/contract.test.ts
@@ -17,7 +17,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/reservations/src/routes/events.integration.test.ts
+++ b/services/reservations/src/routes/events.integration.test.ts
@@ -29,7 +29,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/reservations/src/routes/floor-plans.test.ts
+++ b/services/reservations/src/routes/floor-plans.test.ts
@@ -85,7 +85,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/reservations/src/routes/guests.test.ts
+++ b/services/reservations/src/routes/guests.test.ts
@@ -87,7 +87,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/reservations/src/routes/health.ts
+++ b/services/reservations/src/routes/health.ts
@@ -1,9 +1,5 @@
 import type { FastifyPluginAsync } from "fastify";
-import {
-  registerHealthRoutes,
-  createLatencyTracker,
-  checkAuth0,
-} from "@mbe/database";
+import { registerHealthRoutes, createLatencyTracker, checkAuth0 } from "@mbe/database";
 import {
   prisma,
   getSlowQueryStats,

--- a/services/reservations/src/routes/public-availability.test.ts
+++ b/services/reservations/src/routes/public-availability.test.ts
@@ -77,7 +77,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 vi.mock("jose", () => ({

--- a/services/reservations/src/routes/public-holds.test.ts
+++ b/services/reservations/src/routes/public-holds.test.ts
@@ -75,7 +75,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 vi.mock("jose", () => ({

--- a/services/reservations/src/routes/public-venues.test.ts
+++ b/services/reservations/src/routes/public-venues.test.ts
@@ -76,7 +76,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/reservations/src/routes/reservations.test.ts
+++ b/services/reservations/src/routes/reservations.test.ts
@@ -106,7 +106,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/reservations/src/routes/tables.test.ts
+++ b/services/reservations/src/routes/tables.test.ts
@@ -97,7 +97,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/reservations/src/routes/venues.test.ts
+++ b/services/reservations/src/routes/venues.test.ts
@@ -84,7 +84,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/users/llms-full.txt
+++ b/services/users/llms-full.txt
@@ -171,8 +171,7 @@
               createProblemDetails(403, "Forbidden", "Admin access required to list all users") as never
             );
           }
-          const page = Math.max(1, parseInt(request.query.page ?? "1", 10) || 1);
-          const limit = Math.max(1, Math.min(100, parseInt(request.query.limit ?? "10", 10) || 10));
+          const { page, limit } = parseListQuery(request.query);
           return userService.list(page, limit);
         }
       );
@@ -658,20 +657,6 @@
       await fastify.register(userRoutes, { prefix: "/api/v1/users" });
     
       return fastify;
-    }
-  </file>
-  <file path="src/index.ts">
-    async function main() {
-      const fastify = await buildApp();
-    
-      try {
-        await fastify.listen({ port: PORT, host: HOST });
-        fastify.log.info(`Server running at http://${HOST}:${PORT}`);
-        fastify.log.info(`API docs at http://${HOST}:${PORT}/docs`);
-      } catch (err) {
-        fastify.log.error(err);
-        process.exit(1);
-      }
     }
   </file>
   </section>

--- a/services/users/llms.txt
+++ b/services/users/llms.txt
@@ -73,11 +73,6 @@
       export async function buildApp(options: AppOptions = {}): Promise<FastifyInstance> { /* ... */ }
     </item>
   </file>
-  <file path="src/index.ts">
-    <item priority="low">
-      async function main() { /* ... */ }
-    </item>
-  </file>
   </section>
   <section priority="medium" role="test">
   <file path="src/test/fixtures.ts">

--- a/services/users/src/app.test.ts
+++ b/services/users/src/app.test.ts
@@ -22,7 +22,12 @@ vi.mock("./services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/users/src/routes/contract.test.ts
+++ b/services/users/src/routes/contract.test.ts
@@ -22,7 +22,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/users/src/routes/health.ts
+++ b/services/users/src/routes/health.ts
@@ -1,9 +1,5 @@
 import type { FastifyPluginAsync } from "fastify";
-import {
-  registerHealthRoutes,
-  createLatencyTracker,
-  checkAuth0,
-} from "@mbe/database";
+import { registerHealthRoutes, createLatencyTracker, checkAuth0 } from "@mbe/database";
 import {
   prisma,
   getSlowQueryStats,

--- a/services/users/src/routes/users-auth.test.ts
+++ b/services/users/src/routes/users-auth.test.ts
@@ -27,7 +27,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/users/src/routes/users-edge-cases.test.ts
+++ b/services/users/src/routes/users-edge-cases.test.ts
@@ -20,7 +20,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 

--- a/services/users/src/routes/users.test.ts
+++ b/services/users/src/routes/users.test.ts
@@ -23,7 +23,12 @@ vi.mock("../services/database.js", () => ({
   getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
   getServiceStatus: vi.fn().mockReturnValue("ok"),
   getPoolMetrics: vi.fn().mockReturnValue({
-    active: 1, idle: 4, busy: 1, size: 5, utilization: 0.2, isDegraded: false,
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
   }),
 }));
 


### PR DESCRIPTION
## Summary

Implements the `meta:product-improvements` check function in the ACMM meta-criteria system, replacing the previously stub `check: null` with a working implementation.

### Changes

**`plugins/acmm/scripts/meta-criteria.js`**
- Add `checkProductImprovements(root, opts={})` — reads from `metrics/improvement-activity.jsonl` (fast path) or falls back to `gh` CLI (issues + PRs with `improvement` label)
- Change `meta:product-improvements` detection pattern from `"github:improvement-label"` (non-existent file path) to `"metrics/improvement-activity.jsonl"` — consistent with all other meta criteria
- Change `check: null` → `check: checkProductImprovements`

**`scripts/collect-improvement-activity.mjs`** (new)
- Idempotent collector: queries `gh issue list --label improvement --state closed` + `gh pr list --label improvement --state merged`
- Deduplicates on `type:number` key, appends new entries to `metrics/improvement-activity.jsonl`
- Supports `--dry-run`

**`metrics/improvement-activity.jsonl`** (new — seeded)
- Seed data: 2 recently merged improvement PRs (#1652, #1654)
- `.gitignore` exception added: `!/metrics/improvement-activity.jsonl`

**`plugins/acmm/scripts/__tests__/meta-criteria.test.js`**
- 7 new tests for `checkProductImprovements` (fast-path pass/fail, gh CLI fallback pass/fail, graceful degradation)
- 2 new `META_CRITERIA` tests: non-null check function, file-based detection pattern

### Test results

```
# tests 23
# pass 23
# fail 0
```

Closes #1663

https://claude.ai/code/session_01CUgXMiEY4zyX1SiKFLAspa

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUgXMiEY4zyX1SiKFLAspa)_