### PR TITLE
fix(hospitality): restrict venue switching to sidebar navigation only

### DIFF
--- a/apps/hospitality/src/pages/GuestsPage.test.tsx
+++ b/apps/hospitality/src/pages/GuestsPage.test.tsx
@@ -1052,26 +1052,16 @@ describe("GuestsPage - multi-venue", () => {
     mockApiClient.reservations.list.mockResolvedValue({ data: [], pagination: {} });
   });
 
-  it("shows venue selector when isMultiVenue is true", async () => {
+  it("does not show a venue selector (venue switching is sidebar-only)", async () => {
     renderPage();
 
+    // Wait for the page to finish loading (guest data rendered)
     await waitFor(() => {
-      expect(screen.getByTestId("select-Venue")).toBeDefined();
-    });
-  });
-
-  it("calls setVenueId when venue is changed", async () => {
-    renderPage();
-
-    await waitFor(() => {
-      expect(screen.getByTestId("select-Venue")).toBeDefined();
+      expect(screen.getAllByText("John Doe").length).toBeGreaterThan(0);
     });
 
-    fireEvent.change(screen.getByTestId("select-Venue"), {
-      target: { value: "venue-2" },
-    });
-
-    expect(mockSetVenueId).toHaveBeenCalledWith("venue-2");
+    // Venue selector should NOT be present — switching is sidebar-only
+    expect(screen.queryByTestId("select-Venue")).toBeNull();
   });
 });
 

--- a/apps/hospitality/src/pages/GuestsPage.tsx
+++ b/apps/hospitality/src/pages/GuestsPage.tsx
@@ -10,7 +10,6 @@ import {
   Drawer,
   EmptyState,
   Input,
-  Select,
   Skeleton,
   SkeletonGroup,
   Stack,
@@ -601,7 +600,7 @@ function MobileGuestCard({ guest, onClick }: MobileGuestCardProps) {
 /* ── Main component ─────────────────────────── */
 
 export function GuestsPage() {
-  const { venues, selectedVenueId, setVenueId, isMultiVenue } = useVenue();
+  const { selectedVenueId } = useVenue();
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
 
@@ -647,11 +646,6 @@ export function GuestsPage() {
   );
 
   const drawerOpen = selectedGuestId !== null;
-
-  const venueOptions = useMemo(
-    () => [...venues].map((v) => ({ value: v.id, label: v.name })),
-    [venues]
-  );
 
   const formatDate = (isoString: string | null) => {
     if (!isoString) return "Never";
@@ -719,14 +713,6 @@ export function GuestsPage() {
       <div className={styles.header}>
         <PageHeader title="Guests" description="Manage your guest directory" />
         <div className={styles.headerControls}>
-          {isMultiVenue && (
-            <Select
-              label="Venue"
-              options={venueOptions}
-              value={selectedVenueId ?? ""}
-              onChange={(value) => setVenueId(value)}
-            />
-          )}
           <Input
             type="text"
             placeholder="Search guests..."

--- a/services/agent/llms-full.txt
+++ b/services/agent/llms-full.txt
@@ -966,7 +966,7 @@
         const staleSessions = await sessionService.findStaleSessions(INACTIVITY_THRESHOLD_MS);
     
         for (const session of staleSessions) {
-          console.warn(
+          activeLogger?.warn(
             `[liveness] Session ${session.id} exceeded inactivity threshold — auto-cancelling`
           );
     
@@ -979,13 +979,14 @@
           }
         }
       } catch (error) {
-        console.error("[liveness] Error checking stale sessions:", error);
+        activeLogger?.error({ err: error }, "[liveness] Error checking stale sessions");
       }
     }
-    export function startLivenessMonitor(): void {
+    export function startLivenessMonitor(logger: FastifyBaseLogger): void {
       if (intervalHandle) return;
+      activeLogger = logger;
       intervalHandle = setInterval(checkStaleSessions, CHECK_INTERVAL_MS);
-      console.log(
+      logger.info(
         `[liveness] Monitor started (check every ${CHECK_INTERVAL_MS / 1000}s, timeout ${INACTIVITY_THRESHOLD_MS / 1000}s)`
       );
     }

--- a/services/agent/llms.txt
+++ b/services/agent/llms.txt
@@ -137,7 +137,7 @@
       async function checkStaleSessions(): Promise<void> { /* ... */ }
     </item>
     <item priority="high">
-      export function startLivenessMonitor(): void { /* ... */ }
+      export function startLivenessMonitor(logger: FastifyBaseLogger): void { /* ... */ }
     </item>
   </file>
   <file path="src/services/remediation-circuit-breaker.ts">


### PR DESCRIPTION
## Summary

- Remove inline venue selector from GuestsPage (the only non-sidebar venue switching UI)
- Venue switching is now exclusively available via the VenueSwitcher in the sidebar nav
- Selected venue already persists across page navigations via localStorage in VenueContext

## Test plan

- [x] Updated multi-venue test: asserts venue selector is NOT rendered on GuestsPage
- [x] All 809 hospitality tests pass
- [x] TypeScript typecheck passes
- [x] Pre-push hooks pass (lint, typecheck, test)

Closes #1794