### PR TITLE
fix(health): raise deploy staleness threshold from 24h to 72h

### DIFF
--- a/infrastructure/worker/edge-router.js
+++ b/infrastructure/worker/edge-router.js
@@ -274,7 +274,7 @@ function brandedErrorPage(statusCode, message, requestId, nonce = "") {
 // status is read from KV (written by GitHub Actions).
 
 const HEALTH_TIMEOUT_MS = 5_000;
-const STALENESS_THRESHOLD_MS = 24 * 60 * 60 * 1_000; // 24 hours
+const STALENESS_THRESHOLD_MS = 72 * 60 * 60 * 1_000; // 72 hours — deploys are change-driven, not daily
 
 const SERVICE_ENDPOINTS = {
   users: "/health",


### PR DESCRIPTION
## Summary

- Raises `STALENESS_THRESHOLD_MS` in `edge-router.js` from 24h to 72h
- Fixes false "deploys: degraded" health alerts on quiet days when no infra/static-site commits land

## Root Cause

Deploy health is determined by freshness of KV entries written by the three deploy pipelines (`deploy/static`, `deploy/services`, `deploy/infrastructure`). These pipelines only run when their watched paths are touched (change-driven). With a 24-hour window, any day without infra/rialto/apps commits produces a stale-data alert — today's degraded alert was triggered by the last infra deploy being ~39 hours ago.

72h is a more realistic window: it tolerates a quiet weekend without false alarms, while still surfacing a genuinely stuck pipeline within 3 days.

## Test plan

- [x] `STALENESS_THRESHOLD_MS` updated from `24 * 60 * 60 * 1_000` to `72 * 60 * 60 * 1_000`
- [x] No tests assert the specific 24h boundary
- [x] Merging to `infrastructure/worker/**` will trigger the Pulumi deploy, refreshing the stale KV data as a side-effect

Closes #1887

https://claude.ai/code/session_017wDUwsMXK3bLbVaYhHrdhb

---
_Generated by [Claude Code](https://claude.ai/code/session_017wDUwsMXK3bLbVaYhHrdhb)_