### PR TITLE
feat(reservations): SMS waitlist notifications (#1725)

### DIFF
--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -5,3 +5,6 @@ export type { ResendAdapterConfig } from "./resend-adapter.js";
 export type { NotificationPort, BookingNotificationInput } from "./port.js";
 export { buildBookingEmailContent } from "./booking-email-content.js";
 export type { BookingEmailContent, NotificationEventType } from "./booking-email-content.js";
+export { TwilioSmsAdapter } from "./twilio-adapter.js";
+export type { TwilioAdapterConfig } from "./twilio-adapter.js";
+export type { SmsPort } from "./sms-port.js";

--- a/packages/notifications/src/sms-port.ts
+++ b/packages/notifications/src/sms-port.ts
@@ -1,0 +1,3 @@
+export interface SmsPort {
+  sendSms(to: string, body: string): Promise<void>;
+}

--- a/packages/notifications/src/twilio-adapter.ts
+++ b/packages/notifications/src/twilio-adapter.ts
@@ -1,0 +1,84 @@
+import type { SmsPort } from "./sms-port.js";
+
+/** Minimal HTTP POST client interface — injectable for testing. */
+export interface HttpPostClient {
+  post(
+    url: string,
+    headers: Record<string, string>,
+    body: string
+  ): Promise<{ ok: boolean; status: number; text(): Promise<string> }>;
+}
+
+export interface TwilioAdapterConfig {
+  accountSid: string;
+  authToken: string;
+  fromNumber: string;
+  /** Optional HTTP client — defaults to globalThis.fetch. */
+  httpClient?: HttpPostClient;
+}
+
+function toBase64(str: string): string {
+  // Pure ES2022 base64 encoding without Buffer or btoa
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  let result = "";
+  let i = 0;
+  while (i < str.length) {
+    const a = str.charCodeAt(i++);
+    const b = i < str.length ? str.charCodeAt(i++) : 0;
+    const c = i < str.length ? str.charCodeAt(i++) : 0;
+    result +=
+      chars[a >> 2] +
+      chars[((a & 3) << 4) | (b >> 4)] +
+      (i - 1 < str.length ? chars[((b & 15) << 2) | (c >> 6)] : "=") +
+      (i < str.length + 1 ? chars[c & 63] : "=");
+  }
+  return result;
+}
+
+/**
+ * Sends SMS via Twilio REST API.
+ * Uses injectable httpClient for testability; defaults to globalThis.fetch.
+ */
+export class TwilioSmsAdapter implements SmsPort {
+  private readonly config: TwilioAdapterConfig;
+
+  constructor(config: TwilioAdapterConfig) {
+    this.config = config;
+  }
+
+  async sendSms(to: string, body: string): Promise<void> {
+    const { accountSid, authToken, fromNumber, httpClient } = this.config;
+    const url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages.json`;
+
+    const formBody = [
+      `To=${encodeURIComponent(to)}`,
+      `From=${encodeURIComponent(fromNumber)}`,
+      `Body=${encodeURIComponent(body)}`,
+    ].join("&");
+
+    const credentials = toBase64(`${accountSid}:${authToken}`);
+    const headers = {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Authorization: `Basic ${credentials}`,
+    };
+
+    const client = httpClient ?? defaultHttpClient;
+    const response = await client.post(url, headers, formBody);
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Twilio SMS failed (${response.status}): ${text}`);
+    }
+  }
+}
+
+// Default client using globalThis.fetch (Node 18+ / browser)
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const gFetch = (globalThis as any).fetch as (
+  url: string,
+  init: { method: string; headers: Record<string, string>; body: string }
+) => Promise<{ ok: boolean; status: number; text(): Promise<string> }>;
+
+const defaultHttpClient: HttpPostClient = {
+  post: (url, headers, body) => gFetch(url, { method: "POST", headers, body }),
+};

--- a/services/reservations/prisma/schema.prisma
+++ b/services/reservations/prisma/schema.prisma
@@ -15,6 +15,14 @@ enum ReservationStatus {
   NO_SHOW
 }
 
+enum WaitlistStatus {
+  WAITING
+  NOTIFIED
+  SEATED
+  EXPIRED
+  REMOVED
+}
+
 enum TableStatus {
   AVAILABLE
   OCCUPIED
@@ -48,6 +56,7 @@ model Venue {
   guests         Guest[]
   floorPlans     FloorPlan[]
   holds          ReservationHold[]
+  waitlistEntries WaitlistEntry[]
   createdAt      DateTime          @default(now()) @map("created_at")
   updatedAt      DateTime          @updatedAt @map("updated_at")
 
@@ -150,6 +159,24 @@ model Reservation {
   @@index([venueId, date])
   @@index([guestId])
   @@map("reservations")
+}
+
+model WaitlistEntry {
+  id         String        @id @default(cuid())
+  venueId    String        @map("venue_id")
+  venue      Venue         @relation(fields: [venueId], references: [id])
+  guestName  String        @map("guest_name")
+  guestPhone String        @map("guest_phone")
+  partySize  Int           @map("party_size")
+  status     WaitlistStatus @default(WAITING)
+  position   Int
+  notifyJobId String?      @map("notify_job_id")
+  createdAt  DateTime      @default(now()) @map("created_at")
+  updatedAt  DateTime      @updatedAt @map("updated_at")
+
+  @@index([venueId, status])
+  @@index([venueId, position])
+  @@map("waitlist_entries")
 }
 
 model ReservationHold {

--- a/services/reservations/src/app.ts
+++ b/services/reservations/src/app.ts
@@ -19,6 +19,7 @@ import { confirmAttendanceRoutes } from "./routes/confirm-attendance.js";
 import { manageReservationRoutes } from "./routes/manage-reservation.js";
 import { cancelReservationRoutes } from "./routes/cancel-reservation.js";
 import { modifyReservationRoutes } from "./routes/modify-reservation.js";
+import { waitlistRoutes } from "./routes/waitlist.js";
 
 /**
  * Creates the Fastify application instance.
@@ -63,6 +64,7 @@ export async function buildApp(options: AppOptions = {}): Promise<FastifyInstanc
   await fastify.register(manageReservationRoutes);
   await fastify.register(cancelReservationRoutes);
   await fastify.register(modifyReservationRoutes);
+  await fastify.register(waitlistRoutes, { prefix: "/api/v1/waitlist" });
 
   return fastify;
 }

--- a/services/reservations/src/routes/waitlist.test.ts
+++ b/services/reservations/src/routes/waitlist.test.ts
@@ -1,0 +1,415 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { buildApp } from "../app.js";
+import type { FastifyInstance } from "fastify";
+import type { WaitlistEntry } from "../services/waitlist.js";
+
+// Mock waitlist service
+vi.mock("../services/waitlist.js", () => ({
+  waitlistService: {
+    add: vi.fn(),
+    listWaiting: vi.fn(),
+    getById: vi.fn(),
+    updateStatus: vi.fn(),
+    remove: vi.fn(),
+    getNext: vi.fn(),
+    updatePosition: vi.fn(),
+  },
+}));
+
+// Mock waitlist-sms
+vi.mock("../services/waitlist-sms.js", () => ({
+  buildAddedSms: vi
+    .fn()
+    .mockReturnValue("You're #1, est. 0 min wait. We'll text when your table is ready."),
+  buildPositionUpdateSms: vi.fn().mockReturnValue("Update: you're now #1, est. 0 min."),
+  buildTableReadySms: vi
+    .fn()
+    .mockReturnValue("Your table is ready! Please check in within 5 minutes."),
+  estimateWaitMinutes: vi.fn().mockReturnValue(0),
+  sendWaitlistSms: vi.fn().mockResolvedValue(undefined),
+  scheduleClaimWindow: vi.fn(),
+}));
+
+// Mock table service
+vi.mock("../services/table.js", () => ({
+  tableService: {
+    list: vi.fn(),
+    getById: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    updateStatus: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+// Mock events service
+vi.mock("../services/events.js", () => ({
+  emitTableUpdated: vi.fn(),
+  emitReservationCreated: vi.fn(),
+  emitReservationUpdated: vi.fn(),
+  emitReservationCancelled: vi.fn(),
+  emitHoldCreated: vi.fn(),
+  emitHoldReleased: vi.fn(),
+  emitHoldConfirmed: vi.fn(),
+}));
+
+// Mock reservation service
+vi.mock("../services/reservation.js", () => ({
+  reservationService: {
+    list: vi.fn(),
+    getById: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    listByUserId: vi.fn(),
+    cancel: vi.fn(),
+  },
+}));
+
+// Mock venue service
+vi.mock("../services/venue.js", () => ({
+  venueService: {
+    list: vi.fn(),
+    getById: vi.fn(),
+    getBySlug: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+  venueGroupService: {
+    list: vi.fn(),
+    getById: vi.fn(),
+    getBySlug: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+// Mock guest service
+vi.mock("../services/guest.js", () => ({
+  guestService: {
+    list: vi.fn(),
+    getById: vi.fn(),
+    search: vi.fn(),
+    findOrCreate: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getSegments: vi.fn(),
+  },
+}));
+
+// Mock floor plan service
+vi.mock("../services/floor-plan.js", () => ({
+  floorPlanService: {
+    list: vi.fn(),
+    getById: vi.fn(),
+    getActiveByVenueId: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    setActive: vi.fn(),
+    updateTablePosition: vi.fn(),
+    bulkUpdateTablePositions: vi.fn(),
+    assignTableToFloorPlan: vi.fn(),
+    removeTableFromFloorPlan: vi.fn(),
+  },
+}));
+
+// Mock database
+vi.mock("../services/database.js", () => ({
+  prisma: {
+    $queryRaw: vi.fn(),
+  },
+  getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
+  getServiceStatus: vi.fn().mockReturnValue("ok"),
+  getPoolMetrics: vi.fn().mockReturnValue({
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
+  }),
+}));
+
+// Mock jose
+vi.mock("jose", () => ({
+  createRemoteJWKSet: vi.fn(() => "mock-jwks"),
+  jwtVerify: vi.fn(),
+}));
+
+import { waitlistService } from "../services/waitlist.js";
+import {
+  buildAddedSms,
+  estimateWaitMinutes,
+  sendWaitlistSms,
+  buildTableReadySms,
+  scheduleClaimWindow,
+} from "../services/waitlist-sms.js";
+import { jwtVerify } from "jose";
+
+const mockJWTPayload = {
+  sub: "auth0|user-123",
+  iss: "https://test.auth0.com/",
+  aud: "https://api.example.com",
+  exp: Math.floor(Date.now() / 1000) + 3600,
+  iat: Math.floor(Date.now() / 1000),
+  email: "test@example.com",
+  email_verified: true,
+  name: "Test User",
+  picture: "https://example.com/pic.jpg",
+};
+
+const NOW = new Date().toISOString();
+
+function makeEntry(overrides: Partial<WaitlistEntry> = {}): WaitlistEntry {
+  return {
+    id: "entry-1",
+    venueId: "venue-1",
+    guestName: "Alice",
+    guestPhone: "+15555550001",
+    partySize: 2,
+    status: "WAITING",
+    position: 1,
+    notifyJobId: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+describe("Waitlist Routes", () => {
+  let app: FastifyInstance;
+  const originalEnv = process.env;
+
+  beforeEach(async () => {
+    process.env = {
+      ...originalEnv,
+      AUTH_AUTHORITY: "https://test.auth0.com",
+      AUTH_AUDIENCE: "https://api.example.com",
+      AUTH_BYPASS_IN_TESTS: "true",
+    };
+    app = await buildApp({ logger: false });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    vi.clearAllMocks();
+    process.env = originalEnv;
+  });
+
+  describe("POST /api/v1/waitlist", () => {
+    it("adds entry and sends SMS on waitlist add", async () => {
+      vi.mocked(jwtVerify).mockResolvedValueOnce({
+        payload: mockJWTPayload,
+        protectedHeader: { alg: "RS256" },
+      } as never);
+      vi.mocked(waitlistService.add).mockResolvedValueOnce(makeEntry({ position: 1 }));
+      vi.mocked(estimateWaitMinutes).mockReturnValueOnce(0);
+      vi.mocked(buildAddedSms).mockReturnValueOnce(
+        "You're #1, est. 0 min wait. We'll text when your table is ready."
+      );
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/v1/waitlist",
+        headers: { "x-auth-bypass": "true" },
+        payload: {
+          venueId: "venue-1",
+          guestName: "Alice",
+          guestPhone: "+15555550001",
+          partySize: 2,
+        },
+      });
+
+      expect(response.statusCode).toBe(201);
+      const body = JSON.parse(response.body);
+      expect(body.data.position).toBe(1);
+      expect(body.data.guestPhone).toBe("+15555550001");
+      expect(sendWaitlistSms).toHaveBeenCalledWith(
+        expect.anything(),
+        "+15555550001",
+        expect.stringContaining("#1"),
+        expect.anything()
+      );
+    });
+
+    it("returns 400 when phone is missing", async () => {
+      vi.mocked(jwtVerify).mockResolvedValueOnce({
+        payload: mockJWTPayload,
+        protectedHeader: { alg: "RS256" },
+      } as never);
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/v1/waitlist",
+        headers: { "x-auth-bypass": "true" },
+        payload: {
+          venueId: "venue-1",
+          guestName: "Alice",
+          partySize: 2,
+          // guestPhone intentionally omitted
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it("returns 400 when partySize is missing", async () => {
+      vi.mocked(jwtVerify).mockResolvedValueOnce({
+        payload: mockJWTPayload,
+        protectedHeader: { alg: "RS256" },
+      } as never);
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/v1/waitlist",
+        headers: { "x-auth-bypass": "true" },
+        payload: {
+          venueId: "venue-1",
+          guestName: "Alice",
+          guestPhone: "+15555550001",
+          // partySize intentionally omitted
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it("returns 401 without auth", async () => {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/v1/waitlist",
+        payload: {
+          venueId: "venue-1",
+          guestName: "Alice",
+          guestPhone: "+15555550001",
+          partySize: 2,
+        },
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+  });
+
+  describe("GET /api/v1/waitlist", () => {
+    it("returns waiting entries for a venue", async () => {
+      vi.mocked(waitlistService.listWaiting).mockResolvedValueOnce([
+        makeEntry({ position: 1 }),
+        makeEntry({ id: "entry-2", position: 2, guestName: "Bob", guestPhone: "+15555550002" }),
+      ]);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/v1/waitlist?venueId=venue-1",
+        headers: { "x-auth-bypass": "true" },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.data).toHaveLength(2);
+      expect(body.data[0].position).toBe(1);
+    });
+
+    it("returns 400 when venueId missing", async () => {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/v1/waitlist",
+        headers: { "x-auth-bypass": "true" },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+  });
+
+  describe("PUT /api/v1/waitlist/:id/notify", () => {
+    it("sends table-ready SMS and schedules claim window", async () => {
+      vi.mocked(jwtVerify).mockResolvedValueOnce({
+        payload: mockJWTPayload,
+        protectedHeader: { alg: "RS256" },
+      } as never);
+      vi.mocked(waitlistService.getById).mockResolvedValueOnce(makeEntry({ status: "WAITING" }));
+      vi.mocked(waitlistService.updateStatus).mockResolvedValueOnce(
+        makeEntry({ status: "NOTIFIED" })
+      );
+      vi.mocked(buildTableReadySms).mockReturnValueOnce(
+        "Your table is ready! Please check in within 5 minutes."
+      );
+
+      const response = await app.inject({
+        method: "PUT",
+        url: "/api/v1/waitlist/entry-1/notify",
+        headers: { "x-auth-bypass": "true" },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.data.status).toBe("NOTIFIED");
+      expect(sendWaitlistSms).toHaveBeenCalledWith(
+        expect.anything(),
+        "+15555550001",
+        expect.stringContaining("table is ready"),
+        expect.anything()
+      );
+      // smsAdapter is null in tests (no TWILIO_* env vars) — that's valid
+      expect(scheduleClaimWindow).toHaveBeenCalledWith(
+        "entry-1",
+        expect.toSatisfy((v: unknown) => v === null || typeof v === "object"),
+        expect.anything()
+      );
+    });
+
+    it("returns 404 when entry not found", async () => {
+      vi.mocked(jwtVerify).mockResolvedValueOnce({
+        payload: mockJWTPayload,
+        protectedHeader: { alg: "RS256" },
+      } as never);
+      vi.mocked(waitlistService.getById).mockResolvedValueOnce(null);
+
+      const response = await app.inject({
+        method: "PUT",
+        url: "/api/v1/waitlist/missing/notify",
+        headers: { "x-auth-bypass": "true" },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+  });
+
+  describe("DELETE /api/v1/waitlist/:id", () => {
+    it("removes entry and returns 204", async () => {
+      vi.mocked(jwtVerify).mockResolvedValueOnce({
+        payload: mockJWTPayload,
+        protectedHeader: { alg: "RS256" },
+      } as never);
+      vi.mocked(waitlistService.remove).mockResolvedValueOnce(true);
+
+      const response = await app.inject({
+        method: "DELETE",
+        url: "/api/v1/waitlist/entry-1",
+        headers: { "x-auth-bypass": "true" },
+      });
+
+      expect(response.statusCode).toBe(204);
+    });
+
+    it("returns 404 when entry not found", async () => {
+      vi.mocked(jwtVerify).mockResolvedValueOnce({
+        payload: mockJWTPayload,
+        protectedHeader: { alg: "RS256" },
+      } as never);
+      vi.mocked(waitlistService.remove).mockResolvedValueOnce(false);
+
+      const response = await app.inject({
+        method: "DELETE",
+        url: "/api/v1/waitlist/missing",
+        headers: { "x-auth-bypass": "true" },
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+  });
+});

--- a/services/reservations/src/routes/waitlist.ts
+++ b/services/reservations/src/routes/waitlist.ts
@@ -1,0 +1,186 @@
+import type { FastifyPluginAsync } from "fastify";
+import { createProblemDetails } from "@mbe/types";
+import { requireAuth } from "@mbe/auth/fastify";
+import { TwilioSmsAdapter } from "@mbe/notifications";
+import type { SmsPort } from "@mbe/notifications";
+import { waitlistService } from "../services/waitlist.js";
+import {
+  buildAddedSms,
+  buildTableReadySms,
+  estimateWaitMinutes,
+  sendWaitlistSms,
+  scheduleClaimWindow,
+} from "../services/waitlist-sms.js";
+
+// Build SMS adapter once at module load; null when credentials absent (dev/test).
+const smsAdapter: SmsPort | null =
+  process.env.TWILIO_ACCOUNT_SID && process.env.TWILIO_AUTH_TOKEN && process.env.TWILIO_FROM_NUMBER
+    ? new TwilioSmsAdapter({
+        accountSid: process.env.TWILIO_ACCOUNT_SID,
+        authToken: process.env.TWILIO_AUTH_TOKEN,
+        fromNumber: process.env.TWILIO_FROM_NUMBER,
+      })
+    : null;
+
+export const waitlistRoutes: FastifyPluginAsync = async (fastify) => {
+  // List waitlist entries for a venue (requires auth)
+  fastify.get<{
+    Querystring: { venueId?: string };
+  }>(
+    "/",
+    {
+      preHandler: requireAuth,
+      schema: {
+        summary: "List waitlist entries",
+        operationId: "listWaitlist",
+        tags: ["Waitlist"],
+        security: [{ bearerAuth: [] }],
+        querystring: {
+          type: "object",
+          properties: {
+            venueId: { type: "string" },
+          },
+          required: ["venueId"],
+        },
+      },
+    },
+    async (request, reply) => {
+      const { venueId } = request.query;
+      if (!venueId) {
+        return reply
+          .code(400)
+          .send(createProblemDetails(400, "Bad Request", "venueId is required"));
+      }
+      const entries = await waitlistService.listWaiting(venueId);
+      return { data: entries };
+    }
+  );
+
+  // Add to waitlist (requires auth)
+  fastify.post<{
+    Body: {
+      venueId: string;
+      guestName: string;
+      guestPhone: string;
+      partySize: number;
+    };
+  }>(
+    "/",
+    {
+      preHandler: requireAuth,
+      schema: {
+        summary: "Add guest to waitlist",
+        operationId: "addToWaitlist",
+        tags: ["Waitlist"],
+        security: [{ bearerAuth: [] }],
+        body: {
+          type: "object",
+          properties: {
+            venueId: { type: "string" },
+            guestName: { type: "string" },
+            guestPhone: { type: "string" },
+            partySize: { type: "integer", minimum: 1 },
+          },
+          required: ["venueId", "guestName", "guestPhone", "partySize"],
+        },
+      },
+    },
+    async (request, reply) => {
+      const { venueId, guestName, guestPhone, partySize } = request.body;
+
+      const entry = await waitlistService.add({ venueId, guestName, guestPhone, partySize });
+
+      // SMS notification — non-blocking, no-ops when adapter absent
+      const waitMinutes = estimateWaitMinutes(entry.position);
+      const smsBody = buildAddedSms(entry.position, waitMinutes);
+      await sendWaitlistSms(
+        smsAdapter ?? { sendSms: async () => {} },
+        guestPhone,
+        smsBody,
+        fastify.log
+      );
+
+      return reply.code(201).send({ data: entry });
+    }
+  );
+
+  // Notify guest that table is ready (requires auth)
+  fastify.put<{
+    Params: { id: string };
+  }>(
+    "/:id/notify",
+    {
+      preHandler: requireAuth,
+      schema: {
+        summary: "Notify guest their table is ready",
+        operationId: "notifyWaitlistGuest",
+        tags: ["Waitlist"],
+        security: [{ bearerAuth: [] }],
+        params: {
+          type: "object",
+          properties: { id: { type: "string" } },
+          required: ["id"],
+        },
+      },
+    },
+    async (request, reply) => {
+      const { id } = request.params;
+
+      const entry = await waitlistService.getById(id);
+      if (!entry) {
+        return reply
+          .code(404)
+          .send(createProblemDetails(404, "Not Found", "Waitlist entry not found"));
+      }
+
+      const updated = await waitlistService.updateStatus(id, "NOTIFIED");
+      if (!updated) {
+        return reply
+          .code(500)
+          .send(createProblemDetails(500, "Internal Server Error", "Failed to update entry"));
+      }
+
+      // Send table-ready SMS and schedule 5-min claim window
+      const body = buildTableReadySms();
+      await sendWaitlistSms(
+        smsAdapter ?? { sendSms: async () => {} },
+        entry.guestPhone,
+        body,
+        fastify.log
+      );
+      scheduleClaimWindow(id, smsAdapter, fastify.log);
+
+      return { data: updated };
+    }
+  );
+
+  // Remove from waitlist (requires auth)
+  fastify.delete<{
+    Params: { id: string };
+  }>(
+    "/:id",
+    {
+      preHandler: requireAuth,
+      schema: {
+        summary: "Remove guest from waitlist",
+        operationId: "removeFromWaitlist",
+        tags: ["Waitlist"],
+        security: [{ bearerAuth: [] }],
+        params: {
+          type: "object",
+          properties: { id: { type: "string" } },
+          required: ["id"],
+        },
+      },
+    },
+    async (request, reply) => {
+      const removed = await waitlistService.remove(request.params.id);
+      if (!removed) {
+        return reply
+          .code(404)
+          .send(createProblemDetails(404, "Not Found", "Waitlist entry not found"));
+      }
+      return reply.code(204).send();
+    }
+  );
+};

--- a/services/reservations/src/services/waitlist-sms.test.ts
+++ b/services/reservations/src/services/waitlist-sms.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  buildAddedSms,
+  buildPositionUpdateSms,
+  buildTableReadySms,
+  estimateWaitMinutes,
+  sendWaitlistSms,
+  scheduleClaimWindow,
+} from "./waitlist-sms.js";
+import type { SmsPort } from "@mbe/notifications";
+
+vi.mock("./waitlist.js", () => ({
+  waitlistService: {
+    getById: vi.fn(),
+    getNext: vi.fn(),
+    updateStatus: vi.fn(),
+  },
+}));
+
+import { waitlistService } from "./waitlist.js";
+
+const mockLogger = {
+  error: vi.fn(),
+};
+
+describe("waitlist SMS helpers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("buildAddedSms", () => {
+    it("includes position and wait time", () => {
+      const msg = buildAddedSms(3, 30);
+      expect(msg).toContain("#3");
+      expect(msg).toContain("30 min");
+      expect(msg).toContain("We'll text when your table is ready");
+    });
+  });
+
+  describe("buildPositionUpdateSms", () => {
+    it("includes updated position and wait time", () => {
+      const msg = buildPositionUpdateSms(1, 10);
+      expect(msg).toContain("#1");
+      expect(msg).toContain("10 min");
+      expect(msg).toContain("Update:");
+    });
+  });
+
+  describe("buildTableReadySms", () => {
+    it("contains ready message and 5 minute window", () => {
+      const msg = buildTableReadySms();
+      expect(msg).toContain("table is ready");
+      expect(msg).toContain("5 minutes");
+    });
+  });
+
+  describe("estimateWaitMinutes", () => {
+    it("returns 0 for position 1", () => {
+      expect(estimateWaitMinutes(1)).toBe(0);
+    });
+
+    it("returns 15 per position above 1", () => {
+      expect(estimateWaitMinutes(3)).toBe(30);
+    });
+  });
+
+  describe("sendWaitlistSms", () => {
+    it("calls sms.sendSms with correct args", async () => {
+      const sms: SmsPort = { sendSms: vi.fn().mockResolvedValue(undefined) };
+      await sendWaitlistSms(sms, "+15555550100", "hello", mockLogger);
+      expect(sms.sendSms).toHaveBeenCalledWith("+15555550100", "hello");
+    });
+
+    it("logs error and does not throw on SMS failure", async () => {
+      const sms: SmsPort = {
+        sendSms: vi.fn().mockRejectedValue(new Error("Twilio down")),
+      };
+      await expect(sendWaitlistSms(sms, "+15555550100", "hi", mockLogger)).resolves.toBeUndefined();
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "SMS send failed (non-blocking)",
+        expect.any(Error)
+      );
+    });
+  });
+
+  describe("scheduleClaimWindow", () => {
+    it("schedules a timer (does not throw)", () => {
+      vi.useFakeTimers();
+      const sms: SmsPort = { sendSms: vi.fn().mockResolvedValue(undefined) };
+      expect(() => scheduleClaimWindow("entry-1", sms, mockLogger)).not.toThrow();
+      vi.useRealTimers();
+    });
+
+    it("expires entry and notifies next party after 5 min", async () => {
+      vi.useFakeTimers();
+      const sms: SmsPort = { sendSms: vi.fn().mockResolvedValue(undefined) };
+
+      vi.mocked(waitlistService.getById).mockResolvedValue({
+        id: "entry-1",
+        venueId: "venue-1",
+        guestName: "Alice",
+        guestPhone: "+15555550001",
+        partySize: 2,
+        status: "NOTIFIED",
+        position: 1,
+        notifyJobId: null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(waitlistService.updateStatus).mockResolvedValue({
+        id: "entry-1",
+        venueId: "venue-1",
+        guestName: "Alice",
+        guestPhone: "+15555550001",
+        partySize: 2,
+        status: "EXPIRED",
+        position: 1,
+        notifyJobId: null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(waitlistService.getNext).mockResolvedValue({
+        id: "entry-2",
+        venueId: "venue-1",
+        guestName: "Bob",
+        guestPhone: "+15555550002",
+        partySize: 3,
+        status: "WAITING",
+        position: 1,
+        notifyJobId: null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+
+      scheduleClaimWindow("entry-1", sms, mockLogger);
+      // runOnlyPendingTimersAsync fires only the currently-scheduled timer (the 5-min
+      // claim window for entry-1) without chasing newly-registered timers for entry-2.
+      await vi.runOnlyPendingTimersAsync();
+
+      expect(waitlistService.getById).toHaveBeenCalledWith("entry-1");
+      expect(waitlistService.updateStatus).toHaveBeenCalledWith("entry-1", "EXPIRED");
+      expect(sms.sendSms).toHaveBeenCalledWith("+15555550002", buildTableReadySms());
+      expect(waitlistService.updateStatus).toHaveBeenCalledWith("entry-2", "NOTIFIED");
+
+      vi.useRealTimers();
+    });
+
+    it("does not notify next party when no next entry exists", async () => {
+      vi.useFakeTimers();
+      const sms: SmsPort = { sendSms: vi.fn().mockResolvedValue(undefined) };
+
+      vi.mocked(waitlistService.getById).mockResolvedValue({
+        id: "entry-1",
+        venueId: "venue-1",
+        guestName: "Alice",
+        guestPhone: "+15555550001",
+        partySize: 2,
+        status: "NOTIFIED",
+        position: 1,
+        notifyJobId: null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(waitlistService.updateStatus).mockResolvedValue({
+        id: "entry-1",
+        venueId: "venue-1",
+        guestName: "Alice",
+        guestPhone: "+15555550001",
+        partySize: 2,
+        status: "EXPIRED",
+        position: 1,
+        notifyJobId: null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(waitlistService.getNext).mockResolvedValue(null);
+
+      scheduleClaimWindow("entry-1", sms, mockLogger);
+      await vi.runAllTimersAsync();
+
+      expect(sms.sendSms).not.toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
+  });
+});

--- a/services/reservations/src/services/waitlist-sms.ts
+++ b/services/reservations/src/services/waitlist-sms.ts
@@ -1,0 +1,75 @@
+import type { SmsPort } from "@mbe/notifications";
+import { waitlistService } from "./waitlist.js";
+
+const CLAIM_WINDOW_MS = 5 * 60 * 1000; // 5 minutes
+
+/** Formats a waitlist-added SMS. */
+export function buildAddedSms(position: number, estimatedMinutes: number): string {
+  return `You're #${position}, est. ${estimatedMinutes} min wait. We'll text when your table is ready.`;
+}
+
+/** Formats a position-update SMS. */
+export function buildPositionUpdateSms(position: number, estimatedMinutes: number): string {
+  return `Update: you're now #${position}, est. ${estimatedMinutes} min.`;
+}
+
+/** Formats the table-ready SMS. */
+export function buildTableReadySms(): string {
+  return "Your table is ready! Please check in within 5 minutes.";
+}
+
+/** Estimate wait minutes: 15 min per position ahead. */
+export function estimateWaitMinutes(position: number): number {
+  return Math.max(0, (position - 1) * 15);
+}
+
+/**
+ * Sends an SMS notification. Logs on failure — never throws.
+ */
+export async function sendWaitlistSms(
+  sms: SmsPort,
+  to: string,
+  body: string,
+  logger: { error: (msg: string, err: unknown) => void }
+): Promise<void> {
+  try {
+    await sms.sendSms(to, body);
+  } catch (err) {
+    logger.error("SMS send failed (non-blocking)", err);
+  }
+}
+
+/**
+ * Schedules a 5-minute claim window for a notified entry.
+ * After 5 min, if still NOTIFIED: mark EXPIRED and notify next party.
+ */
+export function scheduleClaimWindow(
+  entryId: string,
+  sms: SmsPort | null,
+  logger: { error: (msg: string, err: unknown) => void }
+): void {
+  setTimeout(() => {
+    void expireIfUnclaimed(entryId, sms, logger);
+  }, CLAIM_WINDOW_MS);
+}
+
+async function expireIfUnclaimed(
+  entryId: string,
+  sms: SmsPort | null,
+  logger: { error: (msg: string, err: unknown) => void }
+): Promise<void> {
+  const entry = await waitlistService.getById(entryId);
+  if (!entry || entry.status !== "NOTIFIED") return;
+
+  const expired = await waitlistService.updateStatus(entryId, "EXPIRED");
+  if (!expired) return;
+
+  // Notify next party in queue (if any)
+  const next = await waitlistService.getNext(expired.venueId);
+  if (next && sms) {
+    const body = buildTableReadySms();
+    await sendWaitlistSms(sms, next.guestPhone, body, logger);
+    await waitlistService.updateStatus(next.id, "NOTIFIED");
+    scheduleClaimWindow(next.id, sms, logger);
+  }
+}

--- a/services/reservations/src/services/waitlist.test.ts
+++ b/services/reservations/src/services/waitlist.test.ts
@@ -1,0 +1,187 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("./database.js", () => ({
+  prisma: {
+    waitlistEntry: {
+      count: vi.fn(),
+      create: vi.fn(),
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+import { waitlistService } from "./waitlist.js";
+import { prisma } from "./database.js";
+
+const db = prisma as any;
+
+const NOW = new Date("2026-05-27T12:00:00Z");
+
+function makeEntry(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "entry-1",
+    venueId: "venue-1",
+    guestName: "Alice",
+    guestPhone: "+15555550001",
+    partySize: 2,
+    status: "WAITING",
+    position: 1,
+    notifyJobId: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+describe("waitlistService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("add", () => {
+    it("creates entry at next position", async () => {
+      db.waitlistEntry.count.mockResolvedValue(2);
+      db.waitlistEntry.create.mockResolvedValue(makeEntry({ position: 3 }));
+
+      const entry = await waitlistService.add({
+        venueId: "venue-1",
+        guestName: "Alice",
+        guestPhone: "+15555550001",
+        partySize: 2,
+      });
+
+      expect(db.waitlistEntry.count).toHaveBeenCalledWith({
+        where: { venueId: "venue-1", status: "WAITING" },
+      });
+      expect(db.waitlistEntry.create).toHaveBeenCalledWith({
+        data: {
+          venueId: "venue-1",
+          guestName: "Alice",
+          guestPhone: "+15555550001",
+          partySize: 2,
+          position: 3,
+          status: "WAITING",
+        },
+      });
+      expect(entry.position).toBe(3);
+      expect(entry.status).toBe("WAITING");
+    });
+
+    it("maps createdAt/updatedAt to ISO strings", async () => {
+      db.waitlistEntry.count.mockResolvedValue(0);
+      db.waitlistEntry.create.mockResolvedValue(makeEntry({ position: 1 }));
+
+      const entry = await waitlistService.add({
+        venueId: "venue-1",
+        guestName: "Bob",
+        guestPhone: "+15555550002",
+        partySize: 4,
+      });
+
+      expect(typeof entry.createdAt).toBe("string");
+      expect(entry.createdAt).toContain("2026");
+    });
+  });
+
+  describe("listWaiting", () => {
+    it("returns waiting entries ordered by position", async () => {
+      db.waitlistEntry.findMany.mockResolvedValue([
+        makeEntry({ position: 1 }),
+        makeEntry({ id: "entry-2", position: 2 }),
+      ]);
+
+      const entries = await waitlistService.listWaiting("venue-1");
+
+      expect(db.waitlistEntry.findMany).toHaveBeenCalledWith({
+        where: { venueId: "venue-1", status: "WAITING" },
+        orderBy: { position: "asc" },
+      });
+      expect(entries).toHaveLength(2);
+    });
+  });
+
+  describe("getById", () => {
+    it("returns entry when found", async () => {
+      db.waitlistEntry.findUnique.mockResolvedValue(makeEntry());
+      const entry = await waitlistService.getById("entry-1");
+      expect(entry).not.toBeNull();
+      expect(entry!.id).toBe("entry-1");
+    });
+
+    it("returns null when not found", async () => {
+      db.waitlistEntry.findUnique.mockResolvedValue(null);
+      const entry = await waitlistService.getById("missing");
+      expect(entry).toBeNull();
+    });
+  });
+
+  describe("updateStatus", () => {
+    it("updates status", async () => {
+      db.waitlistEntry.update.mockResolvedValue(makeEntry({ status: "NOTIFIED" }));
+      const entry = await waitlistService.updateStatus("entry-1", "NOTIFIED");
+      expect(entry!.status).toBe("NOTIFIED");
+      expect(db.waitlistEntry.update).toHaveBeenCalledWith({
+        where: { id: "entry-1" },
+        data: { status: "NOTIFIED" },
+      });
+    });
+
+    it("includes notifyJobId when provided", async () => {
+      db.waitlistEntry.update.mockResolvedValue(
+        makeEntry({ status: "NOTIFIED", notifyJobId: "job-abc" })
+      );
+      await waitlistService.updateStatus("entry-1", "NOTIFIED", "job-abc");
+      expect(db.waitlistEntry.update).toHaveBeenCalledWith({
+        where: { id: "entry-1" },
+        data: { status: "NOTIFIED", notifyJobId: "job-abc" },
+      });
+    });
+
+    it("returns null on error", async () => {
+      db.waitlistEntry.update.mockRejectedValue(new Error("not found"));
+      const result = await waitlistService.updateStatus("missing", "SEATED");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("remove", () => {
+    it("sets status to REMOVED", async () => {
+      db.waitlistEntry.update.mockResolvedValue(makeEntry({ status: "REMOVED" }));
+      const result = await waitlistService.remove("entry-1");
+      expect(result).toBe(true);
+      expect(db.waitlistEntry.update).toHaveBeenCalledWith({
+        where: { id: "entry-1" },
+        data: { status: "REMOVED" },
+      });
+    });
+
+    it("returns false on error", async () => {
+      db.waitlistEntry.update.mockRejectedValue(new Error("not found"));
+      const result = await waitlistService.remove("missing");
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("getNext", () => {
+    it("returns the first WAITING entry", async () => {
+      db.waitlistEntry.findFirst.mockResolvedValue(makeEntry({ position: 1 }));
+      const entry = await waitlistService.getNext("venue-1");
+      expect(entry).not.toBeNull();
+      expect(entry!.position).toBe(1);
+      expect(db.waitlistEntry.findFirst).toHaveBeenCalledWith({
+        where: { venueId: "venue-1", status: "WAITING" },
+        orderBy: { position: "asc" },
+      });
+    });
+
+    it("returns null when queue is empty", async () => {
+      db.waitlistEntry.findFirst.mockResolvedValue(null);
+      const entry = await waitlistService.getNext("venue-1");
+      expect(entry).toBeNull();
+    });
+  });
+});

--- a/services/reservations/src/services/waitlist.ts
+++ b/services/reservations/src/services/waitlist.ts
@@ -1,0 +1,148 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { prisma } from "./database.js";
+
+export type WaitlistStatus = "WAITING" | "NOTIFIED" | "SEATED" | "EXPIRED" | "REMOVED";
+
+export interface WaitlistEntry {
+  id: string;
+  venueId: string;
+  guestName: string;
+  guestPhone: string;
+  partySize: number;
+  status: WaitlistStatus;
+  position: number;
+  notifyJobId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// Prisma client doesn't yet have generated types for WaitlistEntry (schema added,
+// pending next `prisma generate` run). Use the `any` cast until then.
+const db = prisma as any;
+
+function mapEntry(row: any): WaitlistEntry {
+  return {
+    id: row.id,
+    venueId: row.venueId,
+    guestName: row.guestName,
+    guestPhone: row.guestPhone,
+    partySize: row.partySize,
+    status: row.status as WaitlistStatus,
+    position: row.position,
+    notifyJobId: row.notifyJobId ?? null,
+    createdAt: row.createdAt instanceof Date ? row.createdAt.toISOString() : row.createdAt,
+    updatedAt: row.updatedAt instanceof Date ? row.updatedAt.toISOString() : row.updatedAt,
+  };
+}
+
+export const waitlistService = {
+  /**
+   * Adds a guest to the venue waitlist at the next available position.
+   */
+  async add(data: {
+    venueId: string;
+    guestName: string;
+    guestPhone: string;
+    partySize: number;
+  }): Promise<WaitlistEntry> {
+    // Get next position (count of active entries + 1)
+    const count = await db.waitlistEntry.count({
+      where: { venueId: data.venueId, status: "WAITING" },
+    });
+
+    const entry = await db.waitlistEntry.create({
+      data: {
+        venueId: data.venueId,
+        guestName: data.guestName,
+        guestPhone: data.guestPhone,
+        partySize: data.partySize,
+        position: count + 1,
+        status: "WAITING",
+      },
+    });
+
+    return mapEntry(entry);
+  },
+
+  /**
+   * Returns all WAITING entries for a venue ordered by position.
+   */
+  async listWaiting(venueId: string): Promise<WaitlistEntry[]> {
+    const entries = await db.waitlistEntry.findMany({
+      where: { venueId, status: "WAITING" },
+      orderBy: { position: "asc" },
+    });
+    return entries.map(mapEntry);
+  },
+
+  /**
+   * Returns a single entry by ID.
+   */
+  async getById(id: string): Promise<WaitlistEntry | null> {
+    const entry = await db.waitlistEntry.findUnique({ where: { id } });
+    return entry ? mapEntry(entry) : null;
+  },
+
+  /**
+   * Updates a waitlist entry's status (and optionally notifyJobId).
+   */
+  async updateStatus(
+    id: string,
+    status: WaitlistStatus,
+    notifyJobId?: string
+  ): Promise<WaitlistEntry | null> {
+    try {
+      const entry = await db.waitlistEntry.update({
+        where: { id },
+        data: {
+          status,
+          ...(notifyJobId !== undefined ? { notifyJobId } : {}),
+        },
+      });
+      return mapEntry(entry);
+    } catch {
+      return null;
+    }
+  },
+
+  /**
+   * Updates a waitlist entry's position.
+   */
+  async updatePosition(id: string, position: number): Promise<WaitlistEntry | null> {
+    try {
+      const entry = await db.waitlistEntry.update({
+        where: { id },
+        data: { position },
+      });
+      return mapEntry(entry);
+    } catch {
+      return null;
+    }
+  },
+
+  /**
+   * Removes (soft-deletes) an entry by setting status=REMOVED.
+   */
+  async remove(id: string): Promise<boolean> {
+    try {
+      await db.waitlistEntry.update({
+        where: { id },
+        data: { status: "REMOVED" },
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  },
+
+  /**
+   * Gets the next WAITING entry (position 1) for a venue.
+   */
+  async getNext(venueId: string): Promise<WaitlistEntry | null> {
+    const entry = await db.waitlistEntry.findFirst({
+      where: { venueId, status: "WAITING" },
+      orderBy: { position: "asc" },
+    });
+    return entry ? mapEntry(entry) : null;
+  },
+};


### PR DESCRIPTION
## Summary

SMS notifications for the waitlist system at key lifecycle moments.

## Changes

### `packages/notifications`
- `SmsPort` interface — `sendSms(to, body): Promise<void>`
- `TwilioSmsAdapter` — pure-ESM fetch via injectable `HttpPostClient`, pure-TS base64, no `Buffer`/`btoa` deps

### `services/reservations`
- **Prisma schema**: `WaitlistStatus` enum + `WaitlistEntry` model (venueId, guestName, guestPhone, partySize, position, status, notifyJobId)
- **`services/waitlist.ts`**: CRUD service — add, listWaiting, getById, updateStatus, updatePosition, remove, getNext
- **`services/waitlist-sms.ts`**: SMS helpers — `buildAddedSms`, `buildPositionUpdateSms`, `buildTableReadySms`, `estimateWaitMinutes`, `sendWaitlistSms` (non-throwing), `scheduleClaimWindow` (5-min setTimeout → expire + notify next)
- **`routes/waitlist.ts`**: `POST /api/v1/waitlist`, `GET /api/v1/waitlist`, `PUT /api/v1/waitlist/:id/notify`, `DELETE /api/v1/waitlist/:id`
- **`app.ts`**: registers waitlist routes at `/api/v1/waitlist`

## Behaviour

| Event | SMS |
|---|---|
| Add to waitlist | "You're #[pos], est. [N] min wait. We'll text when your table is ready." |
| Table ready (PUT /notify) | "Your table is ready! Please check in within 5 minutes." |
| 5-min window expires unclaimed | Entry → EXPIRED; next WAITING party gets table-ready SMS |

- Phone required on add — missing field → 400
- SMS failures caught, logged, never throw
- `TwilioSmsAdapter` only instantiated when `TWILIO_ACCOUNT_SID` / `TWILIO_AUTH_TOKEN` / `TWILIO_FROM_NUMBER` set; no-ops otherwise

## Tests

- 35 test files, 492 tests, all pass
- `packages/notifications` typecheck clean
- `services/reservations` typecheck clean
- Lint clean on both packages

Closes #1725

https://claude.ai/code/session_01BUXV8E2r4u59G426WpKHxK

---
_Generated by [Claude Code](https://claude.ai/code/session_01BUXV8E2r4u59G426WpKHxK)_