### PR TITLE
refactor(reservations): extract createLapsedGuestMonitor factory

### DIFF
--- a/services/reservations/llms-full.txt
+++ b/services/reservations/llms-full.txt
@@ -512,9 +512,7 @@
         async (request, reply) => {
           const deposit = await depositService.getById(request.params.id);
           if (!deposit) {
-            return reply
-              .code(404)
-              .send(createProblemDetails(404, "Not Found", "Deposit not found"));
+            return reply.code(404).send(createProblemDetails(404, "Not Found", "Deposit not found"));
           }
           return { data: deposit };
         }
@@ -531,7 +529,8 @@
           schema: {
             summary: "Capture (apply) a deposit",
             operationId: "captureDeposit",
-            description: "Capture a held deposit — transitions state from held → applied and charges the card.",
+            description:
+              "Capture a held deposit — transitions state from held → applied and charges the card.",
             tags: ["Deposits"],
             params: {
               type: "object",
@@ -554,9 +553,7 @@
         async (request, reply) => {
           const existing = await depositService.getById(request.params.id);
           if (!existing) {
-            return reply
-              .code(404)
-              .send(createProblemDetails(404, "Not Found", "Deposit not found"));
+            return reply.code(404).send(createProblemDetails(404, "Not Found", "Deposit not found"));
           }
     
           try {
@@ -584,7 +581,8 @@
           schema: {
             summary: "Refund a deposit",
             operationId: "refundDeposit",
-            description: "Refund a held deposit — transitions state from held → refunded and releases the authorization.",
+            description:
+              "Refund a held deposit — transitions state from held → refunded and releases the authorization.",
             tags: ["Deposits"],
             params: {
               type: "object",
@@ -607,9 +605,7 @@
         async (request, reply) => {
           const existing = await depositService.getById(request.params.id);
           if (!existing) {
-            return reply
-              .code(404)
-              .send(createProblemDetails(404, "Not Found", "Deposit not found"));
+            return reply.code(404).send(createProblemDetails(404, "Not Found", "Deposit not found"));
           }
     
           try {
@@ -637,7 +633,8 @@
           schema: {
             summary: "Forfeit a deposit",
             operationId: "forfeitDeposit",
-            description: "Forfeit a held deposit (no-show) — transitions state from held → forfeited and charges the card.",
+            description:
+              "Forfeit a held deposit (no-show) — transitions state from held → forfeited and charges the card.",
             tags: ["Deposits"],
             params: {
               type: "object",
@@ -660,9 +657,7 @@
         async (request, reply) => {
           const existing = await depositService.getById(request.params.id);
           if (!existing) {
-            return reply
-              .code(404)
-              .send(createProblemDetails(404, "Not Found", "Deposit not found"));
+            return reply.code(404).send(createProblemDetails(404, "Not Found", "Deposit not found"));
           }
     
           try {
@@ -1548,7 +1543,7 @@
               .code(400)
               .send(createProblemDetails(400, "Bad Request", "venueId is required"));
           }
-          const lapsing = await runLapsedGuestScan(venueId);
+          const lapsing = await guestService.scanLapsedGuests(venueId);
           return { data: lapsing };
         }
       );
@@ -4931,75 +4926,29 @@
     }
   </file>
   <file path="src/services/lapsed-guest-cron.ts">
-    export function scheduleLapsedGuestCron(log: FastifyBaseLogger): void {
-      const scan = async () => {
-        try {
-          const venues = await prisma.venue.findMany({ select: { id: true } });
-          for (const venue of venues) {
-            const lapsing = await runLapsedGuestScan(venue.id);
-            if (lapsing.length > 0) {
-              log.info(
-                { venueId: venue.id, count: lapsing.length },
-                "lapsed guest scan: found lapsing guests"
-              );
-            }
-          }
-        } catch (err) {
-          log.error({ err }, "lapsed guest scan: error");
-        }
-      };
-    
-      // Run first scan after 1 minute (let service fully start), then daily
-      setTimeout(() => {
-        void scan();
-        setInterval(() => void scan(), DAILY_MS);
-      }, 60_000);
+    export interface LapsedGuestMonitorConfig {
+      getVenueIds: () => Promise<string[]>;
+      runScan: (venueId: string) => Promise<LapsingGuest[]>;
+      startupDelayMs?: number;
+      intervalMs?: number;
+    }
+    export interface LapsedGuestMonitor {
+      start(log: FastifyBaseLogger): void;
+      stop(): void;
     }
   </file>
   <file path="src/services/lapsed-guest-scan.ts">
-    export async function runLapsedGuestScan(venueId: string): Promise<LapsingGuest[]> {
-      // Fetch guests with 3+ visits and a lastVisit date
-      const guests = await prisma.guest.findMany({
-        where: { venueId, visitCount: { gte: MIN_VISITS }, lastVisit: { not: null } },
-        select: {
-          id: true,
-          name: true,
-          email: true,
-          phone: true,
-          communicationPreference: true,
-          reservations: {
-            where: { status: "COMPLETED" },
-            select: { startTime: true },
-            orderBy: { startTime: "asc" },
-          },
-        },
-      });
-    
-      const lapsing: LapsingGuest[] = [];
-    
-      for (const guest of guests) {
-        const visitDates = guest.reservations.map((r) => r.startTime.toISOString());
-        const { avgFrequencyDays, daysSinceLastVisit, isLapsing } = detectLapse(visitDates);
-    
-        if (!isLapsing) continue;
-    
-        lapsing.push({
-          guestId: guest.id,
-          name: guest.name,
-          email: guest.email,
-          phone: guest.phone,
-          communicationPreference: guest.communicationPreference as CommunicationPreference,
-          avgFrequencyDays,
-          daysSinceLastVisit,
-          daysOverdue: daysSinceLastVisit - avgFrequencyDays * 2,
-        });
-      }
-    
-      if (lapsing.length > 0) {
-        emitLapsingGuests(venueId, lapsing);
-      }
-    
-      return lapsing;
+    interface GuestForScan {
+      id: string;
+      name: string;
+      email: string | null;
+      phone: string | null;
+      communicationPreference: string | null;
+      reservations: { startTime: Date }[];
+    }
+    export interface LapsedGuestScanDeps {
+      findGuestsForScan: (venueId: string) => Promise<GuestForScan[]>;
+      emitLapsingGuests: (venueId: string, guests: LapsingGuest[]) => void;
     }
   </file>
   <file path="src/services/reminder.ts">
@@ -5251,9 +5200,34 @@
       await fastify.register(publicDepositRoutes, { prefix: "/public/v1/venues" });
       await fastify.register(stripeWebhookRoutes);
     
-      // Schedule daily lapsed guest scan (skip in test mode)
+      // Wire lapsed-guest monitor with lifecycle hooks
+      const lapsedGuestMonitor = createLapsedGuestMonitor({
+        getVenueIds: () =>
+          prisma.venue.findMany({ select: { id: true } }).then((vs) => vs.map((v) => v.id)),
+        runScan: (venueId) =>
+          runLapsedGuestScan(venueId, {
+            findGuestsForScan: (vid) =>
+              prisma.guest.findMany({
+                where: { venueId: vid, visitCount: { gte: 3 }, lastVisit: { not: null } },
+                select: {
+                  id: true,
+                  name: true,
+                  email: true,
+                  phone: true,
+                  communicationPreference: true,
+                  reservations: {
+                    where: { status: "COMPLETED" },
+                    select: { startTime: true },
+                    orderBy: { startTime: "asc" },
+                  },
+                },
+              }),
+            emitLapsingGuests,
+          }),
+      });
       if (process.env.NODE_ENV !== "test") {
-        scheduleLapsedGuestCron(fastify.log);
+        fastify.addHook("onReady", async () => lapsedGuestMonitor.start(fastify.log));
+        fastify.addHook("onClose", async () => lapsedGuestMonitor.stop());
       }
     
       return fastify;

--- a/services/reservations/llms-full.txt
+++ b/services/reservations/llms-full.txt
@@ -512,7 +512,9 @@
         async (request, reply) => {
           const deposit = await depositService.getById(request.params.id);
           if (!deposit) {
-            return reply.code(404).send(createProblemDetails(404, "Not Found", "Deposit not found"));
+            return reply
+              .code(404)
+              .send(createProblemDetails(404, "Not Found", "Deposit not found"));
           }
           return { data: deposit };
         }
@@ -529,8 +531,7 @@
           schema: {
             summary: "Capture (apply) a deposit",
             operationId: "captureDeposit",
-            description:
-              "Capture a held deposit — transitions state from held → applied and charges the card.",
+            description: "Capture a held deposit — transitions state from held → applied and charges the card.",
             tags: ["Deposits"],
             params: {
               type: "object",
@@ -553,7 +554,9 @@
         async (request, reply) => {
           const existing = await depositService.getById(request.params.id);
           if (!existing) {
-            return reply.code(404).send(createProblemDetails(404, "Not Found", "Deposit not found"));
+            return reply
+              .code(404)
+              .send(createProblemDetails(404, "Not Found", "Deposit not found"));
           }
     
           try {
@@ -581,8 +584,7 @@
           schema: {
             summary: "Refund a deposit",
             operationId: "refundDeposit",
-            description:
-              "Refund a held deposit — transitions state from held → refunded and releases the authorization.",
+            description: "Refund a held deposit — transitions state from held → refunded and releases the authorization.",
             tags: ["Deposits"],
             params: {
               type: "object",
@@ -605,7 +607,9 @@
         async (request, reply) => {
           const existing = await depositService.getById(request.params.id);
           if (!existing) {
-            return reply.code(404).send(createProblemDetails(404, "Not Found", "Deposit not found"));
+            return reply
+              .code(404)
+              .send(createProblemDetails(404, "Not Found", "Deposit not found"));
           }
     
           try {
@@ -633,8 +637,7 @@
           schema: {
             summary: "Forfeit a deposit",
             operationId: "forfeitDeposit",
-            description:
-              "Forfeit a held deposit (no-show) — transitions state from held → forfeited and charges the card.",
+            description: "Forfeit a held deposit (no-show) — transitions state from held → forfeited and charges the card.",
             tags: ["Deposits"],
             params: {
               type: "object",
@@ -657,7 +660,9 @@
         async (request, reply) => {
           const existing = await depositService.getById(request.params.id);
           if (!existing) {
-            return reply.code(404).send(createProblemDetails(404, "Not Found", "Deposit not found"));
+            return reply
+              .code(404)
+              .send(createProblemDetails(404, "Not Found", "Deposit not found"));
           }
     
           try {

--- a/services/reservations/llms.txt
+++ b/services/reservations/llms.txt
@@ -367,13 +367,35 @@
     </item>
   </file>
   <file path="src/services/lapsed-guest-cron.ts">
-    <item priority="high">
-      export function scheduleLapsedGuestCron(log: FastifyBaseLogger): void { /* ... */ }
+    <item priority="low">
+      interface LapsedGuestMonitorConfig {
+        getVenueIds: () => Promise<string[]>;
+        runScan: (venueId: string) => Promise<LapsingGuest[]>;
+        startupDelayMs?: number;
+        intervalMs?: number;
+      }
+    </item>
+    <item priority="low">
+      interface LapsedGuestMonitor {
+        
+      }
     </item>
   </file>
   <file path="src/services/lapsed-guest-scan.ts">
     <item priority="high">
-      export async function runLapsedGuestScan(venueId: string): Promise<LapsingGuest[]> { /* ... */ }
+      interface GuestForScan {
+        id: string;
+        name: string;
+        email: string | null;
+        phone: string | null;
+        communicationPreference: string | null;
+      }
+    </item>
+    <item priority="low">
+      interface LapsedGuestScanDeps {
+        findGuestsForScan: (venueId: string) => Promise<GuestForScan[]>;
+        emitLapsingGuests: (venueId: string, guests: LapsingGuest[]) => void;
+      }
     </item>
   </file>
   <file path="src/services/reminder.ts">

--- a/services/reservations/src/app.ts
+++ b/services/reservations/src/app.ts
@@ -26,7 +26,10 @@ import { publicDepositRoutes } from "./routes/public-deposits.js";
 import { stripeWebhookRoutes } from "./routes/stripe-webhook.js";
 import { waitlistRoutes } from "./routes/waitlist.js";
 import { createNotificationPort } from "./notifications.js";
-import { scheduleLapsedGuestCron } from "./services/lapsed-guest-cron.js";
+import { createLapsedGuestMonitor } from "./services/lapsed-guest-cron.js";
+import { runLapsedGuestScan } from "./services/lapsed-guest-scan.js";
+import { emitLapsingGuests } from "./services/events.js";
+import { prisma } from "./services/database.js";
 
 export interface ReservationsAppOptions extends AppOptions {
   notificationPort?: NotificationPort;
@@ -89,9 +92,34 @@ export async function buildApp(options: ReservationsAppOptions = {}): Promise<Fa
   await fastify.register(publicDepositRoutes, { prefix: "/public/v1/venues" });
   await fastify.register(stripeWebhookRoutes);
 
-  // Schedule daily lapsed guest scan (skip in test mode)
+  // Wire lapsed-guest monitor with lifecycle hooks
+  const lapsedGuestMonitor = createLapsedGuestMonitor({
+    getVenueIds: () =>
+      prisma.venue.findMany({ select: { id: true } }).then((vs) => vs.map((v) => v.id)),
+    runScan: (venueId) =>
+      runLapsedGuestScan(venueId, {
+        findGuestsForScan: (vid) =>
+          prisma.guest.findMany({
+            where: { venueId: vid, visitCount: { gte: 3 }, lastVisit: { not: null } },
+            select: {
+              id: true,
+              name: true,
+              email: true,
+              phone: true,
+              communicationPreference: true,
+              reservations: {
+                where: { status: "COMPLETED" },
+                select: { startTime: true },
+                orderBy: { startTime: "asc" },
+              },
+            },
+          }),
+        emitLapsingGuests,
+      }),
+  });
   if (process.env.NODE_ENV !== "test") {
-    scheduleLapsedGuestCron(fastify.log);
+    fastify.addHook("onReady", async () => lapsedGuestMonitor.start(fastify.log));
+    fastify.addHook("onClose", async () => lapsedGuestMonitor.stop());
   }
 
   return fastify;

--- a/services/reservations/src/routes/guests.ts
+++ b/services/reservations/src/routes/guests.ts
@@ -12,7 +12,6 @@ import type {
 import { createProblemDetails } from "@mbe/types";
 import { requireAuth } from "@mbe/auth/fastify";
 import { guestService } from "../services/guest.js";
-import { runLapsedGuestScan } from "../services/lapsed-guest-scan.js";
 import { sendWinBack } from "../services/win-back.js";
 
 export const guestRoutes: FastifyPluginAsync = async (fastify) => {
@@ -533,7 +532,7 @@ export const guestRoutes: FastifyPluginAsync = async (fastify) => {
           .code(400)
           .send(createProblemDetails(400, "Bad Request", "venueId is required"));
       }
-      const lapsing = await runLapsedGuestScan(venueId);
+      const lapsing = await guestService.scanLapsedGuests(venueId);
       return { data: lapsing };
     }
   );

--- a/services/reservations/src/services/guest.ts
+++ b/services/reservations/src/services/guest.ts
@@ -1,5 +1,6 @@
 import type {
   Guest,
+  LapsingGuest,
   StaffNote,
   CommunicationPreference,
   CreateGuestRequest,
@@ -10,6 +11,8 @@ import type {
 } from "@mbe/types";
 import { Prisma } from "../generated/prisma/index.js";
 import { prisma } from "./database.js";
+import { runLapsedGuestScan } from "./lapsed-guest-scan.js";
+import { emitLapsingGuests } from "./events.js";
 
 function isPrismaNotFound(err: unknown): boolean {
   return (
@@ -435,5 +438,27 @@ export const guestService = {
       { name: "Lapsed", description: "No visit in 90+ days", count: lapsedGuests },
       { name: "New", description: "Booked but never visited", count: newGuests },
     ];
+  },
+
+  async scanLapsedGuests(venueId: string): Promise<LapsingGuest[]> {
+    return runLapsedGuestScan(venueId, {
+      findGuestsForScan: (vid) =>
+        prisma.guest.findMany({
+          where: { venueId: vid, visitCount: { gte: 3 }, lastVisit: { not: null } },
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            phone: true,
+            communicationPreference: true,
+            reservations: {
+              where: { status: "COMPLETED" },
+              select: { startTime: true },
+              orderBy: { startTime: "asc" },
+            },
+          },
+        }),
+      emitLapsingGuests,
+    });
   },
 };

--- a/services/reservations/src/services/lapsed-guest-cron.test.ts
+++ b/services/reservations/src/services/lapsed-guest-cron.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { createLapsedGuestMonitor } from "./lapsed-guest-cron.js";
+import type { LapsingGuest } from "@mbe/types";
+import type { FastifyBaseLogger } from "fastify";
+
+function makeLogger(): FastifyBaseLogger {
+  return {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    trace: vi.fn(),
+    fatal: vi.fn(),
+    child: vi.fn(),
+    level: "info",
+    silent: vi.fn(),
+  } as unknown as FastifyBaseLogger;
+}
+
+function makeDeps(overrides: Partial<Parameters<typeof createLapsedGuestMonitor>[0]> = {}) {
+  return {
+    getVenueIds: vi.fn<() => Promise<string[]>>().mockResolvedValue(["venue-1"]),
+    runScan: vi.fn<(venueId: string) => Promise<LapsingGuest[]>>().mockResolvedValue([]),
+    startupDelayMs: 0,
+    intervalMs: 100,
+    ...overrides,
+  };
+}
+
+describe("createLapsedGuestMonitor", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls runScan for each venue after startup", async () => {
+    const deps = makeDeps({ startupDelayMs: 0 });
+    const log = makeLogger();
+    const monitor = createLapsedGuestMonitor(deps);
+
+    monitor.start(log);
+    await new Promise((r) => setTimeout(r, 10));
+    monitor.stop();
+
+    expect(deps.getVenueIds).toHaveBeenCalledTimes(1);
+    expect(deps.runScan).toHaveBeenCalledWith("venue-1");
+  });
+
+  it("logs when lapsing guests are found", async () => {
+    const lapsingGuest = { guestId: "g-1" } as LapsingGuest;
+    const deps = makeDeps({
+      startupDelayMs: 0,
+      runScan: vi.fn().mockResolvedValue([lapsingGuest]),
+    });
+    const log = makeLogger();
+    const monitor = createLapsedGuestMonitor(deps);
+
+    monitor.start(log);
+    await new Promise((r) => setTimeout(r, 10));
+    monitor.stop();
+
+    expect(log.info).toHaveBeenCalledWith(
+      { venueId: "venue-1", count: 1 },
+      "lapsed guest scan: found lapsing guests"
+    );
+  });
+
+  it("logs error when scan throws", async () => {
+    const err = new Error("db failure");
+    const deps = makeDeps({
+      startupDelayMs: 0,
+      getVenueIds: vi.fn().mockRejectedValue(err),
+    });
+    const log = makeLogger();
+    const monitor = createLapsedGuestMonitor(deps);
+
+    monitor.start(log);
+    await new Promise((r) => setTimeout(r, 10));
+    monitor.stop();
+
+    expect(log.error).toHaveBeenCalledWith({ err }, "lapsed guest scan: error");
+  });
+
+  it("stop() prevents further scans from running", async () => {
+    const runScan = vi.fn<(venueId: string) => Promise<LapsingGuest[]>>().mockResolvedValue([]);
+    const deps = makeDeps({ startupDelayMs: 0, intervalMs: 50, runScan });
+    const log = makeLogger();
+    const monitor = createLapsedGuestMonitor(deps);
+
+    monitor.start(log);
+    await new Promise((r) => setTimeout(r, 10));
+    monitor.stop();
+
+    const callsAfterStop = runScan.mock.calls.length;
+    await new Promise((r) => setTimeout(r, 120));
+    expect(runScan.mock.calls.length).toBe(callsAfterStop);
+  });
+});

--- a/services/reservations/src/services/lapsed-guest-cron.ts
+++ b/services/reservations/src/services/lapsed-guest-cron.ts
@@ -1,34 +1,66 @@
 import type { FastifyBaseLogger } from "fastify";
-import { prisma } from "./database.js";
-import { runLapsedGuestScan } from "./lapsed-guest-scan.js";
+import type { LapsingGuest } from "@mbe/types";
 
-const DAILY_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_STARTUP_DELAY_MS = 60_000;
+const DEFAULT_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
-/**
- * Schedule a daily lapsed-guest scan across all venues.
- * Runs once immediately at startup (after a short delay), then every 24h.
- */
-export function scheduleLapsedGuestCron(log: FastifyBaseLogger): void {
-  const scan = async () => {
-    try {
-      const venues = await prisma.venue.findMany({ select: { id: true } });
-      for (const venue of venues) {
-        const lapsing = await runLapsedGuestScan(venue.id);
-        if (lapsing.length > 0) {
-          log.info(
-            { venueId: venue.id, count: lapsing.length },
-            "lapsed guest scan: found lapsing guests"
-          );
+export interface LapsedGuestMonitorConfig {
+  getVenueIds: () => Promise<string[]>;
+  runScan: (venueId: string) => Promise<LapsingGuest[]>;
+  startupDelayMs?: number;
+  intervalMs?: number;
+}
+
+export interface LapsedGuestMonitor {
+  start(log: FastifyBaseLogger): void;
+  stop(): void;
+}
+
+export function createLapsedGuestMonitor(config: LapsedGuestMonitorConfig): LapsedGuestMonitor {
+  const {
+    getVenueIds,
+    runScan,
+    startupDelayMs = DEFAULT_STARTUP_DELAY_MS,
+    intervalMs = DEFAULT_INTERVAL_MS,
+  } = config;
+
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  let intervalHandle: ReturnType<typeof setInterval> | null = null;
+
+  return {
+    start(log: FastifyBaseLogger): void {
+      const scan = async () => {
+        try {
+          const venueIds = await getVenueIds();
+          for (const venueId of venueIds) {
+            const lapsing = await runScan(venueId);
+            if (lapsing.length > 0) {
+              log.info(
+                { venueId, count: lapsing.length },
+                "lapsed guest scan: found lapsing guests"
+              );
+            }
+          }
+        } catch (err) {
+          log.error({ err }, "lapsed guest scan: error");
         }
-      }
-    } catch (err) {
-      log.error({ err }, "lapsed guest scan: error");
-    }
-  };
+      };
 
-  // Run first scan after 1 minute (let service fully start), then daily
-  setTimeout(() => {
-    void scan();
-    setInterval(() => void scan(), DAILY_MS);
-  }, 60_000);
+      timeoutHandle = setTimeout(() => {
+        void scan();
+        intervalHandle = setInterval(() => void scan(), intervalMs);
+      }, startupDelayMs);
+    },
+
+    stop(): void {
+      if (timeoutHandle !== null) {
+        clearTimeout(timeoutHandle);
+        timeoutHandle = null;
+      }
+      if (intervalHandle !== null) {
+        clearInterval(intervalHandle);
+        intervalHandle = null;
+      }
+    },
+  };
 }

--- a/services/reservations/src/services/lapsed-guest-scan.test.ts
+++ b/services/reservations/src/services/lapsed-guest-scan.test.ts
@@ -1,20 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-
-vi.mock("./database.js", () => ({
-  prisma: {
-    guest: {
-      findMany: vi.fn(),
-    },
-  },
-}));
-
-vi.mock("./events.js", () => ({
-  emitLapsingGuests: vi.fn(),
-}));
-
+import { describe, it, expect, vi } from "vitest";
 import { runLapsedGuestScan } from "./lapsed-guest-scan.js";
-import { prisma } from "./database.js";
-import { emitLapsingGuests } from "./events.js";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -29,19 +14,21 @@ function makeGuest(overrides: Record<string, unknown> = {}) {
     email: "jane@example.com",
     phone: "+15551234567",
     communicationPreference: "both",
-    reservations: [],
+    reservations: [] as { startTime: Date }[],
     ...overrides,
   };
 }
 
-describe("runLapsedGuestScan", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+function makeDeps(guests: ReturnType<typeof makeGuest>[] = []) {
+  return {
+    findGuestsForScan: vi.fn().mockResolvedValue(guests),
+    emitLapsingGuests: vi.fn(),
+  };
+}
 
+describe("runLapsedGuestScan", () => {
   it("returns empty array and does not emit when no guests are lapsing", async () => {
-    // Weekly guest visited 6 days ago — not lapsing
-    vi.mocked(prisma.guest.findMany).mockResolvedValueOnce([
+    const deps = makeDeps([
       makeGuest({
         reservations: [
           { startTime: daysAgo(20) },
@@ -49,16 +36,15 @@ describe("runLapsedGuestScan", () => {
           { startTime: daysAgo(6) },
         ],
       }),
-    ] as never);
+    ]);
 
-    const result = await runLapsedGuestScan("venue-1");
+    const result = await runLapsedGuestScan("venue-1", deps);
     expect(result).toHaveLength(0);
-    expect(emitLapsingGuests).not.toHaveBeenCalled();
+    expect(deps.emitLapsingGuests).not.toHaveBeenCalled();
   });
 
   it("detects lapsing guest and emits SSE event", async () => {
-    // Weekly guest last visited 21 days ago — lapsing (21 > 7*2=14)
-    vi.mocked(prisma.guest.findMany).mockResolvedValueOnce([
+    const deps = makeDeps([
       makeGuest({
         reservations: [
           { startTime: daysAgo(35) },
@@ -66,19 +52,18 @@ describe("runLapsedGuestScan", () => {
           { startTime: daysAgo(21) },
         ],
       }),
-    ] as never);
+    ]);
 
-    const result = await runLapsedGuestScan("venue-1");
+    const result = await runLapsedGuestScan("venue-1", deps);
     expect(result).toHaveLength(1);
     expect(result[0].guestId).toBe("guest-1");
     expect(result[0].name).toBe("Jane Doe");
     expect(result[0].daysOverdue).toBeGreaterThan(0);
-    expect(emitLapsingGuests).toHaveBeenCalledWith("venue-1", result);
+    expect(deps.emitLapsingGuests).toHaveBeenCalledWith("venue-1", result);
   });
 
   it("skips guests with transactional_only communication preference for winback but still lists them", async () => {
-    // The scan itself lists all lapsing guests; winback skip is at send-time
-    vi.mocked(prisma.guest.findMany).mockResolvedValueOnce([
+    const deps = makeDeps([
       makeGuest({
         communicationPreference: "transactional_only",
         reservations: [
@@ -87,18 +72,17 @@ describe("runLapsedGuestScan", () => {
           { startTime: daysAgo(21) },
         ],
       }),
-    ] as never);
+    ]);
 
-    const result = await runLapsedGuestScan("venue-1");
+    const result = await runLapsedGuestScan("venue-1", deps);
     expect(result).toHaveLength(1);
     expect(result[0].communicationPreference).toBe("transactional_only");
   });
 
   it("handles multiple guests with mixed lapse status", async () => {
-    vi.mocked(prisma.guest.findMany).mockResolvedValueOnce([
+    const deps = makeDeps([
       makeGuest({
         id: "guest-1",
-        // Lapsing: last visit 21 days ago, weekly freq
         reservations: [
           { startTime: daysAgo(35) },
           { startTime: daysAgo(28) },
@@ -107,16 +91,15 @@ describe("runLapsedGuestScan", () => {
       }),
       makeGuest({
         id: "guest-2",
-        // Not lapsing: last visit 6 days ago, weekly freq
         reservations: [
           { startTime: daysAgo(20) },
           { startTime: daysAgo(13) },
           { startTime: daysAgo(6) },
         ],
       }),
-    ] as never);
+    ]);
 
-    const result = await runLapsedGuestScan("venue-1");
+    const result = await runLapsedGuestScan("venue-1", deps);
     expect(result).toHaveLength(1);
     expect(result[0].guestId).toBe("guest-1");
   });

--- a/services/reservations/src/services/lapsed-guest-scan.ts
+++ b/services/reservations/src/services/lapsed-guest-scan.ts
@@ -1,35 +1,25 @@
 import type { LapsingGuest, CommunicationPreference } from "@mbe/types";
-import { prisma } from "./database.js";
 import { detectLapse } from "./lapse-detector.js";
-import { emitLapsingGuests } from "./events.js";
 
-const MIN_VISITS = 3;
+interface GuestForScan {
+  id: string;
+  name: string;
+  email: string | null;
+  phone: string | null;
+  communicationPreference: string | null;
+  reservations: { startTime: Date }[];
+}
 
-/**
- * Scan all guests for a venue with 3+ visits, detect lapsing ones,
- * emit a guest:lapsing SSE event, and return the list.
- *
- * For each lapsing guest, we need their visit dates — these come from
- * COMPLETED reservations linked to the guest.
- */
-export async function runLapsedGuestScan(venueId: string): Promise<LapsingGuest[]> {
-  // Fetch guests with 3+ visits and a lastVisit date
-  const guests = await prisma.guest.findMany({
-    where: { venueId, visitCount: { gte: MIN_VISITS }, lastVisit: { not: null } },
-    select: {
-      id: true,
-      name: true,
-      email: true,
-      phone: true,
-      communicationPreference: true,
-      reservations: {
-        where: { status: "COMPLETED" },
-        select: { startTime: true },
-        orderBy: { startTime: "asc" },
-      },
-    },
-  });
+export interface LapsedGuestScanDeps {
+  findGuestsForScan: (venueId: string) => Promise<GuestForScan[]>;
+  emitLapsingGuests: (venueId: string, guests: LapsingGuest[]) => void;
+}
 
+export async function runLapsedGuestScan(
+  venueId: string,
+  deps: LapsedGuestScanDeps
+): Promise<LapsingGuest[]> {
+  const guests = await deps.findGuestsForScan(venueId);
   const lapsing: LapsingGuest[] = [];
 
   for (const guest of guests) {
@@ -51,7 +41,7 @@ export async function runLapsedGuestScan(venueId: string): Promise<LapsingGuest[
   }
 
   if (lapsing.length > 0) {
-    emitLapsingGuests(venueId, lapsing);
+    deps.emitLapsingGuests(venueId, lapsing);
   }
 
   return lapsing;


### PR DESCRIPTION
## Summary

- Replace module-level `prisma` imports in `lapsed-guest-scan.ts` and `lapsed-guest-cron.ts` with injected deps
- Extract `createLapsedGuestMonitor(config)` factory replacing `scheduleLapsedGuestCron` — holds no module-level state
- `runLapsedGuestScan(venueId, deps)` accepts `findGuestsForScan` + `emitLapsingGuests` — no direct prisma/events import
- `app.ts` constructs one monitor instance and wires Fastify `onReady`/`onClose` lifecycle hooks
- `guestService.scanLapsedGuests(venueId)` wires production prisma deps for the on-demand route handler, keeping routes clean of direct DB imports
- Scan and cron tests rewritten using injected stubs — no `vi.mock('./database.js')` or `vi.useFakeTimers()` advancing 60_000ms

## Test plan

- [x] TDD: new test interfaces written first (RED), then implementation (GREEN)
- [x] `lapsed-guest-scan.test.ts` — 4 tests, no `vi.mock` or global state
- [x] `lapsed-guest-cron.test.ts` — 4 tests using `startupDelayMs: 0`, no fake timers
- [x] `pnpm test` — 621 tests pass across 47 test files
- [x] `pnpm typecheck` — clean on `@mbe/reservations-service`
- [x] Pre-push turbo typecheck + test across all packages pass

Closes #1890

https://claude.ai/code/session_014n83QKEGefARh2yMBBhkYg

---
_Generated by [Claude Code](https://claude.ai/code/session_014n83QKEGefARh2yMBBhkYg)_