### PR TITLE
feat: service briefing page with guest intelligence (#1738)

### DIFF
--- a/apps/hospitality/llms-full.txt
+++ b/apps/hospitality/llms-full.txt
@@ -156,6 +156,14 @@
       );
     }
   </file>
+  <file path="src/hooks/useBriefing.ts">
+    export const BRIEFING_QUERY_KEY = "briefing" as const;
+    export interface UseBriefingParams {
+      venueId?: string;
+      date?: string;
+      enabled?: boolean;
+    }
+  </file>
   <file path="src/hooks/useDashboardStats.ts">
     export interface DashboardStats {
       totalReservations: number;

--- a/apps/hospitality/llms.txt
+++ b/apps/hospitality/llms.txt
@@ -88,6 +88,18 @@
       export function useApiClient() { /* ... */ }
     </item>
   </file>
+  <file path="src/hooks/useBriefing.ts">
+    <item priority="high">
+      export const BRIEFING_QUERY_KEY: unknown;
+    </item>
+    <item priority="low">
+      interface UseBriefingParams {
+        venueId?: string;
+        date?: string;
+        enabled?: boolean;
+      }
+    </item>
+  </file>
   <file path="src/hooks/useDashboardStats.ts">
     <item priority="low">
       interface DashboardStats {

--- a/apps/hospitality/src/hooks/useBriefing.ts
+++ b/apps/hospitality/src/hooks/useBriefing.ts
@@ -1,0 +1,38 @@
+import { useQuery } from "@tanstack/react-query";
+import type { BriefingResponse } from "@mbe/api-client";
+import { useApiClient } from "./useApiClient.js";
+
+export const BRIEFING_QUERY_KEY = "briefing" as const;
+
+export interface UseBriefingParams {
+  venueId?: string;
+  date?: string;
+  enabled?: boolean;
+}
+
+export interface UseBriefingResult {
+  data: BriefingResponse | undefined;
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => void;
+}
+
+export function useBriefing(params: UseBriefingParams = {}): UseBriefingResult {
+  const { venueId, date, enabled = true } = params;
+  const api = useApiClient();
+
+  const query = useQuery({
+    queryKey: [BRIEFING_QUERY_KEY, venueId, date],
+    queryFn: async () => {
+      return api.briefing.get(venueId!, date);
+    },
+    enabled: enabled && Boolean(venueId),
+  });
+
+  return {
+    data: query.data,
+    isLoading: query.isLoading,
+    error: query.error ?? null,
+    refetch: query.refetch,
+  };
+}

--- a/apps/hospitality/src/main.tsx
+++ b/apps/hospitality/src/main.tsx
@@ -84,6 +84,9 @@ const ManageReservationPage = lazy(() =>
   }))
 );
 const ChatPage = lazy(() => import("./pages/ChatPage.js").then((m) => ({ default: m.ChatPage })));
+const BriefingPage = lazy(() =>
+  import("./pages/BriefingPage.js").then((m) => ({ default: m.BriefingPage }))
+);
 
 // Validate auth config at startup — fail fast with a user-friendly error
 const authConfigResult = validateAuthConfig();
@@ -166,6 +169,14 @@ const router = createBrowserRouter(
               element: (
                 <Suspense fallback={<LoadingPage />}>
                   <HomePage />
+                </Suspense>
+              ),
+            },
+            {
+              path: "briefing",
+              element: (
+                <Suspense fallback={<LoadingPage />}>
+                  <BriefingPage />
                 </Suspense>
               ),
             },

--- a/apps/hospitality/src/nav-sections.test.ts
+++ b/apps/hospitality/src/nav-sections.test.ts
@@ -68,7 +68,9 @@ describe("buildNavSections", () => {
       // First section has no label (primary nav)
       const primary = sections[0];
       expect(primary.label).toBeUndefined();
-      expect(primary.items[0].id).toBe("timeline");
+      expect(primary.items[0].id).toBe("briefing");
+      const timelineItem = primary.items.find((i) => i.id === "timeline");
+      expect(timelineItem).toBeDefined();
     });
 
     it("includes a Manage section", () => {

--- a/apps/hospitality/src/nav-sections.ts
+++ b/apps/hospitality/src/nav-sections.ts
@@ -83,6 +83,7 @@ function buildSetupSections(readiness: VenueReadiness): readonly NavSection[] {
 function buildOperationalSections(): readonly NavSection[] {
   const PRIMARY: NavSection = {
     items: [
+      { id: "briefing", label: "Tonight's Service", path: "/briefing" },
       { id: "timeline", label: "Timeline", path: "/timeline" },
       { id: "reservations", label: "Reservations", path: "/reservations" },
       { id: "guests", label: "Guests", path: "/guests" },

--- a/apps/hospitality/src/pages/BriefingPage.module.css
+++ b/apps/hospitality/src/pages/BriefingPage.module.css
@@ -1,0 +1,110 @@
+.container {
+  padding: var(--rialto-space-lg);
+  max-width: 900px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--rialto-space-lg);
+}
+
+.controls {
+  display: flex;
+  gap: var(--rialto-space-md);
+  flex-wrap: wrap;
+}
+
+.stats {
+  padding: var(--rialto-space-xs) 0;
+}
+
+/* Time slot section */
+.slotSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--rialto-space-sm);
+}
+
+.slotHeader {
+  display: flex;
+  align-items: baseline;
+  gap: var(--rialto-space-sm);
+  padding-bottom: var(--rialto-space-xs);
+  border-bottom: 1px solid var(--rialto-border);
+}
+
+.cardList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--rialto-space-sm);
+}
+
+/* Reservation card */
+.card {
+  padding: var(--rialto-space-md);
+}
+
+.cardAllergies {
+  border-left: 3px solid var(--rialto-error);
+}
+
+.cardHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.timeGroup {
+  display: flex;
+  align-items: center;
+  gap: var(--rialto-space-xs);
+}
+
+.guestRow {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--rialto-space-sm);
+}
+
+.guestName {
+  font-weight: 600;
+}
+
+.badgeRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--rialto-space-xs);
+}
+
+.dietaryLabel {
+  margin-bottom: var(--rialto-space-xs);
+}
+
+.dietaryFlags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--rialto-space-xs);
+}
+
+.crmSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--rialto-space-xs);
+}
+
+.tagRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--rialto-space-xs);
+}
+
+.staffNote {
+  font-style: italic;
+  color: var(--rialto-text-secondary);
+  border-left: 2px solid var(--rialto-border);
+  padding-left: var(--rialto-space-sm);
+}
+
+.reservationNote {
+  color: var(--rialto-text-secondary);
+}

--- a/apps/hospitality/src/pages/BriefingPage.test.tsx
+++ b/apps/hospitality/src/pages/BriefingPage.test.tsx
@@ -1,0 +1,282 @@
+import "@testing-library/jest-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { BriefingPage } from "./BriefingPage.js";
+import { useVenue } from "../contexts/VenueContext.js";
+import type { VenueContextValue } from "../contexts/VenueContext.js";
+import { useBriefing } from "../hooks/useBriefing.js";
+import type { UseBriefingResult } from "../hooks/useBriefing.js";
+import { useReservationEvents } from "../hooks/useReservationEvents.js";
+import type { BriefingResponse, BriefingReservation } from "@mbe/api-client";
+import React from "react";
+
+vi.mock("../contexts/VenueContext.js", () => ({ useVenue: vi.fn() }));
+vi.mock("../hooks/useBriefing.js", () => ({ useBriefing: vi.fn() }));
+vi.mock("../hooks/useReservationEvents.js", () => ({
+  useReservationEvents: vi.fn().mockReturnValue({ isConnected: false, error: null, reconnect: vi.fn() }),
+}));
+
+vi.mock("../components/PageHeader.js", () => ({
+  PageHeader: ({ title }: { title: string }) => <div data-testid="page-header">{title}</div>,
+}));
+
+vi.mock("@mattbutlerengineering/rialto", () => ({
+  Alert: ({ children }: { children: React.ReactNode }) => <div data-testid="alert">{children}</div>,
+  Badge: ({ children }: { children: React.ReactNode }) => (
+    <span data-testid="badge">{children}</span>
+  ),
+  Card: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div data-testid="card" className={className}>{children}</div>
+  ),
+  EmptyState: ({
+    heading,
+    description,
+  }: {
+    heading: React.ReactNode;
+    description?: React.ReactNode;
+  }) => (
+    <div data-testid="empty-state">
+      <span>{heading}</span>
+      {description && <span>{description}</span>}
+    </div>
+  ),
+  Input: (props: {
+    type?: string;
+    value?: string;
+    onChange?: React.ChangeEventHandler<HTMLInputElement>;
+    placeholder?: string;
+    "aria-label"?: string;
+  }) => (
+    <input
+      data-testid={props.type === "date" ? "date-input" : "time-input"}
+      type={props.type}
+      value={props.value}
+      onChange={props.onChange}
+      placeholder={props.placeholder}
+      aria-label={props["aria-label"]}
+    />
+  ),
+  Skeleton: () => <div data-testid="skeleton" />,
+  SkeletonGroup: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="skeleton-group">{children}</div>
+  ),
+  Stack: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Text: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}));
+
+/* ── Helpers ─────────────────────────────────── */
+
+function makeVenueContext(overrides: Partial<VenueContextValue> = {}): VenueContextValue {
+  return {
+    selectedVenueId: "venue-1",
+    venues: [],
+    selectedVenue: null,
+    setVenueId: vi.fn(),
+    isLoading: false,
+    isMultiVenue: false,
+    refetchVenues: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeReservation(overrides: Partial<BriefingReservation> = {}): BriefingReservation {
+  return {
+    id: "res-1",
+    startTime: "2026-05-26T18:00:00.000Z",
+    endTime: "2026-05-26T19:30:00.000Z",
+    partySize: 2,
+    status: "CONFIRMED",
+    notes: null,
+    occasion: null,
+    seatingPreference: null,
+    guestName: "Jane Smith",
+    tableId: "table-1",
+    tableName: "Table 1",
+    venueId: "venue-1",
+    guest: null,
+    ...overrides,
+  };
+}
+
+function makeBriefingResult(overrides: Partial<UseBriefingResult> = {}): UseBriefingResult {
+  return {
+    data: undefined,
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeBriefingData(reservations: BriefingReservation[]): BriefingResponse {
+  return {
+    date: "2026-05-26",
+    venueId: "venue-1",
+    reservations,
+  };
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <BriefingPage />
+    </MemoryRouter>
+  );
+}
+
+/* ── Tests ─────────────────────────────────── */
+
+describe("BriefingPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useVenue).mockReturnValue(makeVenueContext());
+    vi.mocked(useBriefing).mockReturnValue(makeBriefingResult());
+    vi.mocked(useReservationEvents).mockReturnValue({
+      isConnected: false,
+      error: null,
+      reconnect: vi.fn(),
+    });
+  });
+
+  it("renders page header", () => {
+    vi.mocked(useBriefing).mockReturnValue(
+      makeBriefingResult({ data: makeBriefingData([]) })
+    );
+    renderPage();
+    expect(screen.getByTestId("page-header")).toBeInTheDocument();
+  });
+
+  it("shows loading skeleton while data is loading", () => {
+    vi.mocked(useBriefing).mockReturnValue(makeBriefingResult({ isLoading: true }));
+    renderPage();
+    expect(screen.getByTestId("skeleton-group")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no reservations", () => {
+    vi.mocked(useBriefing).mockReturnValue(
+      makeBriefingResult({ data: makeBriefingData([]) })
+    );
+    renderPage();
+    expect(screen.getByTestId("empty-state")).toBeInTheDocument();
+  });
+
+  it("renders reservation cards", () => {
+    const reservations = [
+      makeReservation({ id: "res-1", guestName: "Alice" }),
+      makeReservation({ id: "res-2", guestName: "Bob", startTime: "2026-05-26T19:00:00.000Z" }),
+    ];
+    vi.mocked(useBriefing).mockReturnValue(
+      makeBriefingResult({ data: makeBriefingData(reservations) })
+    );
+    renderPage();
+    expect(screen.getAllByTestId("card")).toHaveLength(2);
+  });
+
+  it("groups reservations by time slot", () => {
+    const reservations = [
+      makeReservation({ id: "res-1", startTime: "2026-05-26T18:00:00.000Z" }),
+      makeReservation({ id: "res-2", startTime: "2026-05-26T18:15:00.000Z" }), // same 18:00 slot
+      makeReservation({ id: "res-3", startTime: "2026-05-26T19:00:00.000Z" }), // different slot
+    ];
+    vi.mocked(useBriefing).mockReturnValue(
+      makeBriefingResult({ data: makeBriefingData(reservations) })
+    );
+    renderPage();
+    // Should have 2 time slot sections (18:00 and 19:00)
+    expect(screen.getAllByTestId("time-slot")).toHaveLength(2);
+  });
+
+  it("displays guest CRM data when guest is present", () => {
+    const reservations = [
+      makeReservation({
+        id: "res-1",
+        guest: {
+          id: "guest-1",
+          name: "Jane Smith",
+          email: "jane@example.com",
+          phone: null,
+          visitCount: 5,
+          lastVisit: "2026-04-01T19:00:00.000Z",
+          dietaryRestrictions: ["gluten-free"],
+          tags: ["VIP"],
+          staffNotes: [{ text: "Prefers quiet corner", createdBy: "staff", createdAt: "2026-01-01T00:00:00Z" }],
+        },
+      }),
+    ];
+    vi.mocked(useBriefing).mockReturnValue(
+      makeBriefingResult({ data: makeBriefingData(reservations) })
+    );
+    renderPage();
+    expect(screen.getByText("gluten-free")).toBeInTheDocument();
+    expect(screen.getByText("VIP")).toBeInTheDocument();
+    expect(screen.getByText("Prefers quiet corner")).toBeInTheDocument();
+  });
+
+  it("shows occasion badge when occasion is set", () => {
+    const reservations = [
+      makeReservation({ id: "res-1", occasion: "anniversary" }),
+    ];
+    vi.mocked(useBriefing).mockReturnValue(
+      makeBriefingResult({ data: makeBriefingData(reservations) })
+    );
+    renderPage();
+    expect(screen.getByText("Anniversary")).toBeInTheDocument();
+  });
+
+  it("shows error alert on failure", () => {
+    vi.mocked(useBriefing).mockReturnValue(
+      makeBriefingResult({ error: new Error("API error") })
+    );
+    renderPage();
+    expect(screen.getByTestId("alert")).toBeInTheDocument();
+  });
+
+  it("subscribes to SSE events for real-time updates", () => {
+    vi.mocked(useBriefing).mockReturnValue(
+      makeBriefingResult({ data: makeBriefingData([]) })
+    );
+    renderPage();
+    expect(useReservationEvents).toHaveBeenCalledWith(
+      expect.objectContaining({
+        venueId: "venue-1",
+        onReservationCreated: expect.any(Function),
+        onReservationUpdated: expect.any(Function),
+        onReservationCancelled: expect.any(Function),
+      })
+    );
+  });
+
+  it("renders date input for navigation", () => {
+    vi.mocked(useBriefing).mockReturnValue(
+      makeBriefingResult({ data: makeBriefingData([]) })
+    );
+    renderPage();
+    expect(screen.getByTestId("date-input")).toBeInTheDocument();
+  });
+
+  it("shows dietary allergy badges highlighted on card", () => {
+    const reservations = [
+      makeReservation({
+        id: "res-1",
+        guest: {
+          id: "guest-1",
+          name: "Celiac Guest",
+          email: null,
+          phone: null,
+          visitCount: 1,
+          lastVisit: null,
+          dietaryRestrictions: ["gluten-free", "dairy-free"],
+          tags: null,
+          staffNotes: [],
+        },
+      }),
+    ];
+    vi.mocked(useBriefing).mockReturnValue(
+      makeBriefingResult({ data: makeBriefingData(reservations) })
+    );
+    renderPage();
+    expect(screen.getByText("gluten-free")).toBeInTheDocument();
+    expect(screen.getByText("dairy-free")).toBeInTheDocument();
+  });
+});

--- a/apps/hospitality/src/pages/BriefingPage.tsx
+++ b/apps/hospitality/src/pages/BriefingPage.tsx
@@ -1,0 +1,348 @@
+import { useState, useCallback, useRef } from "react";
+import {
+  Alert,
+  Badge,
+  Card,
+  EmptyState,
+  Input,
+  Skeleton,
+  SkeletonGroup,
+  Stack,
+  Text,
+} from "@mattbutlerengineering/rialto";
+import type { BriefingReservation } from "@mbe/api-client";
+import { useVenue } from "../contexts/VenueContext.js";
+import { useBriefing } from "../hooks/useBriefing.js";
+import { useReservationEvents } from "../hooks/useReservationEvents.js";
+import { PageHeader } from "../components/PageHeader.js";
+import styles from "./BriefingPage.module.css";
+
+/* ── Helpers ────────────────────────────────── */
+
+function formatTime(isoString: string): string {
+  const date = new Date(isoString);
+  return date.toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  });
+}
+
+function formatDateInput(date: Date): string {
+  return date.toLocaleDateString("en-CA"); // YYYY-MM-DD
+}
+
+/* ── Occasion badge ─────────────────────────── */
+
+const OCCASION_LABELS: Record<string, string> = {
+  birthday: "Birthday",
+  anniversary: "Anniversary",
+  business: "Business",
+  date_night: "Date Night",
+  other: "Special",
+};
+
+function OccasionBadge({ occasion }: { readonly occasion: string | null }) {
+  if (!occasion || occasion === "none") return null;
+  const label = OCCASION_LABELS[occasion] ?? occasion;
+  return (
+    <Badge variant="warning" size="sm">
+      {label}
+    </Badge>
+  );
+}
+
+/* ── Dietary flags ──────────────────────────── */
+
+function DietaryFlags({ restrictions }: { readonly restrictions: string[] | null }) {
+  if (!restrictions || restrictions.length === 0) return null;
+  return (
+    <div className={styles.dietaryFlags}>
+      {restrictions.map((r) => (
+        <Badge key={r} variant="error" size="sm">
+          {r}
+        </Badge>
+      ))}
+    </div>
+  );
+}
+
+/* ── Reservation card ───────────────────────── */
+
+function BriefingCard({ reservation }: { readonly reservation: BriefingReservation }) {
+  const guest = reservation.guest;
+  const guestName = guest?.name ?? reservation.guestName ?? "Unknown Guest";
+  const hasAllergies =
+    guest?.dietaryRestrictions != null && guest.dietaryRestrictions.length > 0;
+
+  return (
+    <Card className={`${styles.card} ${hasAllergies ? styles.cardAllergies : ""}`}>
+      <Stack gap="sm">
+        {/* Header row: time + party size */}
+        <div className={styles.cardHeader}>
+          <div className={styles.timeGroup}>
+            <Text variant="label" color="secondary">
+              {formatTime(reservation.startTime)}
+            </Text>
+            <Text variant="label" color="secondary">
+              &ndash;
+            </Text>
+            <Text variant="label" color="secondary">
+              {formatTime(reservation.endTime)}
+            </Text>
+          </div>
+          <Badge variant={reservation.status === "CONFIRMED" ? "success" : "warning"} size="sm">
+            {reservation.status === "CONFIRMED" ? "Confirmed" : "Pending"}
+          </Badge>
+        </div>
+
+        {/* Guest name + party size */}
+        <div className={styles.guestRow}>
+          <Text variant="body" color="primary" className={styles.guestName}>
+            {guestName}
+          </Text>
+          <Text variant="caption" color="secondary">
+            {reservation.partySize} {reservation.partySize === 1 ? "cover" : "covers"}
+          </Text>
+        </div>
+
+        {/* Table assignment */}
+        {reservation.tableName && (
+          <Text variant="caption" color="secondary">
+            {reservation.tableName}
+          </Text>
+        )}
+
+        {/* Badges row: occasion + seating preference */}
+        <div className={styles.badgeRow}>
+          <OccasionBadge occasion={reservation.occasion} />
+          {reservation.seatingPreference && reservation.seatingPreference !== "no_preference" && (
+            <Badge variant="neutral" size="sm">
+              {reservation.seatingPreference}
+            </Badge>
+          )}
+        </div>
+
+        {/* Dietary restrictions */}
+        {hasAllergies && (
+          <div>
+            <Text variant="caption" color="secondary" className={styles.dietaryLabel}>
+              Dietary:
+            </Text>
+            <DietaryFlags restrictions={guest?.dietaryRestrictions ?? null} />
+          </div>
+        )}
+
+        {/* CRM data */}
+        {guest && (
+          <div className={styles.crmSection}>
+            <Text variant="caption" color="secondary">
+              {guest.visitCount === 0
+                ? "First visit"
+                : `${guest.visitCount} visit${guest.visitCount === 1 ? "" : "s"}`}
+              {guest.lastVisit
+                ? ` · Last: ${new Date(guest.lastVisit).toLocaleDateString("en-US", { month: "short", day: "numeric" })}`
+                : ""}
+            </Text>
+            {guest.tags && guest.tags.length > 0 && (
+              <div className={styles.tagRow}>
+                {guest.tags.map((tag) => (
+                  <Badge key={tag} variant="neutral" size="sm">
+                    {tag}
+                  </Badge>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Staff notes excerpt */}
+        {guest?.staffNotes && guest.staffNotes.length > 0 && (
+          <Text variant="caption" color="secondary" className={styles.staffNote}>
+            {guest.staffNotes[0].text}
+          </Text>
+        )}
+
+        {/* Reservation notes */}
+        {reservation.notes && (
+          <Text variant="caption" color="secondary" className={styles.reservationNote}>
+            Note: {reservation.notes}
+          </Text>
+        )}
+      </Stack>
+    </Card>
+  );
+}
+
+/* ── Time slot group ────────────────────────── */
+
+function timeSlotKey(isoString: string): string {
+  const d = new Date(isoString);
+  const h = d.getHours();
+  const m = d.getMinutes();
+  // Round down to nearest 30 min
+  const slotMinute = m < 30 ? 0 : 30;
+  return `${String(h).padStart(2, "0")}:${String(slotMinute).padStart(2, "0")}`;
+}
+
+function formatSlotLabel(slotKey: string): string {
+  const [h, m] = slotKey.split(":").map(Number);
+  const period = h < 12 ? "AM" : "PM";
+  const hour12 = h % 12 || 12;
+  return `${hour12}:${String(m).padStart(2, "0")} ${period}`;
+}
+
+interface TimeSlot {
+  key: string;
+  label: string;
+  reservations: BriefingReservation[];
+  totalCovers: number;
+}
+
+function groupByTimeSlot(reservations: BriefingReservation[]): TimeSlot[] {
+  const map = new Map<string, BriefingReservation[]>();
+
+  for (const r of reservations) {
+    const key = timeSlotKey(r.startTime);
+    const existing = map.get(key) ?? [];
+    map.set(key, [...existing, r]);
+  }
+
+  return Array.from(map.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, rsvps]) => ({
+      key,
+      label: formatSlotLabel(key),
+      reservations: rsvps,
+      totalCovers: rsvps.reduce((sum, r) => sum + r.partySize, 0),
+    }));
+}
+
+/* ── Loading skeleton ───────────────────────── */
+
+function BriefingLoadingSkeleton() {
+  return (
+    <div className={styles.container}>
+      <PageHeader title="Tonight&apos;s Service" description="Pre-service guest intelligence" />
+      <SkeletonGroup>
+        <Skeleton variant="card" width="100%" height={200} />
+        <Skeleton variant="card" width="100%" height={200} />
+      </SkeletonGroup>
+    </div>
+  );
+}
+
+/* ── Main page ──────────────────────────────── */
+
+export function BriefingPage() {
+  const { selectedVenueId } = useVenue();
+  const [selectedDate, setSelectedDate] = useState<string>(formatDateInput(new Date()));
+  const [timeFilter, setTimeFilter] = useState<string>("");
+
+  const { data, isLoading, error, refetch } = useBriefing({
+    venueId: selectedVenueId ?? undefined,
+    date: selectedDate,
+    enabled: Boolean(selectedVenueId),
+  });
+
+  // SSE: update briefing on reservation changes using refs to avoid reconnect
+  const refetchRef = useRef(refetch);
+  refetchRef.current = refetch;
+
+  const handleReservationChange = useCallback(() => {
+    refetchRef.current();
+  }, []);
+
+  useReservationEvents({
+    venueId: selectedVenueId ?? undefined,
+    onReservationCreated: handleReservationChange,
+    onReservationUpdated: handleReservationChange,
+    onReservationCancelled: handleReservationChange,
+    enabled: Boolean(selectedVenueId),
+  });
+
+  if (isLoading) {
+    return <BriefingLoadingSkeleton />;
+  }
+
+  const reservations = data?.reservations ?? [];
+
+  // Filter by time slot if a filter is active
+  const filtered = timeFilter
+    ? reservations.filter((r) => timeSlotKey(r.startTime) >= timeFilter)
+    : reservations;
+
+  const timeSlots = groupByTimeSlot(filtered);
+  const totalCovers = filtered.reduce((sum, r) => sum + r.partySize, 0);
+  const confirmedCount = filtered.filter((r) => r.status === "CONFIRMED").length;
+
+  return (
+    <div className={styles.container} data-testid="briefing-page">
+      <PageHeader
+        title="Tonight's Service"
+        description="Pre-service guest intelligence briefing"
+      />
+
+      {error && (
+        <Alert variant="error">Failed to load briefing. Please try again.</Alert>
+      )}
+
+      {/* Controls */}
+      <div className={styles.controls}>
+        <Input
+          type="date"
+          value={selectedDate}
+          onChange={(e) => setSelectedDate(e.target.value)}
+          aria-label="Select date"
+        />
+        <Input
+          type="time"
+          value={timeFilter}
+          onChange={(e) => setTimeFilter(e.target.value)}
+          placeholder="Filter from time..."
+          aria-label="Filter by start time"
+        />
+      </div>
+
+      {/* Summary stats */}
+      {reservations.length > 0 && (
+        <div className={styles.stats}>
+          <Text variant="caption" color="secondary">
+            {filtered.length} reservation{filtered.length === 1 ? "" : "s"} &middot; {totalCovers} covers &middot; {confirmedCount} confirmed
+          </Text>
+        </div>
+      )}
+
+      {/* Empty state */}
+      {filtered.length === 0 && !isLoading && !error && (
+        <EmptyState
+          heading="No reservations"
+          description={
+            timeFilter
+              ? "No reservations match the selected time filter."
+              : `No upcoming reservations for ${selectedDate}.`
+          }
+        />
+      )}
+
+      {/* Time slot groups */}
+      {timeSlots.map((slot) => (
+        <section key={slot.key} className={styles.slotSection} data-testid="time-slot">
+          <div className={styles.slotHeader}>
+            <Text variant="label" color="primary">
+              {slot.label}
+            </Text>
+            <Text variant="caption" color="secondary">
+              {slot.reservations.length} {slot.reservations.length === 1 ? "party" : "parties"} &middot; {slot.totalCovers} covers
+            </Text>
+          </div>
+          <div className={styles.cardList}>
+            {slot.reservations.map((r) => (
+              <BriefingCard key={r.id} reservation={r} />
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/apps/hospitality/src/pages/BriefingPage.tsx
+++ b/apps/hospitality/src/pages/BriefingPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
 import {
   Alert,
   Badge,
@@ -72,8 +72,7 @@ function DietaryFlags({ restrictions }: { readonly restrictions: string[] | null
 function BriefingCard({ reservation }: { readonly reservation: BriefingReservation }) {
   const guest = reservation.guest;
   const guestName = guest?.name ?? reservation.guestName ?? "Unknown Guest";
-  const hasAllergies =
-    guest?.dietaryRestrictions != null && guest.dietaryRestrictions.length > 0;
+  const hasAllergies = guest?.dietaryRestrictions != null && guest.dietaryRestrictions.length > 0;
 
   return (
     <Card className={`${styles.card} ${hasAllergies ? styles.cardAllergies : ""}`}>
@@ -223,7 +222,7 @@ function groupByTimeSlot(reservations: BriefingReservation[]): TimeSlot[] {
 function BriefingLoadingSkeleton() {
   return (
     <div className={styles.container}>
-      <PageHeader title="Tonight&apos;s Service" description="Pre-service guest intelligence" />
+      <PageHeader title="Tonight's Service" description="Pre-service guest intelligence" />
       <SkeletonGroup>
         <Skeleton variant="card" width="100%" height={200} />
         <Skeleton variant="card" width="100%" height={200} />
@@ -247,7 +246,9 @@ export function BriefingPage() {
 
   // SSE: update briefing on reservation changes using refs to avoid reconnect
   const refetchRef = useRef(refetch);
-  refetchRef.current = refetch;
+  useEffect(() => {
+    refetchRef.current = refetch;
+  }, [refetch]);
 
   const handleReservationChange = useCallback(() => {
     refetchRef.current();
@@ -278,14 +279,9 @@ export function BriefingPage() {
 
   return (
     <div className={styles.container} data-testid="briefing-page">
-      <PageHeader
-        title="Tonight's Service"
-        description="Pre-service guest intelligence briefing"
-      />
+      <PageHeader title="Tonight's Service" description="Pre-service guest intelligence briefing" />
 
-      {error && (
-        <Alert variant="error">Failed to load briefing. Please try again.</Alert>
-      )}
+      {error && <Alert variant="error">Failed to load briefing. Please try again.</Alert>}
 
       {/* Controls */}
       <div className={styles.controls}>
@@ -308,7 +304,8 @@ export function BriefingPage() {
       {reservations.length > 0 && (
         <div className={styles.stats}>
           <Text variant="caption" color="secondary">
-            {filtered.length} reservation{filtered.length === 1 ? "" : "s"} &middot; {totalCovers} covers &middot; {confirmedCount} confirmed
+            {filtered.length} reservation{filtered.length === 1 ? "" : "s"} &middot; {totalCovers}{" "}
+            covers &middot; {confirmedCount} confirmed
           </Text>
         </div>
       )}
@@ -333,7 +330,8 @@ export function BriefingPage() {
               {slot.label}
             </Text>
             <Text variant="caption" color="secondary">
-              {slot.reservations.length} {slot.reservations.length === 1 ? "party" : "parties"} &middot; {slot.totalCovers} covers
+              {slot.reservations.length} {slot.reservations.length === 1 ? "party" : "parties"}{" "}
+              &middot; {slot.totalCovers} covers
             </Text>
           </div>
           <div className={styles.cardList}>

--- a/packages/api-client/llms-full.txt
+++ b/packages/api-client/llms-full.txt
@@ -14,6 +14,34 @@
       partySize: number;
     }
   </file>
+  <file path="src/briefing.ts">
+    export interface BriefingGuest {
+      id: string;
+      name: string;
+      email: string | null;
+      phone: string | null;
+      visitCount: number;
+      lastVisit: string | null;
+      dietaryRestrictions: string[] | null;
+      tags: string[] | null;
+      staffNotes: Array<{ text: string; createdBy: string; createdAt: string }>;
+    }
+    export interface BriefingReservation {
+      id: string;
+      startTime: string;
+      endTime: string;
+      partySize: number;
+      status: "PENDING" | "CONFIRMED";
+      notes: string | null;
+      occasion: string | null;
+      seatingPreference: string | null;
+      guestName: string | null;
+      tableId: string;
+      tableName: string | null;
+      venueId: string | null;
+      guest: BriefingGuest | null;
+    }
+  </file>
   <file path="src/client.ts">
     export interface ClientConfig {
       baseUrl: string;
@@ -150,6 +178,7 @@
         availability: new AvailabilityClient(client),
         holds: new HoldsClient(client),
         health: new HealthClient(client),
+        briefing: new BriefingClient(client),
       };
     }
   </file>

--- a/packages/api-client/llms.txt
+++ b/packages/api-client/llms.txt
@@ -18,6 +18,26 @@
       }
     </item>
   </file>
+  <file path="src/briefing.ts">
+    <item priority="low">
+      interface BriefingGuest {
+        id: string;
+        name: string;
+        email: string | null;
+        phone: string | null;
+        visitCount: number;
+      }
+    </item>
+    <item priority="low">
+      interface BriefingReservation {
+        id: string;
+        startTime: string;
+        endTime: string;
+        partySize: number;
+        status: "PENDING" | "CONFIRMED";
+      }
+    </item>
+  </file>
   <file path="src/client.ts">
     <item priority="low">
       interface ClientConfig {

--- a/packages/api-client/src/briefing.ts
+++ b/packages/api-client/src/briefing.ts
@@ -1,0 +1,45 @@
+import type { ApiClient } from "./client.js";
+
+export interface BriefingGuest {
+  id: string;
+  name: string;
+  email: string | null;
+  phone: string | null;
+  visitCount: number;
+  lastVisit: string | null;
+  dietaryRestrictions: string[] | null;
+  tags: string[] | null;
+  staffNotes: Array<{ text: string; createdBy: string; createdAt: string }>;
+}
+
+export interface BriefingReservation {
+  id: string;
+  startTime: string;
+  endTime: string;
+  partySize: number;
+  status: "PENDING" | "CONFIRMED";
+  notes: string | null;
+  occasion: string | null;
+  seatingPreference: string | null;
+  guestName: string | null;
+  tableId: string;
+  tableName: string | null;
+  venueId: string | null;
+  guest: BriefingGuest | null;
+}
+
+export interface BriefingResponse {
+  date: string;
+  venueId: string;
+  reservations: BriefingReservation[];
+}
+
+export class BriefingClient {
+  constructor(private client: ApiClient) {}
+
+  async get(venueId: string, date?: string): Promise<BriefingResponse> {
+    const params = new URLSearchParams({ venueId });
+    if (date) params.set("date", date);
+    return this.client.get<BriefingResponse>(`/api/v1/briefing?${params.toString()}`);
+  }
+}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -20,6 +20,12 @@ export {
 } from "./availability.js";
 export { streamNDJSON, type StreamConfig } from "./streaming.js";
 export { HealthClient, type SystemHealth, type ServiceHealth } from "./health.js";
+export {
+  BriefingClient,
+  type BriefingGuest,
+  type BriefingReservation,
+  type BriefingResponse,
+} from "./briefing.js";
 
 import { ApiClient } from "./client.js";
 import type { ApiClientError } from "./client.js";
@@ -31,6 +37,7 @@ import { GuestsClient } from "./guests.js";
 import { FloorPlansClient } from "./floor-plans.js";
 import { AvailabilityClient, HoldsClient } from "./availability.js";
 import { HealthClient } from "./health.js";
+import { BriefingClient } from "./briefing.js";
 
 /**
  * Create a configured API client for the MBE platform
@@ -62,5 +69,6 @@ export function createApiClient(config: {
     availability: new AvailabilityClient(client),
     holds: new HoldsClient(client),
     health: new HealthClient(client),
+    briefing: new BriefingClient(client),
   };
 }

--- a/services/reservations/llms-full.txt
+++ b/services/reservations/llms-full.txt
@@ -279,6 +279,82 @@
       );
     };
   </file>
+  <file path="src/routes/briefing.ts">
+    export const briefingRoutes: FastifyPluginAsync = async (fastify) => {
+      fastify.get<{
+        Querystring: { date?: string; venueId: string };
+        Reply: BriefingResponse | ApiError;
+      }>(
+        "/",
+        {
+          preHandler: requireAuth,
+          schema: {
+            summary: "Get tonight's service briefing",
+            operationId: "getServiceBriefing",
+            description:
+              "Returns PENDING and CONFIRMED reservations enriched with full guest CRM data for a service briefing.",
+            tags: ["Briefing"],
+            security: [{ bearerAuth: [] }],
+            querystring: {
+              type: "object",
+              required: ["venueId"],
+              properties: {
+                date: {
+                  type: "string",
+                  format: "date",
+                  description: "Date to retrieve briefing for (YYYY-MM-DD). Defaults to today.",
+                },
+                venueId: {
+                  type: "string",
+                  description: "Venue ID to retrieve briefing for",
+                },
+              },
+            },
+            response: {
+              200: {
+                description: "Service briefing with enriched reservations",
+                type: "object",
+                additionalProperties: true,
+                properties: {
+                  date: { type: "string" },
+                  venueId: { type: "string" },
+                  reservations: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      additionalProperties: true,
+                    },
+                  },
+                },
+              },
+              400: { description: "Bad request", $ref: "Error#" },
+              401: { description: "Authentication required", $ref: "Error#" },
+              403: { description: "Access denied", $ref: "Error#" },
+              404: { description: "Venue not found", $ref: "Error#" },
+            },
+          },
+        },
+        async (request, reply) => {
+          const { venueId, date } = request.query;
+    
+          const result = await briefingService.getBriefing({ venueId, date });
+    
+          if (!result.success) {
+            if (result.error === "VENUE_NOT_FOUND") {
+              return reply
+                .code(404)
+                .send(createProblemDetails(404, "Not Found", "Venue not found"));
+            }
+            return reply
+              .code(400)
+              .send(createProblemDetails(400, "Bad Request", result.error ?? "Failed to load briefing"));
+          }
+    
+          return reply.send(result.data!);
+        }
+      );
+    };
+  </file>
   <file path="src/routes/cancel-reservation.ts">
     export const cancelReservationRoutes: FastifyPluginAsync = async (fastify) => {
       fastify.delete<{ Querystring: { token?: string } }>(
@@ -4571,6 +4647,34 @@
       return largestRule.durationMinutes + extraTime;
     }
   </file>
+  <file path="src/services/briefing.ts">
+    export interface BriefingGuest {
+      id: string;
+      name: string;
+      email: string | null;
+      phone: string | null;
+      visitCount: number;
+      lastVisit: string | null;
+      dietaryRestrictions: string[] | null;
+      tags: string[] | null;
+      staffNotes: Array<{ text: string; createdBy: string; createdAt: string }>;
+    }
+    export interface BriefingReservation {
+      id: string;
+      startTime: string;
+      endTime: string;
+      partySize: number;
+      status: "PENDING" | "CONFIRMED";
+      notes: string | null;
+      occasion: Occasion | null;
+      seatingPreference: SeatingPreference | null;
+      guestName: string | null;
+      tableId: string;
+      tableName: string | null;
+      venueId: string | null;
+      guest: BriefingGuest | null;
+    }
+  </file>
   <file path="src/services/confirm-hold.ts">
     type ConfirmHoldErrorCode = "NOT_FOUND" | "EXPIRED" | "SESSION_MISMATCH" | "CONFLICT";
     export interface ConfirmHoldInput {
@@ -4935,6 +5039,7 @@
       await fastify.register(floorPlanRoutes, { prefix: "/api/v1/floor-plans" });
       await fastify.register(guestRoutes, { prefix: "/api/v1/guests" });
       await fastify.register(waitlistRoutes, { prefix: "/api/v1/waitlist" });
+      await fastify.register(briefingRoutes, { prefix: "/api/v1/briefing" });
     
       // Public routes (no auth required)
       await fastify.register(publicVenueRoutes, { prefix: "/public/v1/venues" });

--- a/services/reservations/llms.txt
+++ b/services/reservations/llms.txt
@@ -35,6 +35,11 @@
       export const availabilityRoutes: FastifyPluginAsync;
     </item>
   </file>
+  <file path="src/routes/briefing.ts">
+    <item priority="high">
+      export const briefingRoutes: FastifyPluginAsync;
+    </item>
+  </file>
   <file path="src/routes/cancel-reservation.ts">
     <item priority="high">
       export const cancelReservationRoutes: FastifyPluginAsync;
@@ -209,6 +214,26 @@
     </item>
     <item priority="high">
       export function estimateDuration(partySize: number, venueSettings?: VenueSettings | null): number { /* ... */ }
+    </item>
+  </file>
+  <file path="src/services/briefing.ts">
+    <item priority="low">
+      interface BriefingGuest {
+        id: string;
+        name: string;
+        email: string | null;
+        phone: string | null;
+        visitCount: number;
+      }
+    </item>
+    <item priority="low">
+      interface BriefingReservation {
+        id: string;
+        startTime: string;
+        endTime: string;
+        partySize: number;
+        status: "PENDING" | "CONFIRMED";
+      }
     </item>
   </file>
   <file path="src/services/confirm-hold.ts">

--- a/services/reservations/src/app.ts
+++ b/services/reservations/src/app.ts
@@ -24,6 +24,7 @@ import { modifyReservationRoutes } from "./routes/modify-reservation.js";
 import { depositRoutes } from "./routes/deposits.js";
 import { stripeWebhookRoutes } from "./routes/stripe-webhook.js";
 import { waitlistRoutes } from "./routes/waitlist.js";
+import { briefingRoutes } from "./routes/briefing.js";
 import { createNotificationPort } from "./notifications.js";
 
 export interface ReservationsAppOptions extends AppOptions {
@@ -64,6 +65,7 @@ export async function buildApp(options: ReservationsAppOptions = {}): Promise<Fa
   await fastify.register(floorPlanRoutes, { prefix: "/api/v1/floor-plans" });
   await fastify.register(guestRoutes, { prefix: "/api/v1/guests" });
   await fastify.register(waitlistRoutes, { prefix: "/api/v1/waitlist" });
+  await fastify.register(briefingRoutes, { prefix: "/api/v1/briefing" });
 
   // Public routes (no auth required)
   await fastify.register(publicVenueRoutes, { prefix: "/public/v1/venues" });

--- a/services/reservations/src/routes/briefing.test.ts
+++ b/services/reservations/src/routes/briefing.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { buildApp } from "../app.js";
+import type { FastifyInstance } from "fastify";
+
+vi.mock("../services/briefing.js", () => ({
+  briefingService: {
+    getBriefing: vi.fn(),
+  },
+}));
+
+vi.mock("../services/guest.js", () => ({
+  guestService: {
+    list: vi.fn(),
+    getById: vi.fn(),
+    findByEmail: vi.fn(),
+    findByPhone: vi.fn(),
+    findOrCreate: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    recordVisit: vi.fn(),
+    search: vi.fn(),
+    getSegments: vi.fn(),
+    addNote: vi.fn(),
+  },
+}));
+
+vi.mock("../services/venue.js", () => ({
+  venueService: {
+    list: vi.fn(),
+    getById: vi.fn(),
+    getBySlug: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+  venueGroupService: {
+    list: vi.fn(),
+    getById: vi.fn(),
+    getBySlug: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("../services/table.js", () => ({
+  tableService: {
+    list: vi.fn(),
+    getById: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    updateStatus: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("../services/reservation.js", () => ({
+  reservationService: {
+    list: vi.fn(),
+    getById: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    listByUserId: vi.fn(),
+    createWithConflictCheck: vi.fn(),
+    updateWithConflictCheck: vi.fn(),
+    createWalkIn: vi.fn(),
+    cancel: vi.fn(),
+  },
+}));
+
+vi.mock("../services/floor-plan.js", () => ({
+  floorPlanService: {
+    list: vi.fn(),
+    getById: vi.fn(),
+    getActiveByVenueId: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    setActive: vi.fn(),
+    updateTablePosition: vi.fn(),
+    bulkUpdateTablePositions: vi.fn(),
+    assignTableToFloorPlan: vi.fn(),
+    removeTableFromFloorPlan: vi.fn(),
+  },
+}));
+
+vi.mock("../services/database.js", () => ({
+  prisma: {
+    $queryRaw: vi.fn(),
+  },
+  getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
+  getServiceStatus: vi.fn().mockReturnValue("ok"),
+  getPoolMetrics: vi.fn().mockReturnValue({
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
+  }),
+}));
+
+vi.mock("jose", () => ({
+  createRemoteJWKSet: vi.fn(() => "mock-jwks"),
+  jwtVerify: vi.fn(),
+}));
+
+import { briefingService } from "../services/briefing.js";
+import { jwtVerify } from "jose";
+
+const mockBriefingReservation = {
+  id: "res-1",
+  startTime: "2026-05-26T18:00:00.000Z",
+  endTime: "2026-05-26T19:30:00.000Z",
+  partySize: 2,
+  status: "CONFIRMED" as const,
+  notes: "Anniversary dinner",
+  occasion: "anniversary" as const,
+  seatingPreference: "window" as const,
+  guestName: "Jane Smith",
+  tableId: "table-1",
+  tableName: "Table 1",
+  venueId: "venue-1",
+  guest: {
+    id: "guest-1",
+    name: "Jane Smith",
+    email: "jane@example.com",
+    phone: "+1-555-987-6543",
+    visitCount: 4,
+    lastVisit: "2026-04-01T19:00:00.000Z",
+    dietaryRestrictions: ["gluten-free"],
+    tags: ["VIP"],
+    staffNotes: [{ text: "Prefers quiet corner", createdBy: "staff-1", createdAt: "2026-01-01T00:00:00.000Z" }],
+  },
+};
+
+const mockBriefingResponse = {
+  date: "2026-05-26",
+  venueId: "venue-1",
+  reservations: [mockBriefingReservation],
+};
+
+const mockJWTPayload = {
+  sub: "auth0|user-123",
+  iss: "https://test.auth0.com/",
+  aud: "https://api.example.com",
+  exp: Math.floor(Date.now() / 1000) + 3600,
+  iat: Math.floor(Date.now() / 1000),
+  email: "test@example.com",
+  email_verified: true,
+  name: "Test User",
+  picture: "https://example.com/pic.jpg",
+};
+
+describe("Briefing Routes", () => {
+  let app: FastifyInstance;
+  const originalEnv = process.env;
+
+  beforeEach(async () => {
+    process.env = {
+      ...originalEnv,
+      AUTH_AUTHORITY: "https://test.auth0.com",
+      AUTH_AUDIENCE: "https://api.example.com",
+      AUTH_BYPASS_IN_TESTS: "true",
+    };
+    app = await buildApp({ logger: false });
+    await app.ready();
+
+    vi.mocked(jwtVerify).mockResolvedValue({
+      payload: mockJWTPayload,
+      protectedHeader: { alg: "RS256" },
+    } as never);
+  });
+
+  afterEach(async () => {
+    process.env = originalEnv;
+    await app.close();
+    vi.clearAllMocks();
+  });
+
+  describe("GET /api/v1/briefing", () => {
+    it("returns 401 when not authenticated", async () => {
+      vi.mocked(jwtVerify).mockRejectedValueOnce(new Error("Invalid token"));
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/v1/briefing?venueId=venue-1",
+        headers: { authorization: "Bearer invalid-token" },
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it("returns briefing data with reservations", async () => {
+      vi.mocked(briefingService.getBriefing).mockResolvedValueOnce({
+        success: true,
+        data: mockBriefingResponse,
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/v1/briefing?venueId=venue-1&date=2026-05-26",
+        headers: { authorization: "Bearer valid-token" },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.date).toBe("2026-05-26");
+      expect(body.venueId).toBe("venue-1");
+      expect(body.reservations).toHaveLength(1);
+      expect(body.reservations[0].guest.dietaryRestrictions).toEqual(["gluten-free"]);
+      expect(body.reservations[0].occasion).toBe("anniversary");
+    });
+
+    it("returns 404 when venue not found", async () => {
+      vi.mocked(briefingService.getBriefing).mockResolvedValueOnce({
+        success: false,
+        error: "VENUE_NOT_FOUND",
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/v1/briefing?venueId=nonexistent",
+        headers: { authorization: "Bearer valid-token" },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it("returns 400 when venueId is missing", async () => {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/v1/briefing",
+        headers: { authorization: "Bearer valid-token" },
+      });
+
+      // Fastify validation rejects missing required query param
+      expect(response.statusCode).toBe(400);
+    });
+
+    it("passes date to briefing service", async () => {
+      vi.mocked(briefingService.getBriefing).mockResolvedValueOnce({
+        success: true,
+        data: { date: "2026-06-01", venueId: "venue-1", reservations: [] },
+      });
+
+      await app.inject({
+        method: "GET",
+        url: "/api/v1/briefing?venueId=venue-1&date=2026-06-01",
+        headers: { authorization: "Bearer valid-token" },
+      });
+
+      expect(briefingService.getBriefing).toHaveBeenCalledWith({
+        venueId: "venue-1",
+        date: "2026-06-01",
+      });
+    });
+
+    it("returns empty reservations array for date with no bookings", async () => {
+      vi.mocked(briefingService.getBriefing).mockResolvedValueOnce({
+        success: true,
+        data: { date: "2026-05-26", venueId: "venue-1", reservations: [] },
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/v1/briefing?venueId=venue-1&date=2026-05-26",
+        headers: { authorization: "Bearer valid-token" },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.reservations).toEqual([]);
+    });
+
+    it("enriches reservations with guest CRM data", async () => {
+      vi.mocked(briefingService.getBriefing).mockResolvedValueOnce({
+        success: true,
+        data: mockBriefingResponse,
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/v1/briefing?venueId=venue-1",
+        headers: { authorization: "Bearer valid-token" },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      const res = body.reservations[0];
+      expect(res.guest.visitCount).toBe(4);
+      expect(res.guest.lastVisit).toBe("2026-04-01T19:00:00.000Z");
+      expect(res.guest.staffNotes).toHaveLength(1);
+      expect(res.guest.tags).toEqual(["VIP"]);
+    });
+  });
+});

--- a/services/reservations/src/routes/briefing.ts
+++ b/services/reservations/src/routes/briefing.ts
@@ -1,0 +1,81 @@
+import type { FastifyPluginAsync } from "fastify";
+import type { ApiError } from "@mbe/types";
+import { createProblemDetails } from "@mbe/types";
+import { requireAuth } from "@mbe/auth/fastify";
+import { briefingService } from "../services/briefing.js";
+import type { BriefingResponse } from "../services/briefing.js";
+
+export const briefingRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.get<{
+    Querystring: { date?: string; venueId: string };
+    Reply: BriefingResponse | ApiError;
+  }>(
+    "/",
+    {
+      preHandler: requireAuth,
+      schema: {
+        summary: "Get tonight's service briefing",
+        operationId: "getServiceBriefing",
+        description:
+          "Returns PENDING and CONFIRMED reservations enriched with full guest CRM data for a service briefing.",
+        tags: ["Briefing"],
+        security: [{ bearerAuth: [] }],
+        querystring: {
+          type: "object",
+          required: ["venueId"],
+          properties: {
+            date: {
+              type: "string",
+              format: "date",
+              description: "Date to retrieve briefing for (YYYY-MM-DD). Defaults to today.",
+            },
+            venueId: {
+              type: "string",
+              description: "Venue ID to retrieve briefing for",
+            },
+          },
+        },
+        response: {
+          200: {
+            description: "Service briefing with enriched reservations",
+            type: "object",
+            additionalProperties: true,
+            properties: {
+              date: { type: "string" },
+              venueId: { type: "string" },
+              reservations: {
+                type: "array",
+                items: {
+                  type: "object",
+                  additionalProperties: true,
+                },
+              },
+            },
+          },
+          400: { description: "Bad request", $ref: "Error#" },
+          401: { description: "Authentication required", $ref: "Error#" },
+          403: { description: "Access denied", $ref: "Error#" },
+          404: { description: "Venue not found", $ref: "Error#" },
+        },
+      },
+    },
+    async (request, reply) => {
+      const { venueId, date } = request.query;
+
+      const result = await briefingService.getBriefing({ venueId, date });
+
+      if (!result.success) {
+        if (result.error === "VENUE_NOT_FOUND") {
+          return reply
+            .code(404)
+            .send(createProblemDetails(404, "Not Found", "Venue not found"));
+        }
+        return reply
+          .code(400)
+          .send(createProblemDetails(400, "Bad Request", result.error ?? "Failed to load briefing"));
+      }
+
+      return reply.send(result.data!);
+    }
+  );
+};

--- a/services/reservations/src/services/briefing.ts
+++ b/services/reservations/src/services/briefing.ts
@@ -1,0 +1,122 @@
+import type { Occasion, SeatingPreference } from "@mbe/types";
+import { toDateString } from "@mbe/types";
+import { prisma } from "./database.js";
+
+export interface BriefingGuest {
+  id: string;
+  name: string;
+  email: string | null;
+  phone: string | null;
+  visitCount: number;
+  lastVisit: string | null;
+  dietaryRestrictions: string[] | null;
+  tags: string[] | null;
+  staffNotes: Array<{ text: string; createdBy: string; createdAt: string }>;
+}
+
+export interface BriefingReservation {
+  id: string;
+  startTime: string;
+  endTime: string;
+  partySize: number;
+  status: "PENDING" | "CONFIRMED";
+  notes: string | null;
+  occasion: Occasion | null;
+  seatingPreference: SeatingPreference | null;
+  guestName: string | null;
+  tableId: string;
+  tableName: string | null;
+  venueId: string | null;
+  guest: BriefingGuest | null;
+}
+
+export interface BriefingResponse {
+  date: string;
+  venueId: string;
+  reservations: BriefingReservation[];
+}
+
+interface BriefingServiceResult {
+  success: boolean;
+  data?: BriefingResponse;
+  error?: string;
+}
+
+export const briefingService = {
+  async getBriefing({
+    venueId,
+    date,
+  }: {
+    venueId: string;
+    date?: string;
+  }): Promise<BriefingServiceResult> {
+    // Verify venue exists
+    const venue = await prisma.venue.findUnique({ where: { id: venueId } });
+    if (!venue) {
+      return { success: false, error: "VENUE_NOT_FOUND" };
+    }
+
+    const targetDate = date ? new Date(date) : new Date();
+    // Normalize to date-only (midnight UTC) to match DB date field
+    const dateOnly = new Date(
+      Date.UTC(targetDate.getUTCFullYear(), targetDate.getUTCMonth(), targetDate.getUTCDate())
+    );
+
+    const reservations = await prisma.reservation.findMany({
+      where: {
+        venueId,
+        date: dateOnly,
+        status: { in: ["PENDING", "CONFIRMED"] },
+      },
+      include: {
+        table: { select: { id: true, name: true } },
+        guest: true,
+      },
+      orderBy: [{ startTime: "asc" }],
+    });
+
+    const briefingReservations: BriefingReservation[] = reservations.map((r) => {
+      const g = r.guest;
+      const briefingGuest: BriefingGuest | null = g
+        ? {
+            id: g.id,
+            name: g.name,
+            email: g.email,
+            phone: g.phone,
+            visitCount: g.visitCount,
+            lastVisit: g.lastVisit?.toISOString() ?? null,
+            dietaryRestrictions: (g.dietaryRestrictions as string[] | null) ?? null,
+            tags: (g.tags as string[] | null) ?? null,
+            staffNotes: (
+              g.staffNotes as Array<{ text: string; createdBy: string; createdAt: string }> | null
+            ) ?? [],
+          }
+        : null;
+
+      return {
+        id: r.id,
+        startTime: r.startTime.toISOString(),
+        endTime: r.endTime.toISOString(),
+        partySize: r.partySize,
+        status: r.status as "PENDING" | "CONFIRMED",
+        notes: r.notes,
+        occasion: r.occasion as Occasion | null,
+        seatingPreference: r.seatingPreference as SeatingPreference | null,
+        guestName: r.guestName,
+        tableId: r.tableId,
+        tableName: r.table?.name ?? null,
+        venueId: r.venueId,
+        guest: briefingGuest,
+      };
+    });
+
+    return {
+      success: true,
+      data: {
+        date: toDateString(dateOnly),
+        venueId,
+        reservations: briefingReservations,
+      },
+    };
+  },
+};


### PR DESCRIPTION
## What

"Tonight's Service" briefing page for operators to prep for evening service in under a minute.

### Backend (`services/reservations`)

- New `GET /api/v1/briefing?venueId=&date=` endpoint — authenticated, venue-scoped, returns reservations enriched with full guest CRM data (visit count, dietary restrictions, occasion, seating preferences, staff notes, tags)
- `briefing.ts` service layer — single Prisma query joining reservations + tables + guests
- 7 integration tests (auth, 404 venue, date filtering, guest enrichment, empty state)
- Registered at `/api/v1/briefing` in `app.ts`

### API Client (`packages/api-client`)

- `BriefingClient` with typed `BriefingResponse`, `BriefingReservation`, `BriefingGuest`
- Wired into `createApiClient` factory as `api.briefing`

### Frontend (`apps/hospitality`)

- `/briefing` page: card list grouped by time slot, dietary flags highlighted, occasion badges, SSE subscription via `useReservationEvents` for real-time updates
- `useBriefing` React Query hook
- CSS using `var(--rialto-*)` tokens throughout
- "Tonight's Service" added to sidebar nav (first item in operational nav)
- 11 component tests

## Test results

- Backend: 7/7 pass
- Frontend: 11/11 pass
- Both typechecks clean

## Notes

CRM fields (dietary, occasion, seating pref) are progressive enhancement — rendered when present, omitted when absent. No hard dependency on #1708-#1712.

Closes #1738

https://claude.ai/code/session_01NKhjBHihtuLwPYk1eYV4QG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKhjBHihtuLwPYk1eYV4QG)_