### PR TITLE
fix(ci): retry postgres pull in migration-dry-run to survive Docker Hub timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -674,25 +674,25 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
-    services:
-      postgres:
-        image: postgres:16-alpine
-        env:
-          POSTGRES_USER: dryrun
-          POSTGRES_PASSWORD: dryrun_test
-          POSTGRES_DB: dryrun
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U dryrun"
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 10
-
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4/v5
         with:
           fetch-depth: 0
+
+      - name: Start postgres
+        run: |
+          for i in 1 2 3; do
+            docker pull postgres:16-alpine && break || (echo "Pull attempt $i failed, retrying in 10s..." && sleep 10)
+          done
+          docker run -d --name postgres \
+            -p 5432:5432 \
+            -e POSTGRES_USER=dryrun \
+            -e POSTGRES_PASSWORD=dryrun_test \
+            -e POSTGRES_DB=dryrun \
+            postgres:16-alpine
+          for i in $(seq 1 20); do
+            docker exec postgres pg_isready -U dryrun && break || sleep 3
+          done
 
       - name: Check for migration changes
         id: changes


### PR DESCRIPTION
## Summary

- Replace the `services.postgres` service container in `migration-dry-run` with an explicit `docker pull` + `docker run` step that retries up to 3 times with 10s delays between attempts
- Add a health-check loop (20 × 3s polls) to wait for postgres readiness before proceeding
- All `DATABASE_URL` references remain unchanged (`localhost:5432`)

Service containers pull images before job steps execute and have no built-in retry mechanism. When Docker Hub is transiently unreachable, the entire job fails immediately. Moving the pull into a step gives us retry control.

## Test plan

- [ ] YAML validates (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Migration Dry-Run passes on a PR that touches prisma migrations
- [ ] Migration Dry-Run fast-exits on PRs with no migration changes (unchanged `has_migrations` logic)

Closes #1901

---
_Generated by [Claude Code](https://claude.ai/code/session_01239tYQxVmnzAz1nUkcGzqs)_