### PR TITLE
refactor(hospitality,gen): replace raw fetch with @mbe/api-client

### DIFF
--- a/apps/gen/src/hooks/useSpecsApi.test.ts
+++ b/apps/gen/src/hooks/useSpecsApi.test.ts
@@ -7,8 +7,28 @@ vi.mock("@mbe/auth/react", () => ({
   useAuth: vi.fn(() => ({ accessToken: "test-token", user: null, signOut: vi.fn() })),
 }));
 
-const mockFetch = vi.fn();
-vi.stubGlobal("fetch", mockFetch);
+// Shared mock for all ApiClient method calls
+const mockGet = vi.fn();
+const mockPost = vi.fn();
+const mockPatch = vi.fn();
+const mockDelete = vi.fn();
+
+// Mock @mbe/api-client — ApiClient must be a class (constructable) in the mock
+vi.mock("@mbe/api-client", () => {
+  class MockApiClient {
+    get = mockGet;
+    post = mockPost;
+    patch = mockPatch;
+    delete = mockDelete;
+    request = mockGet;
+    getOne = mockGet;
+    postOne = mockPost;
+    patchOne = mockPatch;
+  }
+  return {
+    ApiClient: MockApiClient,
+  };
+});
 
 function makeSpec(overrides?: Partial<StoredSpec>): StoredSpec {
   return {
@@ -24,40 +44,38 @@ function makeSpec(overrides?: Partial<StoredSpec>): StoredSpec {
   };
 }
 
-function makeOkResponse(body: unknown) {
-  return {
-    ok: true,
-    statusText: "OK",
-    json: async () => body,
-  };
-}
-
-function makeErrorResponse(statusText = "Internal Server Error") {
-  return {
-    ok: false,
-    statusText,
-    json: async () => ({}),
-  };
-}
-
 beforeEach(() => {
-  mockFetch.mockReset();
+  mockGet.mockReset();
+  mockPost.mockReset();
+  mockPatch.mockReset();
+  mockDelete.mockReset();
 });
 
 describe("useSpecsApi — initial state", () => {
   it("starts with isLoading=true and empty specs array", async () => {
     // Never resolve so we can check loading state
-    mockFetch.mockReturnValue(new Promise(() => {}));
+    mockGet.mockReturnValue(new Promise(() => {}));
     const { result } = renderHook(() => useSpecsApi());
     expect(result.current.isLoading).toBe(true);
     expect(result.current.specs).toEqual([]);
   });
 });
 
+describe("useSpecsApi — uses ApiClient not raw fetch", () => {
+  it("calls ApiClient.get for fetchSpecs (not globalThis.fetch)", async () => {
+    const spec = makeSpec();
+    mockGet.mockResolvedValue({ data: [spec] });
+    const { result } = renderHook(() => useSpecsApi());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    // ApiClient.get was called with the specs endpoint
+    expect(mockGet).toHaveBeenCalledWith("/api/gen/specs");
+  });
+});
+
 describe("useSpecsApi — fetchSpecs", () => {
   it("populates specs from API response and sets isLoading=false", async () => {
     const spec = makeSpec();
-    mockFetch.mockResolvedValue(makeOkResponse({ data: [spec] }));
+    mockGet.mockResolvedValue({ data: [spec] });
     const { result } = renderHook(() => useSpecsApi());
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.specs).toHaveLength(1);
@@ -65,7 +83,7 @@ describe("useSpecsApi — fetchSpecs", () => {
   });
 
   it("sets isLoading=false and leaves specs empty on fetch error", async () => {
-    mockFetch.mockRejectedValue(new Error("Network error"));
+    mockGet.mockRejectedValue(new Error("Network error"));
     const { result } = renderHook(() => useSpecsApi());
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.specs).toEqual([]);
@@ -75,13 +93,13 @@ describe("useSpecsApi — fetchSpecs", () => {
 describe("useSpecsApi — saveSpec", () => {
   it("adds the new spec to the front of the list", async () => {
     const existing = makeSpec({ id: "old-1" });
-    mockFetch.mockResolvedValueOnce(makeOkResponse({ data: [existing] }));
+    mockGet.mockResolvedValueOnce({ data: [existing] });
 
     const { result } = renderHook(() => useSpecsApi());
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     const created = makeSpec({ id: "new-1", prompt: "New prompt" });
-    mockFetch.mockResolvedValueOnce(makeOkResponse({ data: created }));
+    mockPost.mockResolvedValueOnce({ data: created });
 
     await act(async () => {
       await result.current.saveSpec({
@@ -100,13 +118,13 @@ describe("useSpecsApi — saveSpec", () => {
 describe("useSpecsApi — toggleFavorite", () => {
   it("optimistically flips isFavorite", async () => {
     const spec = makeSpec({ isFavorite: false });
-    mockFetch.mockResolvedValueOnce(makeOkResponse({ data: [spec] }));
+    mockGet.mockResolvedValueOnce({ data: [spec] });
 
     const { result } = renderHook(() => useSpecsApi());
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     // The PATCH call resolves successfully
-    mockFetch.mockResolvedValueOnce(makeOkResponse({}));
+    mockPatch.mockResolvedValueOnce({});
 
     await act(async () => {
       await result.current.toggleFavorite("spec-1");
@@ -117,13 +135,13 @@ describe("useSpecsApi — toggleFavorite", () => {
 
   it("reverts optimistic update on API error", async () => {
     const spec = makeSpec({ isFavorite: false });
-    mockFetch.mockResolvedValueOnce(makeOkResponse({ data: [spec] }));
+    mockGet.mockResolvedValueOnce({ data: [spec] });
 
     const { result } = renderHook(() => useSpecsApi());
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     // The PATCH call fails
-    mockFetch.mockResolvedValueOnce(makeErrorResponse("Server Error"));
+    mockPatch.mockRejectedValueOnce(new Error("Server Error"));
 
     await act(async () => {
       await result.current.toggleFavorite("spec-1");
@@ -138,12 +156,12 @@ describe("useSpecsApi — deleteSpec", () => {
   it("removes spec optimistically", async () => {
     const spec1 = makeSpec({ id: "spec-1" });
     const spec2 = makeSpec({ id: "spec-2", prompt: "Another" });
-    mockFetch.mockResolvedValueOnce(makeOkResponse({ data: [spec1, spec2] }));
+    mockGet.mockResolvedValueOnce({ data: [spec1, spec2] });
 
     const { result } = renderHook(() => useSpecsApi());
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    mockFetch.mockResolvedValueOnce(makeOkResponse({}));
+    mockDelete.mockResolvedValueOnce({});
 
     await act(async () => {
       await result.current.deleteSpec("spec-1");
@@ -155,12 +173,12 @@ describe("useSpecsApi — deleteSpec", () => {
 
   it("reverts optimistic removal on API error", async () => {
     const spec = makeSpec();
-    mockFetch.mockResolvedValueOnce(makeOkResponse({ data: [spec] }));
+    mockGet.mockResolvedValueOnce({ data: [spec] });
 
     const { result } = renderHook(() => useSpecsApi());
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    mockFetch.mockResolvedValueOnce(makeErrorResponse("Server Error"));
+    mockDelete.mockRejectedValueOnce(new Error("Server Error"));
 
     await act(async () => {
       await result.current.deleteSpec("spec-1");

--- a/apps/gen/src/hooks/useSpecsApi.ts
+++ b/apps/gen/src/hooks/useSpecsApi.ts
@@ -1,5 +1,6 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import { useAuth } from "@mbe/auth/react";
+import { ApiClient } from "@mbe/api-client";
 import type { StoredSpec } from "../types.js";
 
 export interface SaveSpecData {
@@ -18,29 +19,24 @@ export interface UseSpecsApiReturn {
 }
 
 /**
- * Custom hook wrapping specs CRUD API calls with auth.
+ * Custom hook wrapping specs CRUD API calls with auth via @mbe/api-client.
  * Provides optimistic updates for toggleFavorite and deleteSpec.
  * Auto-fetches specs on mount.
  */
 export function useSpecsApi(): UseSpecsApiReturn {
   const { accessToken } = useAuth();
 
-  const [specs, setSpecs] = useState<StoredSpec[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-
-  const authFetch = useCallback(
-    async (input: string, init?: RequestInit): Promise<Response> => {
-      return fetch(input, {
-        ...init,
-        headers: {
-          "Content-Type": "application/json",
-          ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
-          ...init?.headers,
-        },
-      });
-    },
+  const client = useMemo(
+    () =>
+      new ApiClient({
+        baseUrl: "",
+        getAccessToken: () => accessToken,
+      }),
     [accessToken]
   );
+
+  const [specs, setSpecs] = useState<StoredSpec[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
 
   const fetchSpecs = useCallback(async (): Promise<void> => {
     // NOTE: We deliberately do NOT call setIsLoading(true) synchronously here.
@@ -51,35 +47,24 @@ export function useSpecsApi(): UseSpecsApiReturn {
     // `isLoading` (which flips to false after first success) and manage their
     // own UI state, or we can introduce a separate `isRefreshing` flag later.
     try {
-      const response = await authFetch("/api/gen/specs");
-      if (!response.ok) {
-        throw new Error(`Failed to fetch specs: ${response.statusText}`);
-      }
-      const json = (await response.json()) as { data: StoredSpec[] };
+      const json = await client.get<{ data: StoredSpec[] }>("/api/gen/specs");
       setSpecs(json.data);
     } catch (err) {
       console.error("[useSpecsApi] fetchSpecs error:", err);
     } finally {
       setIsLoading(false);
     }
-  }, [authFetch]);
+  }, [client]);
 
   const saveSpec = useCallback(
     async (data: SaveSpecData): Promise<StoredSpec> => {
-      const response = await authFetch("/api/gen/specs", {
-        method: "POST",
-        body: JSON.stringify(data),
-      });
-      if (!response.ok) {
-        throw new Error(`Failed to save spec: ${response.statusText}`);
-      }
-      const json = (await response.json()) as { data: StoredSpec };
+      const json = await client.post<{ data: StoredSpec }>("/api/gen/specs", data);
       const created = json.data;
       // Prepend to local state (immutable update)
       setSpecs((prev) => [created, ...prev]);
       return created;
     },
-    [authFetch]
+    [client]
   );
 
   const toggleFavorite = useCallback(
@@ -87,12 +72,7 @@ export function useSpecsApi(): UseSpecsApiReturn {
       // Optimistic update — immediately flip isFavorite
       setSpecs((prev) => prev.map((s) => (s.id === id ? { ...s, isFavorite: !s.isFavorite } : s)));
       try {
-        const response = await authFetch(`/api/gen/specs/${id}/favorite`, {
-          method: "PATCH",
-        });
-        if (!response.ok) {
-          throw new Error(`Failed to toggle favorite: ${response.statusText}`);
-        }
+        await client.patch(`/api/gen/specs/${id}/favorite`, {});
       } catch (err) {
         // Revert optimistic update on error
         setSpecs((prev) =>
@@ -101,7 +81,7 @@ export function useSpecsApi(): UseSpecsApiReturn {
         console.error("[useSpecsApi] toggleFavorite error:", err);
       }
     },
-    [authFetch]
+    [client]
   );
 
   const deleteSpec = useCallback(
@@ -110,19 +90,14 @@ export function useSpecsApi(): UseSpecsApiReturn {
       const previous = specs;
       setSpecs((prev) => prev.filter((s) => s.id !== id));
       try {
-        const response = await authFetch(`/api/gen/specs/${id}`, {
-          method: "DELETE",
-        });
-        if (!response.ok) {
-          throw new Error(`Failed to delete spec: ${response.statusText}`);
-        }
+        await client.delete(`/api/gen/specs/${id}`);
       } catch (err) {
         // Revert on error
         setSpecs(previous);
         console.error("[useSpecsApi] deleteSpec error:", err);
       }
     },
-    [authFetch, specs]
+    [client, specs]
   );
 
   useEffect(() => {

--- a/apps/hospitality/src/pages/ManageReservationPage.test.tsx
+++ b/apps/hospitality/src/pages/ManageReservationPage.test.tsx
@@ -16,8 +16,24 @@ vi.mock("@mattbutlerengineering/rialto", () => ({
   Card: ({ children }: any) => <div data-testid="card">{children}</div>,
 }));
 
+// ApiClient uses fetch internally. Stub it so we control responses and can
+// assert on the URL pattern it calls (verifying ApiClient routing is used).
 const mockFetch = vi.fn();
-globalThis.fetch = mockFetch;
+vi.stubGlobal("fetch", mockFetch);
+
+function makeOkResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeErrorResponse(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
 
 function createWrapper() {
   const queryClient = new QueryClient({
@@ -30,7 +46,11 @@ function createWrapper() {
 
 function renderPage() {
   const Wrapper = createWrapper();
-  return render(<Wrapper><ManageReservationPage /></Wrapper>);
+  return render(
+    <Wrapper>
+      <ManageReservationPage />
+    </Wrapper>
+  );
 }
 
 beforeEach(() => {
@@ -44,34 +64,68 @@ describe("ManageReservationPage", () => {
     expect(screen.getByText("Invalid Link")).toBeDefined();
   });
 
+  it("routes reservation lookup through ApiClient — calls manage endpoint via structured URL", async () => {
+    mockSearchParams.set("token", "valid-token-abc");
+    mockFetch.mockResolvedValueOnce(
+      makeOkResponse({
+        data: {
+          reservation: {
+            id: "res_1",
+            date: "2026-06-15",
+            startTime: "19:00",
+            endTime: "21:00",
+            partySize: 4,
+            guestName: "Jane Doe",
+            guestEmail: "jane@example.com",
+            guestPhone: "+1555000111",
+            status: "PENDING",
+            notes: null,
+          },
+          venue: {
+            id: "venue_1",
+            name: "The Oak Table",
+            slug: "the-oak-table",
+            ianaTimezone: "America/Los_Angeles",
+          },
+        },
+      })
+    );
+
+    renderPage();
+    await waitFor(() => expect(screen.getByText("Jane Doe")).toBeDefined());
+
+    // ApiClient constructs the URL from baseUrl + path
+    const calledUrl: string = mockFetch.mock.calls[0][0] as string;
+    expect(calledUrl).toContain("/public/v1/reservations/manage");
+    expect(calledUrl).toContain("token=valid-token-abc");
+  });
+
   it("shows reservation details for valid token", async () => {
     mockSearchParams.set("token", "valid-token-abc");
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () =>
-        Promise.resolve({
-          data: {
-            reservation: {
-              id: "res_1",
-              date: "2026-06-15",
-              startTime: "19:00",
-              endTime: "21:00",
-              partySize: 4,
-              guestName: "Jane Doe",
-              guestEmail: "jane@example.com",
-              guestPhone: "+1555000111",
-              status: "PENDING",
-              notes: "Window seat please",
-            },
-            venue: {
-              id: "venue_1",
-              name: "The Oak Table",
-              slug: "the-oak-table",
-              ianaTimezone: "America/Los_Angeles",
-            },
+    mockFetch.mockResolvedValueOnce(
+      makeOkResponse({
+        data: {
+          reservation: {
+            id: "res_1",
+            date: "2026-06-15",
+            startTime: "19:00",
+            endTime: "21:00",
+            partySize: 4,
+            guestName: "Jane Doe",
+            guestEmail: "jane@example.com",
+            guestPhone: "+1555000111",
+            status: "PENDING",
+            notes: "Window seat please",
           },
-        }),
-    });
+          venue: {
+            id: "venue_1",
+            name: "The Oak Table",
+            slug: "the-oak-table",
+            ianaTimezone: "America/Los_Angeles",
+          },
+        },
+      })
+    );
 
     renderPage();
 
@@ -84,11 +138,9 @@ describe("ManageReservationPage", () => {
 
   it("shows expired message for 410 response", async () => {
     mockSearchParams.set("token", "expired-token");
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 410,
-      json: () => Promise.resolve({ error: "TOKEN_EXPIRED" }),
-    });
+    mockFetch.mockResolvedValueOnce(
+      makeErrorResponse(410, { status: 410, detail: "Token expired" })
+    );
 
     renderPage();
 
@@ -99,11 +151,9 @@ describe("ManageReservationPage", () => {
 
   it("shows invalid message for 401 response", async () => {
     mockSearchParams.set("token", "bad-token");
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 401,
-      json: () => Promise.resolve({ error: "INVALID_TOKEN" }),
-    });
+    mockFetch.mockResolvedValueOnce(
+      makeErrorResponse(401, { status: 401, detail: "Invalid token" })
+    );
 
     renderPage();
 

--- a/apps/hospitality/src/pages/ManageReservationPage.tsx
+++ b/apps/hospitality/src/pages/ManageReservationPage.tsx
@@ -1,8 +1,12 @@
 import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { Stack, Text, Card } from "@mattbutlerengineering/rialto";
+import { ApiClient, ApiClientError } from "@mbe/api-client";
 
 const API_BASE = import.meta.env.VITE_API_URL ?? "";
+
+// Public endpoint client — no auth token required
+const publicApiClient = new ApiClient({ baseUrl: API_BASE, maxRetries: 3 });
 
 interface ReservationDetails {
   id: string;
@@ -41,20 +45,17 @@ class ManageTokenError extends Error {
 }
 
 async function fetchManageReservation(token: string): Promise<ManageReservationData> {
-  const res = await fetch(
-    `${API_BASE}/public/v1/reservations/manage?token=${encodeURIComponent(token)}`
-  );
-
-  if (res.ok) {
-    const json = await res.json();
+  try {
+    const json = await publicApiClient.get<{ data: ManageReservationData }>(
+      `/public/v1/reservations/manage?token=${encodeURIComponent(token)}`
+    );
     return { reservation: json.data.reservation, venue: json.data.venue };
+  } catch (err) {
+    if (err instanceof ApiClientError && err.statusCode === 410) {
+      throw new ManageTokenError("Link expired", "expired");
+    }
+    throw new ManageTokenError("Invalid link", "invalid");
   }
-
-  if (res.status === 410) {
-    throw new ManageTokenError("Link expired", "expired");
-  }
-
-  throw new ManageTokenError("Invalid link", "invalid");
 }
 
 export function ManageReservationPage() {
@@ -93,8 +94,7 @@ export function ManageReservationPage() {
   }
 
   if (error || !data) {
-    const errorType =
-      error instanceof ManageTokenError ? error.type : "invalid";
+    const errorType = error instanceof ManageTokenError ? error.type : "invalid";
 
     return (
       <Stack align="center" justify="center" style={{ minHeight: "100vh", padding: "2rem" }}>


### PR DESCRIPTION
## Summary

Fixes #1784 — two frontend modules were calling API endpoints with bare `fetch()`, missing retry, timeout, and structured errors.

## Changes

### `apps/hospitality/src/pages/ManageReservationPage.tsx`
- Replaced `fetch()` with `ApiClient` (no auth — public endpoint, `getAccessToken` omitted)
- Maps `ApiClientError.statusCode === 410` to `ManageTokenError("expired")`; all other errors map to `"invalid"`
- Module-scoped `publicApiClient` instance reused across queries

### `apps/gen/src/hooks/useSpecsApi.ts`
- Replaced hand-rolled `authFetch` wrapper with `ApiClient` instance created in `useMemo`
- Auth-header injection, retry (3x on 502/503/504), and 30s timeout now handled by the shared client
- All five CRUD operations (fetchSpecs, saveSpec, toggleFavorite, deleteSpec) use `client.get/post/patch/delete`

## Tests

Both test suites updated to use proper class-based ApiClient mocks:
- `ManageReservationPage.test.tsx`: stubs `fetch` via `vi.stubGlobal`, asserts URL routed through ApiClient
- `useSpecsApi.test.ts`: class mock for `ApiClient` with separate `mockGet/mockPost/mockPatch/mockDelete` fns

Results:
- hospitality: 797/797 tests pass
- gen: 178/178 tests pass
- Both apps typecheck clean

## Test Plan
- [ ] CI passes
- [ ] ManageReservationPage still renders reservation details on valid token
- [ ] ManageReservationPage shows "Link Expired" on 410 and "Invalid Link" on other errors
- [ ] useSpecsApi fetchSpecs, saveSpec, toggleFavorite, deleteSpec all work in gen playground

🤖 Generated with [Claude Code](https://claude.com/claude-code)