### PR TITLE
feat(hospitality): timeline mobile responsive list view

### DIFF
--- a/apps/hospitality/e2e/auth.setup.ts
+++ b/apps/hospitality/e2e/auth.setup.ts
@@ -11,6 +11,6 @@ import { injectAuth0Session } from "./auth-helpers.js";
 setup("authenticate via Auth0", async ({ page }) => {
   await injectAuth0Session(page);
 
-  await expect(page.getByTestId("dashboard-layout")).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByTestId("auth-layout")).toBeVisible({ timeout: 10_000 });
   await expect(page.getByRole("button", { name: "Sign In" })).not.toBeVisible();
 });

--- a/apps/hospitality/e2e/auth.spec.ts
+++ b/apps/hospitality/e2e/auth.spec.ts
@@ -11,7 +11,7 @@ base.describe("Authentication — unauthenticated", () => {
     await page.goto("http://localhost:3002/hospitality/");
 
     await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
-    await expect(page.getByTestId("dashboard-layout")).not.toBeVisible();
+    await expect(page.getByTestId("auth-layout")).not.toBeVisible();
     await page.screenshot({ path: "e2e/screenshots/auth-login.png", fullPage: true });
 
     await context.close();
@@ -20,7 +20,7 @@ base.describe("Authentication — unauthenticated", () => {
 
 test.describe("Authentication — authenticated", () => {
   test("programmatic login loads dashboard", async ({ mockedPage }) => {
-    await expect(mockedPage.getByTestId("dashboard-layout")).toBeVisible();
+    await expect(mockedPage.getByTestId("auth-layout")).toBeVisible();
     await expect(mockedPage.getByRole("button", { name: "Sign In" })).not.toBeVisible();
     await mockedPage.screenshot({ path: "e2e/screenshots/auth-dashboard.png", fullPage: true });
   });
@@ -34,7 +34,7 @@ test.describe("Authentication — authenticated", () => {
       .click();
 
     // Should still be authenticated
-    await expect(mockedPage.getByTestId("dashboard-layout")).toBeVisible();
+    await expect(mockedPage.getByTestId("auth-layout")).toBeVisible();
     await expect(mockedPage.getByRole("button", { name: "Sign In" })).not.toBeVisible();
   });
 });

--- a/apps/hospitality/llms-full.txt
+++ b/apps/hospitality/llms-full.txt
@@ -187,6 +187,41 @@
       data: Reservation | Table | ReservationHold;
     }
   </file>
+  <file path="src/hooks/useReservationQuerySync.ts">
+    export function useReservationQuerySync() {
+      const queryClient = useQueryClient();
+      const { selectedVenueId } = useVenue();
+    
+      const invalidateReservations = () => {
+        queryClient.invalidateQueries({ queryKey: [RESERVATIONS_QUERY_KEY] });
+      };
+    
+      const invalidateTables = () => {
+        queryClient.invalidateQueries({ queryKey: [TABLES_QUERY_KEY] });
+      };
+    
+      return useReservationEvents({
+        venueId: selectedVenueId ?? undefined,
+        onReservationCreated: invalidateReservations,
+        onReservationUpdated: invalidateReservations,
+        onReservationCancelled: invalidateReservations,
+        onHoldConfirmed: invalidateReservations,
+        onTableUpdated: invalidateTables,
+      });
+    }
+  </file>
+  <file path="src/hooks/useReservations.ts">
+    export const RESERVATIONS_QUERY_KEY = "reservations" as const;
+    export interface UseReservationsParams extends ListReservationsParams {
+      enabled?: boolean;
+    }
+  </file>
+  <file path="src/hooks/useTables.ts">
+    export const TABLES_QUERY_KEY = "tables" as const;
+    export interface UseTablesParams extends ListTablesParams {
+      enabled?: boolean;
+    }
+  </file>
   <file path="src/hooks/useVenueReadiness.ts">
     export type SetupStep = "onboarding" | "operating-hours" | "floor-plan";
     export interface VenueReadiness {

--- a/apps/hospitality/llms.txt
+++ b/apps/hospitality/llms.txt
@@ -135,6 +135,31 @@
       }
     </item>
   </file>
+  <file path="src/hooks/useReservationQuerySync.ts">
+    <item priority="high">
+      export function useReservationQuerySync() { /* ... */ }
+    </item>
+  </file>
+  <file path="src/hooks/useReservations.ts">
+    <item priority="high">
+      export const RESERVATIONS_QUERY_KEY: unknown;
+    </item>
+    <item priority="low">
+      interface UseReservationsParams {
+        enabled?: boolean;
+      }
+    </item>
+  </file>
+  <file path="src/hooks/useTables.ts">
+    <item priority="high">
+      export const TABLES_QUERY_KEY: unknown;
+    </item>
+    <item priority="low">
+      interface UseTablesParams {
+        enabled?: boolean;
+      }
+    </item>
+  </file>
   <file path="src/hooks/useVenueReadiness.ts">
     <item priority="low">
       type SetupStep = "onboarding" | "operating-hours" | "floor-plan";

--- a/apps/hospitality/src/components/timeline/TimelineMobileView.module.css
+++ b/apps/hospitality/src/components/timeline/TimelineMobileView.module.css
@@ -1,0 +1,85 @@
+.root {
+  padding: var(--rialto-space-xs);
+}
+
+/* Filter chip row */
+.filterRow {
+  padding-block-end: var(--rialto-space-xs);
+}
+
+/* Time slot label */
+.slotLabel {
+  font-size: var(--rialto-text-xs);
+  font-weight: var(--rialto-weight-medium);
+  color: var(--rialto-text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding-inline-start: var(--rialto-space-xs);
+}
+
+/* Reservation card button — full-width, touch-friendly */
+.card {
+  display: block;
+  width: 100%;
+  min-block-size: 44px;
+  padding: var(--rialto-space-sm) var(--rialto-space-md);
+  background: var(--rialto-surface-elevated);
+  border: 1px solid var(--rialto-border);
+  border-radius: var(--rialto-radius-soft);
+  cursor: pointer;
+  text-align: start;
+  transition:
+    background var(--rialto-ease-precision) 120ms,
+    border-color var(--rialto-ease-precision) 120ms;
+}
+
+.card:hover {
+  background: var(--rialto-surface-recessed);
+  border-color: var(--rialto-border-strong);
+}
+
+.card:active {
+  background: var(--rialto-surface-recessed);
+}
+
+.cardSelected {
+  border-color: var(--rialto-accent);
+  background: color-mix(in srgb, var(--rialto-accent) 8%, var(--rialto-surface-elevated));
+}
+
+.cardRow {
+  width: 100%;
+}
+
+.cardMain {
+  flex: 1;
+  min-inline-size: 0;
+}
+
+.guestName {
+  font-weight: var(--rialto-weight-medium);
+  color: var(--rialto-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cardMeta {
+  color: var(--rialto-text-secondary);
+  font-size: var(--rialto-text-xs);
+}
+
+.cardMetaDot {
+  color: var(--rialto-text-tertiary);
+  font-size: var(--rialto-text-xs);
+}
+
+/* Empty state */
+.emptyCard {
+  padding: var(--rialto-space-xl);
+  text-align: center;
+}
+
+.emptyText {
+  color: var(--rialto-text-secondary);
+}

--- a/apps/hospitality/src/components/timeline/TimelineMobileView.tsx
+++ b/apps/hospitality/src/components/timeline/TimelineMobileView.tsx
@@ -1,0 +1,220 @@
+import { useMemo, useState } from "react";
+import type { Reservation, Table } from "@mbe/types";
+import { Card, Stack, Text, Tag } from "@mattbutlerengineering/rialto";
+import styles from "./TimelineMobileView.module.css";
+
+export type StatusFilter = "ALL" | "CONFIRMED" | "PENDING" | "CANCELLED";
+
+const STATUS_FILTERS: { value: StatusFilter; label: string }[] = [
+  { value: "ALL", label: "All" },
+  { value: "CONFIRMED", label: "Seated" },
+  { value: "PENDING", label: "Upcoming" },
+  { value: "CANCELLED", label: "Cancelled" },
+];
+
+function formatTime(isoString: string): string {
+  return new Date(isoString).toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  });
+}
+
+function formatSlotLabel(isoString: string): string {
+  const d = new Date(isoString);
+  const hours = d.getHours();
+  const minutes = d.getMinutes();
+  const ampm = hours >= 12 ? "PM" : "AM";
+  const displayHour = hours % 12 || 12;
+  return minutes === 0
+    ? `${displayHour}:00 ${ampm}`
+    : `${displayHour}:${String(minutes).padStart(2, "0")} ${ampm}`;
+}
+
+function getSlotKey(isoString: string): string {
+  const d = new Date(isoString);
+  // Round down to nearest 30 min slot
+  const slot = d.getMinutes() < 30 ? 0 : 30;
+  return `${d.getHours()}:${String(slot).padStart(2, "0")}`;
+}
+
+function getSlotLabel(isoString: string): string {
+  const d = new Date(isoString);
+  const slot = d.getMinutes() < 30 ? 0 : 30;
+  const slotDate = new Date(d);
+  slotDate.setMinutes(slot, 0, 0);
+  return formatSlotLabel(slotDate.toISOString());
+}
+
+function statusVariant(status: Reservation["status"]): "default" | "accent" | "success" | "error" {
+  switch (status) {
+    case "CONFIRMED":
+      return "accent";
+    case "PENDING":
+      return "default";
+    case "COMPLETED":
+      return "success";
+    case "CANCELLED":
+    case "NO_SHOW":
+      return "error";
+    default:
+      return "default";
+  }
+}
+
+function statusLabel(status: Reservation["status"]): string {
+  switch (status) {
+    case "CONFIRMED":
+      return "Confirmed";
+    case "PENDING":
+      return "Pending";
+    case "COMPLETED":
+      return "Completed";
+    case "CANCELLED":
+      return "Cancelled";
+    case "NO_SHOW":
+      return "No Show";
+    default:
+      return status;
+  }
+}
+
+interface ReservationCardProps {
+  reservation: Reservation;
+  table: Table | undefined;
+  onClick: (reservation: Reservation) => void;
+  isSelected: boolean;
+}
+
+function ReservationCard({ reservation, table, onClick, isSelected }: ReservationCardProps) {
+  const tableLabel = table?.tableNumber || table?.name || "Unassigned";
+  const timeLabel = `${formatTime(reservation.startTime)} – ${formatTime(reservation.endTime)}`;
+
+  return (
+    <button
+      className={`${styles.card} ${isSelected ? styles.cardSelected : ""}`}
+      onClick={() => onClick(reservation)}
+      aria-label={`${reservation.guestName || "Guest"}, party of ${reservation.partySize}, ${timeLabel}, table ${tableLabel}`}
+      type="button"
+    >
+      <Stack direction="row" align="center" justify="between" gap="sm" className={styles.cardRow}>
+        <Stack gap="2xs" className={styles.cardMain}>
+          <Text variant="label" className={styles.guestName}>
+            {reservation.guestName || "Guest"}
+          </Text>
+          <Stack direction="row" gap="xs" align="center" wrap>
+            <Text variant="caption" className={styles.cardMeta}>
+              {timeLabel}
+            </Text>
+            <Text variant="caption" className={styles.cardMetaDot}>
+              ·
+            </Text>
+            <Text variant="caption" className={styles.cardMeta}>
+              {reservation.partySize} {reservation.partySize === 1 ? "guest" : "guests"}
+            </Text>
+            <Text variant="caption" className={styles.cardMetaDot}>
+              ·
+            </Text>
+            <Text variant="caption" className={styles.cardMeta}>
+              {tableLabel}
+            </Text>
+          </Stack>
+        </Stack>
+        <Tag variant={statusVariant(reservation.status)}>{statusLabel(reservation.status)}</Tag>
+      </Stack>
+    </button>
+  );
+}
+
+export interface TimelineMobileViewProps {
+  reservations: Reservation[];
+  tables: Table[];
+  onReservationClick: (reservation: Reservation) => void;
+  selectedReservationId?: string | null;
+}
+
+export function TimelineMobileView({
+  reservations,
+  tables,
+  onReservationClick,
+  selectedReservationId,
+}: TimelineMobileViewProps) {
+  const [activeFilter, setActiveFilter] = useState<StatusFilter>("ALL");
+
+  const tableMap = useMemo(() => {
+    const m = new Map<string, Table>();
+    for (const t of tables) m.set(t.id, t);
+    return m;
+  }, [tables]);
+
+  const filtered = useMemo(() => {
+    if (activeFilter === "ALL") return reservations;
+    return reservations.filter((r) => {
+      if (activeFilter === "CONFIRMED") return r.status === "CONFIRMED" || r.status === "COMPLETED";
+      if (activeFilter === "PENDING") return r.status === "PENDING";
+      if (activeFilter === "CANCELLED") return r.status === "CANCELLED" || r.status === "NO_SHOW";
+      return true;
+    });
+  }, [reservations, activeFilter]);
+
+  // Group by 30-min slot key, sorted chronologically
+  const slots = useMemo(() => {
+    const grouped = new Map<string, { label: string; reservations: Reservation[] }>();
+    const sorted = [...filtered].sort(
+      (a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
+    );
+    for (const r of sorted) {
+      const key = getSlotKey(r.startTime);
+      if (!grouped.has(key)) {
+        grouped.set(key, { label: getSlotLabel(r.startTime), reservations: [] });
+      }
+      grouped.get(key)!.reservations.push(r);
+    }
+    return Array.from(grouped.entries()).sort(([a], [b]) => {
+      const [ah, am] = a.split(":").map(Number);
+      const [bh, bm] = b.split(":").map(Number);
+      return ah! * 60 + (am ?? 0) - (bh! * 60 + (bm ?? 0));
+    });
+  }, [filtered]);
+
+  return (
+    <Stack gap="sm" className={styles.root}>
+      {/* Status filter chips */}
+      <Stack direction="row" gap="xs" wrap className={styles.filterRow}>
+        {STATUS_FILTERS.map(({ value, label }) => (
+          <Tag key={value} onClick={() => setActiveFilter(value)} selected={activeFilter === value}>
+            {label}
+          </Tag>
+        ))}
+      </Stack>
+
+      {/* Time slot groups */}
+      {slots.length === 0 ? (
+        <Card variant="flat" className={styles.emptyCard}>
+          <Text variant="body" className={styles.emptyText}>
+            No reservations
+          </Text>
+        </Card>
+      ) : (
+        slots.map(([key, { label, reservations: slotReservations }]) => (
+          <Stack key={key} gap="xs">
+            <Text variant="label" className={styles.slotLabel}>
+              {label}
+            </Text>
+            <Stack gap="xs">
+              {slotReservations.map((r) => (
+                <ReservationCard
+                  key={r.id}
+                  reservation={r}
+                  table={tableMap.get(r.tableId)}
+                  onClick={onReservationClick}
+                  isSelected={r.id === selectedReservationId}
+                />
+              ))}
+            </Stack>
+          </Stack>
+        ))
+      )}
+    </Stack>
+  );
+}

--- a/apps/hospitality/src/components/timeline/index.ts
+++ b/apps/hospitality/src/components/timeline/index.ts
@@ -3,3 +3,8 @@ export { ReservationBlock, type ReservationBlockProps } from "./ReservationBlock
 export { CancelReservationDialog } from "./CancelReservationDialog";
 export { EditReservationDrawer } from "./EditReservationDrawer";
 export { WalkInDialog } from "./WalkInDialog";
+export {
+  TimelineMobileView,
+  type TimelineMobileViewProps,
+  type StatusFilter,
+} from "./TimelineMobileView";

--- a/apps/hospitality/src/pages/TimelinePage.test.tsx
+++ b/apps/hospitality/src/pages/TimelinePage.test.tsx
@@ -51,6 +51,15 @@ vi.mock("../components/timeline", () => ({
       ))}
     </div>
   ),
+  TimelineMobileView: ({ reservations, onReservationClick }: any) => (
+    <div data-testid="timeline-mobile-view">
+      {reservations?.map((r: any) => (
+        <button key={r.id} data-testid={`res-${r.id}`} onClick={() => onReservationClick?.(r)}>
+          {r.guestName}
+        </button>
+      ))}
+    </div>
+  ),
 }));
 
 vi.mock("../components/timeline/CancelReservationDialog", () => ({

--- a/apps/hospitality/src/pages/TimelinePage.tsx
+++ b/apps/hospitality/src/pages/TimelinePage.tsx
@@ -4,7 +4,7 @@ import { useAuth } from "@mbe/auth/react";
 import { createApiClient } from "@mbe/api-client";
 import { Drawer, Button, Stack, Text, Card } from "@mattbutlerengineering/rialto";
 import type { Reservation, TableStatus, UpdateReservationRequest } from "@mbe/types";
-import { TimelineGrid } from "../components/timeline";
+import { TimelineGrid, TimelineMobileView } from "../components/timeline";
 import { CancelReservationDialog } from "../components/timeline/CancelReservationDialog";
 import { EditReservationDrawer } from "../components/timeline/EditReservationDrawer";
 import { WalkInDialog } from "../components/timeline/WalkInDialog";
@@ -468,6 +468,13 @@ export function TimelinePage() {
               <Text className={styles.emptyStateText}>No tables configured for this venue.</Text>
               <Text className={styles.emptyStateHint}>Add tables in the Floor Plans section.</Text>
             </div>
+          ) : isMobile ? (
+            <TimelineMobileView
+              reservations={reservations}
+              tables={tables}
+              onReservationClick={handleReservationClick}
+              selectedReservationId={selectedReservation?.id}
+            />
           ) : (
             <TimelineGrid
               tables={tables}

--- a/packages/agent-core/llms-full.txt
+++ b/packages/agent-core/llms-full.txt
@@ -352,6 +352,647 @@
     }
   </file>
   </section>
+  <section priority="medium" role="phases">
+  <file path="src/phases/feedback-phase.ts">
+    export class FeedbackPhase implements PipelinePhase {
+      readonly name = "feedback" as const;
+    
+      async run(ctx: PipelineContext): Promise<{ result: PhaseResult; ctx: PipelineContext }> {
+        const { config, onEvent, worktree, resultMessage, prNumber } = ctx;
+    
+        if (!config.feedbackLoop?.enabled || !prNumber || !ctx.prUrl || !worktree) {
+          return {
+            result: { phase: this.name, status: "skipped", errors: [] },
+            ctx,
+          };
+        }
+    
+        // Use remaining budget instead of fixed 50% ratio
+        const sessionCost = resultMessage?.total_cost_usd ?? 0;
+        const remainingBudget = Math.max(0, config.maxBudgetUsd - sessionCost);
+    
+        const fbSpan = tracer.startSpan("agent_core.feedback_loop");
+        let feedbackResult;
+        try {
+          feedbackResult = await runFeedbackLoop(
+            {
+              prNumber,
+              branchName: worktree.branchName,
+              repoPath: worktree.path,
+              model: getFeedbackLoopModel(config.model),
+              maxRetries: config.feedbackLoop.maxRetries ?? 2,
+              pollIntervalMs: config.feedbackLoop.pollIntervalMs ?? 30_000,
+              pollTimeoutMs: config.feedbackLoop.pollTimeoutMs ?? 300_000,
+              maxBudgetUsd: remainingBudget,
+              allowedTools: config.allowedTools,
+            },
+            onEvent
+          );
+          fbSpan.setAttribute("feedback.retries_used", feedbackResult.retriesUsed);
+          fbSpan.setAttribute("feedback.resolved", feedbackResult.resolved);
+        } finally {
+          fbSpan.end();
+        }
+    
+        emitEvent(onEvent, "session:result", {
+          message: `Feedback loop: ${feedbackResult.resolved ? "resolved" : "escalated"} after ${feedbackResult.retriesUsed} retries`,
+        });
+    
+        return {
+          result: { phase: this.name, status: "success", errors: [] },
+          ctx,
+        };
+      }
+    }
+  </file>
+  <file path="src/phases/pipeline-types.ts">
+    export type PhaseStatus = "success" | "failed" | "skipped";
+    export interface PhaseResult {
+      readonly phase: string;
+      readonly status: PhaseStatus;
+      readonly errors: readonly string[];
+    }
+  </file>
+  <file path="src/phases/publish-phase.ts">
+    export class PublishPhase implements PipelinePhase {
+      readonly name = "publish" as const;
+    
+      async run(ctx: PipelineContext): Promise<{ result: PhaseResult; ctx: PipelineContext }> {
+        const { config, worktree } = ctx;
+    
+        if (!config.createPr || !ctx.hasChanges || !worktree) {
+          return {
+            result: { phase: this.name, status: "skipped", errors: [] },
+            ctx,
+          };
+        }
+    
+        const { prUrl, prNumber } = await this.createOrMergePr(ctx, worktree);
+    
+        return {
+          result: { phase: this.name, status: "success", errors: [] },
+          ctx: { ...ctx, prUrl, prNumber },
+        };
+      }
+    
+      private async createOrMergePr(
+        ctx: PipelineContext,
+        worktree: WorktreeInfo
+      ): Promise<{ prUrl: string | null; prNumber?: number }> {
+        const { config, onEvent, resultMessage, stuckReason, gatewayVerdict } = ctx;
+    
+        if (gatewayVerdict?.outcome === "merge-direct") {
+          const commitTitle = buildPrTitle(config.taskDescription);
+          const mergedUrl = await mergeDirectly({
+            branchName: worktree.branchName,
+            baseBranch: config.baseBranch,
+            repoPath: worktree.path,
+            commitTitle,
+          });
+          emitEvent(onEvent, "session:result", {
+            message: `Trivial dep bump — direct-merged: ${mergedUrl}`,
+          });
+          return { prUrl: mergedUrl };
+        }
+    
+        if (!gatewayVerdict || gatewayVerdict.outcome === "create-pr") {
+          const title = buildPrTitle(config.taskDescription);
+          const body = resultMessage
+            ? buildPrBody(
+                config.taskDescription,
+                resultMessage.session_id,
+                resultMessage.total_cost_usd,
+                resultMessage.num_turns
+              )
+            : buildFailurePrBody(config.taskDescription, [...ctx.errors], stuckReason?.type);
+    
+          const prSpan = tracer.startSpan("agent_core.create_pr");
+          try {
+            const { value: pr } = await withRetry(
+              () =>
+                createPullRequest({
+                  title,
+                  body,
+                  baseBranch: config.baseBranch,
+                  branchName: worktree.branchName,
+                  repoPath: worktree.path,
+                  draft: false,
+                }),
+              { maxRetries: 3 }
+            );
+            prSpan.setAttribute("pr.url", pr.url);
+            prSpan.setAttribute("pr.number", pr.number);
+            prSpan.setAttribute("pr.draft", false);
+    
+            emitEvent(onEvent, "session:result", {
+              message: `PR created: ${pr.url}`,
+            });
+            return { prUrl: pr.url, prNumber: pr.number };
+          } finally {
+            prSpan.end();
+          }
+        }
+    
+        // verdict.outcome === "create-draft-pr" — quality gates failed
+        const title = `wip: ${config.taskDescription.slice(0, 57)}`;
+        const body = buildFailurePrBody(config.taskDescription, [...ctx.errors], stuckReason?.type);
+    
+        const { value: pr } = await withRetry(
+          () =>
+            createPullRequest({
+              title,
+              body,
+              baseBranch: config.baseBranch,
+              branchName: worktree.branchName,
+              repoPath: worktree.path,
+              draft: true,
+            }),
+          { maxRetries: 3 }
+        );
+    
+        emitEvent(onEvent, "session:result", {
+          message: `Draft PR created (failed gates: ${gatewayVerdict!.gateFailures.join(", ")}): ${pr.url}`,
+        });
+        return { prUrl: pr.url, prNumber: pr.number };
+      }
+    }
+  </file>
+  <file path="src/phases/query-phase.ts">
+    interface StreamingResult {
+      readonly resultMessage: SDKResultMessage | null;
+      readonly stuckDetected: StuckPattern | null;
+    }
+    export class QueryPhase implements PipelinePhase {
+      readonly name = "query" as const;
+    
+      async run(ctx: PipelineContext): Promise<{ result: PhaseResult; ctx: PipelineContext }> {
+        const { config, onEvent, worktree, systemPrompt } = ctx;
+    
+        if (!worktree || !systemPrompt) {
+          const msg = "QueryPhase requires worktree and systemPrompt in context";
+          return {
+            result: { phase: this.name, status: "failed", errors: [msg] },
+            ctx: { ...ctx, errors: [...ctx.errors, msg] },
+          };
+        }
+    
+        // Fail fast if the circuit breaker is open
+        if (apiCircuitBreaker.getState() === CircuitState.Open) {
+          const circuitMsg =
+            "Circuit breaker is OPEN — Anthropic API appears degraded. Skipping session.";
+          emitEvent(onEvent, "session:error", { message: circuitMsg });
+          return {
+            result: { phase: this.name, status: "failed", errors: [circuitMsg] },
+            ctx: { ...ctx, errors: [...ctx.errors, circuitMsg] },
+          };
+        }
+    
+        const abortController = new AbortController();
+        const canUseTool = createToolPermissionHandler(worktree.path);
+    
+        const detector = createStuckDetector(config.stuckDetectorConfig);
+    
+        let conversation: ReturnType<typeof query>;
+        try {
+          conversation = query({
+            prompt: config.taskDescription,
+            options: {
+              abortController,
+              cwd: worktree.path,
+              model: config.model,
+              maxTurns: config.maxTurns,
+              maxBudgetUsd: config.maxBudgetUsd,
+              allowedTools: [...config.allowedTools],
+              permissionMode: "acceptEdits",
+              settingSources: ["project"],
+              systemPrompt: {
+                type: "preset",
+                preset: "claude_code",
+                append: systemPrompt,
+              },
+              canUseTool: async (toolName, input) => canUseTool(toolName, input),
+            },
+          });
+        } catch (err) {
+          const errMsg = err instanceof Error ? err.message : String(err);
+          return {
+            result: { phase: this.name, status: "failed", errors: [errMsg] },
+            ctx: { ...ctx, errors: [...ctx.errors, errMsg] },
+          };
+        }
+    
+        const querySpan = tracer.startSpan("agent_core.sdk_query", {
+          attributes: { "sdk.model": config.model },
+        });
+    
+        let compactionCount = 0;
+        let turnIndex = 0;
+    
+        const rawTurnMetrics: Array<{
+          turnIndex: number;
+          startedAt: string;
+          inputTokens: number;
+          outputTokens: number;
+          thinkingTokens: number;
+          costUsd: number;
+          modelId: string;
+        }> = [];
+    
+        const rawToolCallMetrics: Array<{
+          toolName: string;
+          toolUseId: string;
+          latencyMs: number;
+          isError: boolean;
+        }> = [];
+    
+        const pendingToolCalls = new Map<string, { toolName: string; startMs: number }>();
+    
+        // Heartbeat: periodic liveness signal + inactivity timeout
+        const heartbeat = DEFAULT_HEARTBEAT_CONFIG;
+        const startTime = Date.now();
+        let lastActivityMs = Date.now();
+        let stuckReason: StuckPattern | null = null;
+    
+        const heartbeatInterval = setInterval(() => {
+          const silenceMs = Date.now() - lastActivityMs;
+          emitEvent(onEvent, "session:heartbeat", {
+            message: JSON.stringify({
+              turnCount: turnIndex,
+              compactionCount,
+              elapsedMs: Date.now() - startTime,
+              lastActivityMs: silenceMs,
+            }),
+          });
+          if (silenceMs >= heartbeat.inactivityTimeoutMs) {
+            stuckReason = {
+              type: "zero_progress" as const,
+              count: 0,
+              threshold: 0,
+              description: `No SDK activity for ${Math.round(silenceMs / 1000)}s — session appears hung`,
+              severity: "error" as const,
+            };
+            emitEvent(onEvent, "session:stuck", {
+              message: `Inactivity timeout: no messages for ${Math.round(silenceMs / 1000)}s`,
+            });
+            abortController.abort();
+          }
+        }, heartbeat.intervalMs);
+    
+        let streamResult: StreamingResult = { resultMessage: null, stuckDetected: null };
+        let circuitBreakerTripped = false;
+    
+        try {
+          streamResult = await apiCircuitBreaker.wrap(async (): Promise<StreamingResult> => {
+            let innerResult: SDKResultMessage | null = null;
+            let innerStuck: StuckPattern | null = null;
+            try {
+              for await (const message of conversation) {
+                lastActivityMs = Date.now();
+                emitEvent(onEvent, "session:message", message);
+    
+                if (message.type === "assistant") {
+                  turnIndex++;
+                }
+    
+                // Track assistant messages as Langfuse generation observations
+                if (message.type === "assistant" && "message" in message) {
+                  const msg = message.message as {
+                    role: string;
+                    content: unknown;
+                    usage?: { input_tokens?: number; output_tokens?: number };
+                  };
+                  const gen = startObservation(
+                    `llm-turn-${turnIndex}`,
+                    { model: config.model, input: msg.content },
+                    { asType: "generation" }
+                  );
+                  gen
+                    .update({
+                      output: msg.content,
+                      usageDetails: {
+                        input: msg.usage?.input_tokens ?? 0,
+                        output: msg.usage?.output_tokens ?? 0,
+                      },
+                    })
+                    .end();
+                }
+    
+                // Emit typed events for observability
+                for (const mapped of mapSdkMessage(message, turnIndex)) {
+                  emitEvent(onEvent, mapped.type, {
+                    message: sanitizeStreamChunk(JSON.stringify(mapped)),
+                  });
+    
+                  if (mapped.type === "session:turn_metrics") {
+                    const tm = mapped as TurnMetricsEvent;
+                    rawTurnMetrics.push({
+                      turnIndex: tm.turnIndex,
+                      startedAt: new Date().toISOString(),
+                      inputTokens: tm.inputTokens,
+                      outputTokens: tm.outputTokens,
+                      thinkingTokens: tm.thinkingTokens,
+                      costUsd: tm.costUsd,
+                      modelId: tm.modelId,
+                    });
+                  }
+    
+                  if (mapped.type === "session:tool_use") {
+                    pendingToolCalls.set(mapped.toolUseId, {
+                      toolName: mapped.toolName,
+                      startMs: Date.now(),
+                    });
+                  }
+    
+                  if (mapped.type === "session:tool_result") {
+                    const pending = pendingToolCalls.get(mapped.toolUseId);
+                    if (pending) {
+                      const latencyMs = Date.now() - pending.startMs;
+                      rawToolCallMetrics.push({
+                        toolName: pending.toolName,
+                        toolUseId: mapped.toolUseId,
+                        latencyMs,
+                        isError: mapped.isError,
+                      });
+                      pendingToolCalls.delete(mapped.toolUseId);
+                      emitEvent(onEvent, "session:tool_latency", {
+                        message: JSON.stringify({
+                          toolName: pending.toolName,
+                          toolUseId: mapped.toolUseId,
+                          latencyMs,
+                          isError: mapped.isError,
+                        }),
+                      });
+                    }
+                  }
+                }
+    
+                // Track compaction events
+                if (
+                  message.type === "system" &&
+                  "subtype" in message &&
+                  message.subtype === "compact_boundary"
+                ) {
+                  compactionCount++;
+                  if (compactionCount >= MAX_COMPACTIONS) {
+                    innerStuck = {
+                      type: "context_window_loop",
+                      count: compactionCount,
+                      threshold: MAX_COMPACTIONS,
+                      description: `Context window compacted ${compactionCount} times — session exhausted`,
+                      severity: "error",
+                    };
+                    emitEvent(onEvent, "session:stuck", {
+                      message: `Context window exhaustion: ${compactionCount} compactions reached limit of ${MAX_COMPACTIONS}`,
+                    });
+                    querySpan.setAttribute("sdk.compaction_count", compactionCount);
+                    abortController.abort();
+                    break;
+                  }
+                }
+    
+                if (message.type === "result") {
+                  innerResult = message as SDKResultMessage;
+                  continue;
+                }
+    
+                const stuckPattern = detector.ingest(message);
+                if (stuckPattern) {
+                  if (stuckPattern.severity === "error") {
+                    innerStuck = stuckPattern;
+                    emitEvent(onEvent, "session:stuck", {
+                      message: `Stuck detected: ${stuckPattern.description}`,
+                    });
+                    querySpan.setAttribute("sdk.stuck_pattern", stuckPattern.type);
+                    abortController.abort();
+                    break;
+                  }
+                  emitEvent(onEvent, "session:stuck", {
+                    message: `Stuck warning: ${stuckPattern.description}`,
+                  });
+                }
+              }
+    
+              querySpan.setAttribute("sdk.turns_completed", innerResult?.num_turns ?? 0);
+              querySpan.setAttribute("sdk.compaction_count", compactionCount);
+            } catch (err) {
+              if (err instanceof ContextWindowExhaustedError) {
+                innerStuck = {
+                  type: "context_window_loop",
+                  count: compactionCount,
+                  threshold: MAX_COMPACTIONS,
+                  description: err.message,
+                  severity: "error",
+                };
+                emitEvent(onEvent, "session:stuck", {
+                  message: `Context window exhaustion: ${err.message}`,
+                });
+              } else {
+                querySpan.recordException(err as Error);
+                querySpan.setStatus({ code: SpanStatusCode.ERROR });
+                throw err;
+              }
+            }
+            return { resultMessage: innerResult, stuckDetected: innerStuck };
+          });
+        } catch (err) {
+          const errMsg = err instanceof Error ? err.message : String(err);
+          if (errMsg.includes("Circuit breaker is OPEN")) {
+            circuitBreakerTripped = true;
+            emitEvent(onEvent, "session:error", {
+              message: `Circuit breaker tripped: ${errMsg}`,
+            });
+            querySpan.setAttribute("session.circuit_breaker", "tripped");
+          } else {
+            clearInterval(heartbeatInterval);
+            querySpan.end();
+            return {
+              result: { phase: this.name, status: "failed", errors: [errMsg] },
+              ctx: { ...ctx, errors: [...ctx.errors, errMsg] },
+            };
+          }
+        } finally {
+          clearInterval(heartbeatInterval);
+          querySpan.end();
+        }
+    
+        const resultMessage = streamResult.resultMessage ?? undefined;
+        const detectedStuck = streamResult.stuckDetected ?? stuckReason ?? undefined;
+    
+        if (circuitBreakerTripped) {
+          const circuitMsg = "Circuit breaker tripped — too many consecutive API failures";
+          return {
+            result: { phase: this.name, status: "failed", errors: [circuitMsg] },
+            ctx: { ...ctx, errors: [...ctx.errors, circuitMsg] },
+          };
+        }
+    
+        const { buildTurnMetricsList, buildToolCallMetricsList } = await import("../observability.js");
+    
+        return {
+          result: { phase: this.name, status: "success", errors: [] },
+          ctx: {
+            ...ctx,
+            resultMessage,
+            stuckReason: detectedStuck,
+            turnMetrics: buildTurnMetricsList(rawTurnMetrics),
+            toolCallMetrics: buildToolCallMetricsList(rawToolCallMetrics),
+          },
+        };
+      }
+    }
+  </file>
+  <file path="src/phases/verification-phase.ts">
+    export class VerificationPhase implements PipelinePhase {
+      readonly name = "verification" as const;
+    
+      async run(ctx: PipelineContext): Promise<{ result: PhaseResult; ctx: PipelineContext }> {
+        const { config, onEvent, worktree, resultMessage, stuckReason } = ctx;
+    
+        if (!worktree) {
+          return {
+            result: { phase: this.name, status: "skipped", errors: [] },
+            ctx,
+          };
+        }
+    
+        const changed = await hasChanges(worktree.path);
+    
+        if (!changed) {
+          emitEvent(onEvent, "session:result", {
+            message: "No changes were made by the agent",
+          });
+          return {
+            result: { phase: this.name, status: "success", errors: [] },
+            ctx: { ...ctx, hasChanges: false },
+          };
+        }
+    
+        // Commit changes
+        const isSuccess = resultMessage?.subtype === "success" && !stuckReason;
+        const prefix = isSuccess ? "feat" : "wip";
+        const commitMsg = `${prefix}: ${sanitizeForCommitMessage(config.taskDescription)}`;
+        await commitChanges(worktree.path, commitMsg);
+    
+        // Push with retry for transient network failures
+        await withRetry(() => pushBranch(worktree.path, worktree.branchName), { maxRetries: 3 });
+    
+        // Run post-commit gateway (verification + quality gates) only on success
+        const errors: string[] = [];
+        let gatewayVerdict;
+        let gatewayEvaluation;
+        let cachedDiff: string | undefined;
+    
+        if (isSuccess) {
+          cachedDiff = await getGitDiff(worktree.path);
+          gatewayVerdict = await runPostCommitGateway(
+            {
+              worktreePath: worktree.path,
+              diff: cachedDiff,
+              commitMsg,
+              taskDescription: config.taskDescription,
+              config: {
+                evaluateSuccess: config.evaluateSuccess,
+                runSecurityReview: true,
+                runStaticAnalysis: true,
+              },
+            },
+            onEvent
+          );
+          errors.push(...gatewayVerdict.errors);
+          gatewayEvaluation = gatewayVerdict.evaluation;
+        }
+    
+        return {
+          result: { phase: this.name, status: "success", errors },
+          ctx: {
+            ...ctx,
+            hasChanges: true,
+            commitMsg,
+            cachedDiff,
+            gatewayVerdict,
+            gatewayEvaluation,
+            errors: [...ctx.errors, ...errors],
+          },
+        };
+      }
+    }
+  </file>
+  <file path="src/phases/worktree-phase.ts">
+    export class WorktreePhase implements PipelinePhase {
+      readonly name = "worktree" as const;
+    
+      async run(ctx: PipelineContext): Promise<{ result: PhaseResult; ctx: PipelineContext }> {
+        const { config, onEvent } = ctx;
+    
+        emitEvent(onEvent, "session:start", { message: "Creating worktree..." });
+    
+        const wtSpan = tracer.startSpan("agent_core.create_worktree");
+        try {
+          // 1. Create isolated worktree (with retry for transient git failures)
+          const { value: worktree } = await withRetry(
+            () => createWorktree(config.repoPath, config.baseBranch, config.taskDescription),
+            { maxRetries: 2 }
+          );
+          wtSpan.setAttribute("worktree.branch", worktree.branchName);
+          wtSpan.setAttribute("worktree.mode", worktree.mode);
+          wtSpan.end();
+    
+          // 2. Build system prompt with failure context, source files, and PR examples
+          const failureMemory = await loadMemory(config.repoPath);
+          const pastFailures = queryPastFailures(failureMemory, config.taskDescription);
+          const failureContext = buildFailureContext(pastFailures);
+    
+          // Auto-resolve source files from task description if none provided
+          const resolvedSourcePaths =
+            config.sourceFiles ??
+            (async () => {
+              const { resolveSourceFiles } = await import("../source-resolver.js");
+              return resolveSourceFiles(config.taskDescription);
+            })();
+    
+          const finalSourcePaths = await resolvedSourcePaths;
+    
+          const sourceFileEntries =
+            finalSourcePaths.length > 0 ? await loadSourceFiles(finalSourcePaths) : undefined;
+    
+          // Fetch recent successful PRs as examples (non-blocking)
+          const { fetchRecentPrExamples, formatPrExamples } = await import("../budget-calculator.js");
+          const prExamples = await fetchRecentPrExamples(config.repoPath).catch(() => []);
+          const prExamplesSection = formatPrExamples(prExamples);
+    
+          // Load project CLAUDE.md for coding conventions (non-blocking)
+          const projectContext = await loadProjectContext(worktree.path).catch(() => null);
+          const projectSection = projectContext
+            ? `\n\n## Project Conventions (from CLAUDE.md)\n\n${projectContext}`
+            : "";
+    
+          const systemPrompt =
+            (await buildSystemPrompt(config.taskDescription, {
+              sourceFileEntries,
+              prExamplesSection,
+              failureContext,
+            })) + projectSection;
+    
+          emitEvent(onEvent, "session:start", {
+            message: `Starting agent on branch ${worktree.branchName}`,
+          });
+    
+          return {
+            result: { phase: this.name, status: "success", errors: [] },
+            ctx: { ...ctx, worktree, systemPrompt },
+          };
+        } catch (error) {
+          wtSpan.end();
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          return {
+            result: { phase: this.name, status: "failed", errors: [errorMessage] },
+            ctx: { ...ctx, errors: [...ctx.errors, errorMessage] },
+          };
+        }
+      }
+    }
+  </file>
+  </section>
   <section priority="medium" role="src">
   <file path="src/audit-inventory.ts">
     export type Zone =
@@ -1025,8 +1666,7 @@
               },
             },
             async (): Promise<SessionResult> => {
-              // Apply QA tuning defaults from .github/auto-qa-tuning.json.
-              // Explicit config (e.g. CLI --max-budget) wins over tuning values.
+              // Apply QA tuning defaults from .github/auto-qa-tuning.json
               const tuning = loadQaTuning(config.repoPath);
               const tuningOverrides = tuning
                 ? applyTuningDefaults(
@@ -1067,762 +1707,202 @@
                 },
               });
     
-              {
-                // Fail fast if the circuit breaker is open (API is degraded)
-                if (apiCircuitBreaker.getState() === CircuitState.Open) {
-                  const circuitMsg =
-                    "Circuit breaker is OPEN — Anthropic API appears degraded. Skipping session.";
-                  emitEvent(onEvent, "session:error", { message: circuitMsg });
-                  rootSpan.setAttribute("session.status", "failed");
-                  rootSpan.setAttribute("session.circuit_breaker", "open");
-                  rootSpan.end();
-                  return {
-                    sessionId: "",
-                    status: "failed",
-                    branchName: "",
-                    prUrl: null,
-                    costUsd: 0,
-                    tokenUsage: { inputTokens: 0, outputTokens: 0 },
-                    durationMs: 0,
-                    numTurns: 0,
-                    resultText: "",
-                    errors: [circuitMsg],
-                  };
-                }
+              const cleanupErrors: string[] = [];
+              let ctx: PipelineContext = {
+                config: effectiveConfig,
+                onEvent,
+                errors: [],
+              };
     
-                const abortController = new AbortController();
-                let worktree: WorktreeInfo | undefined;
-                let stuckReason: StuckPattern | null = null;
-                const cleanupErrors: string[] = [];
-                let pendingResult: SessionResult | undefined;
+              let pendingResult: SessionResult | undefined;
     
-                // Cached git diff — computed once, reused across evaluation, static analysis,
-                // security review, dep-bump check, and PR body generation.
-                let cachedDiff: string | null = null;
+              try {
+                // Run pipeline phases sequentially
+                for (const phase of phases) {
+                  const { result, ctx: nextCtx } = await phase.run(ctx);
+                  ctx = nextCtx;
     
-                async function getCachedDiff(worktreePath: string): Promise<string> {
-                  if (cachedDiff === null) {
-                    cachedDiff = await getGitDiff(worktreePath);
+                  if (result.status === "failed") {
+                    // Phase failure — attempt partial work push then abort
+                    if (ctx.worktree && effectiveConfig.createPr) {
+                      const errorMsg = result.errors[0] ?? "Phase failed";
+                      const prUrl = await pushPartialWork(ctx, errorMsg);
+                      if (prUrl) {
+                        ctx = { ...ctx, prUrl };
+                      }
+                    }
+                    break;
                   }
-                  return cachedDiff;
                 }
     
-                try {
-                  // 1. Create isolated worktree (with retry for transient git failures)
-                  emitEvent(onEvent, "session:start", { message: "Creating worktree..." });
+                pendingResult = buildFinalResult(ctx, rootSpan);
+              } catch (error) {
+                const errorMessage = error instanceof Error ? error.message : String(error);
+                emitEvent(onEvent, "session:error", { message: errorMessage });
+                rootSpan.recordException(error as Error);
+                rootSpan.setStatus({ code: SpanStatusCode.ERROR, message: errorMessage });
     
-                  const wtSpan = tracer.startSpan("agent_core.create_worktree");
+                // Attempt to push partial work from failed sessions
+                const prUrl = await pushPartialWork(ctx, errorMessage);
+    
+                rootSpan.setAttribute("session.status", "failed");
+                pendingResult = {
+                  sessionId: "",
+                  status: "failed",
+                  branchName: ctx.worktree?.branchName ?? "",
+                  prUrl,
+                  costUsd: 0,
+                  tokenUsage: { inputTokens: 0, outputTokens: 0 },
+                  durationMs: 0,
+                  numTurns: 0,
+                  resultText: "",
+                  errors: [errorMessage],
+                  stuckPattern: ctx.stuckReason?.type,
+                };
+              } finally {
+                // Clean up worktree when PR was created (branch is pushed)
+                // Keep worktree when --no-pr so user can inspect
+                if (ctx.worktree && effectiveConfig.createPr) {
                   try {
-                    const { value: wt } = await withRetry(
-                      () => createWorktree(config.repoPath, config.baseBranch, config.taskDescription),
-                      { maxRetries: 2 }
-                    );
-                    worktree = wt;
-                    wtSpan.setAttribute("worktree.branch", worktree.branchName);
-                    wtSpan.setAttribute("worktree.mode", worktree.mode);
-                  } finally {
-                    wtSpan.end();
-                  }
-    
-                  // 2. Build system prompt with failure context, source files, and PR examples
-                  const failureMemory = await loadMemory(config.repoPath);
-                  const pastFailures = queryPastFailures(failureMemory, config.taskDescription);
-                  const failureContext = buildFailureContext(pastFailures);
-    
-                  // Auto-resolve source files from task description if none provided
-                  const resolvedSourcePaths =
-                    config.sourceFiles ??
-                    (async () => {
-                      const { resolveSourceFiles } = await import("./source-resolver.js");
-                      return resolveSourceFiles(config.taskDescription);
-                    })();
-    
-                  // Wait for resolved source paths if it was an async resolution
-                  const finalSourcePaths = await resolvedSourcePaths;
-    
-                  const sourceFileEntries =
-                    finalSourcePaths.length > 0 ? await loadSourceFiles(finalSourcePaths) : undefined;
-    
-                  // Fetch recent successful PRs as examples (non-blocking)
-                  const { fetchRecentPrExamples, formatPrExamples } =
-                    await import("./budget-calculator.js");
-                  const prExamples = await fetchRecentPrExamples(config.repoPath).catch(() => []);
-                  const prExamplesSection = formatPrExamples(prExamples);
-    
-                  // Load project CLAUDE.md for coding conventions (non-blocking)
-                  const projectContext = await loadProjectContext(worktree.path).catch(() => null);
-                  const projectSection = projectContext
-                    ? `\n\n## Project Conventions (from CLAUDE.md)\n\n${projectContext}`
-                    : "";
-    
-                  const systemPrompt =
-                    (await buildSystemPrompt(config.taskDescription, {
-                      sourceFileEntries,
-                      prExamplesSection,
-                      failureContext,
-                    })) + projectSection;
-    
-                  // 3. Run the agent via SDK query()
-                  emitEvent(onEvent, "session:start", {
-                    message: `Starting agent on branch ${worktree.branchName}`,
-                  });
-    
-                  const canUseTool = createToolPermissionHandler(worktree.path);
-    
-                  const detector = createStuckDetector(effectiveConfig.stuckDetectorConfig);
-                  const conversation = query({
-                    prompt: effectiveConfig.taskDescription,
-                    options: {
-                      abortController,
-                      cwd: worktree.path,
-                      model: effectiveConfig.model,
-                      maxTurns: effectiveConfig.maxTurns,
-                      maxBudgetUsd: effectiveConfig.maxBudgetUsd,
-                      allowedTools: [...effectiveConfig.allowedTools],
-                      permissionMode: "acceptEdits",
-                      settingSources: ["project"],
-                      systemPrompt: {
-                        type: "preset",
-                        preset: "claude_code",
-                        append: systemPrompt,
-                      },
-                      canUseTool: async (toolName, input) => canUseTool(toolName, input),
-                    },
-                  });
-    
-                  // 4. Stream events with stuck detection, context exhaustion tracking,
-                  //    and event mapping
-                  const querySpan = tracer.startSpan("agent_core.sdk_query", {
-                    attributes: { "sdk.model": config.model },
-                  });
-    
-                  let compactionCount = 0;
-    
-                  // Per-turn and tool-call metrics accumulators
-                  let turnIndex = 0;
-                  const rawTurnMetrics: Array<{
-                    turnIndex: number;
-                    startedAt: string;
-                    inputTokens: number;
-                    outputTokens: number;
-                    thinkingTokens: number;
-                    costUsd: number;
-                    modelId: string;
-                  }> = [];
-                  const rawToolCallMetrics: Array<{
-                    toolName: string;
-                    toolUseId: string;
-                    latencyMs: number;
-                    isError: boolean;
-                  }> = [];
-    
-                  // Track pending tool calls by toolUseId → { name, startMs }
-                  const pendingToolCalls = new Map<string, { toolName: string; startMs: number }>();
-    
-                  // Heartbeat: periodic liveness signal + inactivity timeout
-                  const heartbeat = DEFAULT_HEARTBEAT_CONFIG;
-                  const startTime = Date.now();
-                  let lastActivityMs = Date.now();
-                  const heartbeatInterval = setInterval(() => {
-                    const silenceMs = Date.now() - lastActivityMs;
-                    emitEvent(onEvent, "session:heartbeat", {
-                      message: JSON.stringify({
-                        turnCount: turnIndex,
-                        compactionCount,
-                        elapsedMs: Date.now() - startTime,
-                        lastActivityMs: silenceMs,
-                      }),
-                    });
-                    if (silenceMs >= heartbeat.inactivityTimeoutMs) {
-                      stuckReason = {
-                        type: "zero_progress" as const,
-                        count: 0,
-                        threshold: 0,
-                        description: `No SDK activity for ${Math.round(silenceMs / 1000)}s — session appears hung`,
-                        severity: "error" as const,
-                      };
-                      emitEvent(onEvent, "session:stuck", {
-                        message: `Inactivity timeout: no messages for ${Math.round(silenceMs / 1000)}s`,
-                      });
-                      abortController.abort();
-                    }
-                  }, heartbeat.intervalMs);
-    
-                  // Wrap the SDK streaming loop with the circuit breaker so that
-                  // repeated API failures trip the breaker and subsequent sessions
-                  // fail fast instead of hammering a degraded API.
-                  interface StreamingResult {
-                    readonly resultMessage: SDKResultMessage | null;
-                    readonly stuckDetected: StuckPattern | null;
-                  }
-    
-                  let streamResult: StreamingResult = { resultMessage: null, stuckDetected: null };
-                  let circuitBreakerTripped = false;
-    
-                  try {
-                    streamResult = await apiCircuitBreaker.wrap(async (): Promise<StreamingResult> => {
-                      let innerResult: SDKResultMessage | null = null;
-                      let innerStuck: StuckPattern | null = null;
-                      try {
-                        for await (const message of conversation) {
-                          lastActivityMs = Date.now();
-                          emitEvent(onEvent, "session:message", message);
-    
-                          // Increment turn counter for assistant messages
-                          if (message.type === "assistant") {
-                            turnIndex++;
-                          }
-    
-                          // Track assistant messages as Langfuse generation observations
-                          if (message.type === "assistant" && "message" in message) {
-                            const msg = message.message as {
-                              role: string;
-                              content: unknown;
-                              usage?: { input_tokens?: number; output_tokens?: number };
-                            };
-                            const gen = startObservation(
-                              `llm-turn-${turnIndex}`,
-                              { model: config.model, input: msg.content },
-                              { asType: "generation" }
-                            );
-                            gen
-                              .update({
-                                output: msg.content,
-                                usageDetails: {
-                                  input: msg.usage?.input_tokens ?? 0,
-                                  output: msg.usage?.output_tokens ?? 0,
-                                },
-                              })
-                              .end();
-                          }
-    
-                          // Emit typed events for observability (pass current turn index)
-                          for (const mapped of mapSdkMessage(message, turnIndex)) {
-                            emitEvent(onEvent, mapped.type, {
-                              message: sanitizeStreamChunk(JSON.stringify(mapped)),
-                            });
-    
-                            // Accumulate per-turn metrics
-                            if (mapped.type === "session:turn_metrics") {
-                              const tm = mapped as TurnMetricsEvent;
-                              rawTurnMetrics.push({
-                                turnIndex: tm.turnIndex,
-                                startedAt: new Date().toISOString(),
-                                inputTokens: tm.inputTokens,
-                                outputTokens: tm.outputTokens,
-                                thinkingTokens: tm.thinkingTokens,
-                                costUsd: tm.costUsd,
-                                modelId: tm.modelId,
-                              });
-                            }
-    
-                            // Record tool call start time for latency tracking
-                            if (mapped.type === "session:tool_use") {
-                              pendingToolCalls.set(mapped.toolUseId, {
-                                toolName: mapped.toolName,
-                                startMs: Date.now(),
-                              });
-                            }
-    
-                            // Record tool call completion and compute latency
-                            if (mapped.type === "session:tool_result") {
-                              const pending = pendingToolCalls.get(mapped.toolUseId);
-                              if (pending) {
-                                const latencyMs = Date.now() - pending.startMs;
-                                rawToolCallMetrics.push({
-                                  toolName: pending.toolName,
-                                  toolUseId: mapped.toolUseId,
-                                  latencyMs,
-                                  isError: mapped.isError,
-                                });
-                                pendingToolCalls.delete(mapped.toolUseId);
-                                emitEvent(onEvent, "session:tool_latency", {
-                                  message: JSON.stringify({
-                                    toolName: pending.toolName,
-                                    toolUseId: mapped.toolUseId,
-                                    latencyMs,
-                                    isError: mapped.isError,
-                                  }),
-                                });
-                              }
-                            }
-                          }
-    
-                          // Track compaction events for context window exhaustion detection
-                          if (
-                            message.type === "system" &&
-                            "subtype" in message &&
-                            message.subtype === "compact_boundary"
-                          ) {
-                            compactionCount++;
-                            if (compactionCount >= MAX_COMPACTIONS) {
-                              innerStuck = {
-                                type: "context_window_loop",
-                                count: compactionCount,
-                                threshold: MAX_COMPACTIONS,
-                                description: `Context window compacted ${compactionCount} times — session exhausted`,
-                                severity: "error",
-                              };
-                              emitEvent(onEvent, "session:stuck", {
-                                message: `Context window exhaustion: ${compactionCount} compactions reached limit of ${MAX_COMPACTIONS}`,
-                              });
-                              querySpan.setAttribute("sdk.compaction_count", compactionCount);
-                              abortController.abort();
-                              break;
-                            }
-                          }
-    
-                          if (message.type === "result") {
-                            innerResult = message as SDKResultMessage;
-                            continue;
-                          }
-    
-                          const stuckPattern = detector.ingest(message);
-                          if (stuckPattern) {
-                            if (stuckPattern.severity === "error") {
-                              innerStuck = stuckPattern;
-                              emitEvent(onEvent, "session:stuck", {
-                                message: `Stuck detected: ${stuckPattern.description}`,
-                              });
-                              querySpan.setAttribute("sdk.stuck_pattern", stuckPattern.type);
-                              abortController.abort();
-                              break;
-                            }
-                            // Warnings are emitted but don't abort the session
-                            emitEvent(onEvent, "session:stuck", {
-                              message: `Stuck warning: ${stuckPattern.description}`,
-                            });
-                          }
-                        }
-    
-                        querySpan.setAttribute("sdk.turns_completed", innerResult?.num_turns ?? 0);
-                        querySpan.setAttribute("sdk.compaction_count", compactionCount);
-                      } catch (err) {
-                        // Detect context window exhaustion from SDK errors
-                        if (err instanceof ContextWindowExhaustedError) {
-                          innerStuck = {
-                            type: "context_window_loop",
-                            count: compactionCount,
-                            threshold: MAX_COMPACTIONS,
-                            description: err.message,
-                            severity: "error",
-                          };
-                          emitEvent(onEvent, "session:stuck", {
-                            message: `Context window exhaustion: ${err.message}`,
-                          });
-                        } else {
-                          querySpan.recordException(err as Error);
-                          querySpan.setStatus({ code: SpanStatusCode.ERROR });
-                          throw err;
-                        }
-                      }
-                      return { resultMessage: innerResult, stuckDetected: innerStuck };
-                    });
-                  } catch (err) {
-                    // Handle circuit breaker OPEN — graceful exit instead of crash
-                    const errMsg = err instanceof Error ? err.message : String(err);
-                    if (errMsg.includes("Circuit breaker is OPEN")) {
-                      circuitBreakerTripped = true;
-                      emitEvent(onEvent, "session:error", {
-                        message: `Circuit breaker tripped: ${errMsg}`,
-                      });
-                      querySpan.setAttribute("session.circuit_breaker", "tripped");
-                    } else {
-                      // Re-throw non-circuit-breaker errors for the outer handler
-                      throw err;
-                    }
-                  } finally {
-                    clearInterval(heartbeatInterval);
-                    querySpan.end();
-                  }
-    
-                  // Unpack streaming results for downstream consumption
-                  const resultMessage = streamResult.resultMessage;
-                  stuckReason = streamResult.stuckDetected;
-    
-                  // If the circuit breaker tripped mid-session, treat as a failed session
-                  if (circuitBreakerTripped) {
-                    const circuitMsg = "Circuit breaker tripped — too many consecutive API failures";
-                    emitEvent(onEvent, "session:error", { message: circuitMsg });
-                    rootSpan.setAttribute("session.status", "failed");
-                    rootSpan.setAttribute("session.circuit_breaker", "tripped");
-                    rootSpan.end();
-                    return {
-                      sessionId: "",
-                      status: "failed",
-                      branchName: worktree?.branchName ?? "",
-                      prUrl: null,
-                      costUsd: 0,
-                      tokenUsage: { inputTokens: 0, outputTokens: 0 },
-                      durationMs: 0,
-                      numTurns: 0,
-                      resultText: "",
-                      errors: [circuitMsg],
-                    };
-                  }
-    
-                  // 5. Determine success/failure
-                  const isSuccess = resultMessage?.subtype === "success" && !stuckReason;
-                  const errors: string[] = [];
-    
-                  if (stuckReason) {
-                    errors.push(`Stuck: ${stuckReason.description}`);
-                  }
-                  if (!resultMessage) {
-                    errors.push("No result message received from agent");
-                  }
-    
-                  // 6. Commit, push, and create PR if there are changes
-                  let prUrl: string | null = null;
-                  const changed = worktree ? await hasChanges(worktree.path) : false;
-    
-                  let gatewayEvaluation: EvaluationResult | undefined;
-    
-                  if (changed && worktree) {
-                    // Capture narrowed worktree for use in closures (TS loses narrowing in callbacks)
-                    const wt = worktree;
-                    const prefix = isSuccess ? "feat" : "wip";
-                    const commitMsg = `${prefix}: ${sanitizeForCommitMessage(config.taskDescription)}`;
-                    await commitChanges(wt.path, commitMsg);
-    
-                    // Push with retry for transient network failures
-                    await withRetry(() => pushBranch(wt.path, wt.branchName), { maxRetries: 3 });
-    
-                    // 6a–6d. Run post-commit gateway (verification + quality gates)
-                    let verdict;
-                    if (isSuccess) {
-                      const diff = await getCachedDiff(wt.path);
-                      verdict = await runPostCommitGateway(
-                        {
-                          worktreePath: wt.path,
-                          diff,
-                          commitMsg,
-                          taskDescription: config.taskDescription,
-                          config: {
-                            evaluateSuccess: config.evaluateSuccess,
-                            runSecurityReview: true,
-                            runStaticAnalysis: true,
-                          },
-                        },
-                        onEvent
-                      );
-                      errors.push(...verdict.errors);
-                      gatewayEvaluation = verdict.evaluation;
-                    }
-    
-                    if (config.createPr) {
-                      if (verdict?.outcome === "merge-direct") {
-                        // Fast-path: trivial dep bump — direct-merge
-                        const commitTitle = buildPrTitle(config.taskDescription);
-                        prUrl = await mergeDirectly({
-                          branchName: wt.branchName,
-                          baseBranch: config.baseBranch,
-                          repoPath: wt.path,
-                          commitTitle,
-                        });
-                        emitEvent(onEvent, "session:result", {
-                          message: `Trivial dep bump — direct-merged: ${prUrl}`,
-                        });
-                      } else if (!verdict || verdict.outcome === "create-pr") {
-                        // All gates passed — create normal PR
-                        const title = buildPrTitle(config.taskDescription);
-                        const body = resultMessage
-                          ? buildPrBody(
-                              config.taskDescription,
-                              resultMessage.session_id,
-                              resultMessage.total_cost_usd,
-                              resultMessage.num_turns
-                            )
-                          : buildFailurePrBody(config.taskDescription, errors, stuckReason?.type);
-    
-                        const prSpan = tracer.startSpan("agent_core.create_pr");
-                        let pr;
-                        try {
-                          // Retry PR creation for transient GitHub API failures
-                          const { value: prResult } = await withRetry(
-                            () =>
-                              createPullRequest({
-                                title,
-                                body,
-                                baseBranch: config.baseBranch,
-                                branchName: wt.branchName,
-                                repoPath: wt.path,
-                                draft: false,
-                              }),
-                            { maxRetries: 3 }
-                          );
-                          pr = prResult;
-                          prSpan.setAttribute("pr.url", pr.url);
-                          prSpan.setAttribute("pr.number", pr.number);
-                          prSpan.setAttribute("pr.draft", false);
-                        } finally {
-                          prSpan.end();
-                        }
-    
-                        prUrl = pr.url;
-                        emitEvent(onEvent, "session:result", {
-                          message: `PR created: ${pr.url}`,
-                        });
-    
-                        // Run feedback loop if enabled (poll for review comments / CI failures)
-                        if (config.feedbackLoop?.enabled) {
-                          // Use remaining budget instead of fixed 50% ratio
-                          const sessionCost = resultMessage?.total_cost_usd ?? 0;
-                          const remainingBudget = Math.max(
-                            0,
-                            effectiveConfig.maxBudgetUsd - sessionCost
-                          );
-    
-                          const fbSpan = tracer.startSpan("agent_core.feedback_loop");
-                          let feedbackResult;
-                          try {
-                            feedbackResult = await runFeedbackLoop(
-                              {
-                                prNumber: pr.number,
-                                branchName: wt.branchName,
-                                repoPath: wt.path,
-                                model: getFeedbackLoopModel(config.model),
-                                maxRetries: config.feedbackLoop.maxRetries ?? 2,
-                                pollIntervalMs: config.feedbackLoop.pollIntervalMs ?? 30_000,
-                                pollTimeoutMs: config.feedbackLoop.pollTimeoutMs ?? 300_000,
-                                maxBudgetUsd: remainingBudget,
-                                allowedTools: config.allowedTools,
-                              },
-                              onEvent
-                            );
-                            fbSpan.setAttribute("feedback.retries_used", feedbackResult.retriesUsed);
-                            fbSpan.setAttribute("feedback.resolved", feedbackResult.resolved);
-                          } finally {
-                            fbSpan.end();
-                          }
-    
-                          emitEvent(onEvent, "session:result", {
-                            message: `Feedback loop: ${feedbackResult.resolved ? "resolved" : "escalated"} after ${feedbackResult.retriesUsed} retries`,
-                          });
-                        }
-                      } else {
-                        // verdict.outcome === "create-draft-pr" — quality gates failed
-                        const title = `wip: ${config.taskDescription.slice(0, 57)}`;
-                        const body = buildFailurePrBody(
-                          config.taskDescription,
-                          errors,
-                          stuckReason?.type
-                        );
-    
-                        // Retry draft PR creation for transient failures
-                        const { value: pr } = await withRetry(
-                          () =>
-                            createPullRequest({
-                              title,
-                              body,
-                              baseBranch: config.baseBranch,
-                              branchName: wt.branchName,
-                              repoPath: wt.path,
-                              draft: true,
-                            }),
-                          { maxRetries: 3 }
-                        );
-    
-                        prUrl = pr.url;
-                        emitEvent(onEvent, "session:result", {
-                          message: `Draft PR created (failed gates: ${verdict.gateFailures.join(", ")}): ${pr.url}`,
-                        });
-                      }
-                    }
-                  } else {
-                    emitEvent(onEvent, "session:result", {
-                      message: "No changes were made by the agent",
+                    await removeWorktree(effectiveConfig.repoPath, ctx.worktree.path);
+                  } catch (cleanupErr) {
+                    const cleanupMsg =
+                      cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr);
+                    cleanupErrors.push(cleanupMsg);
+                    console.warn(`Worktree cleanup failed: ${cleanupMsg}`);
+                    emitEvent(onEvent, "session:cleanup_warning", {
+                      message: `Worktree cleanup failed: ${cleanupMsg}`,
                     });
                   }
-    
-                  // 7. Build final result
-                  const evalSummary = gatewayEvaluation
-                    ? {
-                        passed: gatewayEvaluation.passed,
-                        confidence: gatewayEvaluation.confidence,
-                        reasoning: gatewayEvaluation.reasoning,
-                      }
-                    : undefined;
-    
-                  const collectedTurnMetrics = buildTurnMetricsList(rawTurnMetrics);
-                  const collectedToolCallMetrics = buildToolCallMetricsList(rawToolCallMetrics);
-    
-                  if (resultMessage) {
-                    const sessionResult = buildSessionResult(
-                      resultMessage,
-                      worktree?.branchName ?? "",
-                      prUrl
-                    );
-    
-                    const isFailed = sessionResult.status === "failed" || !!stuckReason;
-    
-                    const failureCategory = isFailed
-                      ? categorizeFailure(errors, stuckReason?.type)
-                      : undefined;
-    
-                    const finalResult = {
-                      ...sessionResult,
-                      ...(stuckReason
-                        ? { status: "failed" as const, stuckPattern: stuckReason.type }
-                        : {}),
-                      ...(evalSummary ? { evaluation: evalSummary } : {}),
-                      ...(failureCategory ? { failureCategory } : {}),
-                      turnMetrics: collectedTurnMetrics,
-                      toolCallMetrics: collectedToolCallMetrics,
-                    };
-    
-                    // Record failure for future context
-                    if (finalResult.status === "failed") {
-                      await recordFailure(config.repoPath, {
-                        taskDescription: config.taskDescription,
-                        timestamp: new Date().toISOString(),
-                        stuckPattern: stuckReason?.type,
-                        errors,
-                        approach: finalResult.resultText || "Unknown approach",
-                      }).catch(() => {});
-                    }
-    
-                    // Set final span attributes
-                    rootSpan.setAttribute("session.status", finalResult.status);
-                    rootSpan.setAttribute("session.cost_usd", finalResult.costUsd);
-                    rootSpan.setAttribute("session.num_turns", finalResult.numTurns);
-                    rootSpan.setAttribute("session.branch", finalResult.branchName);
-                    if (finalResult.prUrl) rootSpan.setAttribute("session.pr_url", finalResult.prUrl);
-                    if (finalResult.stuckPattern)
-                      rootSpan.setAttribute("session.stuck_pattern", finalResult.stuckPattern);
-                    if (failureCategory)
-                      rootSpan.setAttribute("session.failure_category", failureCategory);
-                    rootSpan.setAttribute("session.turn_count", collectedTurnMetrics.length);
-                    rootSpan.setAttribute("session.tool_call_count", collectedToolCallMetrics.length);
-    
-                    emitEvent(onEvent, "session:result", {
-                      message: `Session completed: ${finalResult.status}`,
-                    });
-    
-                    // Attach session metrics to the Langfuse trace as metadata
-                    updateActiveObservation({
-                      metadata: {
-                        success: String(finalResult.status === "succeeded" ? 1 : 0),
-                        cost_usd: String(finalResult.costUsd),
-                        num_turns: String(finalResult.numTurns),
-                        stuck: String(stuckReason ? 1 : 0),
-                        ...(evalSummary
-                          ? {
-                              evaluation_confidence: String(evalSummary.confidence),
-                              evaluation_reasoning: evalSummary.reasoning,
-                            }
-                          : {}),
-                      },
-                    });
-    
-                    pendingResult = finalResult;
-                  } else {
-                    const failureCategoryNoResult = categorizeFailure(errors, stuckReason?.type);
-    
-                    rootSpan.setAttribute("session.status", "failed");
-                    pendingResult = {
-                      sessionId: "",
-                      status: "failed",
-                      branchName: worktree?.branchName ?? "",
-                      prUrl,
-                      costUsd: 0,
-                      tokenUsage: { inputTokens: 0, outputTokens: 0 },
-                      durationMs: 0,
-                      numTurns: 0,
-                      resultText: "",
-                      errors,
-                      stuckPattern: stuckReason?.type,
-                      evaluation: evalSummary,
-                      ...(failureCategoryNoResult ? { failureCategory: failureCategoryNoResult } : {}),
-                      turnMetrics: collectedTurnMetrics,
-                      toolCallMetrics: collectedToolCallMetrics,
-                    };
-                  }
-                } catch (error) {
-                  const errorMessage = error instanceof Error ? error.message : String(error);
-                  emitEvent(onEvent, "session:error", { message: errorMessage });
-                  rootSpan.recordException(error as Error);
-                  rootSpan.setStatus({ code: SpanStatusCode.ERROR, message: errorMessage });
-    
-                  // Attempt to push partial work from failed sessions
-                  let prUrl: string | null = null;
-                  if (worktree && config.createPr) {
-                    const failedWt = worktree;
-                    try {
-                      const changed = await hasChanges(failedWt.path);
-                      if (changed) {
-                        const commitMsg = `wip: ${sanitizeForCommitMessage(config.taskDescription)}`;
-                        await commitChanges(failedWt.path, commitMsg);
-                        await withRetry(() => pushBranch(failedWt.path, failedWt.branchName), {
-                          maxRetries: 2,
-                        });
-    
-                        const { value: pr } = await withRetry(
-                          () =>
-                            createPullRequest({
-                              title: `wip: ${config.taskDescription.slice(0, 57)}`,
-                              body: buildFailurePrBody(
-                                config.taskDescription,
-                                [errorMessage],
-                                stuckReason?.type
-                              ),
-                              baseBranch: config.baseBranch,
-                              branchName: failedWt.branchName,
-                              repoPath: failedWt.path,
-                              draft: true,
-                            }),
-                          { maxRetries: 2 }
-                        );
-                        prUrl = pr.url;
-                        emitEvent(onEvent, "session:result", {
-                          message: `Draft PR created from failed session: ${pr.url}`,
-                        });
-                      }
-                    } catch {
-                      // Best-effort — don't mask the original error
-                    }
-                  }
-    
-                  rootSpan.setAttribute("session.status", "failed");
-                  pendingResult = {
-                    sessionId: "",
-                    status: "failed",
-                    branchName: worktree?.branchName ?? "",
-                    prUrl,
-                    costUsd: 0,
-                    tokenUsage: { inputTokens: 0, outputTokens: 0 },
-                    durationMs: 0,
-                    numTurns: 0,
-                    resultText: "",
-                    errors: [errorMessage],
-                    stuckPattern: stuckReason?.type,
-                  };
-                } finally {
-                  // Clean up worktree when PR was created (branch is pushed, worktree not needed)
-                  // Keep worktree when --no-pr so user can inspect the agent's work
-                  if (worktree && config.createPr) {
-                    try {
-                      await removeWorktree(config.repoPath, worktree.path);
-                    } catch (cleanupErr) {
-                      const cleanupMsg =
-                        cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr);
-                      cleanupErrors.push(cleanupMsg);
-                      console.warn(`Worktree cleanup failed: ${cleanupMsg}`);
-                      emitEvent(onEvent, "session:cleanup_warning", {
-                        message: `Worktree cleanup failed: ${cleanupMsg}`,
-                      });
-                    }
-                  }
-                  rootSpan.end();
                 }
-    
-                // Attach any cleanup errors to the final result (immutable spread)
-                return cleanupErrors.length > 0 ? { ...pendingResult!, cleanupErrors } : pendingResult!;
+                rootSpan.end();
               }
+    
+              // Attach cleanup errors to the final result (immutable spread)
+              return cleanupErrors.length > 0 ? { ...pendingResult!, cleanupErrors } : pendingResult!;
             }
           );
         }
       );
+    }
+    function buildFinalResult(
+      ctx: PipelineContext,
+      rootSpan: ReturnType<ReturnType<typeof trace.getTracer>["startSpan"]>
+    ): SessionResult {
+      const { resultMessage, stuckReason, gatewayEvaluation, turnMetrics, toolCallMetrics } = ctx;
+      const errors = [...ctx.errors];
+    
+      if (stuckReason) {
+        // Deduplicate — stuck error may already be in ctx.errors
+        const stuckMsg = `Stuck: ${stuckReason.description}`;
+        if (!errors.includes(stuckMsg)) {
+          errors.push(stuckMsg);
+        }
+      }
+      if (!resultMessage) {
+        const noResultMsg = "No result message received from agent";
+        if (!errors.includes(noResultMsg)) {
+          errors.push(noResultMsg);
+        }
+      }
+    
+      const evalSummary = gatewayEvaluation
+        ? {
+            passed: gatewayEvaluation.passed,
+            confidence: gatewayEvaluation.confidence,
+            reasoning: gatewayEvaluation.reasoning,
+          }
+        : undefined;
+    
+      const collectedTurnMetrics = turnMetrics ?? [];
+      const collectedToolCallMetrics = toolCallMetrics ?? [];
+    
+      if (resultMessage) {
+        const sessionResult = buildSessionResult(
+          resultMessage,
+          ctx.worktree?.branchName ?? "",
+          ctx.prUrl ?? null
+        );
+    
+        const isFailed = sessionResult.status === "failed" || !!stuckReason;
+        const failureCategory = isFailed ? categorizeFailure(errors, stuckReason?.type) : undefined;
+    
+        const finalResult: SessionResult = {
+          ...sessionResult,
+          ...(stuckReason ? { status: "failed" as const, stuckPattern: stuckReason.type } : {}),
+          ...(evalSummary ? { evaluation: evalSummary } : {}),
+          ...(failureCategory ? { failureCategory } : {}),
+          turnMetrics: collectedTurnMetrics,
+          toolCallMetrics: collectedToolCallMetrics,
+        };
+    
+        // Record failure for future context
+        if (finalResult.status === "failed") {
+          recordFailure(ctx.config.repoPath, {
+            taskDescription: ctx.config.taskDescription,
+            timestamp: new Date().toISOString(),
+            stuckPattern: stuckReason?.type,
+            errors,
+            approach: finalResult.resultText || "Unknown approach",
+          }).catch(() => {});
+        }
+    
+        // Set final span attributes
+        rootSpan.setAttribute("session.status", finalResult.status);
+        rootSpan.setAttribute("session.cost_usd", finalResult.costUsd);
+        rootSpan.setAttribute("session.num_turns", finalResult.numTurns);
+        rootSpan.setAttribute("session.branch", finalResult.branchName);
+        if (finalResult.prUrl) rootSpan.setAttribute("session.pr_url", finalResult.prUrl);
+        if (finalResult.stuckPattern)
+          rootSpan.setAttribute("session.stuck_pattern", finalResult.stuckPattern);
+        if (failureCategory) rootSpan.setAttribute("session.failure_category", failureCategory);
+        rootSpan.setAttribute("session.turn_count", collectedTurnMetrics.length);
+        rootSpan.setAttribute("session.tool_call_count", collectedToolCallMetrics.length);
+    
+        emitEvent(ctx.onEvent, "session:result", {
+          message: `Session completed: ${finalResult.status}`,
+        });
+    
+        // Attach session metrics to the Langfuse trace
+        updateActiveObservation({
+          metadata: {
+            success: String(finalResult.status === "succeeded" ? 1 : 0),
+            cost_usd: String(finalResult.costUsd),
+            num_turns: String(finalResult.numTurns),
+            stuck: String(stuckReason ? 1 : 0),
+            ...(evalSummary
+              ? {
+                  evaluation_confidence: String(evalSummary.confidence),
+                  evaluation_reasoning: evalSummary.reasoning,
+                }
+              : {}),
+          },
+        });
+    
+        return finalResult;
+      }
+    
+      // No result message — build a failure result
+      const failureCategoryNoResult = categorizeFailure(errors, stuckReason?.type);
+      rootSpan.setAttribute("session.status", "failed");
+    
+      return {
+        sessionId: "",
+        status: "failed",
+        branchName: ctx.worktree?.branchName ?? "",
+        prUrl: ctx.prUrl ?? null,
+        costUsd: 0,
+        tokenUsage: { inputTokens: 0, outputTokens: 0 },
+        durationMs: 0,
+        numTurns: 0,
+        resultText: "",
+        errors,
+        stuckPattern: stuckReason?.type,
+        evaluation: evalSummary,
+        ...(failureCategoryNoResult ? { failureCategory: failureCategoryNoResult } : {}),
+        turnMetrics: collectedTurnMetrics,
+        toolCallMetrics: collectedToolCallMetrics,
+      };
     }
   </file>
   <file path="src/source-resolver.ts">

--- a/packages/agent-core/llms.txt
+++ b/packages/agent-core/llms.txt
@@ -68,6 +68,67 @@
     </item>
   </file>
   </section>
+  <section priority="medium" role="phases">
+  <file path="src/phases/feedback-phase.ts">
+    <item priority="high">
+      class FeedbackPhase {
+        name: unknown;
+        async run(): Promise<unknown>;
+      }
+    </item>
+  </file>
+  <file path="src/phases/pipeline-types.ts">
+    <item priority="low">
+      type PhaseStatus = "success" | "failed" | "skipped";
+    </item>
+    <item priority="low">
+      interface PhaseResult {
+        phase: string;
+        status: PhaseStatus;
+        errors: readonly string[];
+      }
+    </item>
+  </file>
+  <file path="src/phases/publish-phase.ts">
+    <item priority="high">
+      class PublishPhase {
+        name: unknown;
+        async run(): Promise<unknown>;
+        async createOrMergePr(): Promise<unknown>;
+      }
+    </item>
+  </file>
+  <file path="src/phases/query-phase.ts">
+    <item priority="high">
+      interface StreamingResult {
+        resultMessage: SDKResultMessage | null;
+        stuckDetected: StuckPattern | null;
+      }
+    </item>
+    <item priority="high">
+      class QueryPhase {
+        name: unknown;
+        async run(): Promise<unknown>;
+      }
+    </item>
+  </file>
+  <file path="src/phases/verification-phase.ts">
+    <item priority="high">
+      class VerificationPhase {
+        name: unknown;
+        async run(): Promise<unknown>;
+      }
+    </item>
+  </file>
+  <file path="src/phases/worktree-phase.ts">
+    <item priority="high">
+      class WorktreePhase {
+        name: unknown;
+        async run(): Promise<unknown>;
+      }
+    </item>
+  </file>
+  </section>
   <section priority="medium" role="src">
   <file path="src/audit-inventory.ts">
     <item priority="low">
@@ -520,6 +581,12 @@
         config: SessionConfig,
         onEvent?: SessionEventCallback
       ): Promise<SessionResult> { /* ... */ }
+    </item>
+    <item priority="medium">
+      function buildFinalResult(
+        ctx: PipelineContext,
+        rootSpan: ReturnType<ReturnType<typeof trace.getTracer>["startSpan"]>
+      ): SessionResult { /* ... */ }
     </item>
   </file>
   <file path="src/source-resolver.ts">

--- a/services/reservations/llms-full.txt
+++ b/services/reservations/llms-full.txt
@@ -1926,6 +1926,66 @@
       );
     };
   </file>
+  <file path="src/routes/public-guest-recognition.ts">
+    export const publicGuestRecognitionRoutes: FastifyPluginAsync = async (fastify) => {
+      fastify.get<{
+        Params: { slug: string };
+        Querystring: { email?: string };
+        Reply: ApiResponse<GuestRecognition>;
+      }>(
+        "/:slug/guests/recognize",
+        {
+          config: {
+            rateLimit: { max: 10, timeWindow: "1 minute" },
+          },
+          schema: {
+            summary: "Recognize a guest by email (public)",
+            description:
+              "Read-only lookup that returns limited guest info for the booking widget. No auth required. Rate-limited to 10 req/min per IP.",
+            tags: ["Public"],
+            params: {
+              type: "object",
+              properties: {
+                slug: { type: "string" },
+              },
+              required: ["slug"],
+            },
+            querystring: {
+              type: "object",
+              properties: {
+                email: { type: "string", format: "email" },
+              },
+              required: ["email"],
+            },
+          },
+        },
+        async (request, reply) => {
+          const { slug } = request.params;
+          const { email } = request.query;
+    
+          if (!email) {
+            return reply.status(400).send({
+              success: false,
+              error: "email query parameter is required",
+            } as never);
+          }
+    
+          const venue = await venueService.getBySlug(slug);
+    
+          if (!venue) {
+            return reply.status(404).send({
+              success: false,
+              error: "Venue not found",
+            } as never);
+          }
+    
+          const recognition = await recognizeGuest(venue.id, email);
+    
+          return reply.send({ data: recognition });
+        }
+      );
+    };
+  </file>
   <file path="src/routes/public-holds.ts">
     export const publicHoldRoutes: FastifyPluginAsync = async (fastify) => {
       fastify.post<{
@@ -3971,6 +4031,19 @@
       tables?: PrismaTable[];
     };
   </file>
+  <file path="src/services/guest-recognition.ts">
+    export interface GuestRecognition {
+      recognized: boolean;
+      firstName: string | null;
+      phone: string | null;
+      visitCount: number;
+      hasPreferences: boolean;
+      lastVisit: string | null;
+    }
+    function extractFirstName(fullName: string): string {
+      return fullName.split(" ")[0];
+    }
+  </file>
   <file path="src/services/guest.ts">
     function isPrismaNotFound(err: unknown): boolean {
       return (
@@ -4189,6 +4262,9 @@
       });
       await fastify.register(publicHoldRoutes, { prefix: "/public/v1/venues" });
       await fastify.register(publicReservationRoutes, {
+        prefix: "/public/v1/venues",
+      });
+      await fastify.register(publicGuestRecognitionRoutes, {
         prefix: "/public/v1/venues",
       });
       await fastify.register(confirmAttendanceRoutes);

--- a/services/reservations/llms.txt
+++ b/services/reservations/llms.txt
@@ -105,6 +105,11 @@
       export const publicAvailabilityRoutes: FastifyPluginAsync;
     </item>
   </file>
+  <file path="src/routes/public-guest-recognition.ts">
+    <item priority="high">
+      export const publicGuestRecognitionRoutes: FastifyPluginAsync;
+    </item>
+  </file>
   <file path="src/routes/public-holds.ts">
     <item priority="high">
       export const publicHoldRoutes: FastifyPluginAsync;
@@ -227,6 +232,20 @@
         venueId: string;
         name: string;
         isAc...;
+    </item>
+  </file>
+  <file path="src/services/guest-recognition.ts">
+    <item priority="low">
+      interface GuestRecognition {
+        recognized: boolean;
+        firstName: string | null;
+        phone: string | null;
+        visitCount: number;
+        hasPreferences: boolean;
+      }
+    </item>
+    <item priority="medium">
+      function extractFirstName(fullName: string): string { /* ... */ }
     </item>
   </file>
   <file path="src/services/guest.ts">


### PR DESCRIPTION
## What

Below 768px, replaces the time-grid with a reservation card list grouped by 30-min time slots. Desktop grid unchanged.

## Changes

- **`TimelineMobileView.tsx`** — new component: reservations sorted chronologically into 30-min slots, status filter chips (All / Seated / Upcoming / Cancelled), tappable cards (opens existing Drawer), Rialto `Card`/`Stack`/`Text`/`Tag` only
- **`TimelineMobileView.module.css`** — rialto design tokens throughout; 44px min tap targets; selected/hover/active states; empty state
- **`timeline/index.ts`** — export `TimelineMobileView`, `TimelineMobileViewProps`, `StatusFilter`
- **`TimelinePage.tsx`** — import + wire: `isMobile` hook (matchMedia 768px) renders mobile list OR desktop grid; existing detail Drawer opens on card tap; walk-in button already in header (accessible on mobile via existing CSS)

## Acceptance criteria

- [x] Below 768px → card list grouped by time slot
- [x] Cards show: guest name, party size, time, table, status badge
- [x] Card tap → opens existing detail Drawer
- [x] Walk-in button accessible on mobile (header button, visible at all widths)
- [x] Date navigation works on mobile (compact via existing CSS)
- [x] Status filter chips on mobile
- [x] Touch-friendly: min 44px tap targets
- [x] Grid unchanged for desktop (>768px)
- [x] Rialto components only (raw `<button>` in card follows same pattern as `ReservationBlock`)

Closes #1707

https://claude.ai/code/session_01PrHTnGtwBFGJFYq9ho7DeM

---
_Generated by [Claude Code](https://claude.ai/code/session_01PrHTnGtwBFGJFYq9ho7DeM)_