### PR TITLE
fix(integrity): remove deleted api-versioning refs (unblocks all PR CI)

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -18,7 +18,7 @@
 
 - `apps/` — Frontend React (Vite) applications: `marketing` (/), `hospitality` (/hospitality), `rialto-web` (/rialto), `gen` (/gen).
 - `services/` — Backend Fastify/Node APIs: `users` (3001), `agent` (3003), `reservations` (3004).
-- `packages/` — Shared libraries: `agent-core`, `api-client`, `api-versioning`, `auth`, `config`, `observability`, `rialto` (Design System) + `rialto-catalog`/`rialto-plugin`, `sentry`, `types`. Each has its own `CLAUDE.md`.
+- `packages/` — Shared libraries: `agent-core`, `api-client`, `auth`, `config`, `observability`, `rialto` (Design System) + `rialto-catalog`/`rialto-plugin`, `sentry`, `types`. Each has its own `CLAUDE.md`.
 - `infrastructure/` — Pulumi (IaC) and Docker configuration.
 - `tools/` — Developer CLI (`mbe`).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@
 
 - `apps/` — Frontend React (Vite) applications: `marketing` (/), `hospitality` (/hospitality), `rialto-web` (/rialto), `gen` (/gen).
 - `services/` — Backend Fastify/Node APIs: `users` (3001), `agent` (3003), `reservations` (3004).
-- `packages/` — Shared libraries: `agent-core`, `api-client`, `api-versioning`, `auth`, `config`, `observability`, `rialto` (Design System) + `rialto-catalog`/`rialto-plugin`, `sentry`, `types`. Each has its own `CLAUDE.md`.
+- `packages/` — Shared libraries: `agent-core`, `api-client`, `auth`, `config`, `observability`, `rialto` (Design System) + `rialto-catalog`/`rialto-plugin`, `sentry`, `types`. Each has its own `CLAUDE.md`.
 - `infrastructure/` — Pulumi (IaC) and Docker configuration.
 - `tools/` — Developer CLI (`mbe`).
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ mattbutlerengineering/
 │   ├── agent-core/           # Agent session runner and worktree management
 │   ├── agent-test-utils/     # Test helpers for agent sessions
 │   ├── api-client/           # Typed fetch client for frontend apps
-│   ├── api-versioning/       # API version negotiation middleware
 │   ├── auth/                 # Auth utilities (React hooks + Fastify plugin)
 │   ├── config/               # Shared ESLint, TypeScript, Prettier configs
 │   ├── feature-flags/        # Feature flag evaluation library

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1378,13 +1378,6 @@
       partySize: number;
     }
   </file>
-  <file path="packages/api-versioning/src/fastify.ts">
-    export interface ApiVersioningOptions {
-      currentVersion: string;
-      successorVersion?: string;
-      sunsetMonthsFromNow?: number;
-    }
-  </file>
   <file path="packages/agent-test-utils/src/worktree-simulator.ts">
     export type RepoState = "clean" | "dirty" | "conflicted";
     export interface SimulatedFile {

--- a/llms.txt
+++ b/llms.txt
@@ -519,15 +519,6 @@
       }
     </item>
   </file>
-  <file path="packages/api-versioning/src/fastify.ts">
-    <item priority="low">
-      interface ApiVersioningOptions {
-        currentVersion: string;
-        successorVersion?: string | undefined;
-        sunsetMonthsFromNow?: number | undefined;
-      }
-    </item>
-  </file>
   <file path="packages/agent-test-utils/src/worktree-simulator.ts">
     <item priority="low">
       type RepoState = "clean" | "dirty" | "conflicted";


### PR DESCRIPTION
## Problem

`packages/api-versioning` was deleted in #1656 but stale references remained, causing **Integrity CI failures on every PR** — blocking #1676, #1677, #1678, #1683, #1687, and all future PRs.

Two checks fail:

| Check | File | Why |
|-------|------|-----|
| `detect-instruction-rot.mjs` | `llms.txt` / `llms-full.txt` | Regex catches `packages/api-versioning` → deleted package |
| `check-doc-freshness.mjs` | `README.md` | Tree entry `api-versioning/` under `packages/` → deleted dir |

## What PR #1683 missed

PR #1683 only removed the `llms.txt`/`llms-full.txt` references but **not the `README.md` tree entry**, so its Integrity job still failed. This PR supersedes #1683 with a complete fix.

## Changes

- **`llms.txt`** — remove `packages/api-versioning/src/fastify.ts` block
- **`llms-full.txt`** — same
- **`README.md`** — remove `│   ├── api-versioning/` from project structure tree
- **`AGENTS.md`** — remove `api-versioning` from packages list (prose hygiene)
- **`.cursorrules`** — same

Closes #1682

https://claude.ai/code/session_01U6XQ9k77ttn9NWZeb3WaRX

---
_Generated by [Claude Code](https://claude.ai/code/session_01U6XQ9k77ttn9NWZeb3WaRX)_