### PR TITLE
refactor(agent): extract createLivenessMonitor factory to eliminate module-level singleton state

### DIFF
--- a/services/agent/llms-full.txt
+++ b/services/agent/llms-full.txt
@@ -961,34 +961,18 @@
     export const getSlowQueryStats = db.getSlowQueryStats;
   </file>
   <file path="src/services/liveness-monitor.ts">
-    async function checkStaleSessions(): Promise<void> {
-      try {
-        const staleSessions = await sessionService.findStaleSessions(INACTIVITY_THRESHOLD_MS);
-    
-        for (const session of staleSessions) {
-          activeLogger?.warn(
-            `[liveness] Session ${session.id} exceeded inactivity threshold — auto-cancelling`
-          );
-    
-          const cancelled = await cancelSession(session.id);
-          if (cancelled) {
-            await sessionService.addEvent(session.id, "session:error", {
-              message: `Auto-cancelled: exceeded inactivity threshold (${INACTIVITY_THRESHOLD_MS / 1000}s)`,
-              reason: "liveness_timeout",
-            });
-          }
-        }
-      } catch (error) {
-        activeLogger?.error({ err: error }, "[liveness] Error checking stale sessions");
-      }
+    export interface LivenessMonitorConfig {
+      inactivityThresholdMs: number;
+      checkIntervalMs: number;
+      sessionService: {
+        findStaleSessions(ms: number): Promise<Array<{ id: string }>>;
+        addEvent(id: string, type: string, payload: Record<string, unknown>): Promise<unknown>;
+      };
+      cancelSession: (id: string) => Promise<boolean>;
     }
-    export function startLivenessMonitor(logger: FastifyBaseLogger): void {
-      if (intervalHandle) return;
-      activeLogger = logger;
-      intervalHandle = setInterval(checkStaleSessions, CHECK_INTERVAL_MS);
-      logger.info(
-        `[liveness] Monitor started (check every ${CHECK_INTERVAL_MS / 1000}s, timeout ${INACTIVITY_THRESHOLD_MS / 1000}s)`
-      );
+    export interface LivenessMonitor {
+      start(logger: FastifyBaseLogger): void;
+      stop(): void;
     }
   </file>
   <file path="src/services/remediation-circuit-breaker.ts">

--- a/services/agent/llms.txt
+++ b/services/agent/llms.txt
@@ -134,10 +134,18 @@
   </file>
   <file path="src/services/liveness-monitor.ts">
     <item priority="low">
-      async function checkStaleSessions(): Promise<void> { /* ... */ }
+      interface LivenessMonitorConfig {
+        inactivityThresholdMs: number;
+        checkIntervalMs: number;
+        sessionService: {
+          findStaleSessions(ms: number): Promise<Array<{ id: ...;
+        cancelSession: (id: string) => Promise<boolean>;
+      }
     </item>
-    <item priority="high">
-      export function startLivenessMonitor(logger: FastifyBaseLogger): void { /* ... */ }
+    <item priority="low">
+      interface LivenessMonitor {
+        
+      }
     </item>
   </file>
   <file path="src/services/remediation-circuit-breaker.ts">

--- a/services/agent/src/index.ts
+++ b/services/agent/src/index.ts
@@ -10,13 +10,23 @@ await startServiceServer({
   port: PORT,
   buildApp: async () => {
     const { buildApp } = await import("./app.js");
-    const { startLivenessMonitor } = await import("./services/liveness-monitor.js");
+    const { createLivenessMonitor } = await import("./services/liveness-monitor.js");
+    const { sessionService } = await import("./services/session.js");
+    const { cancelSession } = await import("./services/session-executor.js");
+    const { DEFAULT_HEARTBEAT_CONFIG } = await import("@mbe/agent-core");
     const fastify = await buildApp();
-    startLivenessMonitor(fastify.log);
+    const monitor = createLivenessMonitor({
+      inactivityThresholdMs: DEFAULT_HEARTBEAT_CONFIG.inactivityTimeoutMs,
+      checkIntervalMs: 120_000,
+      sessionService,
+      cancelSession,
+    });
+    fastify.addHook("onReady", () => {
+      monitor.start(fastify.log);
+    });
+    fastify.addHook("onClose", () => {
+      monitor.stop();
+    });
     return fastify;
-  },
-  beforeShutdown: async () => {
-    const { stopLivenessMonitor } = await import("./services/liveness-monitor.js");
-    stopLivenessMonitor();
   },
 });

--- a/services/agent/src/services/liveness-monitor.test.ts
+++ b/services/agent/src/services/liveness-monitor.test.ts
@@ -1,27 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { FastifyBaseLogger } from "fastify";
-
-vi.mock("@mbe/agent-core", () => ({
-  DEFAULT_HEARTBEAT_CONFIG: {
-    intervalMs: 60_000,
-    inactivityTimeoutMs: 600_000,
-  },
-}));
-
-vi.mock("./session.js", () => ({
-  sessionService: {
-    findStaleSessions: vi.fn().mockResolvedValue([]),
-    addEvent: vi.fn().mockResolvedValue(null),
-  },
-}));
-
-vi.mock("./session-executor.js", () => ({
-  cancelSession: vi.fn().mockResolvedValue(false),
-}));
-
-import { sessionService } from "./session.js";
-import { cancelSession } from "./session-executor.js";
-import { startLivenessMonitor, stopLivenessMonitor } from "./liveness-monitor.js";
+import { createLivenessMonitor } from "./liveness-monitor.js";
+import type { LivenessMonitorConfig } from "./liveness-monitor.js";
 
 function createMockLogger(): FastifyBaseLogger {
   return {
@@ -35,6 +15,19 @@ function createMockLogger(): FastifyBaseLogger {
     silent: vi.fn(),
     level: "info",
   } as unknown as FastifyBaseLogger;
+}
+
+function createMockConfig(overrides: Partial<LivenessMonitorConfig> = {}): LivenessMonitorConfig {
+  return {
+    inactivityThresholdMs: 600_000,
+    checkIntervalMs: 120_000,
+    sessionService: {
+      findStaleSessions: vi.fn().mockResolvedValue([]),
+      addEvent: vi.fn().mockResolvedValue(null),
+    },
+    cancelSession: vi.fn().mockResolvedValue(false),
+    ...overrides,
+  };
 }
 
 const makeRunningSession = (id: string, updatedAt: string) => ({
@@ -62,62 +55,76 @@ const makeRunningSession = (id: string, updatedAt: string) => ({
   updatedAt,
 });
 
-describe("liveness-monitor", () => {
+describe("createLivenessMonitor", () => {
   let mockLogger: FastifyBaseLogger;
 
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.clearAllMocks();
     mockLogger = createMockLogger();
   });
 
   afterEach(() => {
-    stopLivenessMonitor();
     vi.useRealTimers();
   });
 
-  describe("startLivenessMonitor", () => {
+  describe("start", () => {
     it("starts periodic checks", async () => {
-      startLivenessMonitor(mockLogger);
+      const config = createMockConfig();
+      const monitor = createLivenessMonitor(config);
+      monitor.start(mockLogger);
 
       await vi.advanceTimersByTimeAsync(120_000);
 
-      expect(sessionService.findStaleSessions).toHaveBeenCalledWith(600_000);
+      expect(config.sessionService.findStaleSessions).toHaveBeenCalledWith(600_000);
+      monitor.stop();
     });
 
     it("does not start a second monitor when already running", async () => {
-      startLivenessMonitor(mockLogger);
-      startLivenessMonitor(mockLogger);
+      const config = createMockConfig();
+      const monitor = createLivenessMonitor(config);
+      monitor.start(mockLogger);
+      monitor.start(mockLogger);
 
       await vi.advanceTimersByTimeAsync(120_000);
 
-      expect(sessionService.findStaleSessions).toHaveBeenCalledTimes(1);
+      expect(config.sessionService.findStaleSessions).toHaveBeenCalledTimes(1);
+      monitor.stop();
     });
 
     it("logs info when monitor starts", () => {
-      startLivenessMonitor(mockLogger);
+      const config = createMockConfig();
+      const monitor = createLivenessMonitor(config);
+      monitor.start(mockLogger);
 
       expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining("Monitor started"));
+      monitor.stop();
     });
   });
 
-  describe("stopLivenessMonitor", () => {
+  describe("stop", () => {
     it("stops the periodic checks", async () => {
-      startLivenessMonitor(mockLogger);
-      stopLivenessMonitor();
+      const config = createMockConfig();
+      const monitor = createLivenessMonitor(config);
+      monitor.start(mockLogger);
+      monitor.stop();
 
       await vi.advanceTimersByTimeAsync(240_000);
 
-      expect(sessionService.findStaleSessions).not.toHaveBeenCalled();
+      expect(config.sessionService.findStaleSessions).not.toHaveBeenCalled();
     });
 
     it("is safe to call when not running", () => {
-      expect(() => stopLivenessMonitor()).not.toThrow();
+      const config = createMockConfig();
+      const monitor = createLivenessMonitor(config);
+
+      expect(() => monitor.stop()).not.toThrow();
     });
 
     it("logs info when monitor stops", () => {
-      startLivenessMonitor(mockLogger);
-      stopLivenessMonitor();
+      const config = createMockConfig();
+      const monitor = createLivenessMonitor(config);
+      monitor.start(mockLogger);
+      monitor.stop();
 
       expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining("Monitor stopped"));
     });
@@ -126,86 +133,118 @@ describe("liveness-monitor", () => {
   describe("stale session detection", () => {
     it("cancels session returned by findStaleSessions", async () => {
       const staleSession = makeRunningSession("stale-1", new Date().toISOString());
-
-      vi.mocked(sessionService.findStaleSessions).mockResolvedValueOnce([staleSession]);
-      vi.mocked(cancelSession).mockResolvedValueOnce(true);
-
-      startLivenessMonitor(mockLogger);
+      const config = createMockConfig({
+        sessionService: {
+          findStaleSessions: vi.fn().mockResolvedValueOnce([staleSession]),
+          addEvent: vi.fn().mockResolvedValue(null),
+        },
+        cancelSession: vi.fn().mockResolvedValueOnce(true),
+      });
+      const monitor = createLivenessMonitor(config);
+      monitor.start(mockLogger);
       await vi.advanceTimersByTimeAsync(120_000);
 
-      expect(cancelSession).toHaveBeenCalledWith("stale-1");
-      expect(sessionService.addEvent).toHaveBeenCalledWith(
+      expect(config.cancelSession).toHaveBeenCalledWith("stale-1");
+      expect(config.sessionService.addEvent).toHaveBeenCalledWith(
         "stale-1",
         "session:error",
         expect.objectContaining({
           reason: "liveness_timeout",
         })
       );
+      monitor.stop();
     });
 
     it("logs warn when a stale session is auto-cancelled", async () => {
       const staleSession = makeRunningSession("stale-1", new Date().toISOString());
-
-      vi.mocked(sessionService.findStaleSessions).mockResolvedValueOnce([staleSession]);
-      vi.mocked(cancelSession).mockResolvedValueOnce(true);
-
-      startLivenessMonitor(mockLogger);
+      const config = createMockConfig({
+        sessionService: {
+          findStaleSessions: vi.fn().mockResolvedValueOnce([staleSession]),
+          addEvent: vi.fn().mockResolvedValue(null),
+        },
+        cancelSession: vi.fn().mockResolvedValueOnce(true),
+      });
+      const monitor = createLivenessMonitor(config);
+      monitor.start(mockLogger);
       await vi.advanceTimersByTimeAsync(120_000);
 
       expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining("stale-1"));
+      monitor.stop();
     });
 
     it("does not cancel when findStaleSessions returns empty", async () => {
-      vi.mocked(sessionService.findStaleSessions).mockResolvedValueOnce([]);
-
-      startLivenessMonitor(mockLogger);
+      const config = createMockConfig({
+        sessionService: {
+          findStaleSessions: vi.fn().mockResolvedValueOnce([]),
+          addEvent: vi.fn().mockResolvedValue(null),
+        },
+      });
+      const monitor = createLivenessMonitor(config);
+      monitor.start(mockLogger);
       await vi.advanceTimersByTimeAsync(120_000);
 
-      expect(cancelSession).not.toHaveBeenCalled();
+      expect(config.cancelSession).not.toHaveBeenCalled();
+      monitor.stop();
     });
 
     it("does not add error event when cancellation returns false", async () => {
       const staleSession = makeRunningSession("stale-2", new Date().toISOString());
-
-      vi.mocked(sessionService.findStaleSessions).mockResolvedValueOnce([staleSession]);
-      vi.mocked(cancelSession).mockResolvedValueOnce(false);
-
-      startLivenessMonitor(mockLogger);
+      const config = createMockConfig({
+        sessionService: {
+          findStaleSessions: vi.fn().mockResolvedValueOnce([staleSession]),
+          addEvent: vi.fn().mockResolvedValue(null),
+        },
+        cancelSession: vi.fn().mockResolvedValueOnce(false),
+      });
+      const monitor = createLivenessMonitor(config);
+      monitor.start(mockLogger);
       await vi.advanceTimersByTimeAsync(120_000);
 
-      expect(cancelSession).toHaveBeenCalledWith("stale-2");
-      expect(sessionService.addEvent).not.toHaveBeenCalledWith(
+      expect(config.cancelSession).toHaveBeenCalledWith("stale-2");
+      expect(config.sessionService.addEvent).not.toHaveBeenCalledWith(
         "stale-2",
         "session:error",
         expect.anything()
       );
+      monitor.stop();
     });
 
     it("logs error when check throws", async () => {
-      vi.mocked(sessionService.findStaleSessions).mockRejectedValueOnce(
-        new Error("DB unavailable")
-      );
-
-      startLivenessMonitor(mockLogger);
+      const config = createMockConfig({
+        sessionService: {
+          findStaleSessions: vi.fn().mockRejectedValueOnce(new Error("DB unavailable")),
+          addEvent: vi.fn().mockResolvedValue(null),
+        },
+      });
+      const monitor = createLivenessMonitor(config);
+      monitor.start(mockLogger);
       await vi.advanceTimersByTimeAsync(120_000);
 
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.objectContaining({ err: expect.any(Error) }),
         expect.stringContaining("Error checking stale sessions")
       );
+      monitor.stop();
     });
 
     it("handles errors in check gracefully without crashing", async () => {
-      vi.mocked(sessionService.findStaleSessions)
+      const findStaleSessions = vi
+        .fn()
         .mockRejectedValueOnce(new Error("DB unavailable"))
         .mockResolvedValueOnce([]);
-
-      startLivenessMonitor(mockLogger);
+      const config = createMockConfig({
+        sessionService: {
+          findStaleSessions,
+          addEvent: vi.fn().mockResolvedValue(null),
+        },
+      });
+      const monitor = createLivenessMonitor(config);
+      monitor.start(mockLogger);
+      await vi.advanceTimersByTimeAsync(120_000);
       await vi.advanceTimersByTimeAsync(120_000);
 
-      await vi.advanceTimersByTimeAsync(120_000);
-
-      expect(sessionService.findStaleSessions).toHaveBeenCalledTimes(2);
+      expect(findStaleSessions).toHaveBeenCalledTimes(2);
+      monitor.stop();
     });
 
     it("processes multiple stale sessions in one check cycle", async () => {
@@ -213,15 +252,20 @@ describe("liveness-monitor", () => {
         makeRunningSession("stale-a", new Date().toISOString()),
         makeRunningSession("stale-b", new Date().toISOString()),
       ];
-
-      vi.mocked(sessionService.findStaleSessions).mockResolvedValueOnce(staleSessions);
-      vi.mocked(cancelSession).mockResolvedValue(true);
-
-      startLivenessMonitor(mockLogger);
+      const config = createMockConfig({
+        sessionService: {
+          findStaleSessions: vi.fn().mockResolvedValueOnce(staleSessions),
+          addEvent: vi.fn().mockResolvedValue(null),
+        },
+        cancelSession: vi.fn().mockResolvedValue(true),
+      });
+      const monitor = createLivenessMonitor(config);
+      monitor.start(mockLogger);
       await vi.advanceTimersByTimeAsync(120_000);
 
-      expect(cancelSession).toHaveBeenCalledWith("stale-a");
-      expect(cancelSession).toHaveBeenCalledWith("stale-b");
+      expect(config.cancelSession).toHaveBeenCalledWith("stale-a");
+      expect(config.cancelSession).toHaveBeenCalledWith("stale-b");
+      monitor.stop();
     });
   });
 });

--- a/services/agent/src/services/liveness-monitor.ts
+++ b/services/agent/src/services/liveness-monitor.ts
@@ -1,7 +1,4 @@
 import type { FastifyBaseLogger } from "fastify";
-import { DEFAULT_HEARTBEAT_CONFIG } from "@mbe/agent-core";
-import { sessionService } from "./session.js";
-import { cancelSession } from "./session-executor.js";
 
 /**
  * Background liveness monitor for agent sessions.
@@ -15,48 +12,66 @@ import { cancelSession } from "./session-executor.js";
  * cases where the runner itself hangs (e.g., process crash, network partition).
  */
 
-const CHECK_INTERVAL_MS = 120_000; // 2 minutes
-const INACTIVITY_THRESHOLD_MS = DEFAULT_HEARTBEAT_CONFIG.inactivityTimeoutMs;
+export interface LivenessMonitorConfig {
+  inactivityThresholdMs: number;
+  checkIntervalMs: number;
+  sessionService: {
+    findStaleSessions(ms: number): Promise<Array<{ id: string }>>;
+    addEvent(id: string, type: string, payload: Record<string, unknown>): Promise<unknown>;
+  };
+  cancelSession: (id: string) => Promise<boolean>;
+}
 
-let intervalHandle: ReturnType<typeof setInterval> | null = null;
-let activeLogger: FastifyBaseLogger | null = null;
+export interface LivenessMonitor {
+  start(logger: FastifyBaseLogger): void;
+  stop(): void;
+}
 
-async function checkStaleSessions(): Promise<void> {
-  try {
-    const staleSessions = await sessionService.findStaleSessions(INACTIVITY_THRESHOLD_MS);
+export function createLivenessMonitor(config: LivenessMonitorConfig): LivenessMonitor {
+  const { inactivityThresholdMs, checkIntervalMs, sessionService, cancelSession } = config;
 
-    for (const session of staleSessions) {
-      activeLogger?.warn(
-        `[liveness] Session ${session.id} exceeded inactivity threshold — auto-cancelling`
-      );
+  let intervalHandle: ReturnType<typeof setInterval> | null = null;
+  let activeLogger: FastifyBaseLogger | null = null;
 
-      const cancelled = await cancelSession(session.id);
-      if (cancelled) {
-        await sessionService.addEvent(session.id, "session:error", {
-          message: `Auto-cancelled: exceeded inactivity threshold (${INACTIVITY_THRESHOLD_MS / 1000}s)`,
-          reason: "liveness_timeout",
-        });
+  async function checkStaleSessions(): Promise<void> {
+    try {
+      const staleSessions = await sessionService.findStaleSessions(inactivityThresholdMs);
+
+      for (const session of staleSessions) {
+        activeLogger?.warn(
+          `[liveness] Session ${session.id} exceeded inactivity threshold — auto-cancelling`
+        );
+
+        const cancelled = await cancelSession(session.id);
+        if (cancelled) {
+          await sessionService.addEvent(session.id, "session:error", {
+            message: `Auto-cancelled: exceeded inactivity threshold (${inactivityThresholdMs / 1000}s)`,
+            reason: "liveness_timeout",
+          });
+        }
       }
+    } catch (error) {
+      activeLogger?.error({ err: error }, "[liveness] Error checking stale sessions");
     }
-  } catch (error) {
-    activeLogger?.error({ err: error }, "[liveness] Error checking stale sessions");
   }
-}
 
-export function startLivenessMonitor(logger: FastifyBaseLogger): void {
-  if (intervalHandle) return;
-  activeLogger = logger;
-  intervalHandle = setInterval(checkStaleSessions, CHECK_INTERVAL_MS);
-  logger.info(
-    `[liveness] Monitor started (check every ${CHECK_INTERVAL_MS / 1000}s, timeout ${INACTIVITY_THRESHOLD_MS / 1000}s)`
-  );
-}
+  return {
+    start(logger: FastifyBaseLogger): void {
+      if (intervalHandle) return;
+      activeLogger = logger;
+      intervalHandle = setInterval(() => void checkStaleSessions(), checkIntervalMs);
+      logger.info(
+        `[liveness] Monitor started (check every ${checkIntervalMs / 1000}s, timeout ${inactivityThresholdMs / 1000}s)`
+      );
+    },
 
-export function stopLivenessMonitor(): void {
-  if (intervalHandle) {
-    clearInterval(intervalHandle);
-    intervalHandle = null;
-    activeLogger?.info("[liveness] Monitor stopped");
-    activeLogger = null;
-  }
+    stop(): void {
+      if (intervalHandle) {
+        clearInterval(intervalHandle);
+        intervalHandle = null;
+        activeLogger?.info("[liveness] Monitor stopped");
+        activeLogger = null;
+      }
+    },
+  };
 }


### PR DESCRIPTION
## Summary

- Replace module-level `let intervalHandle` and `let activeLogger` with a `createLivenessMonitor(config)` factory
- `sessionService` and `cancelSession` injected via `LivenessMonitorConfig` — no direct module-scope imports
- `services/agent/src/index.ts` constructs one monitor instance and wires Fastify `onReady`/`onClose` hooks
- Tests rewritten: each test creates its own instance with mock config objects — no `vi.mock`, no `afterEach(stopLivenessMonitor)` global cleanup

## Changes

- `liveness-monitor.ts`: exports `LivenessMonitorConfig`, `LivenessMonitor`, `createLivenessMonitor` — removes `startLivenessMonitor`/`stopLivenessMonitor`
- `liveness-monitor.test.ts`: TDD — tests written against new factory interface; instance-based state; no shared globals
- `index.ts`: constructs monitor with injected deps, wires lifecycle hooks

## Test plan

- [x] Tests written TDD (new factory interface first, then impl)
- [x] `pnpm test --filter @mbe/agent-service` — all tests pass
- [x] `pnpm typecheck --filter @mbe/agent-service` — clean
- [x] Pre-push hook passed

Closes #1881

https://claude.ai/code/session_01FNJBgmMoitzjk5E5mr5jJe

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNJBgmMoitzjk5E5mr5jJe)_