### PR TITLE
refactor(agent): narrow findStaleSessions to string[] — delete RawStaleSessionRow and mapRawStaleRow

### DIFF
--- a/services/agent/llms-full.txt
+++ b/services/agent/llms-full.txt
@@ -967,7 +967,7 @@
       inactivityThresholdMs: number;
       checkIntervalMs: number;
       sessionService: {
-        findStaleSessions(ms: number): Promise<Array<{ id: string }>>;
+        findStaleSessions(ms: number): Promise<string[]>;
         addEvent(id: string, type: string, payload: Record<string, unknown>): Promise<unknown>;
       };
       cancelSession: (id: string) => Promise<boolean>;

--- a/services/agent/llms.txt
+++ b/services/agent/llms.txt
@@ -138,7 +138,8 @@
         inactivityThresholdMs: number;
         checkIntervalMs: number;
         sessionService: {
-          findStaleSessions(ms: number): Promise<Array<{ id: ...;
+          findStaleSessions(ms: number): Promise<string[]>;
+       ...;
         cancelSession: (id: string) => Promise<boolean>;
       }
     </item>

--- a/services/agent/src/services/liveness-monitor.test.ts
+++ b/services/agent/src/services/liveness-monitor.test.ts
@@ -30,31 +30,6 @@ function createMockConfig(overrides: Partial<LivenessMonitorConfig> = {}): Liven
   };
 }
 
-const makeRunningSession = (id: string, updatedAt: string) => ({
-  id,
-  status: "running" as const,
-  taskDescription: `Task ${id}`,
-  branchName: null,
-  baseBranch: "main",
-  model: "claude-sonnet-4-6",
-  maxTurns: 50,
-  maxBudgetUsd: 1.0,
-  prUrl: null,
-  prNumber: null,
-  resultText: null,
-  costUsd: null,
-  inputTokens: null,
-  outputTokens: null,
-  numTurns: null,
-  durationMs: null,
-  parentId: null,
-  errors: [],
-  startedAt: null,
-  completedAt: null,
-  createdAt: updatedAt,
-  updatedAt,
-});
-
 describe("createLivenessMonitor", () => {
   let mockLogger: FastifyBaseLogger;
 
@@ -132,10 +107,9 @@ describe("createLivenessMonitor", () => {
 
   describe("stale session detection", () => {
     it("cancels session returned by findStaleSessions", async () => {
-      const staleSession = makeRunningSession("stale-1", new Date().toISOString());
       const config = createMockConfig({
         sessionService: {
-          findStaleSessions: vi.fn().mockResolvedValueOnce([staleSession]),
+          findStaleSessions: vi.fn().mockResolvedValueOnce(["stale-1"]),
           addEvent: vi.fn().mockResolvedValue(null),
         },
         cancelSession: vi.fn().mockResolvedValueOnce(true),
@@ -156,10 +130,9 @@ describe("createLivenessMonitor", () => {
     });
 
     it("logs warn when a stale session is auto-cancelled", async () => {
-      const staleSession = makeRunningSession("stale-1", new Date().toISOString());
       const config = createMockConfig({
         sessionService: {
-          findStaleSessions: vi.fn().mockResolvedValueOnce([staleSession]),
+          findStaleSessions: vi.fn().mockResolvedValueOnce(["stale-1"]),
           addEvent: vi.fn().mockResolvedValue(null),
         },
         cancelSession: vi.fn().mockResolvedValueOnce(true),
@@ -188,10 +161,9 @@ describe("createLivenessMonitor", () => {
     });
 
     it("does not add error event when cancellation returns false", async () => {
-      const staleSession = makeRunningSession("stale-2", new Date().toISOString());
       const config = createMockConfig({
         sessionService: {
-          findStaleSessions: vi.fn().mockResolvedValueOnce([staleSession]),
+          findStaleSessions: vi.fn().mockResolvedValueOnce(["stale-2"]),
           addEvent: vi.fn().mockResolvedValue(null),
         },
         cancelSession: vi.fn().mockResolvedValueOnce(false),
@@ -248,13 +220,9 @@ describe("createLivenessMonitor", () => {
     });
 
     it("processes multiple stale sessions in one check cycle", async () => {
-      const staleSessions = [
-        makeRunningSession("stale-a", new Date().toISOString()),
-        makeRunningSession("stale-b", new Date().toISOString()),
-      ];
       const config = createMockConfig({
         sessionService: {
-          findStaleSessions: vi.fn().mockResolvedValueOnce(staleSessions),
+          findStaleSessions: vi.fn().mockResolvedValueOnce(["stale-a", "stale-b"]),
           addEvent: vi.fn().mockResolvedValue(null),
         },
         cancelSession: vi.fn().mockResolvedValue(true),

--- a/services/agent/src/services/liveness-monitor.ts
+++ b/services/agent/src/services/liveness-monitor.ts
@@ -16,7 +16,7 @@ export interface LivenessMonitorConfig {
   inactivityThresholdMs: number;
   checkIntervalMs: number;
   sessionService: {
-    findStaleSessions(ms: number): Promise<Array<{ id: string }>>;
+    findStaleSessions(ms: number): Promise<string[]>;
     addEvent(id: string, type: string, payload: Record<string, unknown>): Promise<unknown>;
   };
   cancelSession: (id: string) => Promise<boolean>;
@@ -35,16 +35,16 @@ export function createLivenessMonitor(config: LivenessMonitorConfig): LivenessMo
 
   async function checkStaleSessions(): Promise<void> {
     try {
-      const staleSessions = await sessionService.findStaleSessions(inactivityThresholdMs);
+      const staleSessionIds = await sessionService.findStaleSessions(inactivityThresholdMs);
 
-      for (const session of staleSessions) {
+      for (const sessionId of staleSessionIds) {
         activeLogger?.warn(
-          `[liveness] Session ${session.id} exceeded inactivity threshold — auto-cancelling`
+          `[liveness] Session ${sessionId} exceeded inactivity threshold — auto-cancelling`
         );
 
-        const cancelled = await cancelSession(session.id);
+        const cancelled = await cancelSession(sessionId);
         if (cancelled) {
-          await sessionService.addEvent(session.id, "session:error", {
+          await sessionService.addEvent(sessionId, "session:error", {
             message: `Auto-cancelled: exceeded inactivity threshold (${inactivityThresholdMs / 1000}s)`,
             reason: "liveness_timeout",
           });

--- a/services/agent/src/services/session.test.ts
+++ b/services/agent/src/services/session.test.ts
@@ -517,92 +517,20 @@ describe("sessionService", () => {
   });
 
   describe("findStaleSessions", () => {
-    it("returns sessions with no events older than threshold", async () => {
-      const now = new Date("2026-03-01T12:00:00Z");
-      vi.setSystemTime(now);
-
-      // Session updated 700s ago, threshold is 600s — stale
-      const staleRow = {
-        id: "sess-stale",
-        status: "RUNNING",
-        task_description: "Stale task",
-        branch_name: null,
-        base_branch: "main",
-        model: "claude-sonnet-4-6",
-        max_turns: 50,
-        max_budget_usd: 1.0,
-        pr_url: null,
-        pr_number: null,
-        result_text: null,
-        cost_usd: null,
-        input_tokens: null,
-        output_tokens: null,
-        num_turns: null,
-        duration_ms: null,
-        parent_id: null,
-        errors: "[]",
-        sdk_session_id: null,
-        create_pr: true,
-        failure_category: null,
-        started_at: null,
-        completed_at: null,
-        created_at: new Date(now.getTime() - 700_000),
-        updated_at: new Date(now.getTime() - 700_000),
-        last_activity: new Date(now.getTime() - 700_000),
-      };
-
-      vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([staleRow]);
+    it("returns session IDs with no events older than threshold", async () => {
+      vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([{ id: "sess-stale" }]);
 
       const result = await sessionService.findStaleSessions(600_000);
 
-      expect(result).toHaveLength(1);
-      expect(result[0].id).toBe("sess-stale");
-      expect(result[0].status).toBe("running");
-
-      vi.useRealTimers();
+      expect(result).toEqual(["sess-stale"]);
     });
 
-    it("returns sessions where latest event is older than threshold", async () => {
-      const now = new Date("2026-03-01T12:00:00Z");
-      vi.setSystemTime(now);
-
-      const staleRow = {
-        id: "sess-old-event",
-        status: "RUNNING",
-        task_description: "Old event task",
-        branch_name: null,
-        base_branch: "main",
-        model: "claude-sonnet-4-6",
-        max_turns: 50,
-        max_budget_usd: 1.0,
-        pr_url: null,
-        pr_number: null,
-        result_text: null,
-        cost_usd: null,
-        input_tokens: null,
-        output_tokens: null,
-        num_turns: null,
-        duration_ms: null,
-        parent_id: null,
-        errors: "[]",
-        sdk_session_id: null,
-        create_pr: true,
-        failure_category: null,
-        started_at: null,
-        completed_at: null,
-        created_at: new Date(now.getTime() - 900_000),
-        updated_at: new Date(now.getTime() - 900_000),
-        last_activity: new Date(now.getTime() - 700_000),
-      };
-
-      vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([staleRow]);
+    it("returns session IDs where latest event is older than threshold", async () => {
+      vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([{ id: "sess-old-event" }]);
 
       const result = await sessionService.findStaleSessions(600_000);
 
-      expect(result).toHaveLength(1);
-      expect(result[0].id).toBe("sess-old-event");
-
-      vi.useRealTimers();
+      expect(result).toEqual(["sess-old-event"]);
     });
 
     it("does NOT return sessions with recent events", async () => {
@@ -624,47 +552,11 @@ describe("sessionService", () => {
     });
 
     it("uses updatedAt as fallback when no events exist", async () => {
-      const now = new Date("2026-03-01T12:00:00Z");
-      vi.setSystemTime(now);
-
-      // last_activity equals updated_at (no events, so COALESCE falls back)
-      const staleRow = {
-        id: "sess-no-events",
-        status: "RUNNING",
-        task_description: "No events task",
-        branch_name: null,
-        base_branch: "main",
-        model: "claude-sonnet-4-6",
-        max_turns: 50,
-        max_budget_usd: 1.0,
-        pr_url: null,
-        pr_number: null,
-        result_text: null,
-        cost_usd: null,
-        input_tokens: null,
-        output_tokens: null,
-        num_turns: null,
-        duration_ms: null,
-        parent_id: null,
-        errors: "[]",
-        sdk_session_id: null,
-        create_pr: true,
-        failure_category: null,
-        started_at: null,
-        completed_at: null,
-        created_at: new Date(now.getTime() - 800_000),
-        updated_at: new Date(now.getTime() - 800_000),
-        last_activity: new Date(now.getTime() - 800_000),
-      };
-
-      vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([staleRow]);
+      vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([{ id: "sess-no-events" }]);
 
       const result = await sessionService.findStaleSessions(600_000);
 
-      expect(result).toHaveLength(1);
-      expect(result[0].id).toBe("sess-no-events");
-
-      vi.useRealTimers();
+      expect(result).toEqual(["sess-no-events"]);
     });
 
     it("passes the threshold as interval to the query", async () => {

--- a/services/agent/src/services/session.ts
+++ b/services/agent/src/services/session.ts
@@ -48,75 +48,6 @@ function mapPrismaEvent(event: SessionEvent): AgentSessionEvent {
   };
 }
 
-interface RawStaleSessionRow {
-  readonly id: string;
-  readonly status: string;
-  readonly task_description: string;
-  readonly branch_name: string | null;
-  readonly base_branch: string;
-  readonly model: string;
-  readonly max_turns: number;
-  readonly max_budget_usd: number;
-  readonly pr_url: string | null;
-  readonly pr_number: number | null;
-  readonly result_text: string | null;
-  readonly cost_usd: number | null;
-  readonly input_tokens: number | null;
-  readonly output_tokens: number | null;
-  readonly num_turns: number | null;
-  readonly duration_ms: number | null;
-  readonly parent_id: string | null;
-  readonly errors: unknown;
-  readonly sdk_session_id: string | null;
-  readonly create_pr: boolean;
-  readonly failure_category: string | null;
-  readonly started_at: Date | null;
-  readonly completed_at: Date | null;
-  readonly created_at: Date;
-  readonly updated_at: Date;
-  readonly last_activity: Date;
-}
-
-function mapRawStaleRow(row: RawStaleSessionRow): AgentSession {
-  const parseErrors = (raw: unknown): string[] => {
-    if (Array.isArray(raw)) return raw as string[];
-    if (typeof raw === "string") {
-      try {
-        const parsed = JSON.parse(raw);
-        return Array.isArray(parsed) ? parsed : [];
-      } catch {
-        return [];
-      }
-    }
-    return [];
-  };
-
-  return {
-    id: row.id,
-    status: row.status.toLowerCase() as AgentSession["status"],
-    taskDescription: row.task_description,
-    branchName: row.branch_name,
-    baseBranch: row.base_branch,
-    model: row.model,
-    maxTurns: row.max_turns,
-    maxBudgetUsd: row.max_budget_usd,
-    prUrl: row.pr_url,
-    prNumber: row.pr_number,
-    resultText: row.result_text,
-    costUsd: row.cost_usd,
-    inputTokens: row.input_tokens,
-    outputTokens: row.output_tokens,
-    numTurns: row.num_turns,
-    durationMs: row.duration_ms,
-    parentId: row.parent_id,
-    errors: parseErrors(row.errors),
-    startedAt: row.started_at ? new Date(row.started_at).toISOString() : null,
-    completedAt: row.completed_at ? new Date(row.completed_at).toISOString() : null,
-    createdAt: new Date(row.created_at).toISOString(),
-    updatedAt: new Date(row.updated_at).toISOString(),
-  };
-}
-
 interface ListOptions {
   readonly page: number;
   readonly limit: number;
@@ -240,14 +171,10 @@ export const sessionService = {
     }
   },
 
-  async findStaleSessions(thresholdMs: number): Promise<AgentSession[]> {
+  async findStaleSessions(thresholdMs: number): Promise<string[]> {
     const thresholdSeconds = Math.floor(thresholdMs / 1000);
-    const rows = await prisma.$queryRaw<RawStaleSessionRow[]>`
-      SELECT s.*,
-             COALESCE(
-               (SELECT MAX(e.created_at) FROM session_events e WHERE e.session_id = s.id),
-               s.updated_at
-             ) AS last_activity
+    const rows = await prisma.$queryRaw<{ id: string }[]>`
+      SELECT s.id
         FROM sessions s
        WHERE s.status = 'RUNNING'
          AND COALESCE(
@@ -256,7 +183,7 @@ export const sessionService = {
              ) < NOW() - INTERVAL '1 second' * ${thresholdSeconds}
        ORDER BY s.updated_at ASC
     `;
-    return rows.map(mapRawStaleRow);
+    return rows.map((r) => r.id);
   },
 
   async findByStatus(status: SessionStatus): Promise<AgentSession[]> {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `findStaleSessions` now returns `Promise<string[]>` (session IDs only) instead of `Promise<AgentSession[]>`
- Deleted `RawStaleSessionRow` interface (25 fields) and `mapRawStaleRow` function (38 lines) — both existed only to map data that was immediately discarded
- Raw SQL query changed from `SELECT s.*` to `SELECT s.id`
- `liveness-monitor.ts` iterates `for (const sessionId of staleSessionIds)` — no more `.id` dereference
- `liveness-monitor.test.ts` stubs updated from full `AgentSession` objects to plain `string[]`
- Net: -217 lines of dead mapping code

Closes #1880

## Test plan

- [ ] `pnpm test --filter @mbe/agent-service` — all 51 session + liveness-monitor tests pass
- [ ] `pnpm typecheck --filter @mbe/agent-service` — no new type errors (pre-existing `@mbe/agent-core` resolution errors are unrelated)
- [ ] Pre-push hook passed: 21/21 tasks successful across 10 packages

https://claude.ai/code/session_01HZFtA4wFQAPT34KpDqZ6Yv
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZFtA4wFQAPT34KpDqZ6Yv)_