### PR TITLE
perf(gen): lazy-load route components to eliminate eager bundle

### DIFF
--- a/apps/gen/src/pages/LoadingPage.module.css
+++ b/apps/gen/src/pages/LoadingPage.module.css
@@ -1,0 +1,7 @@
+.container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  min-height: 200px;
+}

--- a/apps/gen/src/pages/LoadingPage.tsx
+++ b/apps/gen/src/pages/LoadingPage.tsx
@@ -1,0 +1,14 @@
+import { Stack, Text } from "@mattbutlerengineering/rialto";
+import styles from "./LoadingPage.module.css";
+
+export function LoadingPage() {
+  return (
+    <div className={styles.container}>
+      <Stack gap="sm" align="center">
+        <Text variant="body" color="secondary">
+          Loading...
+        </Text>
+      </Stack>
+    </div>
+  );
+}

--- a/apps/gen/src/router.tsx
+++ b/apps/gen/src/router.tsx
@@ -1,7 +1,14 @@
+import { lazy, Suspense } from "react";
 import { createBrowserRouter, Navigate } from "react-router-dom";
 import { App, CallbackRedirect } from "./App";
-import { PlaygroundPage } from "./pages/PlaygroundPage";
-import { SharedSpecPage } from "./pages/SharedSpecPage";
+import { LoadingPage } from "./pages/LoadingPage";
+
+const PlaygroundPage = lazy(() =>
+  import("./pages/PlaygroundPage").then((m) => ({ default: m.PlaygroundPage }))
+);
+const SharedSpecPage = lazy(() =>
+  import("./pages/SharedSpecPage").then((m) => ({ default: m.SharedSpecPage }))
+);
 
 /**
  * Uses createBrowserRouter (React Router v7 recommended API) instead of
@@ -15,9 +22,20 @@ export const router = createBrowserRouter(
         { path: "callback", element: <CallbackRedirect /> },
         {
           index: true,
-          element: <PlaygroundPage />,
+          element: (
+            <Suspense fallback={<LoadingPage />}>
+              <PlaygroundPage />
+            </Suspense>
+          ),
         },
-        { path: "s/:id", element: <SharedSpecPage /> },
+        {
+          path: "s/:id",
+          element: (
+            <Suspense fallback={<LoadingPage />}>
+              <SharedSpecPage />
+            </Suspense>
+          ),
+        },
         { path: "*", element: <Navigate to="/" replace /> },
       ],
     },


### PR DESCRIPTION
## Summary

- Replace static imports of `PlaygroundPage` and `SharedSpecPage` in `apps/gen/src/router.tsx` with `React.lazy()` — matches the pattern already used in marketing, hospitality, and rialto-web
- Add `LoadingPage` to `apps/gen/src/pages/` (mirrors `apps/hospitality/src/pages/LoadingPage.tsx`)
- Wrap each lazy route element in `<Suspense fallback={<LoadingPage />}>`

`PlaygroundPage` alone imports 8+ local components — keeping it in the initial bundle bloats first-load JS for routes the user may never visit.

## Test plan

- [ ] Typecheck clean on `@mbe/gen`
- [ ] Build passes — Vite code-splits `PlaygroundPage` and `SharedSpecPage` into separate chunks
- [ ] App loads at `/gen` with no visible regression

Closes #1892

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPcZFnRee8LUXcUbg8XDom)_