### PR TITLE
feat(acmm): seed process-metrics.jsonl with initial collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,7 +86,8 @@ test.txt
 # Test artifacts
 playwright-report/
 test-results/
-/metrics/
+/metrics/*
+!/metrics/*.jsonl
 
 # Playwright
 e2e/.auth/

--- a/metrics/process-metrics.jsonl
+++ b/metrics/process-metrics.jsonl
@@ -1,0 +1,1 @@
+{"date":"2026-05-23","fp_rate":15,"avg_cost_usd":null,"median_cycle_hours":null,"issues_closed_7d":100}


### PR DESCRIPTION
## Summary

- Run `collect-process-metrics.mjs` to seed `metrics/process-metrics.jsonl` with the first entry (fp_rate=15, derived from auto-qa-tuning.json acceptanceRateFloor)
- Fix `.gitignore` to allow `*.jsonl` files in `metrics/` — changed `/metrics/` (blocks entire directory) to `/metrics/*` + `!/metrics/*.jsonl` (negation pattern lets JSONL metric files be tracked without force-add)

Closes #1700

## Test plan

- [x] `scripts/__tests__/collect-process-metrics.test.mjs` — 11/11 tests pass
- [x] `metrics/process-metrics.jsonl` contains entry with `fp_rate` field
- [x] Pre-push hook: typecheck + tests pass (21/21 tasks)
- [x] Verify `acmm-evals.jsonl` remains tracked (negation covers all JSONL)