### PR TITLE
refactor(agent-core): consolidate rate-limit patterns into rate-limit-detector

### DIFF
--- a/packages/agent-core/llms-full.txt
+++ b/packages/agent-core/llms-full.txt
@@ -1,15 +1,71 @@
 <codebase path="packages/agent-core">
   <section priority="medium" role="adapters">
   <file path="src/adapters/claude-adapter.ts">
-    function detectRateLimitInError(message: string): boolean {
-      return RATE_LIMIT_PATTERNS.some((pattern) => pattern.test(message));
-    }
     function deriveHasChanges(result: SessionResult): boolean {
       if (result.prUrl !== null) return true;
       // If the session succeeded and produced a branch, there were likely changes
       // even if the PR wasn't created (createPr: false path).
       if (result.status === "succeeded" && result.branchName.length > 0) return true;
       return false;
+    }
+    export class ClaudeAdapter implements AgentAdapter {
+      readonly name = "claude";
+    
+      /**
+       * The Claude SDK adapter is available when the ANTHROPIC_API_KEY env var is set.
+       */
+      async isAvailable(): Promise<boolean> {
+        return (
+          typeof process.env["ANTHROPIC_API_KEY"] === "string" &&
+          process.env["ANTHROPIC_API_KEY"].length > 0
+        );
+      }
+    
+      /**
+       * Map AdapterConfig to SessionConfig, invoke runSession(), and normalise the
+       * result back to AdapterResult.
+       */
+      async run(config: AdapterConfig): Promise<AdapterResult> {
+        const startTime = Date.now();
+    
+        try {
+          const sessionResult = await runSession({
+            taskDescription: config.taskDescription,
+            repoPath: config.repoPath,
+            baseBranch: config.baseBranch,
+            model: config.model ?? DEFAULT_SESSION_CONFIG.model,
+            maxTurns: config.maxTurns ?? DEFAULT_SESSION_CONFIG.maxTurns,
+            maxBudgetUsd: DEFAULT_SESSION_CONFIG.maxBudgetUsd,
+            allowedTools: [...DEFAULT_SESSION_CONFIG.allowedTools],
+            createPr: false, // Worktree lifecycle is managed by the caller / router
+          });
+    
+          const durationMs = Date.now() - startTime;
+          const rateLimited = sessionResult.failureCategory === "rate_limited";
+          const success = sessionResult.status === "succeeded";
+          const hasChanges = deriveHasChanges(sessionResult);
+    
+          return {
+            success,
+            hasChanges,
+            rateLimited,
+            durationMs,
+            ...(success ? {} : { error: sessionResult.errors.join("; ") || undefined }),
+          };
+        } catch (err: unknown) {
+          const durationMs = Date.now() - startTime;
+          const message = err instanceof Error ? err.message : String(err);
+          const rateLimited = scanForRateLimitPatterns(message);
+    
+          return {
+            success: false,
+            hasChanges: false,
+            rateLimited,
+            durationMs,
+            error: message,
+          };
+        }
+      }
     }
   </file>
   <file path="src/adapters/cli-adapter-base.ts">
@@ -116,9 +172,10 @@
     
       /**
        * Scan combined CLI output for rate-limit indicators.
+       * Delegates to the shared scanForRateLimitPatterns utility in rate-limit-detector.ts.
        */
       protected detectRateLimiting(output: string): boolean {
-        return RATE_LIMIT_PATTERNS.some((pattern) => pattern.test(output));
+        return scanForRateLimitPatterns(output);
       }
     
       /**

--- a/packages/agent-core/llms.txt
+++ b/packages/agent-core/llms.txt
@@ -2,10 +2,14 @@
   <section priority="medium" role="adapters">
   <file path="src/adapters/claude-adapter.ts">
     <item priority="medium">
-      function detectRateLimitInError(message: string): boolean { /* ... */ }
-    </item>
-    <item priority="medium">
       function deriveHasChanges(result: SessionResult): boolean { /* ... */ }
+    </item>
+    <item priority="high">
+      class ClaudeAdapter {
+        name: unknown;
+        async isAvailable(): Promise<unknown>;
+        async run(): Promise<unknown>;
+      }
     </item>
   </file>
   <file path="src/adapters/cli-adapter-base.ts">

--- a/packages/agent-core/src/adapters/claude-adapter.ts
+++ b/packages/agent-core/src/adapters/claude-adapter.ts
@@ -9,25 +9,9 @@
 
 import type { AgentAdapter, AdapterConfig, AdapterResult } from "../cli-adapter.js";
 import { runSession } from "../session-runner.js";
+import { scanForRateLimitPatterns } from "../rate-limit-detector.js";
 import { DEFAULT_SESSION_CONFIG } from "../types.js";
 import type { SessionResult } from "../types.js";
-
-/**
- * Case-insensitive patterns that indicate rate limiting in error messages.
- */
-const RATE_LIMIT_PATTERNS: readonly RegExp[] = [
-  /rate.?limit/i,
-  /\b429\b/,
-  /throttled/i,
-  /too.?many.?requests/i,
-];
-
-/**
- * Scan an error string for rate-limit indicators.
- */
-function detectRateLimitInError(message: string): boolean {
-  return RATE_LIMIT_PATTERNS.some((pattern) => pattern.test(message));
-}
 
 /**
  * Determine whether a SessionResult indicates the agent made git-visible changes.
@@ -92,7 +76,7 @@ export class ClaudeAdapter implements AgentAdapter {
     } catch (err: unknown) {
       const durationMs = Date.now() - startTime;
       const message = err instanceof Error ? err.message : String(err);
-      const rateLimited = detectRateLimitInError(message);
+      const rateLimited = scanForRateLimitPatterns(message);
 
       return {
         success: false,

--- a/packages/agent-core/src/adapters/cli-adapter-base.ts
+++ b/packages/agent-core/src/adapters/cli-adapter-base.ts
@@ -14,6 +14,7 @@
 import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
 import type { AgentAdapter, AdapterConfig, AdapterResult } from "../cli-adapter.js";
+import { scanForRateLimitPatterns } from "../rate-limit-detector.js";
 
 const execFileAsync = promisify(execFileCb);
 
@@ -22,17 +23,6 @@ const DEFAULT_TIMEOUT_MS = 600_000;
 
 /** Maximum task description length passed to CLI (prevent arg overflow) */
 const MAX_TASK_LENGTH = 8_000;
-
-/**
- * Case-insensitive patterns that indicate rate limiting in CLI output.
- */
-const RATE_LIMIT_PATTERNS: readonly RegExp[] = [
-  /rate.?limit/i,
-  /quota.?exceeded/i,
-  /\b429\b/,
-  /throttled/i,
-  /too.?many.?requests/i,
-];
 
 export abstract class CliAdapterBase implements AgentAdapter {
   /** Unique adapter name matching AgentAdapter.name. */
@@ -137,9 +127,10 @@ export abstract class CliAdapterBase implements AgentAdapter {
 
   /**
    * Scan combined CLI output for rate-limit indicators.
+   * Delegates to the shared scanForRateLimitPatterns utility in rate-limit-detector.ts.
    */
   protected detectRateLimiting(output: string): boolean {
-    return RATE_LIMIT_PATTERNS.some((pattern) => pattern.test(output));
+    return scanForRateLimitPatterns(output);
   }
 
   /**


### PR DESCRIPTION
## Problem

Three independent copies of `RATE_LIMIT_PATTERNS` existed across the codebase with slightly different coverage:

| File | Patterns | Missing |
|---|---|---|
| `adapters/cli-adapter-base.ts` | 5 | `usage.?limit`, `try.?again.?later` |
| `adapters/claude-adapter.ts` | 4 | `quota.?exceeded`, `usage.?limit`, `try.?again.?later` |
| `rate-limit-detector.ts` | 7 (superset) | — |

`rate-limit-detector.ts` already exported `scanForRateLimitPatterns()` but neither adapter used it.

## Fix

- **`cli-adapter-base.ts`**: Remove local `RATE_LIMIT_PATTERNS`; `detectRateLimiting()` now delegates to `scanForRateLimitPatterns` from `rate-limit-detector.ts`
- **`claude-adapter.ts`**: Remove local `RATE_LIMIT_PATTERNS` + `detectRateLimitInError()` function; call `scanForRateLimitPatterns` directly

Single source of truth. Both adapters now detect all 7 rate-limit patterns instead of 4–5.

## Verification

```
pnpm --dir packages/agent-core typecheck  # clean
pnpm --dir packages/agent-core test       # 991/991 pass
```

Part of #1641 (architectural deepening — eliminate shallow duplication)

https://claude.ai/code/session_01D9VMS3kCpsyRgWaVdyjEYY

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9VMS3kCpsyRgWaVdyjEYY)_