### PR TITLE
refactor(reservations): wire NotificationDispatcher as notificationPort (closes #1842)

### DIFF
--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -5,3 +5,7 @@ export type { ResendAdapterConfig } from "./resend-adapter.js";
 export type { NotificationPort, BookingNotificationInput } from "./port.js";
 export { buildBookingEmailContent } from "./booking-email-content.js";
 export type { BookingEmailContent, NotificationEventType } from "./booking-email-content.js";
+export { NotificationDispatcher } from "./notification-dispatcher.js";
+export type { CommunicationPreference } from "./notification-dispatcher.js";
+export { TwilioSmsAdapter } from "./twilio-sms-adapter.js";
+export type { TwilioAdapterConfig } from "./twilio-sms-adapter.js";

--- a/packages/notifications/src/notification-dispatcher.test.ts
+++ b/packages/notifications/src/notification-dispatcher.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NotificationDispatcher } from "./notification-dispatcher.js";
+import type { NotificationPort, BookingNotificationInput } from "./port.js";
+
+const makeInput = (): BookingNotificationInput => ({
+  reservationId: "res_1",
+  date: "2026-06-15",
+  startTime: "19:00",
+  endTime: "21:00",
+  partySize: 4,
+  guestName: "Jane Doe",
+  guestEmail: "jane@example.com",
+  guestPhone: "+15550001111",
+  specialRequests: null,
+  venueName: "The Oak Table",
+  venueTimezone: "America/Los_Angeles",
+  venueAddress: null,
+  manageToken: "token_abc",
+});
+
+function makePort(): NotificationPort {
+  return {
+    sendBookingConfirmation: vi.fn().mockResolvedValue(undefined),
+    sendBookingReminder: vi.fn().mockResolvedValue(undefined),
+    sendBookingModified: vi.fn().mockResolvedValue(undefined),
+    sendBookingCancelled: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("NotificationDispatcher", () => {
+  let emailAdapter: NotificationPort;
+  let smsAdapter: NotificationPort;
+
+  beforeEach(() => {
+    emailAdapter = makePort();
+    smsAdapter = makePort();
+  });
+
+  describe("email_only", () => {
+    it("sends via email adapter only", async () => {
+      const dispatcher = new NotificationDispatcher({ email: emailAdapter, sms: smsAdapter });
+      await dispatcher.sendBookingConfirmation(makeInput(), "email_only");
+      expect(emailAdapter.sendBookingConfirmation).toHaveBeenCalledOnce();
+      expect(smsAdapter.sendBookingConfirmation).not.toHaveBeenCalled();
+    });
+
+    it("defaults to email_only when preference is undefined", async () => {
+      const dispatcher = new NotificationDispatcher({ email: emailAdapter, sms: smsAdapter });
+      await dispatcher.sendBookingCancelled(makeInput());
+      expect(emailAdapter.sendBookingCancelled).toHaveBeenCalledOnce();
+      expect(smsAdapter.sendBookingCancelled).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("sms_only", () => {
+    it("sends via sms adapter only, skips email", async () => {
+      const dispatcher = new NotificationDispatcher({ email: emailAdapter, sms: smsAdapter });
+      await dispatcher.sendBookingConfirmation(makeInput(), "sms_only");
+      expect(smsAdapter.sendBookingConfirmation).toHaveBeenCalledOnce();
+      expect(emailAdapter.sendBookingConfirmation).not.toHaveBeenCalled();
+    });
+
+    it("skips sms when sms adapter is null", async () => {
+      const dispatcher = new NotificationDispatcher({ email: emailAdapter, sms: null });
+      await dispatcher.sendBookingConfirmation(makeInput(), "sms_only");
+      expect(emailAdapter.sendBookingConfirmation).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("both", () => {
+    it("sends via both adapters", async () => {
+      const dispatcher = new NotificationDispatcher({ email: emailAdapter, sms: smsAdapter });
+      await dispatcher.sendBookingModified(makeInput(), "both");
+      expect(emailAdapter.sendBookingModified).toHaveBeenCalledOnce();
+      expect(smsAdapter.sendBookingModified).toHaveBeenCalledOnce();
+    });
+
+    it("sends email only when sms adapter is null", async () => {
+      const dispatcher = new NotificationDispatcher({ email: emailAdapter, sms: null });
+      await dispatcher.sendBookingModified(makeInput(), "both");
+      expect(emailAdapter.sendBookingModified).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("transactional_only", () => {
+    it("sends via email adapter only", async () => {
+      const dispatcher = new NotificationDispatcher({ email: emailAdapter, sms: smsAdapter });
+      await dispatcher.sendBookingReminder(makeInput(), "transactional_only");
+      expect(emailAdapter.sendBookingReminder).toHaveBeenCalledOnce();
+      expect(smsAdapter.sendBookingReminder).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("all four methods route correctly", () => {
+    it("sendBookingReminder routes to sms for sms_only", async () => {
+      const dispatcher = new NotificationDispatcher({ email: emailAdapter, sms: smsAdapter });
+      await dispatcher.sendBookingReminder(makeInput(), "sms_only");
+      expect(smsAdapter.sendBookingReminder).toHaveBeenCalledOnce();
+      expect(emailAdapter.sendBookingReminder).not.toHaveBeenCalled();
+    });
+
+    it("sendBookingCancelled routes to both", async () => {
+      const dispatcher = new NotificationDispatcher({ email: emailAdapter, sms: smsAdapter });
+      await dispatcher.sendBookingCancelled(makeInput(), "both");
+      expect(emailAdapter.sendBookingCancelled).toHaveBeenCalledOnce();
+      expect(smsAdapter.sendBookingCancelled).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/packages/notifications/src/notification-dispatcher.ts
+++ b/packages/notifications/src/notification-dispatcher.ts
@@ -1,0 +1,70 @@
+import type { NotificationPort, BookingNotificationInput } from "./port.js";
+
+export type CommunicationPreference = "email_only" | "sms_only" | "both" | "transactional_only";
+
+interface DispatcherConfig {
+  email: NotificationPort;
+  sms: NotificationPort | null;
+}
+
+/**
+ * Routes notifications to email and/or SMS adapters based on guest communication preference.
+ * - email_only / transactional_only → email only
+ * - sms_only → SMS only (skipped if sms adapter is null)
+ * - both → email + SMS (SMS skipped if adapter is null)
+ * Defaults to email_only when preference is omitted.
+ */
+export class NotificationDispatcher implements NotificationPort {
+  private readonly email: NotificationPort;
+  private readonly sms: NotificationPort | null;
+
+  constructor(config: DispatcherConfig) {
+    this.email = config.email;
+    this.sms = config.sms;
+  }
+
+  private async dispatch(
+    method: keyof NotificationPort,
+    input: BookingNotificationInput,
+    preference: CommunicationPreference = "email_only"
+  ): Promise<void> {
+    const useEmail =
+      preference === "email_only" || preference === "transactional_only" || preference === "both";
+    const useSms = preference === "sms_only" || preference === "both";
+
+    const tasks: Promise<void>[] = [];
+    if (useEmail)
+      tasks.push((this.email[method] as (i: BookingNotificationInput) => Promise<void>)(input));
+    if (useSms && this.sms)
+      tasks.push((this.sms[method] as (i: BookingNotificationInput) => Promise<void>)(input));
+    await Promise.all(tasks);
+  }
+
+  async sendBookingConfirmation(
+    input: BookingNotificationInput,
+    preference?: CommunicationPreference
+  ): Promise<void> {
+    await this.dispatch("sendBookingConfirmation", input, preference);
+  }
+
+  async sendBookingReminder(
+    input: BookingNotificationInput,
+    preference?: CommunicationPreference
+  ): Promise<void> {
+    await this.dispatch("sendBookingReminder", input, preference);
+  }
+
+  async sendBookingModified(
+    input: BookingNotificationInput,
+    preference?: CommunicationPreference
+  ): Promise<void> {
+    await this.dispatch("sendBookingModified", input, preference);
+  }
+
+  async sendBookingCancelled(
+    input: BookingNotificationInput,
+    preference?: CommunicationPreference
+  ): Promise<void> {
+    await this.dispatch("sendBookingCancelled", input, preference);
+  }
+}

--- a/packages/notifications/src/twilio-sms-adapter.ts
+++ b/packages/notifications/src/twilio-sms-adapter.ts
@@ -1,0 +1,55 @@
+import type { NotificationPort, BookingNotificationInput } from "./port.js";
+
+interface TwilioClient {
+  messages: {
+    create(params: { body: string; from: string; to: string }): Promise<{ sid: string }>;
+  };
+}
+
+export interface TwilioAdapterConfig {
+  twilio: TwilioClient | null;
+  fromNumber: string;
+}
+
+export class TwilioSmsAdapter implements NotificationPort {
+  private readonly twilio: TwilioClient | null;
+  private readonly fromNumber: string;
+
+  constructor(config: TwilioAdapterConfig) {
+    this.twilio = config.twilio;
+    this.fromNumber = config.fromNumber;
+  }
+
+  private async send(to: string | null, body: string): Promise<void> {
+    if (!this.twilio || !to) return;
+    await this.twilio.messages.create({ body, from: this.fromNumber, to });
+  }
+
+  async sendBookingConfirmation(input: BookingNotificationInput): Promise<void> {
+    await this.send(
+      input.guestPhone,
+      `Your reservation at ${input.venueName} on ${input.date} at ${input.startTime} (party of ${input.partySize}) is confirmed.`
+    );
+  }
+
+  async sendBookingReminder(input: BookingNotificationInput): Promise<void> {
+    await this.send(
+      input.guestPhone,
+      `Reminder: Your reservation at ${input.venueName} is tomorrow at ${input.startTime}.`
+    );
+  }
+
+  async sendBookingModified(input: BookingNotificationInput): Promise<void> {
+    await this.send(
+      input.guestPhone,
+      `Your reservation at ${input.venueName} has been updated: ${input.date} at ${input.startTime} (party of ${input.partySize}).`
+    );
+  }
+
+  async sendBookingCancelled(input: BookingNotificationInput): Promise<void> {
+    await this.send(
+      input.guestPhone,
+      `Your reservation at ${input.venueName} on ${input.date} at ${input.startTime} has been cancelled.`
+    );
+  }
+}

--- a/services/reservations/src/notifications.ts
+++ b/services/reservations/src/notifications.ts
@@ -1,0 +1,53 @@
+import { Resend } from "resend";
+import {
+  ResendNotificationAdapter,
+  TwilioSmsAdapter,
+  NotificationDispatcher,
+} from "@mbe/notifications";
+
+function buildResendClient(): {
+  emails: { send(payload: Record<string, unknown>): Promise<{ id: string }> };
+} | null {
+  if (!process.env.RESEND_API_KEY) return null;
+  return new Resend(process.env.RESEND_API_KEY) as unknown as {
+    emails: { send(payload: Record<string, unknown>): Promise<{ id: string }> };
+  };
+}
+
+function buildTwilioClient(): {
+  messages: {
+    create(params: { body: string; from: string; to: string }): Promise<{ sid: string }>;
+  };
+} | null {
+  const { TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN } = process.env;
+  if (!TWILIO_ACCOUNT_SID || !TWILIO_AUTH_TOKEN) return null;
+  // Lazily require twilio only when credentials are present
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const twilio = require("twilio") as (
+    sid: string,
+    token: string
+  ) => {
+    messages: {
+      create(params: { body: string; from: string; to: string }): Promise<{ sid: string }>;
+    };
+  };
+  return twilio(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN);
+}
+
+export function createNotificationDispatcher(): NotificationDispatcher {
+  const emailAdapter = new ResendNotificationAdapter({
+    resend: buildResendClient(),
+    fromAddress: process.env.EMAIL_FROM ?? "reservations@mattbutlerengineering.com",
+    manageBaseUrl: process.env.MANAGE_BASE_URL ?? "https://mattbutlerengineering.com",
+  });
+
+  const twilioClient = buildTwilioClient();
+  const smsAdapter = twilioClient
+    ? new TwilioSmsAdapter({
+        twilio: twilioClient,
+        fromNumber: process.env.TWILIO_FROM_NUMBER ?? "",
+      })
+    : null;
+
+  return new NotificationDispatcher({ email: emailAdapter, sms: smsAdapter });
+}

--- a/services/reservations/src/routes/cancel-reservation.test.ts
+++ b/services/reservations/src/routes/cancel-reservation.test.ts
@@ -7,15 +7,14 @@ const { mockSendBookingCancelled } = vi.hoisted(() => ({
   mockSendBookingCancelled: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock("@mbe/notifications", () => {
-  class MockResendNotificationAdapter {
-    sendBookingConfirmation = vi.fn().mockResolvedValue(undefined);
-    sendBookingReminder = vi.fn().mockResolvedValue(undefined);
-    sendBookingModified = vi.fn().mockResolvedValue(undefined);
-    sendBookingCancelled = mockSendBookingCancelled;
-  }
-  return { ResendNotificationAdapter: MockResendNotificationAdapter };
-});
+vi.mock("../notifications.js", () => ({
+  createNotificationDispatcher: () => ({
+    sendBookingConfirmation: vi.fn().mockResolvedValue(undefined),
+    sendBookingReminder: vi.fn().mockResolvedValue(undefined),
+    sendBookingModified: vi.fn().mockResolvedValue(undefined),
+    sendBookingCancelled: mockSendBookingCancelled,
+  }),
+}));
 
 vi.mock("../services/reservation.js", () => ({
   reservationService: {
@@ -38,12 +37,6 @@ vi.mock("../services/venue.js", () => ({
 vi.mock("jose", () => ({
   jwtVerify: vi.fn(),
   createRemoteJWKSet: vi.fn(() => vi.fn()),
-}));
-
-vi.mock("resend", () => ({
-  Resend: vi.fn().mockImplementation(() => ({
-    emails: { send: vi.fn().mockResolvedValue({ id: "email_1" }) },
-  })),
 }));
 
 import { reservationService } from "../services/reservation.js";

--- a/services/reservations/src/routes/cancel-reservation.ts
+++ b/services/reservations/src/routes/cancel-reservation.ts
@@ -1,23 +1,10 @@
 import type { FastifyPluginAsync } from "fastify";
-import { Resend } from "resend";
 import { verifyManageToken } from "./public-reservations.js";
 import { reservationService } from "../services/reservation.js";
 import { venueService } from "../services/venue.js";
-import { ResendNotificationAdapter } from "@mbe/notifications";
+import { createNotificationDispatcher } from "../notifications.js";
 
-const resendClient = process.env.RESEND_API_KEY
-  ? (new Resend(process.env.RESEND_API_KEY) as unknown as {
-      emails: {
-        send(payload: Record<string, unknown>): Promise<{ id: string }>;
-      };
-    })
-  : null;
-
-const notificationAdapter = new ResendNotificationAdapter({
-  resend: resendClient,
-  fromAddress: process.env.EMAIL_FROM ?? "reservations@mattbutlerengineering.com",
-  manageBaseUrl: process.env.MANAGE_BASE_URL ?? "https://mattbutlerengineering.com",
-});
+const notificationDispatcher = createNotificationDispatcher();
 
 export const cancelReservationRoutes: FastifyPluginAsync = async (fastify) => {
   fastify.delete<{ Querystring: { token?: string } }>(
@@ -103,7 +90,7 @@ export const cancelReservationRoutes: FastifyPluginAsync = async (fastify) => {
       const venue = reservation.venueId ? await venueService.getById(reservation.venueId) : null;
 
       if (reservation.guestEmail && venue) {
-        await notificationAdapter.sendBookingCancelled({
+        await notificationDispatcher.sendBookingCancelled({
           reservationId: reservation.id,
           date: reservation.date,
           startTime: reservation.startTime,

--- a/services/reservations/src/routes/confirm-attendance.test.ts
+++ b/services/reservations/src/routes/confirm-attendance.test.ts
@@ -3,15 +3,14 @@ import { buildApp } from "../app.js";
 import type { FastifyInstance } from "fastify";
 import { generateManageToken } from "./public-reservations.js";
 
-vi.mock("@mbe/notifications", () => {
-  class MockResendNotificationAdapter {
-    sendBookingConfirmation = vi.fn().mockResolvedValue(undefined);
-    sendBookingReminder = vi.fn().mockResolvedValue(undefined);
-    sendBookingModified = vi.fn().mockResolvedValue(undefined);
-    sendBookingCancelled = vi.fn().mockResolvedValue(undefined);
-  }
-  return { ResendNotificationAdapter: MockResendNotificationAdapter };
-});
+vi.mock("../notifications.js", () => ({
+  createNotificationDispatcher: () => ({
+    sendBookingConfirmation: vi.fn().mockResolvedValue(undefined),
+    sendBookingReminder: vi.fn().mockResolvedValue(undefined),
+    sendBookingModified: vi.fn().mockResolvedValue(undefined),
+    sendBookingCancelled: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
 
 vi.mock("../services/reservation.js", () => ({
   reservationService: {
@@ -34,12 +33,6 @@ vi.mock("../services/venue.js", () => ({
 vi.mock("jose", () => ({
   jwtVerify: vi.fn(),
   createRemoteJWKSet: vi.fn(() => vi.fn()),
-}));
-
-vi.mock("resend", () => ({
-  Resend: vi.fn().mockImplementation(() => ({
-    emails: { send: vi.fn().mockResolvedValue({ id: "email_1" }) },
-  })),
 }));
 
 import { reservationService } from "../services/reservation.js";

--- a/services/reservations/src/routes/manage-reservation.test.ts
+++ b/services/reservations/src/routes/manage-reservation.test.ts
@@ -3,15 +3,14 @@ import { buildApp } from "../app.js";
 import type { FastifyInstance } from "fastify";
 import { generateManageToken } from "./public-reservations.js";
 
-vi.mock("@mbe/notifications", () => {
-  class MockResendNotificationAdapter {
-    sendBookingConfirmation = vi.fn().mockResolvedValue(undefined);
-    sendBookingReminder = vi.fn().mockResolvedValue(undefined);
-    sendBookingModified = vi.fn().mockResolvedValue(undefined);
-    sendBookingCancelled = vi.fn().mockResolvedValue(undefined);
-  }
-  return { ResendNotificationAdapter: MockResendNotificationAdapter };
-});
+vi.mock("../notifications.js", () => ({
+  createNotificationDispatcher: () => ({
+    sendBookingConfirmation: vi.fn().mockResolvedValue(undefined),
+    sendBookingReminder: vi.fn().mockResolvedValue(undefined),
+    sendBookingModified: vi.fn().mockResolvedValue(undefined),
+    sendBookingCancelled: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
 
 vi.mock("../services/reservation.js", () => ({
   reservationService: {
@@ -34,12 +33,6 @@ vi.mock("../services/venue.js", () => ({
 vi.mock("jose", () => ({
   jwtVerify: vi.fn(),
   createRemoteJWKSet: vi.fn(() => vi.fn()),
-}));
-
-vi.mock("resend", () => ({
-  Resend: vi.fn().mockImplementation(() => ({
-    emails: { send: vi.fn().mockResolvedValue({ id: "email_1" }) },
-  })),
 }));
 
 import { reservationService } from "../services/reservation.js";

--- a/services/reservations/src/routes/modify-reservation.test.ts
+++ b/services/reservations/src/routes/modify-reservation.test.ts
@@ -7,15 +7,14 @@ const { mockSendBookingModified } = vi.hoisted(() => ({
   mockSendBookingModified: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock("@mbe/notifications", () => {
-  class MockResendNotificationAdapter {
-    sendBookingConfirmation = vi.fn().mockResolvedValue(undefined);
-    sendBookingReminder = vi.fn().mockResolvedValue(undefined);
-    sendBookingModified = mockSendBookingModified;
-    sendBookingCancelled = vi.fn().mockResolvedValue(undefined);
-  }
-  return { ResendNotificationAdapter: MockResendNotificationAdapter };
-});
+vi.mock("../notifications.js", () => ({
+  createNotificationDispatcher: () => ({
+    sendBookingConfirmation: vi.fn().mockResolvedValue(undefined),
+    sendBookingReminder: vi.fn().mockResolvedValue(undefined),
+    sendBookingModified: mockSendBookingModified,
+    sendBookingCancelled: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
 
 vi.mock("../services/reservation.js", () => ({
   reservationService: {
@@ -39,12 +38,6 @@ vi.mock("../services/venue.js", () => ({
 vi.mock("jose", () => ({
   jwtVerify: vi.fn(),
   createRemoteJWKSet: vi.fn(() => vi.fn()),
-}));
-
-vi.mock("resend", () => ({
-  Resend: vi.fn().mockImplementation(() => ({
-    emails: { send: vi.fn().mockResolvedValue({ id: "email_1" }) },
-  })),
 }));
 
 import { reservationService } from "../services/reservation.js";

--- a/services/reservations/src/routes/modify-reservation.ts
+++ b/services/reservations/src/routes/modify-reservation.ts
@@ -1,23 +1,10 @@
 import type { FastifyPluginAsync } from "fastify";
-import { Resend } from "resend";
 import { verifyManageToken } from "./public-reservations.js";
 import { reservationService } from "../services/reservation.js";
 import { venueService } from "../services/venue.js";
-import { ResendNotificationAdapter } from "@mbe/notifications";
+import { createNotificationDispatcher } from "../notifications.js";
 
-const resendClient = process.env.RESEND_API_KEY
-  ? (new Resend(process.env.RESEND_API_KEY) as unknown as {
-      emails: {
-        send(payload: Record<string, unknown>): Promise<{ id: string }>;
-      };
-    })
-  : null;
-
-const notificationAdapter = new ResendNotificationAdapter({
-  resend: resendClient,
-  fromAddress: process.env.EMAIL_FROM ?? "reservations@mattbutlerengineering.com",
-  manageBaseUrl: process.env.MANAGE_BASE_URL ?? "https://mattbutlerengineering.com",
-});
+const notificationDispatcher = createNotificationDispatcher();
 
 interface ModifyBody {
   date?: string;
@@ -148,7 +135,7 @@ export const modifyReservationRoutes: FastifyPluginAsync = async (fastify) => {
       const venue = updated.venueId ? await venueService.getById(updated.venueId) : null;
 
       if (updated.guestEmail && venue) {
-        await notificationAdapter.sendBookingModified({
+        await notificationDispatcher.sendBookingModified({
           reservationId: updated.id,
           date: updated.date,
           startTime: updated.startTime,


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `NotificationDispatcher` to `@mbe/notifications` — routes notifications to email and/or SMS based on `CommunicationPreference` (`email_only`, `sms_only`, `both`, `transactional_only`)
- Adds `TwilioSmsAdapter` — nullable SMS adapter driven by `TWILIO_ACCOUNT_SID`/`TWILIO_AUTH_TOKEN`/`TWILIO_FROM_NUMBER` env vars
- Creates `services/reservations/src/notifications.ts` with `createNotificationDispatcher()` — wires `ResendNotificationAdapter` + optional `TwilioSmsAdapter` into dispatcher
- Replaces inline `ResendNotificationAdapter` construction in `cancel-reservation.ts` and `modify-reservation.ts` with `createNotificationDispatcher()`
- Updates all four route test files to mock `../notifications.js` instead of `@mbe/notifications` directly

## Test plan

- [x] `pnpm --dir packages/notifications test` — 47 tests pass (includes 9 new dispatcher preference-routing tests)
- [x] `pnpm --dir services/reservations test` — 460 tests pass
- [x] `pnpm --dir packages/notifications typecheck` — clean
- [x] `pnpm --dir services/reservations typecheck` — clean
- [x] `pnpm --dir packages/notifications lint` — clean
- [x] `pnpm --dir services/reservations lint` — clean
- [x] Pre-push turbo typecheck + test — all passed

Closes #1842

https://claude.ai/code/session_01Y1GNcbxxcSVFabbKy6RYZJ
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1GNcbxxcSVFabbKy6RYZJ)_