### PR TITLE
refactor(agent): extract createCircuitBreaker factory from remediation singleton

### DIFF
--- a/services/agent/src/services/remediation-circuit-breaker.test.ts
+++ b/services/agent/src/services/remediation-circuit-breaker.test.ts
@@ -1,54 +1,50 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { checkCircuitBreaker, recordRemediationOutcome } from "./remediation-circuit-breaker.js";
-
-function resetCircuitState(): void {
-  recordRemediationOutcome(true);
-}
+import { describe, it, expect } from "vitest";
+import { createCircuitBreaker } from "./remediation-circuit-breaker.js";
 
 describe("remediation-circuit-breaker", () => {
-  beforeEach(() => {
-    resetCircuitState();
-  });
-
-  describe("checkCircuitBreaker", () => {
+  describe("check", () => {
     it("allows requests when circuit is closed", () => {
-      const result = checkCircuitBreaker();
+      const breaker = createCircuitBreaker();
+      const result = breaker.check();
       expect(result).toEqual({ allowed: true });
     });
 
     it("blocks requests when circuit is open", () => {
-      recordRemediationOutcome(false);
-      recordRemediationOutcome(false);
-      recordRemediationOutcome(false);
+      const breaker = createCircuitBreaker();
+      breaker.recordOutcome(false);
+      breaker.recordOutcome(false);
+      breaker.recordOutcome(false);
 
-      const result = checkCircuitBreaker();
+      const result = breaker.check();
       expect(result.allowed).toBe(false);
       expect(result.reason).toMatch(/Circuit open/);
       expect(result.reason).toMatch(/3 consecutive/);
     });
 
     it("includes time-to-reset in reason when circuit is open", () => {
-      recordRemediationOutcome(false);
-      recordRemediationOutcome(false);
-      recordRemediationOutcome(false);
+      const breaker = createCircuitBreaker();
+      breaker.recordOutcome(false);
+      breaker.recordOutcome(false);
+      breaker.recordOutcome(false);
 
-      const result = checkCircuitBreaker();
+      const result = breaker.check();
       expect(result.allowed).toBe(false);
       expect(result.reason).toMatch(/Resets in \d+ min/);
     });
 
     it("transitions to half-open after reset period elapses", () => {
-      recordRemediationOutcome(false);
-      recordRemediationOutcome(false);
-      recordRemediationOutcome(false);
+      const breaker = createCircuitBreaker();
+      breaker.recordOutcome(false);
+      breaker.recordOutcome(false);
+      breaker.recordOutcome(false);
 
-      expect(checkCircuitBreaker().allowed).toBe(false);
+      expect(breaker.check().allowed).toBe(false);
 
       const originalDateNow = Date.now;
       Date.now = () => originalDateNow() + 31 * 60 * 1000;
 
       try {
-        const result = checkCircuitBreaker();
+        const result = breaker.check();
         expect(result).toEqual({ allowed: true });
       } finally {
         Date.now = originalDateNow;
@@ -56,74 +52,80 @@ describe("remediation-circuit-breaker", () => {
     });
   });
 
-  describe("recordRemediationOutcome", () => {
+  describe("recordOutcome", () => {
     it("keeps circuit closed on fewer than threshold failures", () => {
-      recordRemediationOutcome(false);
-      recordRemediationOutcome(false);
+      const breaker = createCircuitBreaker();
+      breaker.recordOutcome(false);
+      breaker.recordOutcome(false);
 
-      expect(checkCircuitBreaker().allowed).toBe(true);
+      expect(breaker.check().allowed).toBe(true);
     });
 
     it("opens circuit on exactly threshold consecutive failures", () => {
-      recordRemediationOutcome(false);
-      recordRemediationOutcome(false);
-      recordRemediationOutcome(false);
+      const breaker = createCircuitBreaker();
+      breaker.recordOutcome(false);
+      breaker.recordOutcome(false);
+      breaker.recordOutcome(false);
 
-      expect(checkCircuitBreaker().allowed).toBe(false);
+      expect(breaker.check().allowed).toBe(false);
     });
 
     it("opens circuit on more than threshold consecutive failures", () => {
+      const breaker = createCircuitBreaker();
       for (let i = 0; i < 5; i++) {
-        recordRemediationOutcome(false);
+        breaker.recordOutcome(false);
       }
 
-      const result = checkCircuitBreaker();
+      const result = breaker.check();
       expect(result.allowed).toBe(false);
       expect(result.reason).toMatch(/5 consecutive/);
     });
 
     it("resets failure count on success", () => {
-      recordRemediationOutcome(false);
-      recordRemediationOutcome(false);
-      recordRemediationOutcome(true);
+      const breaker = createCircuitBreaker();
+      breaker.recordOutcome(false);
+      breaker.recordOutcome(false);
+      breaker.recordOutcome(true);
 
-      expect(checkCircuitBreaker().allowed).toBe(true);
+      expect(breaker.check().allowed).toBe(true);
     });
 
     it("closes circuit when success follows open state after half-open", () => {
-      recordRemediationOutcome(false);
-      recordRemediationOutcome(false);
-      recordRemediationOutcome(false);
-      expect(checkCircuitBreaker().allowed).toBe(false);
+      const breaker = createCircuitBreaker();
+      breaker.recordOutcome(false);
+      breaker.recordOutcome(false);
+      breaker.recordOutcome(false);
+      expect(breaker.check().allowed).toBe(false);
 
       const originalDateNow = Date.now;
       Date.now = () => originalDateNow() + 31 * 60 * 1000;
 
       try {
-        expect(checkCircuitBreaker().allowed).toBe(true);
-        recordRemediationOutcome(true);
-        expect(checkCircuitBreaker().allowed).toBe(true);
+        expect(breaker.check().allowed).toBe(true);
+        breaker.recordOutcome(true);
+        expect(breaker.check().allowed).toBe(true);
       } finally {
         Date.now = originalDateNow;
       }
     });
 
     it("re-opens circuit if half-open attempt fails", () => {
-      recordRemediationOutcome(false);
-      recordRemediationOutcome(false);
-      recordRemediationOutcome(false);
+      const breaker = createCircuitBreaker();
+      breaker.recordOutcome(false);
+      breaker.recordOutcome(false);
+      breaker.recordOutcome(false);
 
       const originalDateNow = Date.now;
       const baseTime = originalDateNow();
       Date.now = () => baseTime + 31 * 60 * 1000;
 
       try {
-        checkCircuitBreaker();
-        recordRemediationOutcome(false);
-        recordRemediationOutcome(false);
-        recordRemediationOutcome(false);
+        breaker.check();
+        breaker.recordOutcome(false);
+        breaker.recordOutcome(false);
+        breaker.recordOutcome(false);
 
-        const result = checkCircuitBreaker();
+        const result = breaker.check();
         expect(result.allowed).toBe(false);
       } finally {
         Date.now = originalDateNow;
@@ -131,13 +133,35 @@ describe("remediation-circuit-breaker", () => {
     });
 
     it("does not open circuit when failures are non-consecutive", () => {
-      recordRemediationOutcome(false);
-      recordRemediationOutcome(false);
-      recordRemediationOutcome(true);
-      recordRemediationOutcome(false);
-      recordRemediationOutcome(false);
+      const breaker = createCircuitBreaker();
+      breaker.recordOutcome(false);
+      breaker.recordOutcome(false);
+      breaker.recordOutcome(true);
+      breaker.recordOutcome(false);
+      breaker.recordOutcome(false);
 
-      expect(checkCircuitBreaker().allowed).toBe(true);
+      expect(breaker.check().allowed).toBe(true);
+    });
+  });
+
+  describe("instance isolation", () => {
+    it("does not share state between separate breakers", () => {
+      const a = createCircuitBreaker();
+      const b = createCircuitBreaker();
+
+      a.recordOutcome(false);
+      a.recordOutcome(false);
+      a.recordOutcome(false);
+
+      expect(a.check().allowed).toBe(false);
+      expect(b.check().allowed).toBe(true);
+    });
+
+    it("honors a custom failureThreshold", () => {
+      const breaker = createCircuitBreaker({ failureThreshold: 1 });
+      breaker.recordOutcome(false);
+
+      expect(breaker.check().allowed).toBe(false);
     });
   });
 });

--- a/services/agent/src/services/remediation-circuit-breaker.ts
+++ b/services/agent/src/services/remediation-circuit-breaker.ts
@@ -3,10 +3,14 @@
  *
  * Prevents alert storms from spawning unlimited agent sessions.
  * Resets on process restart (acceptable — remediation is fire-and-forget).
+ *
+ * State is owned by a `createCircuitBreaker()` factory instance rather than a
+ * module-level singleton, so multiple breakers can coexist and tests get a
+ * clean instance each without side-channelling a reset through the API.
  */
 
-const FAILURE_THRESHOLD = 3;
-const RESET_AFTER_MS = 30 * 60 * 1000; // 30 minutes
+const DEFAULT_FAILURE_THRESHOLD = 3;
+const DEFAULT_RESET_AFTER_MS = 30 * 60 * 1000; // 30 minutes
 
 interface CircuitState {
   consecutiveFailures: number;
@@ -15,48 +19,80 @@ interface CircuitState {
   openedAt: number | null;
 }
 
-const state: CircuitState = {
-  consecutiveFailures: 0,
-  lastFailureAt: null,
-  isOpen: false,
-  openedAt: null,
-};
-
 export interface CircuitCheckResult {
   readonly allowed: boolean;
   readonly reason?: string;
 }
 
-export function checkCircuitBreaker(): CircuitCheckResult {
-  if (!state.isOpen) {
-    return { allowed: true };
-  }
+export interface CircuitBreaker {
+  check(): CircuitCheckResult;
+  recordOutcome(succeeded: boolean): void;
+}
 
-  const elapsed = Date.now() - (state.openedAt ?? 0);
-  if (elapsed > RESET_AFTER_MS) {
-    // Half-open: allow one attempt to see if things recovered
-    state.isOpen = false;
-    state.consecutiveFailures = 0;
-    return { allowed: true };
-  }
+export function createCircuitBreaker(opts?: {
+  failureThreshold?: number;
+  resetAfterMs?: number;
+}): CircuitBreaker {
+  const failureThreshold = opts?.failureThreshold ?? DEFAULT_FAILURE_THRESHOLD;
+  const resetAfterMs = opts?.resetAfterMs ?? DEFAULT_RESET_AFTER_MS;
+
+  const state: CircuitState = {
+    consecutiveFailures: 0,
+    lastFailureAt: null,
+    isOpen: false,
+    openedAt: null,
+  };
 
   return {
-    allowed: false,
-    reason: `Circuit open — ${state.consecutiveFailures} consecutive remediation failures. Resets in ${Math.ceil((RESET_AFTER_MS - elapsed) / 60_000)} min.`,
+    check(): CircuitCheckResult {
+      if (!state.isOpen) {
+        return { allowed: true };
+      }
+
+      const elapsed = Date.now() - (state.openedAt ?? 0);
+      if (elapsed > resetAfterMs) {
+        // Half-open: allow one attempt to see if things recovered
+        state.isOpen = false;
+        state.consecutiveFailures = 0;
+        return { allowed: true };
+      }
+
+      return {
+        allowed: false,
+        reason: `Circuit open — ${state.consecutiveFailures} consecutive remediation failures. Resets in ${Math.ceil((resetAfterMs - elapsed) / 60_000)} min.`,
+      };
+    },
+
+    recordOutcome(succeeded: boolean): void {
+      if (succeeded) {
+        state.consecutiveFailures = 0;
+        state.isOpen = false;
+        state.openedAt = null;
+      } else {
+        state.consecutiveFailures++;
+        state.lastFailureAt = Date.now();
+        if (state.consecutiveFailures >= failureThreshold) {
+          state.isOpen = true;
+          state.openedAt = Date.now();
+        }
+      }
+    },
   };
 }
 
+/**
+ * Default production instance + back-compat free functions.
+ *
+ * Existing callers (`routes/remediation.ts`) use these. They delegate to a
+ * single shared breaker, preserving the original behaviour. Once those callers
+ * inject a `CircuitBreaker` instance, this default and the two shims can go.
+ */
+const defaultBreaker = createCircuitBreaker();
+
+export function checkCircuitBreaker(): CircuitCheckResult {
+  return defaultBreaker.check();
+}
+
 export function recordRemediationOutcome(succeeded: boolean): void {
-  if (succeeded) {
-    state.consecutiveFailures = 0;
-    state.isOpen = false;
-    state.openedAt = null;
-  } else {
-    state.consecutiveFailures++;
-    state.lastFailureAt = Date.now();
-    if (state.consecutiveFailures >= FAILURE_THRESHOLD) {
-      state.isOpen = true;
-      state.openedAt = Date.now();
-    }
-  }
+  defaultBreaker.recordOutcome(succeeded);
 }


### PR DESCRIPTION
Closes #1935.

Replaces the module-level mutable `CircuitState` singleton in `remediation-circuit-breaker.ts` with a `createCircuitBreaker()` factory that owns its own state. Free functions (`checkCircuitBreaker`/`recordRemediationOutcome`) delegate to a default instance, so `routes/remediation.ts` is unchanged and behaviour is preserved.

The test's `resetCircuitState()`/`beforeEach` workaround (which reset shared state through the production API) is deleted — tests now build fresh breakers. Adds instance-isolation + custom-threshold coverage.

## Validation
- 13 unit tests pass (11 migrated + 2 new isolation/threshold)
- 7 remediation route tests pass (back-compat free functions verified)
- `pnpm --filter @mbe/agent-service typecheck` clean

Follow-up (separate slice): inject the `CircuitBreaker` into `remediationRoutes` via app options and remove the default singleton + shims.