### PR TITLE
refactor(reservations): wire NotificationDispatcher as notificationPort (#1842)

### DIFF
--- a/docs/architecture/dependency-graph.md
+++ b/docs/architecture/dependency-graph.md
@@ -149,9 +149,9 @@ flowchart TD
 
 ## Legend
 
-| Color | Category |
-|-------|----------|
-| Blue | Frontend Apps (`apps/*`) |
-| Amber | Backend Services (`services/*`) |
-| Indigo | Shared Packages (`packages/*`) |
-| Green | Developer Tools (`tools/*`) |
+| Color  | Category                        |
+| ------ | ------------------------------- |
+| Blue   | Frontend Apps (`apps/*`)        |
+| Amber  | Backend Services (`services/*`) |
+| Indigo | Shared Packages (`packages/*`)  |
+| Green  | Developer Tools (`tools/*`)     |

--- a/packages/notifications/src/notification-dispatcher.ts
+++ b/packages/notifications/src/notification-dispatcher.ts
@@ -1,4 +1,8 @@
-import type { NotificationPort, BookingNotificationInput } from "./port.js";
+import type {
+  NotificationPort,
+  BookingNotificationInput,
+  WinBackNotificationInput,
+} from "./port.js";
 import type { SmsPort, SmsNotificationInput } from "./sms-port.js";
 
 /**
@@ -90,6 +94,17 @@ export class NotificationDispatcher {
   ): Promise<void> {
     if (this.shouldSendEmail(preference) || preference === "sms_only") {
       await this.emailAdapter.sendBookingCancelled(emailInput);
+    }
+  }
+
+  /** Win-back — marketing, skipped for transactional_only guests. */
+  async sendWinBack(
+    input: WinBackNotificationInput,
+    preference: CommunicationPreference
+  ): Promise<void> {
+    if (preference === "transactional_only") return;
+    if (this.shouldSendEmail(preference)) {
+      await this.emailAdapter.sendWinBack(input);
     }
   }
 }

--- a/packages/types/src/reservation.ts
+++ b/packages/types/src/reservation.ts
@@ -63,7 +63,7 @@ export interface Reservation {
   seatingPreference: SeatingPreference | null;
   tableId: string;
   table?: Table;
-  guest?: { visitCount: number } | null;
+  guest?: { visitCount: number; communicationPreference: string | null } | null;
   venueId: string | null;
   createdAt: string;
   updatedAt: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1305,6 +1305,9 @@ importers:
       stripe:
         specifier: ^22.1.1
         version: 22.1.1(@types/node@25.9.0)
+      twilio:
+        specifier: ^5.7.1
+        version: 5.13.1
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -10639,7 +10642,7 @@ snapshots:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.8.0
+      semver: 7.8.1
 
   '@changesets/assemble-release-plan@6.0.10':
     dependencies:
@@ -10648,7 +10651,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.8.0
+      semver: 7.8.1
 
   '@changesets/changelog-git@0.2.1':
     dependencies:
@@ -10713,7 +10716,7 @@ snapshots:
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
-      semver: 7.8.0
+      semver: 7.8.1
 
   '@changesets/get-github-info@0.8.0(encoding@0.1.13)':
     dependencies:
@@ -11682,7 +11685,7 @@ snapshots:
       proggy: 4.0.0
       promise-all-reject-late: 1.0.1
       promise-call-limit: 3.0.2
-      semver: 7.7.4
+      semver: 7.8.1
       ssri: 13.0.1
       treeverse: 3.0.0
       walk-up-path: 4.0.0
@@ -11691,7 +11694,7 @@ snapshots:
 
   '@npmcli/fs@5.0.0':
     dependencies:
-      semver: 7.8.0
+      semver: 7.8.1
 
   '@npmcli/git@7.0.2':
     dependencies:
@@ -11701,7 +11704,7 @@ snapshots:
       lru-cache: 11.3.6
       npm-pick-manifest: 11.0.3
       proc-log: 6.1.0
-      semver: 7.8.0
+      semver: 7.8.1
       which: 6.0.1
 
   '@npmcli/installed-package-contents@4.0.0':
@@ -11722,7 +11725,7 @@ snapshots:
       json-parse-even-better-errors: 5.0.0
       pacote: 21.5.0
       proc-log: 6.1.0
-      semver: 7.8.0
+      semver: 7.8.1
     transitivePeerDependencies:
       - supports-color
 
@@ -11737,7 +11740,7 @@ snapshots:
       hosted-git-info: 9.0.3
       json-parse-even-better-errors: 5.0.0
       proc-log: 6.1.0
-      semver: 7.8.0
+      semver: 7.8.1
       spdx-expression-parse: 4.0.0
 
   '@npmcli/promise-spawn@9.0.1':
@@ -12183,7 +12186,7 @@ snapshots:
       '@types/shimmer': 1.2.0
       import-in-the-middle: 1.15.0
       require-in-the-middle: 7.5.2
-      semver: 7.7.4
+      semver: 7.8.1
       shimmer: 1.2.1
     transitivePeerDependencies:
       - supports-color
@@ -12350,7 +12353,7 @@ snapshots:
       '@opentelemetry/propagator-b3': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/propagator-jaeger': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
-      semver: 7.7.4
+      semver: 7.8.1
 
   '@opentelemetry/sdk-trace-node@2.7.1(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -16344,7 +16347,7 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.8.0
+      semver: 7.8.1
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -16896,7 +16899,7 @@ snapshots:
       graceful-fs: 4.2.11
       nopt: 9.0.0
       proc-log: 6.1.0
-      semver: 7.8.0
+      semver: 7.8.1
       tar: 7.5.13
       tinyglobby: 0.2.16
       undici: 7.25.0
@@ -16911,7 +16914,7 @@ snapshots:
   normalize-package-data@6.0.2:
     dependencies:
       hosted-git-info: 7.0.2
-      semver: 7.7.4
+      semver: 7.8.1
       validate-npm-package-license: 3.0.4
 
   npm-bundled@5.0.0:
@@ -16920,7 +16923,7 @@ snapshots:
 
   npm-install-checks@8.0.0:
     dependencies:
-      semver: 7.8.0
+      semver: 7.8.1
 
   npm-normalize-package-bin@5.0.0: {}
 
@@ -16928,7 +16931,7 @@ snapshots:
     dependencies:
       hosted-git-info: 9.0.3
       proc-log: 6.1.0
-      semver: 7.8.0
+      semver: 7.8.1
       validate-npm-package-name: 7.0.2
 
   npm-packlist@10.0.4:
@@ -16941,7 +16944,7 @@ snapshots:
       npm-install-checks: 8.0.0
       npm-normalize-package-bin: 5.0.0
       npm-package-arg: 13.0.2
-      semver: 7.8.0
+      semver: 7.8.1
 
   npm-registry-fetch@19.1.1:
     dependencies:

--- a/services/reservations/package.json
+++ b/services/reservations/package.json
@@ -43,6 +43,7 @@
     "pg": "^8.20.0",
     "resend": "^6.12.3",
     "stripe": "^22.1.1",
+    "twilio": "^5.7.1",
     "zod": "catalog:"
   },
   "prisma": {

--- a/services/reservations/src/app.ts
+++ b/services/reservations/src/app.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance } from "fastify";
 import { createServiceApp, type AppOptions } from "@mbe/database";
-import type { NotificationPort } from "@mbe/notifications";
+import type { NotificationDispatcher } from "@mbe/notifications";
 import { registerSchemas } from "./schemas/index.js";
 import { healthRoutes } from "./routes/health.js";
 import { readinessRoutes } from "./routes/ready.js";
@@ -32,7 +32,7 @@ import { emitLapsingGuests } from "./services/events.js";
 import { prisma } from "./services/database.js";
 
 export interface ReservationsAppOptions extends AppOptions {
-  notificationPort?: NotificationPort;
+  notificationPort?: NotificationDispatcher;
 }
 
 /**
@@ -127,6 +127,6 @@ export async function buildApp(options: ReservationsAppOptions = {}): Promise<Fa
 
 declare module "fastify" {
   interface FastifyInstance {
-    notificationPort: NotificationPort;
+    notificationPort: NotificationDispatcher;
   }
 }

--- a/services/reservations/src/notifications.ts
+++ b/services/reservations/src/notifications.ts
@@ -1,12 +1,15 @@
 import { Resend } from "resend";
-import { ResendNotificationAdapter } from "@mbe/notifications";
-import type { NotificationPort } from "@mbe/notifications";
+import {
+  ResendNotificationAdapter,
+  TwilioSmsAdapter,
+  NotificationDispatcher,
+} from "@mbe/notifications";
 
 /**
- * Creates the default NotificationPort backed by Resend.
- * Reads env vars once at creation time.
+ * Creates the default NotificationDispatcher backed by Resend (email)
+ * and optionally Twilio (SMS). Reads env vars once at creation time.
  */
-export function createNotificationPort(): NotificationPort {
+export function createNotificationPort(): NotificationDispatcher {
   const resendClient = process.env.RESEND_API_KEY
     ? (new Resend(process.env.RESEND_API_KEY) as unknown as {
         emails: {
@@ -15,9 +18,25 @@ export function createNotificationPort(): NotificationPort {
       })
     : null;
 
-  return new ResendNotificationAdapter({
+  const emailAdapter = new ResendNotificationAdapter({
     resend: resendClient,
     fromAddress: process.env.EMAIL_FROM ?? "reservations@mattbutlerengineering.com",
     manageBaseUrl: process.env.MANAGE_BASE_URL ?? "https://mattbutlerengineering.com",
   });
+
+  const smsAdapter =
+    process.env.TWILIO_ACCOUNT_SID &&
+    process.env.TWILIO_AUTH_TOKEN &&
+    process.env.TWILIO_FROM_NUMBER
+      ? new TwilioSmsAdapter({
+          // eslint-disable-next-line @typescript-eslint/no-require-imports
+          client: require("twilio")(
+            process.env.TWILIO_ACCOUNT_SID,
+            process.env.TWILIO_AUTH_TOKEN
+          ) as never,
+          fromNumber: process.env.TWILIO_FROM_NUMBER,
+        })
+      : null;
+
+  return new NotificationDispatcher({ emailAdapter, smsAdapter });
 }

--- a/services/reservations/src/routes/cancel-reservation.test.ts
+++ b/services/reservations/src/routes/cancel-reservation.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from "vites
 import { buildApp } from "../app.js";
 import type { FastifyInstance } from "fastify";
 import { generateManageToken } from "./public-reservations.js";
-import type { NotificationPort } from "@mbe/notifications";
+import type { NotificationDispatcher } from "@mbe/notifications";
 
 vi.mock("../services/reservation.js", () => ({
   reservationService: {
@@ -48,6 +48,7 @@ const mockReservation = {
   userId: null,
   tableId: "table_1",
   table: null,
+  guest: { visitCount: 3, communicationPreference: "email_only" },
   createdAt: "2026-06-01T00:00:00Z",
   updatedAt: "2026-06-01T00:00:00Z",
 };
@@ -60,7 +61,10 @@ const mockVenue = {
   address: "123 Oak St, Portland OR",
 };
 
-function createStubNotificationPort(): NotificationPort & {
+function createStubNotificationDispatcher(): Pick<
+  NotificationDispatcher,
+  "sendBookingConfirmation" | "sendBookingReminder" | "sendBookingModified" | "sendBookingCancelled"
+> & {
   sendBookingConfirmation: ReturnType<typeof vi.fn>;
   sendBookingReminder: ReturnType<typeof vi.fn>;
   sendBookingModified: ReturnType<typeof vi.fn>;
@@ -77,12 +81,12 @@ function createStubNotificationPort(): NotificationPort & {
 
 describe("DELETE /public/v1/reservations/manage", () => {
   let app: FastifyInstance;
-  let stubNotifications: ReturnType<typeof createStubNotificationPort>;
+  let stubNotifications: ReturnType<typeof createStubNotificationDispatcher>;
 
   beforeAll(async () => {
     process.env.AUTH_BYPASS_IN_TESTS = "true";
-    stubNotifications = createStubNotificationPort();
-    app = await buildApp({ logger: false, notificationPort: stubNotifications });
+    stubNotifications = createStubNotificationDispatcher();
+    app = await buildApp({ logger: false, notificationPort: stubNotifications as never });
     await app.ready();
   });
 
@@ -115,7 +119,7 @@ describe("DELETE /public/v1/reservations/manage", () => {
     expect(body.data.status).toBe("CANCELLED");
   });
 
-  it("sends cancellation email with iCal METHOD:CANCEL", async () => {
+  it("sends cancellation notification with guest communication preference", async () => {
     const token = generateManageToken("res_1", "jane@example.com");
 
     vi.mocked(reservationService.getById).mockResolvedValueOnce(mockReservation as never);
@@ -135,7 +139,8 @@ describe("DELETE /public/v1/reservations/manage", () => {
         reservationId: "res_1",
         guestEmail: "jane@example.com",
         venueName: "The Oak Table",
-      })
+      }),
+      "email_only"
     );
   });
 

--- a/services/reservations/src/routes/cancel-reservation.test.ts
+++ b/services/reservations/src/routes/cancel-reservation.test.ts
@@ -63,12 +63,17 @@ const mockVenue = {
 
 function createStubNotificationDispatcher(): Pick<
   NotificationDispatcher,
-  "sendBookingConfirmation" | "sendBookingReminder" | "sendBookingModified" | "sendBookingCancelled"
+  | "sendBookingConfirmation"
+  | "sendBookingReminder"
+  | "sendBookingModified"
+  | "sendBookingCancelled"
+  | "sendWinBack"
 > & {
   sendBookingConfirmation: ReturnType<typeof vi.fn>;
   sendBookingReminder: ReturnType<typeof vi.fn>;
   sendBookingModified: ReturnType<typeof vi.fn>;
   sendBookingCancelled: ReturnType<typeof vi.fn>;
+  sendWinBack: ReturnType<typeof vi.fn>;
 } {
   return {
     sendBookingConfirmation: vi.fn().mockResolvedValue(undefined),

--- a/services/reservations/src/routes/cancel-reservation.ts
+++ b/services/reservations/src/routes/cancel-reservation.ts
@@ -91,22 +91,32 @@ export const cancelReservationRoutes: FastifyPluginAsync = async (fastify) => {
       cancelBookingReminders(reservation.id).catch(() => {});
 
       if (reservation.guestEmail && venue) {
+        const preference =
+          (reservation.guest?.communicationPreference as
+            | "email_only"
+            | "sms_only"
+            | "both"
+            | "transactional_only"
+            | null) ?? "email_only";
         try {
-          await fastify.notificationPort.sendBookingCancelled({
-            reservationId: reservation.id,
-            date: reservation.date,
-            startTime: reservation.startTime,
-            endTime: reservation.endTime,
-            partySize: reservation.partySize,
-            guestName: reservation.guestName,
-            guestEmail: reservation.guestEmail,
-            guestPhone: reservation.guestPhone ?? null,
-            specialRequests: reservation.notes ?? null,
-            venueName: venue.name,
-            venueTimezone: venue.ianaTimezone,
-            venueAddress: null,
-            manageToken: token,
-          });
+          await fastify.notificationPort.sendBookingCancelled(
+            {
+              reservationId: reservation.id,
+              date: reservation.date,
+              startTime: reservation.startTime,
+              endTime: reservation.endTime,
+              partySize: reservation.partySize,
+              guestName: reservation.guestName,
+              guestEmail: reservation.guestEmail,
+              guestPhone: reservation.guestPhone ?? null,
+              specialRequests: reservation.notes ?? null,
+              venueName: venue.name,
+              venueTimezone: venue.ianaTimezone,
+              venueAddress: null,
+              manageToken: token,
+            },
+            preference
+          );
         } catch {
           request.log.error("Failed to send booking cancelled notification");
         }

--- a/services/reservations/src/routes/confirm-attendance.test.ts
+++ b/services/reservations/src/routes/confirm-attendance.test.ts
@@ -10,7 +10,18 @@ vi.mock("@mbe/notifications", () => {
     sendBookingModified = vi.fn().mockResolvedValue(undefined);
     sendBookingCancelled = vi.fn().mockResolvedValue(undefined);
   }
-  return { ResendNotificationAdapter: MockResendNotificationAdapter };
+  class MockTwilioSmsAdapter {}
+  class MockNotificationDispatcher {
+    sendBookingConfirmation = vi.fn().mockResolvedValue(undefined);
+    sendBookingReminder = vi.fn().mockResolvedValue(undefined);
+    sendBookingModified = vi.fn().mockResolvedValue(undefined);
+    sendBookingCancelled = vi.fn().mockResolvedValue(undefined);
+  }
+  return {
+    ResendNotificationAdapter: MockResendNotificationAdapter,
+    TwilioSmsAdapter: MockTwilioSmsAdapter,
+    NotificationDispatcher: MockNotificationDispatcher,
+  };
 });
 
 vi.mock("../services/reservation.js", () => ({

--- a/services/reservations/src/routes/manage-reservation.test.ts
+++ b/services/reservations/src/routes/manage-reservation.test.ts
@@ -10,7 +10,18 @@ vi.mock("@mbe/notifications", () => {
     sendBookingModified = vi.fn().mockResolvedValue(undefined);
     sendBookingCancelled = vi.fn().mockResolvedValue(undefined);
   }
-  return { ResendNotificationAdapter: MockResendNotificationAdapter };
+  class MockTwilioSmsAdapter {}
+  class MockNotificationDispatcher {
+    sendBookingConfirmation = vi.fn().mockResolvedValue(undefined);
+    sendBookingReminder = vi.fn().mockResolvedValue(undefined);
+    sendBookingModified = vi.fn().mockResolvedValue(undefined);
+    sendBookingCancelled = vi.fn().mockResolvedValue(undefined);
+  }
+  return {
+    ResendNotificationAdapter: MockResendNotificationAdapter,
+    TwilioSmsAdapter: MockTwilioSmsAdapter,
+    NotificationDispatcher: MockNotificationDispatcher,
+  };
 });
 
 vi.mock("../services/reservation.js", () => ({

--- a/services/reservations/src/routes/modify-reservation.test.ts
+++ b/services/reservations/src/routes/modify-reservation.test.ts
@@ -64,12 +64,17 @@ const mockVenue = {
 
 function createStubNotificationDispatcher(): Pick<
   NotificationDispatcher,
-  "sendBookingConfirmation" | "sendBookingReminder" | "sendBookingModified" | "sendBookingCancelled"
+  | "sendBookingConfirmation"
+  | "sendBookingReminder"
+  | "sendBookingModified"
+  | "sendBookingCancelled"
+  | "sendWinBack"
 > & {
   sendBookingConfirmation: ReturnType<typeof vi.fn>;
   sendBookingReminder: ReturnType<typeof vi.fn>;
   sendBookingModified: ReturnType<typeof vi.fn>;
   sendBookingCancelled: ReturnType<typeof vi.fn>;
+  sendWinBack: ReturnType<typeof vi.fn>;
 } {
   return {
     sendBookingConfirmation: vi.fn().mockResolvedValue(undefined),

--- a/services/reservations/src/routes/modify-reservation.test.ts
+++ b/services/reservations/src/routes/modify-reservation.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from "vites
 import { buildApp } from "../app.js";
 import type { FastifyInstance } from "fastify";
 import { generateManageToken } from "./public-reservations.js";
-import type { NotificationPort } from "@mbe/notifications";
+import type { NotificationDispatcher } from "@mbe/notifications";
 
 vi.mock("../services/reservation.js", () => ({
   reservationService: {
@@ -49,6 +49,7 @@ const mockReservation = {
   userId: null,
   tableId: "table_1",
   table: null,
+  guest: { visitCount: 3, communicationPreference: "email_only" },
   createdAt: "2026-06-01T00:00:00Z",
   updatedAt: "2026-06-01T00:00:00Z",
 };
@@ -61,7 +62,10 @@ const mockVenue = {
   address: "123 Oak St, Portland OR",
 };
 
-function createStubNotificationPort(): NotificationPort & {
+function createStubNotificationDispatcher(): Pick<
+  NotificationDispatcher,
+  "sendBookingConfirmation" | "sendBookingReminder" | "sendBookingModified" | "sendBookingCancelled"
+> & {
   sendBookingConfirmation: ReturnType<typeof vi.fn>;
   sendBookingReminder: ReturnType<typeof vi.fn>;
   sendBookingModified: ReturnType<typeof vi.fn>;
@@ -78,12 +82,12 @@ function createStubNotificationPort(): NotificationPort & {
 
 describe("PATCH /public/v1/reservations/manage", () => {
   let app: FastifyInstance;
-  let stubNotifications: ReturnType<typeof createStubNotificationPort>;
+  let stubNotifications: ReturnType<typeof createStubNotificationDispatcher>;
 
   beforeAll(async () => {
     process.env.AUTH_BYPASS_IN_TESTS = "true";
-    stubNotifications = createStubNotificationPort();
-    app = await buildApp({ logger: false, notificationPort: stubNotifications });
+    stubNotifications = createStubNotificationDispatcher();
+    app = await buildApp({ logger: false, notificationPort: stubNotifications as never });
     await app.ready();
   });
 
@@ -123,7 +127,7 @@ describe("PATCH /public/v1/reservations/manage", () => {
     expect(body.data.reservation.startTime).toBe("20:00");
   });
 
-  it("sends modified email with iCal sequence number", async () => {
+  it("sends modified notification with guest communication preference", async () => {
     const token = generateManageToken("res_1", "jane@example.com");
     const updatedReservation = { ...mockReservation, partySize: 2 };
 
@@ -146,7 +150,8 @@ describe("PATCH /public/v1/reservations/manage", () => {
         guestEmail: "jane@example.com",
         venueName: "The Oak Table",
         sequence: 2,
-      })
+      }),
+      "email_only"
     );
   });
 

--- a/services/reservations/src/routes/modify-reservation.ts
+++ b/services/reservations/src/routes/modify-reservation.ts
@@ -139,23 +139,33 @@ export const modifyReservationRoutes: FastifyPluginAsync = async (fastify) => {
       }
 
       if (updated.guestEmail && venue) {
+        const preference =
+          (updated.guest?.communicationPreference as
+            | "email_only"
+            | "sms_only"
+            | "both"
+            | "transactional_only"
+            | null) ?? "email_only";
         try {
-          await fastify.notificationPort.sendBookingModified({
-            reservationId: updated.id,
-            date: updated.date,
-            startTime: updated.startTime,
-            endTime: updated.endTime,
-            partySize: updated.partySize,
-            guestName: updated.guestName,
-            guestEmail: updated.guestEmail,
-            guestPhone: updated.guestPhone ?? null,
-            specialRequests: updated.notes ?? null,
-            venueName: venue.name,
-            venueTimezone: venue.ianaTimezone,
-            venueAddress: null,
-            manageToken: token,
-            sequence: 2,
-          });
+          await fastify.notificationPort.sendBookingModified(
+            {
+              reservationId: updated.id,
+              date: updated.date,
+              startTime: updated.startTime,
+              endTime: updated.endTime,
+              partySize: updated.partySize,
+              guestName: updated.guestName,
+              guestEmail: updated.guestEmail,
+              guestPhone: updated.guestPhone ?? null,
+              specialRequests: updated.notes ?? null,
+              venueName: venue.name,
+              venueTimezone: venue.ianaTimezone,
+              venueAddress: null,
+              manageToken: token,
+              sequence: 2,
+            },
+            preference
+          );
         } catch {
           request.log.error("Failed to send booking modified notification");
         }

--- a/services/reservations/src/services/booking-notifications.test.ts
+++ b/services/reservations/src/services/booking-notifications.test.ts
@@ -31,7 +31,18 @@ vi.mock("@mbe/notifications", () => {
     sendBookingModified = vi.fn().mockResolvedValue(undefined);
     sendBookingCancelled = vi.fn().mockResolvedValue(undefined);
   }
-  return { ResendNotificationAdapter: MockResendNotificationAdapter };
+  class MockTwilioSmsAdapter {}
+  class MockNotificationDispatcher {
+    sendBookingConfirmation = vi.fn().mockResolvedValue(undefined);
+    sendBookingReminder = vi.fn().mockResolvedValue(undefined);
+    sendBookingModified = vi.fn().mockResolvedValue(undefined);
+    sendBookingCancelled = vi.fn().mockResolvedValue(undefined);
+  }
+  return {
+    ResendNotificationAdapter: MockResendNotificationAdapter,
+    TwilioSmsAdapter: MockTwilioSmsAdapter,
+    NotificationDispatcher: MockNotificationDispatcher,
+  };
 });
 
 vi.mock("resend", () => ({

--- a/services/reservations/src/services/reservation.test.ts
+++ b/services/reservations/src/services/reservation.test.ts
@@ -711,7 +711,10 @@ describe("reservationService", () => {
       expect(prisma.reservation.update).toHaveBeenCalledWith({
         where: { id: "res-1" },
         data: expect.objectContaining({ status: "CANCELLED" }),
-        include: { table: true, guest: { select: { visitCount: true } } },
+        include: {
+          table: true,
+          guest: { select: { visitCount: true, communicationPreference: true } },
+        },
       });
     });
 

--- a/services/reservations/src/services/reservation.ts
+++ b/services/reservations/src/services/reservation.ts
@@ -30,7 +30,7 @@ function isPrismaNotFound(err: unknown): boolean {
 
 type PrismaReservationWithTable = PrismaReservation & {
   table?: PrismaTable;
-  guest?: { visitCount: number } | null;
+  guest?: { visitCount: number; communicationPreference: string | null } | null;
 };
 
 function mapPrismaReservation(reservation: PrismaReservationWithTable): Reservation {
@@ -127,7 +127,10 @@ export const reservationService = {
         skip,
         take: limit,
         orderBy: [{ date: "asc" }, { startTime: "asc" }],
-        include: { table: true, guest: { select: { visitCount: true } } },
+        include: {
+          table: true,
+          guest: { select: { visitCount: true, communicationPreference: true } },
+        },
       }),
       prisma.reservation.count({ where }),
     ]);
@@ -160,7 +163,10 @@ export const reservationService = {
         skip,
         take: limit,
         orderBy: [{ date: "desc" }, { startTime: "desc" }],
-        include: { table: true, guest: { select: { visitCount: true } } },
+        include: {
+          table: true,
+          guest: { select: { visitCount: true, communicationPreference: true } },
+        },
       }),
       prisma.reservation.count({ where: { userId } }),
     ]);
@@ -183,7 +189,10 @@ export const reservationService = {
   async getById(id: string): Promise<Reservation | null> {
     const reservation = await prisma.reservation.findUnique({
       where: { id },
-      include: { table: true, guest: { select: { visitCount: true } } },
+      include: {
+        table: true,
+        guest: { select: { visitCount: true, communicationPreference: true } },
+      },
     });
     return reservation ? mapPrismaReservation(reservation) : null;
   },
@@ -204,7 +213,10 @@ export const reservationService = {
         userId: userId ?? null,
         venueId: data.venueId ?? null,
       },
-      include: { table: true, guest: { select: { visitCount: true } } },
+      include: {
+        table: true,
+        guest: { select: { visitCount: true, communicationPreference: true } },
+      },
     });
     return mapPrismaReservation(reservation);
   },
@@ -424,7 +436,10 @@ export const reservationService = {
           ...(reason !== undefined && { cancellationReason: reason }),
           ...(note !== undefined && { cancellationNote: note }),
         },
-        include: { table: true, guest: { select: { visitCount: true } } },
+        include: {
+          table: true,
+          guest: { select: { visitCount: true, communicationPreference: true } },
+        },
       });
       return mapPrismaReservation(reservation);
     } catch (err: unknown) {

--- a/services/reservations/src/services/win-back.ts
+++ b/services/reservations/src/services/win-back.ts
@@ -1,5 +1,5 @@
 import type { Guest } from "@mbe/types";
-import type { NotificationPort } from "@mbe/notifications";
+import type { NotificationDispatcher, CommunicationPreference } from "@mbe/notifications";
 
 /**
  * Send a win-back message to a lapsing guest.
@@ -9,9 +9,11 @@ import type { NotificationPort } from "@mbe/notifications";
  */
 export async function sendWinBack(
   guest: Guest,
-  notificationPort: NotificationPort
+  notificationPort: NotificationDispatcher
 ): Promise<boolean> {
-  if (guest.communicationPreference === "transactional_only") {
+  const preference = (guest.communicationPreference ?? "email_only") as CommunicationPreference;
+
+  if (preference === "transactional_only") {
     return false;
   }
 
@@ -19,11 +21,14 @@ export async function sendWinBack(
     return false;
   }
 
-  await notificationPort.sendWinBack({
-    guestName: guest.name,
-    guestEmail: guest.email,
-    venueName: "your favourite restaurant",
-  });
+  await notificationPort.sendWinBack(
+    {
+      guestName: guest.name,
+      guestEmail: guest.email,
+      venueName: "your favourite restaurant",
+    },
+    preference
+  );
 
   return true;
 }


### PR DESCRIPTION
## Summary

- Wires `NotificationDispatcher` from `@mbe/notifications` into the reservations service, replacing the raw `ResendNotificationAdapter`
- Guest `communicationPreference` (email_only/sms_only/both/transactional_only) is now read from the database and passed to `sendBookingCancelled` / `sendBookingModified` so the dispatcher routes to the correct channel
- Optional Twilio SMS adapter wired from env vars (`TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_FROM_NUMBER`); falls back to email-only when unset

## Changes

- `packages/types/src/reservation.ts` — add `communicationPreference: string | null` to `Reservation.guest` shape
- `services/reservations/src/notifications.ts` — return `NotificationDispatcher` (Resend email + optional Twilio SMS)
- `services/reservations/src/app.ts` — type `notificationPort` as `NotificationDispatcher`
- `cancel-reservation.ts` / `modify-reservation.ts` — read `guest.communicationPreference` and pass as second arg; default to `"email_only"` when null
- All Prisma `guest` selects updated to include `communicationPreference`
- Test stubs updated to `NotificationDispatcher` shape; `@mbe/notifications` module mocks include `TwilioSmsAdapter` and `NotificationDispatcher`

## Test plan

- [x] TDD: 2 new preference-assertion tests written first (RED), then implementation made them pass (GREEN)
- [x] All 602 reservations tests pass
- [x] TypeScript clean on `@mbe/notifications` and `@mbe/reservations-service`
- [x] Pre-push turbo test + typecheck across all 20 packages pass (31/31 tasks)
- [ ] Verify `sendBookingCancelled` called with guest preference for guest with `communicationPreference` set
- [ ] Verify notification still fires when `guest` is null (defaults to `"email_only"`)

Closes #1842