### PR TITLE
feat(agent-core): golden-task eval harness tracer

### DIFF
--- a/packages/agent-core/eval-suite/example-bugfix.json
+++ b/packages/agent-core/eval-suite/example-bugfix.json
@@ -1,0 +1,19 @@
+{
+  "id": "example-bugfix",
+  "category": "bugfix",
+  "prompt": "A reservation cancellation email is sent even when the guest opted out of notifications. Fix the bug so opted-out guests receive no cancellation email, and add a regression test.",
+  "fixtureRef": "services/reservations",
+  "rubric": {
+    "testsMustPass": true,
+    "typecheckMustPass": true,
+    "lintMustPass": false,
+    "judgeCriteria": [
+      "The fix gates the cancellation email on the guest's notification opt-in",
+      "A regression test covers the opted-out path"
+    ]
+  },
+  "budget": {
+    "maxTurns": 40,
+    "maxCostUsd": 1.0
+  }
+}

--- a/packages/agent-core/llms-full.txt
+++ b/packages/agent-core/llms-full.txt
@@ -289,6 +289,117 @@
     }
   </file>
   </section>
+  <section priority="medium" role="eval">
+  <file path="src/eval/eval-harness.ts">
+    export interface RunEvalSuiteOptions {
+      /** Agent-invocation seam. Real impl runs `runSession`; tests stub it. */
+      readonly runTask: TaskRunner;
+      /** Stable id for this run (callers pass a timestamp/uuid — kept injectable for determinism in tests). */
+      readonly runId: string;
+      /** When set, run only the task with this id. */
+      readonly only?: string;
+    }
+    export async function runEvalSuite(
+      tasks: readonly Task[],
+      opts: RunEvalSuiteOptions,
+    ): Promise<EvalReport> {
+      const selected = opts.only ? tasks.filter((t) => t.id === opts.only) : tasks;
+    
+      const scores: TaskScore[] = [];
+      for (const task of selected) {
+        try {
+          const runResult = await opts.runTask(task);
+          scores.push(scoreTask(runResult));
+        } catch (err) {
+          scores.push(failedScore(task, err));
+        }
+      }
+    
+      return { runId: opts.runId, tasks: scores, aggregate: aggregate(scores) };
+    }
+  </file>
+  <file path="src/eval/golden-task-set.ts">
+    export async function loadSuite(dir: string): Promise<Task[]> {
+      let entries: string[];
+      try {
+        entries = (await readdir(dir)).filter((f) => f.endsWith(".json")).sort();
+      } catch (err) {
+        throw new Error(
+          `Could not read eval suite directory "${dir}": ${err instanceof Error ? err.message : String(err)}`,
+          { cause: err },
+        );
+      }
+    
+      const tasks: Task[] = [];
+      const seen = new Set<string>();
+      for (const file of entries) {
+        const path = join(dir, file);
+        const task = await loadTaskFile(path);
+        if (seen.has(task.id)) {
+          throw new Error(`Duplicate task id "${task.id}" in eval suite (${file})`);
+        }
+        seen.add(task.id);
+        tasks.push(task);
+      }
+      return tasks;
+    }
+    async function loadTaskFile(path: string): Promise<Task> {
+      let raw: unknown;
+      try {
+        raw = JSON.parse(await readFile(path, "utf8"));
+      } catch (err) {
+        throw new Error(
+          `Invalid JSON in eval task "${path}": ${err instanceof Error ? err.message : String(err)}`,
+          { cause: err },
+        );
+      }
+    
+      const parsed = taskSchema.safeParse(raw);
+      if (!parsed.success) {
+        throw new Error(`Invalid eval task "${path}": ${parsed.error.message}`);
+      }
+      return parsed.data;
+    }
+  </file>
+  <file path="src/eval/task-scorer.ts">
+    export function scoreTask(run: TaskRunResult): TaskScore {
+      const { task, session, checks } = run;
+      const { rubric } = task;
+    
+      const signals: boolean[] = [];
+      if (rubric.testsMustPass) signals.push(checks.testsPass);
+      if (rubric.typecheckMustPass) signals.push(checks.typecheckPass);
+      if (rubric.lintMustPass) signals.push(checks.lintPass);
+      // Budget is always an applicable signal.
+      signals.push(checks.withinBudget);
+    
+      const satisfied = signals.filter(Boolean).length;
+      const score = signals.length === 0 ? 0 : satisfied / signals.length;
+      const passed = signals.every(Boolean);
+    
+      return {
+        taskId: task.id,
+        category: task.category,
+        passed,
+        score,
+        deterministic: checks,
+        selfEvaluation: session.evaluation,
+        costUsd: session.costUsd,
+        turns: session.numTurns,
+      };
+    }
+  </file>
+  <file path="src/eval/types.ts">
+    export const TASK_CATEGORIES = [
+      "bugfix",
+      "refactor",
+      "new-route",
+      "dep-bump",
+      "test-writing",
+    ] as const;
+    export type TaskCategory = (typeof TASK_CATEGORIES)[number];
+  </file>
+  </section>
   <section priority="medium" role="gates">
   <file path="src/gates/llm-evaluation-gate.ts">
     export class LlmEvaluationGate implements QualityGate {

--- a/packages/agent-core/llms.txt
+++ b/packages/agent-core/llms.txt
@@ -43,6 +43,44 @@
     </item>
   </file>
   </section>
+  <section priority="medium" role="eval">
+  <file path="src/eval/eval-harness.ts">
+    <item priority="low">
+      interface RunEvalSuiteOptions {
+        runTask: TaskRunner;
+        runId: string;
+        only?: string;
+      }
+    </item>
+    <item priority="high">
+      export async function runEvalSuite(
+        tasks: readonly Task[],
+        opts: RunEvalSuiteOptions,
+      ): Promise<EvalReport> { /* ... */ }
+    </item>
+  </file>
+  <file path="src/eval/golden-task-set.ts">
+    <item priority="high">
+      export async function loadSuite(dir: string): Promise<Task[]> { /* ... */ }
+    </item>
+    <item priority="low">
+      async function loadTaskFile(path: string): Promise<Task> { /* ... */ }
+    </item>
+  </file>
+  <file path="src/eval/task-scorer.ts">
+    <item priority="high">
+      export function scoreTask(run: TaskRunResult): TaskScore { /* ... */ }
+    </item>
+  </file>
+  <file path="src/eval/types.ts">
+    <item priority="high">
+      export const TASK_CATEGORIES: unknown;
+    </item>
+    <item priority="low">
+      type TaskCategory = (typeof TASK_CATEGORIES)[number];
+    </item>
+  </file>
+  </section>
   <section priority="medium" role="gates">
   <file path="src/gates/llm-evaluation-gate.ts">
     <item priority="high">

--- a/packages/agent-core/src/eval/eval-harness.test.ts
+++ b/packages/agent-core/src/eval/eval-harness.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import { runEvalSuite } from "./eval-harness.js";
+import type { DeterministicChecks, Task, TaskRunResult, TaskRunner } from "./types.js";
+import type { SessionResult } from "../types.js";
+
+function makeTask(id: string, overrides: Partial<Task> = {}): Task {
+  return {
+    id,
+    category: "bugfix",
+    prompt: `do ${id}`,
+    fixtureRef: `fixtures/${id}`,
+    rubric: { testsMustPass: true, typecheckMustPass: true, lintMustPass: false, judgeCriteria: [] },
+    budget: { maxTurns: 50, maxCostUsd: 1 },
+    ...overrides,
+  };
+}
+
+function session(overrides: Partial<SessionResult> = {}): SessionResult {
+  return {
+    sessionId: "s",
+    status: "completed",
+    branchName: "b",
+    prUrl: null,
+    costUsd: 0.1,
+    tokenUsage: { inputTokens: 0, outputTokens: 0 } as SessionResult["tokenUsage"],
+    durationMs: 1,
+    numTurns: 5,
+    resultText: "",
+    errors: [],
+    ...overrides,
+  };
+}
+
+const PASS: DeterministicChecks = { testsPass: true, typecheckPass: true, lintPass: true, withinBudget: true };
+const FAIL: DeterministicChecks = { testsPass: false, typecheckPass: true, lintPass: true, withinBudget: true };
+
+function runnerFrom(map: Record<string, { checks: DeterministicChecks; session?: SessionResult }>): TaskRunner {
+  return async (task: Task): Promise<TaskRunResult> => {
+    const entry = map[task.id];
+    return { task, session: entry.session ?? session(), checks: entry.checks };
+  };
+}
+
+describe("runEvalSuite", () => {
+  it("scores every task and aggregates pass rate", async () => {
+    const tasks = [makeTask("a"), makeTask("b")];
+    const report = await runEvalSuite(tasks, {
+      runId: "run-1",
+      runTask: runnerFrom({ a: { checks: PASS }, b: { checks: FAIL } }),
+    });
+
+    expect(report.runId).toBe("run-1");
+    expect(report.tasks).toHaveLength(2);
+    expect(report.aggregate.total).toBe(2);
+    expect(report.aggregate.passRate).toBe(0.5);
+  });
+
+  it("records a thrown task as a failed score and continues the suite", async () => {
+    const tasks = [makeTask("ok"), makeTask("boom")];
+    const runTask: TaskRunner = async (task) => {
+      if (task.id === "boom") throw new Error("agent crashed");
+      return { task, session: session(), checks: PASS };
+    };
+
+    const report = await runEvalSuite(tasks, { runId: "r", runTask });
+
+    expect(report.tasks).toHaveLength(2);
+    const boom = report.tasks.find((t) => t.taskId === "boom");
+    expect(boom?.passed).toBe(false);
+    expect(boom?.score).toBe(0);
+    expect(boom?.error).toMatch(/agent crashed/);
+    expect(report.aggregate.stuckCount).toBe(1);
+    // the healthy task still scored
+    expect(report.tasks.find((t) => t.taskId === "ok")?.passed).toBe(true);
+  });
+
+  it("runs only the selected task when `only` is set", async () => {
+    const tasks = [makeTask("a"), makeTask("b")];
+    const report = await runEvalSuite(tasks, {
+      runId: "r",
+      only: "b",
+      runTask: runnerFrom({ a: { checks: PASS }, b: { checks: PASS } }),
+    });
+
+    expect(report.tasks).toHaveLength(1);
+    expect(report.tasks[0].taskId).toBe("b");
+  });
+
+  it("returns a zeroed aggregate for an empty suite", async () => {
+    const report = await runEvalSuite([], { runId: "r", runTask: runnerFrom({}) });
+    expect(report.aggregate).toEqual({
+      total: 0,
+      passRate: 0,
+      meanScore: 0,
+      meanCostUsd: 0,
+      meanTurns: 0,
+      stuckCount: 0,
+    });
+  });
+
+  it("averages cost and turns across tasks", async () => {
+    const tasks = [makeTask("a"), makeTask("b")];
+    const report = await runEvalSuite(tasks, {
+      runId: "r",
+      runTask: runnerFrom({
+        a: { checks: PASS, session: session({ costUsd: 0.2, numTurns: 4 }) },
+        b: { checks: PASS, session: session({ costUsd: 0.4, numTurns: 8 }) },
+      }),
+    });
+    expect(report.aggregate.meanCostUsd).toBeCloseTo(0.3);
+    expect(report.aggregate.meanTurns).toBe(6);
+  });
+});

--- a/packages/agent-core/src/eval/eval-harness.ts
+++ b/packages/agent-core/src/eval/eval-harness.ts
@@ -1,0 +1,72 @@
+import type { EvalAggregate, EvalReport, Task, TaskRunner, TaskScore } from "./types.js";
+import { scoreTask } from "./task-scorer.js";
+
+export interface RunEvalSuiteOptions {
+  /** Agent-invocation seam. Real impl runs `runSession`; tests stub it. */
+  readonly runTask: TaskRunner;
+  /** Stable id for this run (callers pass a timestamp/uuid — kept injectable for determinism in tests). */
+  readonly runId: string;
+  /** When set, run only the task with this id. */
+  readonly only?: string;
+}
+
+/**
+ * Runs each task through the agent (via `runTask`), scores it, and aggregates.
+ *
+ * A task that throws is recorded as a failed {@link TaskScore} (score 0) with
+ * its error captured — one bad task never voids the suite.
+ */
+export async function runEvalSuite(
+  tasks: readonly Task[],
+  opts: RunEvalSuiteOptions,
+): Promise<EvalReport> {
+  const selected = opts.only ? tasks.filter((t) => t.id === opts.only) : tasks;
+
+  const scores: TaskScore[] = [];
+  for (const task of selected) {
+    try {
+      const runResult = await opts.runTask(task);
+      scores.push(scoreTask(runResult));
+    } catch (err) {
+      scores.push(failedScore(task, err));
+    }
+  }
+
+  return { runId: opts.runId, tasks: scores, aggregate: aggregate(scores) };
+}
+
+function failedScore(task: Task, err: unknown): TaskScore {
+  return {
+    taskId: task.id,
+    category: task.category,
+    passed: false,
+    score: 0,
+    deterministic: {
+      testsPass: false,
+      typecheckPass: false,
+      lintPass: false,
+      withinBudget: false,
+    },
+    costUsd: 0,
+    turns: 0,
+    error: err instanceof Error ? err.message : String(err),
+  };
+}
+
+function aggregate(scores: readonly TaskScore[]): EvalAggregate {
+  const total = scores.length;
+  if (total === 0) {
+    return { total: 0, passRate: 0, meanScore: 0, meanCostUsd: 0, meanTurns: 0, stuckCount: 0 };
+  }
+  const sum = (pick: (s: TaskScore) => number): number => scores.reduce((acc, s) => acc + pick(s), 0);
+  return {
+    total,
+    passRate: scores.filter((s) => s.passed).length / total,
+    meanScore: sum((s) => s.score) / total,
+    meanCostUsd: sum((s) => s.costUsd) / total,
+    meanTurns: sum((s) => s.turns) / total,
+    // Tasks that failed to complete (crashed mid-run) — a proxy for "stuck"
+    // until session stuckPattern is propagated in a later slice.
+    stuckCount: scores.filter((s) => s.error !== undefined).length,
+  };
+}

--- a/packages/agent-core/src/eval/golden-task-set.test.ts
+++ b/packages/agent-core/src/eval/golden-task-set.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadSuite } from "./golden-task-set.js";
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "eval-suite-"));
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+const validTask = {
+  id: "fix-login",
+  category: "bugfix",
+  prompt: "Fix the login redirect bug",
+  fixtureRef: "fixtures/fix-login",
+};
+
+describe("loadSuite", () => {
+  it("loads and validates a well-formed task (applying schema defaults)", async () => {
+    await writeFile(join(dir, "fix-login.json"), JSON.stringify(validTask));
+
+    const tasks = await loadSuite(dir);
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].id).toBe("fix-login");
+    // defaults applied
+    expect(tasks[0].rubric.testsMustPass).toBe(true);
+    expect(tasks[0].budget.maxTurns).toBe(50);
+  });
+
+  it("rejects a task with an invalid category", async () => {
+    await writeFile(join(dir, "bad.json"), JSON.stringify({ ...validTask, category: "nonsense" }));
+
+    await expect(loadSuite(dir)).rejects.toThrow(/Invalid eval task/);
+  });
+
+  it("rejects malformed JSON with a sourced error", async () => {
+    await writeFile(join(dir, "broken.json"), "{ not json");
+
+    await expect(loadSuite(dir)).rejects.toThrow(/Invalid JSON in eval task/);
+  });
+
+  it("rejects duplicate task ids", async () => {
+    await writeFile(join(dir, "a.json"), JSON.stringify(validTask));
+    await writeFile(join(dir, "b.json"), JSON.stringify(validTask));
+
+    await expect(loadSuite(dir)).rejects.toThrow(/Duplicate task id/);
+  });
+
+  it("throws a clear error when the directory does not exist", async () => {
+    await expect(loadSuite(join(dir, "missing"))).rejects.toThrow(/Could not read eval suite directory/);
+  });
+
+  it("ignores non-JSON files", async () => {
+    await writeFile(join(dir, "fix-login.json"), JSON.stringify(validTask));
+    await writeFile(join(dir, "README.md"), "# not a task");
+
+    const tasks = await loadSuite(dir);
+    expect(tasks).toHaveLength(1);
+  });
+});

--- a/packages/agent-core/src/eval/golden-task-set.ts
+++ b/packages/agent-core/src/eval/golden-task-set.ts
@@ -1,0 +1,52 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { taskSchema, type Task } from "./types.js";
+
+/**
+ * Loads and validates golden tasks from a suite directory.
+ *
+ * Each `*.json` file in the directory is one task. Parsing/validation lives
+ * here so callers get fully-validated {@link Task}s or a clear, sourced error.
+ */
+export async function loadSuite(dir: string): Promise<Task[]> {
+  let entries: string[];
+  try {
+    entries = (await readdir(dir)).filter((f) => f.endsWith(".json")).sort();
+  } catch (err) {
+    throw new Error(
+      `Could not read eval suite directory "${dir}": ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
+
+  const tasks: Task[] = [];
+  const seen = new Set<string>();
+  for (const file of entries) {
+    const path = join(dir, file);
+    const task = await loadTaskFile(path);
+    if (seen.has(task.id)) {
+      throw new Error(`Duplicate task id "${task.id}" in eval suite (${file})`);
+    }
+    seen.add(task.id);
+    tasks.push(task);
+  }
+  return tasks;
+}
+
+async function loadTaskFile(path: string): Promise<Task> {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(await readFile(path, "utf8"));
+  } catch (err) {
+    throw new Error(
+      `Invalid JSON in eval task "${path}": ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
+
+  const parsed = taskSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new Error(`Invalid eval task "${path}": ${parsed.error.message}`);
+  }
+  return parsed.data;
+}

--- a/packages/agent-core/src/eval/task-scorer.test.ts
+++ b/packages/agent-core/src/eval/task-scorer.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { scoreTask } from "./task-scorer.js";
+import type { DeterministicChecks, Task, TaskRunResult } from "./types.js";
+import type { SessionResult } from "../types.js";
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "t1",
+    category: "bugfix",
+    prompt: "fix it",
+    fixtureRef: "fixtures/t1",
+    rubric: { testsMustPass: true, typecheckMustPass: true, lintMustPass: false, judgeCriteria: [] },
+    budget: { maxTurns: 50, maxCostUsd: 1 },
+    ...overrides,
+  };
+}
+
+function makeSession(overrides: Partial<SessionResult> = {}): SessionResult {
+  return {
+    sessionId: "s1",
+    status: "completed",
+    branchName: "b",
+    prUrl: null,
+    costUsd: 0.2,
+    tokenUsage: { inputTokens: 0, outputTokens: 0 } as SessionResult["tokenUsage"],
+    durationMs: 1000,
+    numTurns: 7,
+    resultText: "",
+    errors: [],
+    ...overrides,
+  };
+}
+
+function makeRun(checks: DeterministicChecks, task = makeTask(), session = makeSession()): TaskRunResult {
+  return { task, session, checks };
+}
+
+const ALL_PASS: DeterministicChecks = {
+  testsPass: true,
+  typecheckPass: true,
+  lintPass: true,
+  withinBudget: true,
+};
+
+describe("scoreTask", () => {
+  it("passes and scores 1 when all applicable signals hold", () => {
+    const score = scoreTask(makeRun(ALL_PASS));
+    expect(score.passed).toBe(true);
+    expect(score.score).toBe(1);
+  });
+
+  it("fails when a required signal (tests) is false", () => {
+    const score = scoreTask(makeRun({ ...ALL_PASS, testsPass: false }));
+    expect(score.passed).toBe(false);
+    expect(score.score).toBeLessThan(1);
+  });
+
+  it("ignores lint when rubric.lintMustPass is false", () => {
+    // lint failing but not required → still passes (tests, typecheck, budget hold)
+    const score = scoreTask(makeRun({ ...ALL_PASS, lintPass: false }));
+    expect(score.passed).toBe(true);
+    expect(score.score).toBe(1);
+  });
+
+  it("counts lint when rubric.lintMustPass is true", () => {
+    const task = makeTask({
+      rubric: { testsMustPass: true, typecheckMustPass: true, lintMustPass: true, judgeCriteria: [] },
+    });
+    const score = scoreTask(makeRun({ ...ALL_PASS, lintPass: false }, task));
+    expect(score.passed).toBe(false);
+    // 3 of 4 applicable signals satisfied (tests, typecheck, budget) — lint failed
+    expect(score.score).toBeCloseTo(3 / 4);
+  });
+
+  it("budget is always an applicable signal", () => {
+    const score = scoreTask(makeRun({ ...ALL_PASS, withinBudget: false }));
+    expect(score.passed).toBe(false);
+  });
+
+  it("carries cost, turns, and self-evaluation through for calibration", () => {
+    const session = makeSession({
+      costUsd: 0.5,
+      numTurns: 12,
+      evaluation: { passed: true, confidence: 0.9, reasoning: "looks good" },
+    });
+    const score = scoreTask(makeRun(ALL_PASS, makeTask(), session));
+    expect(score.costUsd).toBe(0.5);
+    expect(score.turns).toBe(12);
+    expect(score.selfEvaluation?.confidence).toBe(0.9);
+  });
+});

--- a/packages/agent-core/src/eval/task-scorer.ts
+++ b/packages/agent-core/src/eval/task-scorer.ts
@@ -1,0 +1,37 @@
+import type { TaskRunResult, TaskScore } from "./types.js";
+
+/**
+ * Scores a single task run against its rubric using deterministic signals only.
+ *
+ * (The LLM-judge half — for rubric `judgeCriteria` a deterministic check can't
+ * express — is added in a later slice and folded into `score`/`passed` here.)
+ *
+ * `score` is the fraction of *applicable* rubric signals that were satisfied;
+ * `passed` requires every applicable signal to hold.
+ */
+export function scoreTask(run: TaskRunResult): TaskScore {
+  const { task, session, checks } = run;
+  const { rubric } = task;
+
+  const signals: boolean[] = [];
+  if (rubric.testsMustPass) signals.push(checks.testsPass);
+  if (rubric.typecheckMustPass) signals.push(checks.typecheckPass);
+  if (rubric.lintMustPass) signals.push(checks.lintPass);
+  // Budget is always an applicable signal.
+  signals.push(checks.withinBudget);
+
+  const satisfied = signals.filter(Boolean).length;
+  const score = signals.length === 0 ? 0 : satisfied / signals.length;
+  const passed = signals.every(Boolean);
+
+  return {
+    taskId: task.id,
+    category: task.category,
+    passed,
+    score,
+    deterministic: checks,
+    selfEvaluation: session.evaluation,
+    costUsd: session.costUsd,
+    turns: session.numTurns,
+  };
+}

--- a/packages/agent-core/src/eval/types.ts
+++ b/packages/agent-core/src/eval/types.ts
@@ -1,0 +1,109 @@
+import { z } from "zod";
+import type { SessionResult } from "../types.js";
+
+/**
+ * Golden-task eval harness types.
+ *
+ * A {@link Task} is a fixed, versioned benchmark case. The harness runs each
+ * task through the agent (via an injected runner — see {@link TaskRunner}),
+ * producing a {@link TaskRunResult}; the scorer turns that into a
+ * {@link TaskScore}; the harness aggregates scores into an {@link EvalReport}.
+ */
+
+export const TASK_CATEGORIES = [
+  "bugfix",
+  "refactor",
+  "new-route",
+  "dep-bump",
+  "test-writing",
+] as const;
+
+export type TaskCategory = (typeof TASK_CATEGORIES)[number];
+
+/** Objective expectations a task is scored against. */
+export const rubricSchema = z.object({
+  /** Target test command(s) that must pass for the change to count. */
+  testsMustPass: z.boolean().default(true),
+  /** Typecheck must be clean. */
+  typecheckMustPass: z.boolean().default(true),
+  /** Lint must be clean. */
+  lintMustPass: z.boolean().default(false),
+  /** Free-text criteria for the LLM judge (added in a later slice). */
+  judgeCriteria: z.array(z.string()).default([]),
+});
+
+export type Rubric = z.infer<typeof rubricSchema>;
+
+export const taskBudgetSchema = z.object({
+  maxTurns: z.number().int().positive().default(50),
+  maxCostUsd: z.number().positive().default(1),
+});
+
+export type TaskBudget = z.infer<typeof taskBudgetSchema>;
+
+export const taskSchema = z.object({
+  id: z.string().min(1),
+  category: z.enum(TASK_CATEGORIES),
+  /** The instruction handed to the agent. */
+  prompt: z.string().min(1),
+  /** Identifier for the fixture the task runs against (repo subdir, ref, etc.). */
+  fixtureRef: z.string().min(1),
+  rubric: rubricSchema.default({
+    testsMustPass: true,
+    typecheckMustPass: true,
+    lintMustPass: false,
+    judgeCriteria: [],
+  }),
+  budget: taskBudgetSchema.default({ maxTurns: 50, maxCostUsd: 1 }),
+});
+
+export type Task = z.infer<typeof taskSchema>;
+
+/** Deterministic check outcomes computed by the runner after the agent runs. */
+export interface DeterministicChecks {
+  readonly testsPass: boolean;
+  readonly typecheckPass: boolean;
+  readonly lintPass: boolean;
+  readonly withinBudget: boolean;
+}
+
+/** Raw outcome of running one task through the agent + deterministic checks. */
+export interface TaskRunResult {
+  readonly task: Task;
+  readonly session: SessionResult;
+  readonly checks: DeterministicChecks;
+}
+
+/** A task's score after applying its rubric to the run result. */
+export interface TaskScore {
+  readonly taskId: string;
+  readonly category: TaskCategory;
+  readonly passed: boolean;
+  /** 0..1 — fraction of applicable rubric signals satisfied. */
+  readonly score: number;
+  readonly deterministic: DeterministicChecks;
+  /** Self-reported agent evaluation, when present — used for calibration. */
+  readonly selfEvaluation?: SessionResult["evaluation"];
+  readonly costUsd: number;
+  readonly turns: number;
+  /** Set when the task crashed mid-run rather than completing. */
+  readonly error?: string;
+}
+
+export interface EvalAggregate {
+  readonly total: number;
+  readonly passRate: number;
+  readonly meanScore: number;
+  readonly meanCostUsd: number;
+  readonly meanTurns: number;
+  readonly stuckCount: number;
+}
+
+export interface EvalReport {
+  readonly runId: string;
+  readonly tasks: readonly TaskScore[];
+  readonly aggregate: EvalAggregate;
+}
+
+/** Injected agent-invocation seam. Real impl runs `runSession` + checks; tests stub it. */
+export type TaskRunner = (task: Task) => Promise<TaskRunResult>;

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -298,3 +298,22 @@ export type { GateContext, GateResult, GateRunResult, QualityGate } from "./gate
 export { StaticAnalysisGate } from "./gates/static-analysis-gate.js";
 export { LlmEvaluationGate } from "./gates/llm-evaluation-gate.js";
 export { SecurityReviewGate } from "./gates/security-review-gate.js";
+
+// Golden-task eval harness — run fixed benchmark tasks through the agent and score them
+export { loadSuite } from "./eval/golden-task-set.js";
+export { scoreTask } from "./eval/task-scorer.js";
+export { runEvalSuite } from "./eval/eval-harness.js";
+export type { RunEvalSuiteOptions } from "./eval/eval-harness.js";
+export { taskSchema, rubricSchema, taskBudgetSchema, TASK_CATEGORIES } from "./eval/types.js";
+export type {
+  Task,
+  TaskCategory,
+  Rubric,
+  TaskBudget,
+  DeterministicChecks,
+  TaskRunResult,
+  TaskScore,
+  TaskRunner,
+  EvalAggregate,
+  EvalReport,
+} from "./eval/types.js";

--- a/tools/cli/src/__tests__/agent.test.ts
+++ b/tools/cli/src/__tests__/agent.test.ts
@@ -13,6 +13,8 @@ vi.mock("@mbe/agent-core", () => ({
     allowedTools: [],
   },
   DEFAULT_FEEDBACK_LOOP_CONFIG: {},
+  loadSuite: vi.fn(),
+  runEvalSuite: vi.fn(),
   resolveBudget: vi.fn(() => ({ budgetUsd: 1.0, maxTurns: 50 })),
   resolveModel: vi.fn(() => "claude-sonnet-4-6"),
   routeModelWithReason: vi.fn(() => ({

--- a/tools/cli/src/commands/agent-eval.test.ts
+++ b/tools/cli/src/commands/agent-eval.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type * as AgentCore from "@mbe/agent-core";
+
+const mockLoadSuite = vi.fn();
+const mockRunSession = vi.fn();
+
+// Keep the real harness/scorer/types; stub only the suite loader + agent run.
+vi.mock("@mbe/agent-core", async (orig) => {
+  const actual = await orig<typeof AgentCore>();
+  return {
+    ...actual,
+    loadSuite: (...a: unknown[]) => mockLoadSuite(...a),
+    runSession: (...a: unknown[]) => mockRunSession(...a),
+  };
+});
+
+// verify() shells out via promisify(execFile); make it resolve (checks pass).
+vi.mock("node:child_process", () => ({
+  execFile: (
+    _cmd: string,
+    _args: string[],
+    optsOrCb: unknown,
+    cb?: (err: unknown, res: { stdout: string; stderr: string }) => void,
+  ) => {
+    const callback = typeof optsOrCb === "function" ? optsOrCb : cb;
+    (callback as (e: unknown, r: { stdout: string; stderr: string }) => void)(null, {
+      stdout: "",
+      stderr: "",
+    });
+  },
+}));
+
+function fakeSession(overrides: Record<string, unknown> = {}) {
+  return {
+    sessionId: "s1",
+    status: "completed",
+    branchName: "agent/t1",
+    prUrl: null,
+    costUsd: 0.2,
+    tokenUsage: { inputTokens: 0, outputTokens: 0 },
+    durationMs: 1,
+    numTurns: 5,
+    resultText: "",
+    errors: [],
+    evaluation: { passed: true, confidence: 0.9, reasoning: "ok" },
+    ...overrides,
+  };
+}
+
+const task = {
+  id: "t1",
+  category: "bugfix",
+  prompt: "fix it",
+  fixtureRef: "services/reservations",
+  rubric: { testsMustPass: true, typecheckMustPass: true, lintMustPass: false, judgeCriteria: [] },
+  budget: { maxTurns: 50, maxCostUsd: 1 },
+};
+
+describe("agent eval command", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    process.exitCode = 0;
+  });
+
+  it("runs the suite and prints a report", async () => {
+    mockLoadSuite.mockResolvedValue([task]);
+    mockRunSession.mockResolvedValue(fakeSession());
+    const { agentEvalCommand } = await import("./agent-eval.js");
+
+    await agentEvalCommand.parseAsync(["--task", "t1"], { from: "user" });
+
+    const out = logSpy.mock.calls.flat().join("\n");
+    expect(out).toContain("Eval Report");
+    expect(out).toContain("t1");
+    expect(out).toContain("Pass rate");
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("emits JSON with --json", async () => {
+    mockLoadSuite.mockResolvedValue([task]);
+    mockRunSession.mockResolvedValue(fakeSession());
+    const { agentEvalCommand } = await import("./agent-eval.js");
+
+    await agentEvalCommand.parseAsync(["--json"], { from: "user" });
+
+    const out = logSpy.mock.calls.flat().join("\n");
+    const parsed = JSON.parse(out);
+    expect(parsed.tasks).toHaveLength(1);
+    expect(parsed.aggregate.total).toBe(1);
+  });
+
+  it("exits 1 when the suite directory cannot be loaded", async () => {
+    mockLoadSuite.mockRejectedValue(new Error("no suite dir"));
+    const { agentEvalCommand } = await import("./agent-eval.js");
+
+    await agentEvalCommand.parseAsync([], { from: "user" });
+
+    expect(process.exitCode).toBe(1);
+    expect(errSpy.mock.calls.flat().join("\n")).toContain("no suite dir");
+  });
+
+  it("exits 1 when pass rate is below --threshold", async () => {
+    mockLoadSuite.mockResolvedValue([task]);
+    // Over budget → withinBudget false → task fails → pass rate 0
+    mockRunSession.mockResolvedValue(fakeSession({ costUsd: 99 }));
+    const { agentEvalCommand } = await import("./agent-eval.js");
+
+    await agentEvalCommand.parseAsync(["--threshold", "50"], { from: "user" });
+
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/tools/cli/src/commands/agent-eval.test.ts
+++ b/tools/cli/src/commands/agent-eval.test.ts
@@ -4,6 +4,11 @@ import type * as AgentCore from "@mbe/agent-core";
 const mockLoadSuite = vi.fn();
 const mockRunSession = vi.fn();
 
+// Static import keeps the heavy module load (real @mbe/agent-core via
+// importOriginal) in file setup, outside the per-test timeout window.
+// vi.mock factories below are hoisted above this import by vitest.
+import { agentEvalCommand } from "./agent-eval.js";
+
 // Keep the real harness/scorer/types; stub only the suite loader + agent run.
 vi.mock("@mbe/agent-core", async (orig) => {
   const actual = await orig<typeof AgentCore>();
@@ -70,7 +75,6 @@ describe("agent eval command", () => {
   it("runs the suite and prints a report", async () => {
     mockLoadSuite.mockResolvedValue([task]);
     mockRunSession.mockResolvedValue(fakeSession());
-    const { agentEvalCommand } = await import("./agent-eval.js");
 
     await agentEvalCommand.parseAsync(["--task", "t1"], { from: "user" });
 
@@ -84,7 +88,6 @@ describe("agent eval command", () => {
   it("emits JSON with --json", async () => {
     mockLoadSuite.mockResolvedValue([task]);
     mockRunSession.mockResolvedValue(fakeSession());
-    const { agentEvalCommand } = await import("./agent-eval.js");
 
     await agentEvalCommand.parseAsync(["--json"], { from: "user" });
 
@@ -96,7 +99,6 @@ describe("agent eval command", () => {
 
   it("exits 1 when the suite directory cannot be loaded", async () => {
     mockLoadSuite.mockRejectedValue(new Error("no suite dir"));
-    const { agentEvalCommand } = await import("./agent-eval.js");
 
     await agentEvalCommand.parseAsync([], { from: "user" });
 
@@ -108,7 +110,6 @@ describe("agent eval command", () => {
     mockLoadSuite.mockResolvedValue([task]);
     // Over budget → withinBudget false → task fails → pass rate 0
     mockRunSession.mockResolvedValue(fakeSession({ costUsd: 99 }));
-    const { agentEvalCommand } = await import("./agent-eval.js");
 
     await agentEvalCommand.parseAsync(["--threshold", "50"], { from: "user" });
 

--- a/tools/cli/src/commands/agent-eval.ts
+++ b/tools/cli/src/commands/agent-eval.ts
@@ -1,0 +1,157 @@
+import { Command } from "commander";
+import { resolve } from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import {
+  runSession,
+  runEvalSuite,
+  loadSuite,
+  DEFAULT_SESSION_CONFIG,
+  DEFAULT_FEEDBACK_LOOP_CONFIG,
+  type SessionConfig,
+  type Task,
+  type TaskRunner,
+  type TaskRunResult,
+  type DeterministicChecks,
+  type EvalReport,
+} from "@mbe/agent-core";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * `mbe agent eval` — run the golden-task suite through the agent and score it.
+ *
+ * The agent invocation + post-run verification (the {@link TaskRunner}) is the
+ * integration seam: it runs the real `runSession` and executes the fixture's
+ * verify scripts. The scoring/aggregation core it feeds is unit-tested in
+ * @mbe/agent-core. Out of scope for this slice: the LLM-judge half of scoring
+ * (#1945) and calibration (#1946).
+ */
+export const agentEvalCommand = new Command("eval")
+  .description("Run the golden-task eval suite through the agent and score the results")
+  .option("--suite <dir>", "Suite directory", "packages/agent-core/eval-suite")
+  .option("--task <id>", "Run only the task with this id")
+  .option("-m, --model <model>", "Model to run the agent with", DEFAULT_SESSION_CONFIG.model)
+  .option("--json", "Emit the EvalReport as JSON", false)
+  .option("--threshold <pct>", "Exit non-zero if suite pass rate is below this percent")
+  .action(
+    async (options: {
+      suite: string;
+      task?: string;
+      model: string;
+      json: boolean;
+      threshold?: string;
+    }) => {
+      const repoPath = resolve(process.cwd());
+      const suiteDir = resolve(repoPath, options.suite);
+
+      let tasks: Task[];
+      try {
+        tasks = await loadSuite(suiteDir);
+      } catch (err) {
+        console.error(err instanceof Error ? err.message : String(err));
+        process.exitCode = 1;
+        return;
+      }
+
+      const runTask = makeAgentTaskRunner(repoPath, options.model);
+      const report = await runEvalSuite(tasks, {
+        runId: `eval-${process.pid}`,
+        only: options.task,
+        runTask,
+      });
+
+      if (options.json) {
+        console.log(JSON.stringify(report, null, 2));
+      } else {
+        printReport(report);
+      }
+
+      if (options.threshold !== undefined) {
+        const threshold = Number(options.threshold) / 100;
+        if (report.aggregate.passRate < threshold) {
+          console.error(
+            `\nPass rate ${(report.aggregate.passRate * 100).toFixed(1)}% is below threshold ${options.threshold}%`
+          );
+          process.exitCode = 1;
+        }
+      }
+    }
+  );
+
+/** Builds the live runner: run the agent on a task, then verify its branch. */
+function makeAgentTaskRunner(repoPath: string, model: string): TaskRunner {
+  return async (task: Task): Promise<TaskRunResult> => {
+    const config: SessionConfig = {
+      taskDescription: task.prompt,
+      repoPath,
+      baseBranch: DEFAULT_SESSION_CONFIG.baseBranch,
+      model,
+      maxTurns: task.budget.maxTurns,
+      maxBudgetUsd: task.budget.maxCostUsd,
+      allowedTools: [...DEFAULT_SESSION_CONFIG.allowedTools],
+      createPr: false,
+      feedbackLoop: DEFAULT_FEEDBACK_LOOP_CONFIG,
+    };
+
+    const session = await runSession(config, () => {});
+
+    const withinBudget =
+      session.costUsd <= task.budget.maxCostUsd && session.numTurns <= task.budget.maxTurns;
+
+    const checks: DeterministicChecks = {
+      withinBudget,
+      testsPass: task.rubric.testsMustPass
+        ? await verify(repoPath, session.branchName, task.fixtureRef, "test")
+        : true,
+      typecheckPass: task.rubric.typecheckMustPass
+        ? await verify(repoPath, session.branchName, task.fixtureRef, "typecheck")
+        : true,
+      lintPass: task.rubric.lintMustPass
+        ? await verify(repoPath, session.branchName, task.fixtureRef, "lint")
+        : true,
+    };
+
+    return { task, session, checks };
+  };
+}
+
+/**
+ * Runs a pnpm script for the fixture's package on the agent's produced branch.
+ * Conservative: any failure (including an inability to run) scores as `false`.
+ */
+async function verify(
+  repoPath: string,
+  branch: string,
+  fixtureRef: string,
+  script: "test" | "typecheck" | "lint"
+): Promise<boolean> {
+  try {
+    await execFileAsync("git", ["-C", repoPath, "checkout", branch], { timeout: 30_000 });
+    await execFileAsync("pnpm", ["--filter", `./${fixtureRef}`, script], {
+      cwd: repoPath,
+      timeout: 300_000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function printReport(report: EvalReport): void {
+  const a = report.aggregate;
+  console.log("Eval Report");
+  console.log("───────────");
+  for (const t of report.tasks) {
+    const mark = t.passed ? "✓" : "✗";
+    const detail = t.error ? `error: ${t.error}` : `score ${(t.score * 100).toFixed(0)}%`;
+    console.log(`${mark} ${t.taskId} [${t.category}] — ${detail} (${t.turns} turns, $${t.costUsd.toFixed(2)})`);
+  }
+  console.log("");
+  console.log(`Tasks:       ${a.total}`);
+  console.log(`Pass rate:   ${(a.passRate * 100).toFixed(1)}%`);
+  console.log(`Mean score:  ${(a.meanScore * 100).toFixed(1)}%`);
+  console.log(`Mean cost:   $${a.meanCostUsd.toFixed(2)}`);
+  console.log(`Mean turns:  ${a.meanTurns.toFixed(1)}`);
+  console.log(`Failed to complete: ${a.stuckCount}`);
+}

--- a/tools/cli/src/commands/agent.ts
+++ b/tools/cli/src/commands/agent.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { resolve } from "node:path";
 import type { SessionConfig, SessionEvent } from "@mbe/agent-core";
+import { agentEvalCommand } from "./agent-eval.js";
 import {
   runSession,
   DEFAULT_SESSION_CONFIG,
@@ -175,6 +176,9 @@ export const checkModelCommand = new Command("check-model")
   });
 
 export const agentCommand = new Command("agent").description("Run autonomous coding agents");
+
+// ── Golden-task eval harness: mbe agent eval ─────────────────────────────
+agentCommand.addCommand(agentEvalCommand);
 
 // ── Local execution: mbe agent run ───────────────────────────────────────
 

--- a/tools/cli/src/commands/agent.ts
+++ b/tools/cli/src/commands/agent.ts
@@ -177,9 +177,6 @@ export const checkModelCommand = new Command("check-model")
 
 export const agentCommand = new Command("agent").description("Run autonomous coding agents");
 
-// ── Golden-task eval harness: mbe agent eval ─────────────────────────────
-agentCommand.addCommand(agentEvalCommand);
-
 // ── Local execution: mbe agent run ───────────────────────────────────────
 
 agentCommand
@@ -1030,3 +1027,8 @@ async function streamEvents(sessionId: string): Promise<void> {
     reader.releaseLock();
   }
 }
+
+// ── Golden-task eval harness: mbe agent eval ─────────────────────────────
+// Registered last so `agentCommand.commands[0]` remains the `run` command,
+// which tests address positionally.
+agentCommand.addCommand(agentEvalCommand);


### PR DESCRIPTION
Closes #1944. Parent: #1943.

Tracer for the agent eval harness — the testable core + CLI wiring.

## Modules (all in `@mbe/agent-core`)
- **GoldenTaskSet** (`loadSuite`) — Zod-validated task fixtures from a suite dir; clear sourced errors on bad JSON / schema / dup ids.
- **TaskScorer** (`scoreTask`) — deterministic rubric scoring (tests / typecheck / lint / budget) → `TaskScore`; carries cost, turns, and self-evaluation for later calibration.
- **EvalHarness** (`runEvalSuite`) — runs each task via an injected `TaskRunner`, records a crashed task as a failed score (suite continues), aggregates into an `EvalReport`.
- **`mbe agent eval`** `[--task --json --model --threshold]` — wires live `runSession` + post-run verify behind the `TaskRunner` seam; prints text or JSON.
- One seed task (`eval-suite/example-bugfix.json`).

## Validation
- 17 unit tests (harness / scorer / loader) pass
- `pnpm --filter @mbe/agent-core typecheck` + `@mbe/cli typecheck` clean
- lint clean; `mbe agent eval --help` wired
- The live `TaskRunner` (real `runSession` + verify) is the integration seam — not unit-tested, per the PRD.

Unblocks #1945 (LLM-judge), #1946 (calibration), #1947 (CI gate/persistence), #1948 (corpus + docs).