### PR TITLE
feat(hospitality): GuestCard component for unified CRM display (#1711)

### DIFF
--- a/apps/hospitality/src/components/crm/GuestCard.module.css
+++ b/apps/hospitality/src/components/crm/GuestCard.module.css
@@ -1,0 +1,25 @@
+.guestCard {
+  padding: var(--rialto-space-md);
+}
+
+.contactLink {
+  text-decoration: none;
+  color: inherit;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--rialto-space-xs);
+}
+
+.contactLink:hover {
+  text-decoration: underline;
+  color: var(--rialto-accent);
+}
+
+.noteItem {
+  padding: var(--rialto-space-xs) 0;
+  border-block-end: 1px solid var(--rialto-border-subtle);
+}
+
+.noteItem:last-child {
+  border-block-end: none;
+}

--- a/apps/hospitality/src/components/crm/GuestCard.test.tsx
+++ b/apps/hospitality/src/components/crm/GuestCard.test.tsx
@@ -1,0 +1,453 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { GuestCard } from "./GuestCard.js";
+import type { Guest, Reservation } from "@mbe/types";
+
+// Mock scrollIntoView for JSDOM
+window.HTMLElement.prototype.scrollIntoView = vi.fn();
+
+/* ── Hook mocks ─────────────────────────────────────── */
+
+const mockUseGuest = vi.fn();
+const mockUseReservations = vi.fn();
+const mockAddStaffNoteMutateAsync = vi.fn();
+const mockUseAddStaffNote = vi.fn();
+
+vi.mock("../../hooks/useGuests.js", () => ({
+  useGuest: (id: string) => mockUseGuest(id),
+  useAddStaffNote: () => mockUseAddStaffNote(),
+}));
+
+vi.mock("../../hooks/useReservations.js", () => ({
+  useReservations: (params: unknown) => mockUseReservations(params),
+}));
+
+/* ── Fixtures ───────────────────────────────────────── */
+
+function makeGuest(overrides: Partial<Guest> = {}): Guest {
+  return {
+    id: "guest-1",
+    venueId: "venue-1",
+    name: "Alice Smith",
+    email: "alice@example.com",
+    phone: "+1 555 000 0001",
+    notes: null,
+    visitCount: 5,
+    lifetimeSpend: "250.00",
+    lastVisit: "2026-04-01T00:00:00.000Z",
+    tags: ["vip"],
+    dietaryRestrictions: null,
+    staffNotes: [],
+    createdAt: "2025-01-01T00:00:00.000Z",
+    updatedAt: "2026-04-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeReservation(overrides: Partial<Reservation> = {}): Reservation {
+  return {
+    id: "res-1",
+    date: "2026-03-15",
+    startTime: "2026-03-15T18:00:00.000Z",
+    endTime: "2026-03-15T20:00:00.000Z",
+    partySize: 2,
+    status: "COMPLETED",
+    notes: null,
+    cancellationReason: null,
+    cancellationNote: null,
+    guestName: "Alice Smith",
+    guestEmail: "alice@example.com",
+    guestPhone: null,
+    guestId: "guest-1",
+    userId: null,
+    tableId: "table-1",
+    venueId: "venue-1",
+    occasion: "birthday",
+    seatingPreference: null,
+    createdAt: "2026-03-01T00:00:00.000Z",
+    updatedAt: "2026-03-15T20:00:00.000Z",
+    ...overrides,
+  };
+}
+
+/* ── Setup default mocks ─────────────────────────────── */
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseGuest.mockReturnValue({
+    data: makeGuest(),
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  });
+  mockUseReservations.mockReturnValue({
+    data: [],
+    isLoading: false,
+    error: null,
+  });
+  mockUseAddStaffNote.mockReturnValue({
+    mutateAsync: mockAddStaffNoteMutateAsync,
+    isPending: false,
+  });
+  mockAddStaffNoteMutateAsync.mockResolvedValue(makeGuest());
+});
+
+/* ── Tests ───────────────────────────────────────────── */
+
+describe("GuestCard", () => {
+  describe("loading state", () => {
+    it("renders skeleton while loading", () => {
+      mockUseGuest.mockReturnValue({ data: undefined, isLoading: true, error: null, refetch: vi.fn() });
+      render(<GuestCard guestId="guest-1" />);
+      expect(screen.getByTestId("guest-card-loading")).toBeDefined();
+    });
+  });
+
+  describe("error state", () => {
+    it("renders error message when fetch fails", () => {
+      mockUseGuest.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: new Error("Not found"),
+        refetch: vi.fn(),
+      });
+      render(<GuestCard guestId="guest-1" />);
+      expect(screen.getByTestId("guest-card-error")).toBeDefined();
+    });
+
+    it("renders retry button in error state", () => {
+      const refetch = vi.fn();
+      mockUseGuest.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: new Error("Network error"),
+        refetch,
+      });
+      render(<GuestCard guestId="guest-1" />);
+      const btn = screen.getByRole("button", { name: /retry/i });
+      fireEvent.click(btn);
+      expect(refetch).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("empty / no guest", () => {
+    it("renders nothing when guestId is null", () => {
+      const { container } = render(<GuestCard guestId={null} />);
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe("header", () => {
+    it("renders guest name", () => {
+      render(<GuestCard guestId="guest-1" />);
+      expect(screen.getByText("Alice Smith")).toBeDefined();
+    });
+
+    it("renders visit count", () => {
+      render(<GuestCard guestId="guest-1" />);
+      expect(screen.getByText(/5\s*visits?/i)).toBeDefined();
+    });
+
+    it("shows VIP badge when visitCount >= 10 and has vip tag", () => {
+      mockUseGuest.mockReturnValue({
+        data: makeGuest({ visitCount: 12, tags: ["vip"] }),
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      render(<GuestCard guestId="guest-1" />);
+      expect(screen.getByText("VIP")).toBeDefined();
+    });
+
+    it("shows Repeat badge when visitCount >= 2 and not VIP", () => {
+      mockUseGuest.mockReturnValue({
+        data: makeGuest({ visitCount: 3, tags: [] }),
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      render(<GuestCard guestId="guest-1" />);
+      expect(screen.getByText("Repeat")).toBeDefined();
+    });
+
+    it("shows New badge when visitCount is 0 or 1", () => {
+      mockUseGuest.mockReturnValue({
+        data: makeGuest({ visitCount: 1, tags: [] }),
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      render(<GuestCard guestId="guest-1" />);
+      expect(screen.getByText("New")).toBeDefined();
+    });
+  });
+
+  describe("allergy warnings", () => {
+    it("shows allergy banner when dietary restrictions include known allergens", () => {
+      mockUseGuest.mockReturnValue({
+        data: makeGuest({ dietaryRestrictions: ["nut", "shellfish"] }),
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      render(<GuestCard guestId="guest-1" />);
+      expect(screen.getByTestId("allergy-warning-banner")).toBeDefined();
+    });
+
+    it("does not show allergy banner when no allergens", () => {
+      mockUseGuest.mockReturnValue({
+        data: makeGuest({ dietaryRestrictions: ["vegan"] }),
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      render(<GuestCard guestId="guest-1" />);
+      expect(screen.queryByTestId("allergy-warning-banner")).toBeNull();
+    });
+
+    it("does not show allergy banner when dietaryRestrictions is null", () => {
+      render(<GuestCard guestId="guest-1" />);
+      expect(screen.queryByTestId("allergy-warning-banner")).toBeNull();
+    });
+
+    it("shows all allergen names in banner", () => {
+      mockUseGuest.mockReturnValue({
+        data: makeGuest({ dietaryRestrictions: ["nut", "dairy"] }),
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      render(<GuestCard guestId="guest-1" />);
+      const banner = screen.getByTestId("allergy-warning-banner");
+      expect(banner.textContent).toContain("nut");
+      expect(banner.textContent).toContain("dairy");
+    });
+  });
+
+  describe("dietary restrictions", () => {
+    it("renders dietary restrictions as badges", () => {
+      mockUseGuest.mockReturnValue({
+        data: makeGuest({ dietaryRestrictions: ["vegan", "gluten-free"] }),
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      render(<GuestCard guestId="guest-1" />);
+      expect(screen.getByText("vegan")).toBeDefined();
+      expect(screen.getByText("gluten-free")).toBeDefined();
+    });
+
+    it("does not render dietary section when null", () => {
+      render(<GuestCard guestId="guest-1" />);
+      expect(screen.queryByTestId("dietary-restrictions")).toBeNull();
+    });
+  });
+
+  describe("contact", () => {
+    it("renders email", () => {
+      render(<GuestCard guestId="guest-1" />);
+      expect(screen.getByText("alice@example.com")).toBeDefined();
+    });
+
+    it("renders phone", () => {
+      render(<GuestCard guestId="guest-1" />);
+      expect(screen.getByText("+1 555 000 0001")).toBeDefined();
+    });
+
+    it("renders email as mailto link", () => {
+      render(<GuestCard guestId="guest-1" />);
+      const link = screen.getByRole("link", { name: /alice@example.com/i });
+      expect(link.getAttribute("href")).toBe("mailto:alice@example.com");
+    });
+
+    it("renders phone as tel link", () => {
+      render(<GuestCard guestId="guest-1" />);
+      const link = screen.getByRole("link", { name: /\+1 555 000 0001/i });
+      expect(link.getAttribute("href")).toContain("tel:");
+    });
+  });
+
+  describe("occasion history", () => {
+    it("shows occasions from linked reservations", () => {
+      mockUseReservations.mockReturnValue({
+        data: [
+          makeReservation({ occasion: "birthday", date: "2026-03-15" }),
+          makeReservation({ id: "res-2", occasion: "anniversary", date: "2026-01-08" }),
+        ],
+        isLoading: false,
+        error: null,
+      });
+      render(<GuestCard guestId="guest-1" />);
+      expect(screen.getByText(/birthday/i)).toBeDefined();
+      expect(screen.getByText(/anniversary/i)).toBeDefined();
+    });
+
+    it("omits reservations with no occasion or occasion=none", () => {
+      mockUseReservations.mockReturnValue({
+        data: [
+          makeReservation({ occasion: null }),
+          makeReservation({ id: "res-2", occasion: "none" }),
+        ],
+        isLoading: false,
+        error: null,
+      });
+      render(<GuestCard guestId="guest-1" />);
+      expect(screen.queryByTestId("occasion-history")).toBeNull();
+    });
+
+    it("does not render occasion section when no reservations", () => {
+      render(<GuestCard guestId="guest-1" />);
+      expect(screen.queryByTestId("occasion-history")).toBeNull();
+    });
+  });
+
+  describe("staff notes", () => {
+    it("shows latest 3 staff notes", () => {
+      mockUseGuest.mockReturnValue({
+        data: makeGuest({
+          staffNotes: [
+            { text: "Note 1", createdBy: "staff-1", createdAt: "2026-04-01T10:00:00.000Z" },
+            { text: "Note 2", createdBy: "staff-2", createdAt: "2026-04-02T10:00:00.000Z" },
+            { text: "Note 3", createdBy: "staff-3", createdAt: "2026-04-03T10:00:00.000Z" },
+            { text: "Note 4", createdBy: "staff-4", createdAt: "2026-04-04T10:00:00.000Z" },
+          ],
+        }),
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      render(<GuestCard guestId="guest-1" />);
+      // Latest 3 shown (Note 4, Note 3, Note 2)
+      expect(screen.getByText("Note 4")).toBeDefined();
+      expect(screen.getByText("Note 3")).toBeDefined();
+      expect(screen.getByText("Note 2")).toBeDefined();
+      expect(screen.queryByText("Note 1")).toBeNull();
+    });
+
+    it("shows show all button when more than 3 notes", () => {
+      mockUseGuest.mockReturnValue({
+        data: makeGuest({
+          staffNotes: [
+            { text: "Note 1", createdBy: "staff-1", createdAt: "2026-04-01T10:00:00.000Z" },
+            { text: "Note 2", createdBy: "staff-2", createdAt: "2026-04-02T10:00:00.000Z" },
+            { text: "Note 3", createdBy: "staff-3", createdAt: "2026-04-03T10:00:00.000Z" },
+            { text: "Note 4", createdBy: "staff-4", createdAt: "2026-04-04T10:00:00.000Z" },
+          ],
+        }),
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      render(<GuestCard guestId="guest-1" />);
+      expect(screen.getByRole("button", { name: /show all/i })).toBeDefined();
+    });
+
+    it("expands to show all notes when show all clicked", async () => {
+      mockUseGuest.mockReturnValue({
+        data: makeGuest({
+          staffNotes: [
+            { text: "Note 1", createdBy: "staff-1", createdAt: "2026-04-01T10:00:00.000Z" },
+            { text: "Note 2", createdBy: "staff-2", createdAt: "2026-04-02T10:00:00.000Z" },
+            { text: "Note 3", createdBy: "staff-3", createdAt: "2026-04-03T10:00:00.000Z" },
+            { text: "Note 4", createdBy: "staff-4", createdAt: "2026-04-04T10:00:00.000Z" },
+          ],
+        }),
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      render(<GuestCard guestId="guest-1" />);
+      fireEvent.click(screen.getByRole("button", { name: /show all/i }));
+      await waitFor(() => {
+        expect(screen.getByText("Note 1")).toBeDefined();
+      });
+    });
+
+    it("does not show show all when 3 or fewer notes", () => {
+      mockUseGuest.mockReturnValue({
+        data: makeGuest({
+          staffNotes: [
+            { text: "Note 1", createdBy: "staff-1", createdAt: "2026-04-01T10:00:00.000Z" },
+            { text: "Note 2", createdBy: "staff-2", createdAt: "2026-04-02T10:00:00.000Z" },
+          ],
+        }),
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      render(<GuestCard guestId="guest-1" />);
+      expect(screen.queryByRole("button", { name: /show all/i })).toBeNull();
+    });
+
+    it("does not render notes section when staffNotes empty", () => {
+      render(<GuestCard guestId="guest-1" />);
+      expect(screen.queryByTestId("staff-notes")).toBeNull();
+    });
+  });
+
+  describe("add note inline action", () => {
+    it("renders Add Note button", () => {
+      render(<GuestCard guestId="guest-1" />);
+      expect(screen.getByRole("button", { name: /add note/i })).toBeDefined();
+    });
+
+    it("shows textarea after clicking Add Note", async () => {
+      render(<GuestCard guestId="guest-1" />);
+      fireEvent.click(screen.getByRole("button", { name: /add note/i }));
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText(/type a note/i)).toBeDefined();
+      });
+    });
+
+    it("calls addNote mutation on submit", async () => {
+      render(<GuestCard guestId="guest-1" />);
+      fireEvent.click(screen.getByRole("button", { name: /add note/i }));
+      const textarea = await screen.findByPlaceholderText(/type a note/i);
+      fireEvent.change(textarea, { target: { value: "Great guest" } });
+      fireEvent.click(screen.getByRole("button", { name: /save note/i }));
+      await waitFor(() => {
+        expect(mockAddStaffNoteMutateAsync).toHaveBeenCalledWith({
+          guestId: "guest-1",
+          text: "Great guest",
+        });
+      });
+    });
+
+    it("hides form after successful note save", async () => {
+      render(<GuestCard guestId="guest-1" />);
+      fireEvent.click(screen.getByRole("button", { name: /add note/i }));
+      const textarea = await screen.findByPlaceholderText(/type a note/i);
+      fireEvent.change(textarea, { target: { value: "Great guest" } });
+      fireEvent.click(screen.getByRole("button", { name: /save note/i }));
+      await waitFor(() => {
+        expect(screen.queryByPlaceholderText(/type a note/i)).toBeNull();
+      });
+    });
+
+    it("cancel hides the note form without saving", async () => {
+      render(<GuestCard guestId="guest-1" />);
+      fireEvent.click(screen.getByRole("button", { name: /add note/i }));
+      await screen.findByPlaceholderText(/type a note/i);
+      fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+      await waitFor(() => {
+        expect(screen.queryByPlaceholderText(/type a note/i)).toBeNull();
+      });
+      expect(mockAddStaffNoteMutateAsync).not.toHaveBeenCalled();
+    });
+
+    it("save note button disabled when textarea empty", async () => {
+      render(<GuestCard guestId="guest-1" />);
+      fireEvent.click(screen.getByRole("button", { name: /add note/i }));
+      await screen.findByPlaceholderText(/type a note/i);
+      expect(screen.getByRole("button", { name: /save note/i })).toBeDisabled();
+    });
+  });
+
+  describe("quick actions", () => {
+    it("renders Edit Profile link when onEditProfile provided", () => {
+      render(<GuestCard guestId="guest-1" onEditProfile={vi.fn()} />);
+      expect(screen.getByRole("button", { name: /edit profile/i })).toBeDefined();
+    });
+  });
+});

--- a/apps/hospitality/src/components/crm/GuestCard.tsx
+++ b/apps/hospitality/src/components/crm/GuestCard.tsx
@@ -1,0 +1,290 @@
+import { useState, useCallback } from "react";
+import {
+  Alert,
+  Badge,
+  Button,
+  Card,
+  Divider,
+  Skeleton,
+  SkeletonGroup,
+  Stack,
+  Tag,
+  Text,
+  TextArea,
+} from "@mattbutlerengineering/rialto";
+import type { Reservation } from "@mbe/types";
+import { useGuest, useAddStaffNote } from "../../hooks/useGuests.js";
+import { useReservations } from "../../hooks/useReservations.js";
+import styles from "./GuestCard.module.css";
+
+/* ── Constants ───────────────────────────────────────── */
+
+const ALLERGY_KEYWORDS = ["nut", "shellfish", "dairy"];
+
+const OCCASION_LABELS: Record<string, string> = {
+  birthday: "Birthday",
+  anniversary: "Anniversary",
+  business: "Business",
+  date_night: "Date Night",
+  other: "Special Occasion",
+};
+
+/* ── Helpers ─────────────────────────────────────────── */
+
+function formatShortDate(isoString: string): string {
+  return new Date(isoString).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function getSegmentLabel(visitCount: number, tags: string[] | null): string {
+  const tagList = tags ?? [];
+  if (tagList.includes("vip") || visitCount >= 10) return "VIP";
+  if (visitCount >= 2) return "Repeat";
+  return "New";
+}
+
+function getSegmentVariant(label: string): "accent" | "success" | "neutral" {
+  if (label === "VIP") return "accent";
+  if (label === "Repeat") return "success";
+  return "neutral";
+}
+
+/* ── Props ───────────────────────────────────────────── */
+
+export interface GuestCardProps {
+  guestId: string | null | undefined;
+  /** Called when user clicks Edit Profile */
+  onEditProfile?: () => void;
+}
+
+/* ── Component ───────────────────────────────────────── */
+
+export function GuestCard({ guestId, onEditProfile }: GuestCardProps) {
+  const { data: guest, isLoading, error, refetch } = useGuest(guestId);
+
+  const { data: reservations = [] } = useReservations({
+    guestId: guestId ?? undefined,
+    limit: 20,
+    enabled: !!guestId,
+  });
+
+  const addNoteMutation = useAddStaffNote();
+
+  const [showAllNotes, setShowAllNotes] = useState(false);
+  const [addingNote, setAddingNote] = useState(false);
+  const [noteText, setNoteText] = useState("");
+
+  const handleSaveNote = useCallback(async () => {
+    if (!guestId || !noteText.trim()) return;
+    await addNoteMutation.mutateAsync({ guestId, text: noteText.trim() });
+    setNoteText("");
+    setAddingNote(false);
+  }, [guestId, noteText, addNoteMutation]);
+
+  const handleCancelNote = useCallback(() => {
+    setNoteText("");
+    setAddingNote(false);
+  }, []);
+
+  // Null guestId → render nothing
+  if (!guestId) return null;
+
+  if (isLoading) {
+    return (
+      <Card data-testid="guest-card-loading">
+        <SkeletonGroup>
+          <Stack gap="md">
+            <Skeleton variant="text" width="60%" height={20} />
+            <Skeleton variant="text" width="40%" height={16} />
+            <Skeleton variant="text" width="80%" height={16} />
+          </Stack>
+        </SkeletonGroup>
+      </Card>
+    );
+  }
+
+  if (error || !guest) {
+    return (
+      <Card data-testid="guest-card-error">
+        <Stack gap="md">
+          <Alert variant="error">Failed to load guest profile.</Alert>
+          <Button variant="secondary" onClick={() => refetch()}>
+            Retry
+          </Button>
+        </Stack>
+      </Card>
+    );
+  }
+
+  /* ── Derived data ─────────────────────────────────── */
+
+  const segmentLabel = getSegmentLabel(guest.visitCount, guest.tags);
+  const segmentVariant = getSegmentVariant(segmentLabel);
+
+  const allergyRestrictions = (guest.dietaryRestrictions ?? []).filter((r) =>
+    ALLERGY_KEYWORDS.some((kw) => r.toLowerCase().includes(kw))
+  );
+
+  const sortedNotes = [...(guest.staffNotes ?? [])].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  );
+  const visibleNotes = showAllNotes ? sortedNotes : sortedNotes.slice(0, 3);
+  const hasMoreNotes = sortedNotes.length > 3;
+
+  const occasionReservations = (reservations as Reservation[]).filter(
+    (r) => r.occasion && r.occasion !== "none"
+  );
+
+  /* ── Render ───────────────────────────────────────── */
+
+  return (
+    <Card className={styles.guestCard}>
+      <Stack gap="lg">
+        {/* Header */}
+        <Stack gap="xs">
+          <Stack direction="row" gap="sm" align="center" wrap>
+            <Text variant="display">{guest.name}</Text>
+            <Badge variant={segmentVariant}>{segmentLabel}</Badge>
+          </Stack>
+          <Text variant="caption" color="secondary">
+            {guest.visitCount} {guest.visitCount === 1 ? "visit" : "visits"}
+          </Text>
+        </Stack>
+
+        {/* Allergy warning banner */}
+        {allergyRestrictions.length > 0 && (
+          <div data-testid="allergy-warning-banner">
+            <Alert variant="warning" title="Allergy Alert">
+              {allergyRestrictions.join(", ")}
+            </Alert>
+          </div>
+        )}
+
+        {/* Dietary restrictions */}
+        {guest.dietaryRestrictions && guest.dietaryRestrictions.length > 0 && (
+          <>
+            <Divider />
+            <Stack gap="xs" data-testid="dietary-restrictions">
+              <Text variant="label" color="secondary">
+                Dietary Restrictions
+              </Text>
+              <Stack direction="row" gap="xs" wrap>
+                {guest.dietaryRestrictions.map((restriction) => (
+                  <Tag key={restriction}>{restriction}</Tag>
+                ))}
+              </Stack>
+            </Stack>
+          </>
+        )}
+
+        {/* Contact */}
+        <Divider />
+        <Stack gap="xs">
+          <Text variant="label" color="secondary">
+            Contact
+          </Text>
+          {/* mailto/tel anchors — no Rialto equivalent */}
+          {guest.email && (
+            <a href={`mailto:${guest.email}`} className={styles.contactLink}>
+              <Text variant="body">{guest.email}</Text>
+            </a>
+          )}
+          {guest.phone && (
+            <a href={`tel:${guest.phone}`} className={styles.contactLink}>
+              <Text variant="body">{guest.phone}</Text>
+            </a>
+          )}
+        </Stack>
+
+        {/* Occasion history */}
+        {occasionReservations.length > 0 && (
+          <>
+            <Divider />
+            <Stack gap="xs" data-testid="occasion-history">
+              <Text variant="label" color="secondary">
+                Occasion History
+              </Text>
+              {occasionReservations.map((r) => (
+                <Text key={r.id} variant="caption" color="secondary">
+                  {OCCASION_LABELS[r.occasion!] ?? r.occasion} &mdash; {formatShortDate(r.date)}
+                </Text>
+              ))}
+            </Stack>
+          </>
+        )}
+
+        {/* Staff notes */}
+        {sortedNotes.length > 0 && (
+          <>
+            <Divider />
+            <Stack gap="sm" data-testid="staff-notes">
+              <Text variant="label" color="secondary">
+                Staff Notes
+              </Text>
+              {visibleNotes.map((note, idx) => (
+                <Stack key={idx} gap="xs" className={styles.noteItem}>
+                  <Text variant="caption" color="secondary">
+                    {new Date(note.createdAt).toLocaleDateString(undefined, {
+                      month: "short",
+                      day: "numeric",
+                      year: "numeric",
+                    })}
+                  </Text>
+                  <Text variant="body">{note.text}</Text>
+                </Stack>
+              ))}
+              {hasMoreNotes && !showAllNotes && (
+                <Button variant="ghost" onClick={() => setShowAllNotes(true)}>
+                  Show All ({sortedNotes.length})
+                </Button>
+              )}
+            </Stack>
+          </>
+        )}
+
+        {/* Add note inline action */}
+        <Divider />
+        {addingNote ? (
+          <Stack gap="sm">
+            <TextArea
+              label="New Staff Note"
+              placeholder="Type a note..."
+              value={noteText}
+              onChange={(e) => setNoteText(e.target.value)}
+              rows={3}
+              disabled={addNoteMutation.isPending}
+            />
+            <Stack direction="row" gap="sm" justify="end">
+              <Button
+                variant="ghost"
+                onClick={handleCancelNote}
+                disabled={addNoteMutation.isPending}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="primary"
+                onClick={handleSaveNote}
+                disabled={!noteText.trim() || addNoteMutation.isPending}
+                isLoading={addNoteMutation.isPending}
+                loadingText="Saving..."
+              >
+                Save Note
+              </Button>
+            </Stack>
+          </Stack>
+        ) : (
+          <Stack direction="row" gap="sm" wrap>
+            <Button variant="secondary" onClick={() => setAddingNote(true)}>
+              Add Note
+            </Button>
+            {onEditProfile && (
+              <Button variant="ghost" onClick={onEditProfile}>
+                Edit Profile
+              </Button>
+            )}
+          </Stack>
+        )}
+      </Stack>
+    </Card>
+  );
+}

--- a/apps/hospitality/src/components/timeline/EditReservationDrawer.tsx
+++ b/apps/hospitality/src/components/timeline/EditReservationDrawer.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
-import { Drawer, Button, Input, Select, TextArea, Stack } from "@mattbutlerengineering/rialto";
+import { Drawer, Button, Input, Select, TextArea, Stack, Divider } from "@mattbutlerengineering/rialto";
 import type { Reservation, Table, UpdateReservationRequest } from "@mbe/types";
+import { GuestCard } from "../crm/GuestCard.js";
 import styles from "./EditReservationDrawer.module.css";
 
 interface EditReservationDrawerProps {
@@ -74,6 +75,13 @@ export function EditReservationDrawer({
   return (
     <Drawer open={true} onClose={onClose} title="Edit Reservation" size="default">
       <Stack gap="lg" style={{ padding: "var(--rialto-space-md)" }}>
+        {reservation.guestId && (
+          <>
+            <GuestCard guestId={reservation.guestId} />
+            <Divider />
+          </>
+        )}
+
         {error && <div className={styles.errorBanner}>{error}</div>}
 
         <Stack gap="md">

--- a/apps/hospitality/src/hooks/useGuests.ts
+++ b/apps/hospitality/src/hooks/useGuests.ts
@@ -129,3 +129,45 @@ export function useUpdateGuest() {
     },
   });
 }
+
+/* ── useGuest (single) ───────────────────────────────── */
+
+export interface UseGuestResult {
+  data: Guest | undefined;
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => void;
+}
+
+export function useGuest(guestId: string | null | undefined): UseGuestResult {
+  const api = useApiClient();
+
+  const query = useQuery({
+    queryKey: [GUESTS_QUERY_KEY, { id: guestId }],
+    queryFn: () => api.guests.get(guestId!),
+    enabled: !!guestId,
+  });
+
+  return {
+    data: query.data,
+    isLoading: query.isLoading,
+    error: query.error ?? null,
+    refetch: query.refetch,
+  };
+}
+
+/* ── useAddStaffNote mutation ────────────────────────── */
+
+export function useAddStaffNote() {
+  const api = useApiClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ guestId, text }: { guestId: string; text: string }) =>
+      api.guests.addNote(guestId, text),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: [GUESTS_QUERY_KEY, { id: variables.guestId }] });
+      queryClient.invalidateQueries({ queryKey: [GUESTS_QUERY_KEY] });
+    },
+  });
+}

--- a/apps/hospitality/src/pages/GuestsPage.tsx
+++ b/apps/hospitality/src/pages/GuestsPage.tsx
@@ -4,7 +4,6 @@ import {
   Badge,
   Button,
   Card,
-  DataList,
   Dialog,
   Divider,
   Drawer,
@@ -31,6 +30,7 @@ import {
   useUpdateGuest,
 } from "../hooks/useGuests.js";
 import { useReservations } from "../hooks/useReservations.js";
+import { GuestCard } from "../components/crm/GuestCard.js";
 import styles from "./GuestsPage.module.css";
 
 /* ── Constants ─────────────────────────────── */
@@ -383,19 +383,11 @@ function GuestDetailDrawer({
         </Stack>
       ) : (
         <Stack gap="lg">
-          <DataList items={detailItems} orientation="horizontal" striped />
-
-          {guest.notes && (
-            <>
-              <Divider />
-              <Stack gap="xs">
-                <Text variant="label" color="secondary">
-                  Notes
-                </Text>
-                <Text variant="body">{guest.notes}</Text>
-              </Stack>
-            </>
-          )}
+          {/* Unified CRM display via GuestCard */}
+          <GuestCard
+            guestId={guest.id}
+            onEditProfile={() => drawerDispatch({ type: "set_editing", isEditing: true })}
+          />
 
           {guest.tags && guest.tags.length > 0 && (
             <>
@@ -428,7 +420,7 @@ function GuestDetailDrawer({
                 </Text>
                 {guestReservations.slice(0, 5).map((r: Reservation) => (
                   <Text key={r.id} variant="caption" color="secondary">
-                    {r.date} · {r.partySize} guests
+                    {r.date} &middot; {r.partySize} guests
                   </Text>
                 ))}
               </Stack>

--- a/apps/hospitality/src/pages/TimelinePage.tsx
+++ b/apps/hospitality/src/pages/TimelinePage.tsx
@@ -1,12 +1,13 @@
 import { useState, useEffect, useMemo, useCallback } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
-import { Drawer, Button, Stack, Text, Card } from "@mattbutlerengineering/rialto";
+import { Drawer, Button, Divider, Stack, Text, Card } from "@mattbutlerengineering/rialto";
 import type { Reservation, TableStatus, UpdateReservationRequest } from "@mbe/types";
 import { TimelineGrid, TimelineMobileView } from "../components/timeline";
 import { CancelReservationDialog } from "../components/timeline/CancelReservationDialog";
 import { EditReservationDrawer } from "../components/timeline/EditReservationDrawer";
 import { WalkInDialog } from "../components/timeline/WalkInDialog";
+import { GuestCard } from "../components/crm/GuestCard.js";
 import { useVenue } from "../contexts/VenueContext.js";
 import { useSSEStatus } from "../hooks/useSSEStatus.js";
 import { useReservations, RESERVATIONS_QUERY_KEY } from "../hooks/useReservations.js";
@@ -57,14 +58,21 @@ interface ReservationDetailsProps {
 function ReservationDetails({ reservation, onEdit, onSeat, onCancel }: ReservationDetailsProps) {
   return (
     <Stack gap="lg" className={styles.detailsStack}>
-      <div>
-        <Text variant="label" color="secondary">
-          Guest
-        </Text>
-        <Text variant="display" as="div">
-          {reservation.guestName || "Guest"}
-        </Text>
-      </div>
+      {reservation.guestId ? (
+        <>
+          <GuestCard guestId={reservation.guestId} />
+          <Divider />
+        </>
+      ) : (
+        <div>
+          <Text variant="label" color="secondary">
+            Guest
+          </Text>
+          <Text variant="display" as="div">
+            {reservation.guestName || "Guest"}
+          </Text>
+        </div>
+      )}
 
       {reservation.guestEmail && (
         <div>

--- a/packages/api-client/src/guests.ts
+++ b/packages/api-client/src/guests.ts
@@ -99,4 +99,11 @@ export class GuestsClient {
   async delete(id: string): Promise<void> {
     await this.client.delete(`/api/v1/guests/${id}`);
   }
+
+  /**
+   * Add a staff note to a guest
+   */
+  async addNote(id: string, text: string): Promise<Guest> {
+    return this.client.postOne<Guest>(`/api/v1/guests/${id}/notes`, { text });
+  }
 }


### PR DESCRIPTION
## Summary

Unified CRM guest display component for the hospitality app. Single `GuestCard` component replaces scattered guest data rendering across three surfaces.

Closes #1711

## Changes

### New files
- `apps/hospitality/src/components/crm/GuestCard.tsx` — main component
- `apps/hospitality/src/components/crm/GuestCard.module.css` — styles
- `apps/hospitality/src/components/crm/GuestCard.test.tsx` — 34 tests

### Modified files
- `packages/api-client/src/guests.ts` — added `addNote(id, text)` method
- `apps/hospitality/src/hooks/useGuests.ts` — added `useGuest` + `useAddStaffNote` hooks
- `apps/hospitality/src/components/timeline/EditReservationDrawer.tsx` — embed GuestCard above form
- `apps/hospitality/src/pages/TimelinePage.tsx` — embed GuestCard in reservation detail sidebar
- `apps/hospitality/src/pages/GuestsPage.tsx` — replace DataList/notes section with GuestCard

## Component features

- Header: guest name, segment badge (VIP/Repeat/New), visit count
- Allergy warning banner (nut/shellfish/dairy keywords trigger `Alert variant="warning"`)
- Dietary restrictions as `Tag` chips
- Contact section with `mailto:` and `tel:` links
- Occasion history from reservations (filtered `occasion !== "none"`)
- Staff notes: latest 3 shown, "Show All" expands
- Inline "Add Note" action with `TextArea` + save/cancel
- "Edit Profile" callback prop
- Loading skeleton state, error+retry state, null guestId renders nothing

## Test coverage

34 tests: loading, error, null guestId, all display sections, allergy detection, note add flow, edit profile callback, segment logic (VIP/Repeat/New).

All 781 hospitality tests pass. Typecheck clean on both `apps/hospitality` and `packages/api-client`.

https://claude.ai/code/session_014aUsWZDfCUNZbVtByEDyR8

---
_Generated by [Claude Code](https://claude.ai/code/session_014aUsWZDfCUNZbVtByEDyR8)_