### PR TITLE
fix(ci): backup-verify use migrate deploy + add missing staffNotes migration

### DIFF
--- a/.github/workflows/backup-verify.yml
+++ b/.github/workflows/backup-verify.yml
@@ -55,13 +55,16 @@ jobs:
             if [ -f "services/$SERVICE/prisma.config.ts" ]; then
               (
                 cd "services/$SERVICE"
+                # Use migrate deploy (not db push) so each service's migrations are additive.
+                # db push syncs the entire schema and drops tables from other services,
+                # causing the validation step to fail with "Expected at least 3 tables".
                 DATABASE_URL="postgresql://verify:verify_test_only@localhost:5432/verify_restore" \
-                  pnpm exec prisma db push --skip-generate --accept-data-loss 2>&1
+                  pnpm exec prisma migrate deploy 2>&1
               ) || {
-                echo "::error::Schema push failed for $SERVICE"
+                echo "::error::Migration deploy failed for $SERVICE"
                 exit 1
               }
-              echo "✓ $SERVICE schema applied"
+              echo "✓ $SERVICE migrations applied"
             fi
           done
 
@@ -111,7 +114,7 @@ jobs:
             echo "### Next Steps"
             echo "1. Check workflow logs for the specific failure"
             echo "2. Verify Prisma schema files are valid"
-            echo "3. Run \`prisma db push\` locally to reproduce"
+            echo "3. Run \`prisma migrate deploy\` locally to reproduce"
             echo
             echo "---"
             echo "*Auto-created by backup-verify workflow*"

--- a/services/reservations/prisma/migrations/20260524053100_add_staff_notes_to_guest/migration.sql
+++ b/services/reservations/prisma/migrations/20260524053100_add_staff_notes_to_guest/migration.sql
@@ -1,0 +1,2 @@
+-- Add staff_notes column to guests table
+ALTER TABLE "guests" ADD COLUMN "staff_notes" JSONB;


### PR DESCRIPTION
## Root Cause

Two bugs caused the first backup-verify run (2026-05-24) to fail.

### Bug 1: `prisma db push` drops tables from other services

The workflow ran `prisma db push` for each service (users → reservations → agent) against the **same** `verify_restore` database. `db push` makes the DB match the schema — it drops tables not in the current schema. After all three pushes, only the `sessions` table (from agent) survived. The validation step then found `TABLE_COUNT < 3` and failed.

**Fix:** Switch to `prisma migrate deploy`, which is additive — it only applies unplayed migrations and never drops tables from other services.

### Bug 2: Missing `staff_notes` migration (#1747 schema drift)

`feat(guests): add staff notes` (#1747) added `staffNotes Json?` to the Guest Prisma schema but never generated a migration. Production deploys via `prisma migrate deploy`, so the `staff_notes` column was never added to the production DB. Any code path that reads or writes `staffNotes` would fail at runtime.

**Fix:** Add `20260524053100_add_staff_notes_to_guest` migration with:
```sql
ALTER TABLE "guests" ADD COLUMN "staff_notes" JSONB;
```

## Changes

- `.github/workflows/backup-verify.yml` — `prisma db push --skip-generate --accept-data-loss` → `prisma migrate deploy`
- `services/reservations/prisma/migrations/20260524053100_add_staff_notes_to_guest/migration.sql` — missing migration for staffNotes

Closes #1752

https://claude.ai/code/session_014EKKTzoLixZLQQDfvBmXmE

---
_Generated by [Claude Code](https://claude.ai/code/session_014EKKTzoLixZLQQDfvBmXmE)_