### PR TITLE
feat(reservations): cancellation policy engine

### DIFF
--- a/services/reservations/llms-full.txt
+++ b/services/reservations/llms-full.txt
@@ -4207,6 +4207,19 @@
       return largestRule.durationMinutes + extraTime;
     }
   </file>
+  <file path="src/services/cancellation-policy.ts">
+    export interface CancellationPolicy {
+      /** Hours before reservation within which cancellation is free (inclusive boundary). */
+      freeCancellationHours: number;
+      /** Percentage of deposit charged for late cancellation (0–100). */
+      lateCancellationFeePercent: number;
+      /** Percentage of deposit charged for no-shows (0–100). */
+      noShowFeePercent: number;
+      /** Deposit amount in cents. */
+      depositAmountCents: number;
+    }
+    export type FeeType = "none" | "late" | "noshow";
+  </file>
   <file path="src/services/confirm-hold.ts">
     type ConfirmHoldErrorCode = "NOT_FOUND" | "EXPIRED" | "SESSION_MISMATCH" | "CONFLICT";
     export interface ConfirmHoldInput {

--- a/services/reservations/llms.txt
+++ b/services/reservations/llms.txt
@@ -193,6 +193,19 @@
       export function estimateDuration(partySize: number, venueSettings?: VenueSettings | null): number { /* ... */ }
     </item>
   </file>
+  <file path="src/services/cancellation-policy.ts">
+    <item priority="low">
+      interface CancellationPolicy {
+        freeCancellationHours: number;
+        lateCancellationFeePercent: number;
+        noShowFeePercent: number;
+        depositAmountCents: number;
+      }
+    </item>
+    <item priority="low">
+      type FeeType = "none" | "late" | "noshow";
+    </item>
+  </file>
   <file path="src/services/confirm-hold.ts">
     <item priority="high">
       type ConfirmHoldErrorCode = "NOT_FOUND" | "EXPIRED" | "SESSION_MISMATCH" | "CONFLICT";

--- a/services/reservations/src/services/cancellation-policy.test.ts
+++ b/services/reservations/src/services/cancellation-policy.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from "vitest";
+import {
+  evaluateCancellationFee,
+  formatPolicySummary,
+  type CancellationPolicy,
+} from "./cancellation-policy.js";
+
+const POLICY: CancellationPolicy = {
+  freeCancellationHours: 24,
+  lateCancellationFeePercent: 50,
+  noShowFeePercent: 100,
+  depositAmountCents: 10000, // $100
+};
+
+// reservation at noon tomorrow
+const RESERVATION = new Date("2026-06-01T12:00:00.000Z");
+
+describe("evaluateCancellationFee", () => {
+  describe("no policy configured", () => {
+    it("returns full refund when policy is null", () => {
+      const result = evaluateCancellationFee(
+        null,
+        RESERVATION,
+        new Date("2026-06-01T08:00:00.000Z")
+      );
+      expect(result).toEqual({
+        feeAmountCents: 0,
+        feeType: "none",
+        refundAmountCents: 0,
+        depositAction: "refund_full",
+      });
+    });
+
+    it("returns full refund when policy is undefined", () => {
+      const result = evaluateCancellationFee(
+        undefined,
+        RESERVATION,
+        new Date("2026-05-30T12:00:00.000Z")
+      );
+      expect(result).toEqual({
+        feeAmountCents: 0,
+        feeType: "none",
+        refundAmountCents: 0,
+        depositAction: "refund_full",
+      });
+    });
+
+    it("returns full refund when deposit is zero", () => {
+      const result = evaluateCancellationFee(
+        { ...POLICY, depositAmountCents: 0 },
+        RESERVATION,
+        new Date("2026-06-01T08:00:00.000Z") // late cancel, but no deposit
+      );
+      expect(result).toEqual({
+        feeAmountCents: 0,
+        feeType: "none",
+        refundAmountCents: 0,
+        depositAction: "refund_full",
+      });
+    });
+  });
+
+  describe("free cancellation window", () => {
+    it("full refund when cancelled well before the free window closes", () => {
+      // 48h before reservation → within 24h free window
+      const cancelTime = new Date("2026-05-30T12:00:00.000Z");
+      const result = evaluateCancellationFee(POLICY, RESERVATION, cancelTime);
+      expect(result).toEqual({
+        feeAmountCents: 0,
+        feeType: "none",
+        refundAmountCents: 10000,
+        depositAction: "refund_full",
+      });
+    });
+
+    it("full refund when cancelled exactly 24h before (inclusive boundary)", () => {
+      // exactly 24h before — should be free (inclusive)
+      const cancelTime = new Date("2026-05-31T12:00:00.000Z");
+      const result = evaluateCancellationFee(POLICY, RESERVATION, cancelTime);
+      expect(result).toEqual({
+        feeAmountCents: 0,
+        feeType: "none",
+        refundAmountCents: 10000,
+        depositAction: "refund_full",
+      });
+    });
+
+    it("full refund for 0-hour free window only if cancelled before reservation", () => {
+      const policy: CancellationPolicy = { ...POLICY, freeCancellationHours: 0 };
+      // 1 minute before reservation
+      const cancelTime = new Date("2026-06-01T11:59:00.000Z");
+      const result = evaluateCancellationFee(policy, RESERVATION, cancelTime);
+      expect(result).toEqual({
+        feeAmountCents: 0,
+        feeType: "none",
+        refundAmountCents: 10000,
+        depositAction: "refund_full",
+      });
+    });
+  });
+
+  describe("late cancellation", () => {
+    it("applies lateCancellationFeePercent when cancelled inside window", () => {
+      // 1h before → inside 24h window → late cancel, 50% fee
+      const cancelTime = new Date("2026-06-01T11:00:00.000Z");
+      const result = evaluateCancellationFee(POLICY, RESERVATION, cancelTime);
+      expect(result).toEqual({
+        feeAmountCents: 5000, // 50% of $100
+        feeType: "late",
+        refundAmountCents: 5000,
+        depositAction: "refund_partial",
+      });
+    });
+
+    it("applies late fee 23h 59m before reservation", () => {
+      // just inside 24h window
+      const cancelTime = new Date("2026-05-31T12:01:00.000Z");
+      const result = evaluateCancellationFee(POLICY, RESERVATION, cancelTime);
+      expect(result).toEqual({
+        feeAmountCents: 5000,
+        feeType: "late",
+        refundAmountCents: 5000,
+        depositAction: "refund_partial",
+      });
+    });
+
+    it("forfeits full deposit when lateCancellationFeePercent is 100", () => {
+      const policy: CancellationPolicy = { ...POLICY, lateCancellationFeePercent: 100 };
+      const cancelTime = new Date("2026-06-01T08:00:00.000Z"); // 4h before
+      const result = evaluateCancellationFee(policy, RESERVATION, cancelTime);
+      expect(result).toEqual({
+        feeAmountCents: 10000,
+        feeType: "late",
+        refundAmountCents: 0,
+        depositAction: "forfeit",
+      });
+    });
+
+    it("rounds fee to nearest cent", () => {
+      const policy: CancellationPolicy = { ...POLICY, lateCancellationFeePercent: 33 };
+      const cancelTime = new Date("2026-06-01T08:00:00.000Z");
+      const result = evaluateCancellationFee(policy, RESERVATION, cancelTime);
+      // 33% of 10000 = 3300
+      expect(result.feeAmountCents).toBe(3300);
+      expect(result.refundAmountCents).toBe(6700);
+      expect(result.depositAction).toBe("refund_partial");
+    });
+
+    it("returns refund_partial when fee > 0 but < 100%", () => {
+      const policy: CancellationPolicy = { ...POLICY, lateCancellationFeePercent: 75 };
+      const cancelTime = new Date("2026-06-01T06:00:00.000Z");
+      const result = evaluateCancellationFee(policy, RESERVATION, cancelTime);
+      expect(result.feeAmountCents).toBe(7500);
+      expect(result.refundAmountCents).toBe(2500);
+      expect(result.depositAction).toBe("refund_partial");
+      expect(result.feeType).toBe("late");
+    });
+
+    it("returns forfeit when lateCancellationFeePercent is 0 (no late fee configured)", () => {
+      const policy: CancellationPolicy = { ...POLICY, lateCancellationFeePercent: 0 };
+      const cancelTime = new Date("2026-06-01T08:00:00.000Z");
+      const result = evaluateCancellationFee(policy, RESERVATION, cancelTime);
+      // 0% fee → still "late" type but full refund
+      expect(result).toEqual({
+        feeAmountCents: 0,
+        feeType: "late",
+        refundAmountCents: 10000,
+        depositAction: "refund_full",
+      });
+    });
+  });
+
+  describe("no-show", () => {
+    it("forfeits full deposit when cancellation is after reservation time", () => {
+      // 1h after reservation
+      const cancelTime = new Date("2026-06-01T13:00:00.000Z");
+      const result = evaluateCancellationFee(POLICY, RESERVATION, cancelTime);
+      expect(result).toEqual({
+        feeAmountCents: 10000,
+        feeType: "noshow",
+        refundAmountCents: 0,
+        depositAction: "forfeit",
+      });
+    });
+
+    it("forfeits full deposit when cancellation is at exact reservation time", () => {
+      const cancelTime = new Date("2026-06-01T12:00:00.000Z");
+      const result = evaluateCancellationFee(POLICY, RESERVATION, cancelTime);
+      expect(result).toEqual({
+        feeAmountCents: 10000,
+        feeType: "noshow",
+        refundAmountCents: 0,
+        depositAction: "forfeit",
+      });
+    });
+
+    it("applies noShowFeePercent when < 100", () => {
+      const policy: CancellationPolicy = { ...POLICY, noShowFeePercent: 50 };
+      const cancelTime = new Date("2026-06-01T14:00:00.000Z");
+      const result = evaluateCancellationFee(policy, RESERVATION, cancelTime);
+      expect(result).toEqual({
+        feeAmountCents: 5000,
+        feeType: "noshow",
+        refundAmountCents: 5000,
+        depositAction: "refund_partial",
+      });
+    });
+  });
+
+  describe("formatPolicySummary", () => {
+    it("is exported alongside evaluateCancellationFee", () => {
+      expect(typeof formatPolicySummary).toBe("function");
+    });
+  });
+});
+
+describe("formatPolicySummary", () => {
+  it("returns empty string for null policy", () => {
+    expect(formatPolicySummary(null)).toBe("");
+  });
+
+  it("includes free cancellation deadline", () => {
+    const summary = formatPolicySummary(POLICY);
+    expect(summary).toContain("24 hour");
+    expect(summary.length).toBeGreaterThan(0);
+  });
+
+  it("mentions fee when late cancellation fee > 0", () => {
+    const summary = formatPolicySummary(POLICY);
+    expect(summary).toContain("50%");
+  });
+
+  it("no-fee message when freeCancellationHours is large", () => {
+    const liberalPolicy: CancellationPolicy = {
+      freeCancellationHours: 168, // 7 days
+      lateCancellationFeePercent: 0,
+      noShowFeePercent: 0,
+      depositAmountCents: 5000,
+    };
+    const summary = formatPolicySummary(liberalPolicy);
+    expect(summary).toContain("168 hour");
+  });
+});

--- a/services/reservations/src/services/cancellation-policy.ts
+++ b/services/reservations/src/services/cancellation-policy.ts
@@ -1,0 +1,124 @@
+/**
+ * Cancellation Policy Engine
+ *
+ * Pure functions — no IO, no DB calls.
+ * Takes policy config and timestamps, returns fee calculations.
+ */
+
+export interface CancellationPolicy {
+  /** Hours before reservation within which cancellation is free (inclusive boundary). */
+  freeCancellationHours: number;
+  /** Percentage of deposit charged for late cancellation (0–100). */
+  lateCancellationFeePercent: number;
+  /** Percentage of deposit charged for no-shows (0–100). */
+  noShowFeePercent: number;
+  /** Deposit amount in cents. */
+  depositAmountCents: number;
+}
+
+export type FeeType = "none" | "late" | "noshow";
+export type DepositAction = "refund_full" | "refund_partial" | "forfeit";
+
+export interface CancellationFeeResult {
+  feeAmountCents: number;
+  feeType: FeeType;
+  refundAmountCents: number;
+  depositAction: DepositAction;
+}
+
+/**
+ * Derive deposit action from fee amount relative to deposit amount.
+ */
+function depositAction(feeAmountCents: number, depositAmountCents: number): DepositAction {
+  if (feeAmountCents <= 0) return "refund_full";
+  if (feeAmountCents >= depositAmountCents) return "forfeit";
+  return "refund_partial";
+}
+
+/**
+ * Calculate the cancellation fee for a reservation.
+ *
+ * @param policy  Venue cancellation policy. Null/undefined → no fee.
+ * @param reservationTime  When the reservation starts.
+ * @param cancellationTime  When the guest is cancelling.
+ * @returns Fee calculation — no IO performed.
+ */
+export function evaluateCancellationFee(
+  policy: CancellationPolicy | null | undefined,
+  reservationTime: Date,
+  cancellationTime: Date
+): CancellationFeeResult {
+  // No policy or no deposit → always full refund
+  if (!policy || policy.depositAmountCents <= 0) {
+    return {
+      feeAmountCents: 0,
+      feeType: "none",
+      refundAmountCents: 0,
+      depositAction: "refund_full",
+    };
+  }
+
+  const {
+    freeCancellationHours,
+    lateCancellationFeePercent,
+    noShowFeePercent,
+    depositAmountCents,
+  } = policy;
+
+  const reservationMs = reservationTime.getTime();
+  const cancellationMs = cancellationTime.getTime();
+
+  // No-show: cancelled at or after reservation start time
+  if (cancellationMs >= reservationMs) {
+    const feeAmountCents = Math.round((depositAmountCents * noShowFeePercent) / 100);
+    const refundAmountCents = depositAmountCents - feeAmountCents;
+    return {
+      feeAmountCents,
+      feeType: "noshow",
+      refundAmountCents,
+      depositAction: depositAction(feeAmountCents, depositAmountCents),
+    };
+  }
+
+  // Free window boundary (inclusive): reservationTime - freeCancellationHours
+  const freeWindowBoundaryMs = reservationMs - freeCancellationHours * 60 * 60 * 1000;
+
+  // Within free window (cancelled at or before the boundary)
+  if (cancellationMs <= freeWindowBoundaryMs) {
+    return {
+      feeAmountCents: 0,
+      feeType: "none",
+      refundAmountCents: depositAmountCents,
+      depositAction: "refund_full",
+    };
+  }
+
+  // Late cancellation: inside the window but before reservation time
+  const feeAmountCents = Math.round((depositAmountCents * lateCancellationFeePercent) / 100);
+  const refundAmountCents = depositAmountCents - feeAmountCents;
+  return {
+    feeAmountCents,
+    feeType: "late",
+    refundAmountCents,
+    depositAction: depositAction(feeAmountCents, depositAmountCents),
+  };
+}
+
+/**
+ * Human-readable summary of cancellation policy for UI display.
+ * Returns empty string when no policy is set.
+ */
+export function formatPolicySummary(policy: CancellationPolicy | null | undefined): string {
+  if (!policy) return "";
+
+  const { freeCancellationHours, lateCancellationFeePercent } = policy;
+
+  if (lateCancellationFeePercent <= 0) {
+    return `Free cancellation up to ${freeCancellationHours} hours before your reservation.`;
+  }
+
+  return (
+    `Free cancellation up to ${freeCancellationHours} hours before your reservation. ` +
+    `After that, a ${lateCancellationFeePercent}% cancellation fee applies.`
+  );
+}


### PR DESCRIPTION
## What

Pure-function cancellation policy engine for the reservations service.

## Changes

- **`cancellation-policy.ts`**: `evaluateCancellationFee(policy, reservationTime, cancellationTime)` — no IO, no DB, takes policy config + timestamps, returns `{ feeAmountCents, feeType, refundAmountCents, depositAction }`
- **`formatPolicySummary(policy)`**: plain-language UI string for booking widget + cancellation dialog
- **`CancellationPolicy` interface**: typed policy config (`freeCancellationHours`, `lateCancellationFeePercent`, `noShowFeePercent`, `depositAmountCents`)

## Fee rules

| Situation | feeType | depositAction |
|---|---|---|
| No policy / zero deposit | `none` | `refund_full` |
| Cancelled ≥ `freeCancellationHours` before (inclusive) | `none` | `refund_full` |
| Cancelled inside window but before reservation | `late` | `refund_partial` or `forfeit` |
| Cancelled at or after reservation time | `noshow` | `forfeit` |

## Tests

20 unit tests — every fee scenario, boundary conditions, 0% fee edges, missing policy.

```
Test Files  1 passed (1)
      Tests  20 passed (20)
```

## Notes

Stripe refund integration (cancel endpoint calling this engine) will follow in a separate PR after #1787 merges — the `depositAction` return value is designed to map directly to `DepositService` transitions.

Closes #1723

https://claude.ai/code/session_012DkXKFtYdjxFtCkNpfeetV

---
_Generated by [Claude Code](https://claude.ai/code/session_012DkXKFtYdjxFtCkNpfeetV)_