### PR TITLE
fix(ci): remove deleted api-versioning from root llms.txt

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1378,13 +1378,6 @@
       partySize: number;
     }
   </file>
-  <file path="packages/api-versioning/src/fastify.ts">
-    export interface ApiVersioningOptions {
-      currentVersion: string;
-      successorVersion?: string;
-      sunsetMonthsFromNow?: number;
-    }
-  </file>
   <file path="packages/agent-test-utils/src/worktree-simulator.ts">
     export type RepoState = "clean" | "dirty" | "conflicted";
     export interface SimulatedFile {

--- a/llms.txt
+++ b/llms.txt
@@ -519,15 +519,6 @@
       }
     </item>
   </file>
-  <file path="packages/api-versioning/src/fastify.ts">
-    <item priority="low">
-      interface ApiVersioningOptions {
-        currentVersion: string;
-        successorVersion?: string | undefined;
-        sunsetMonthsFromNow?: number | undefined;
-      }
-    </item>
-  </file>
   <file path="packages/agent-test-utils/src/worktree-simulator.ts">
     <item priority="low">
       type RepoState = "clean" | "dirty" | "conflicted";


### PR DESCRIPTION
## Summary

Root `llms.txt` and `llms-full.txt` still referenced `packages/api-versioning/src/fastify.ts` after that package was deleted in #1656. The `detect-instruction-rot.mjs` step in the Integrity CI job catches this and fails **every PR** based on current main.

## What changed

- `llms.txt`: removed 9-line `<file path="packages/api-versioning/...">` block
- `llms-full.txt`: removed 7-line `<file path="packages/api-versioning/...">` block

## Branches already hot-fixed

The same fix was pushed directly to these open PR branches to unblock their CI:
- #1676 `worktree-agent-a6e90f189f900a595`
- #1677 `fix/acmm-substance-gaps`
- #1678 `feat/acmm-auto-rollback-drill-1668-clean`
- #1681 `feat/meta-product-improvements-check-1663`

Merging this PR into main prevents future PRs from inheriting the rot.

Closes #1682

https://claude.ai/code/session_015MD4crtLQt1mpivM8hrDrM

---
_Generated by [Claude Code](https://claude.ai/code/session_015MD4crtLQt1mpivM8hrDrM)_