### PR TITLE
chore: weekly CLAUDE.md maintenance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,8 +162,6 @@ Only run `npm publish` from `packages/rialto` when actually cutting a registry r
 
 ## AI Observability (Langfuse)
 
-<!-- TODO: Verify onboarding benchmark results are being correctly tracked -->
-
 Agent sessions are traced to [Langfuse Cloud](https://cloud.langfuse.com) for LLM-specific observability.
 
 ### What's traced


### PR DESCRIPTION
## Summary

Removed stale TODO comment from CLAUDE.md AI Observability section. The "onboarding benchmark results" mention is leftover from an earlier iteration and doesn't reflect what's actually tracked in Langfuse (generic session metrics only).

## Changes

- **CLAUDE.md**: Removed stale TODO comment (line 165), bringing file from 229 to 228 lines

## Reflections Review

Checked `/docs/reflections/*.md` from recent sessions. The three existing reflections are specific to the ACMM audit skill/process (report layout, iteration batching, audit cache) and don't contain general development guidelines suitable for project instructions. No additional entries needed.

## Duplication Check

- Verified worktree agent guidance in CLAUDE.md and gotchas.md serves different purposes (prescriptive vs. reference) — no consolidation needed
- No other duplications or contradictions found
- Organization is current

https://claude.ai/code/session_01A5x3AAyKUi9Lj649ZUdQsN

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5x3AAyKUi9Lj649ZUdQsN)_