### PR TITLE
fix(ci): raise deploy ci-gate check discovery timeout to 600s

### DIFF
--- a/.github/workflows/deploy-services.yml
+++ b/.github/workflows/deploy-services.yml
@@ -68,6 +68,10 @@ jobs:
           check-name: "Build"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
+          # CI's Build job is gated behind Prepare/Detect Changes and can take
+          # >60s to appear on the merge commit; the 60s default discovery
+          # timeout caused 5 straight "check was never run" deploy failures
+          checks-discovery-timeout: 600
 
   blocked:
     needs: [circuit-check]


### PR DESCRIPTION
## Summary
Closes #1977

- `deploy-services.yml` ci-gate (`Wait for CI`) uses `lewagon/wait-on-check-action` with the default 60s `checks-discovery-timeout`
- CI's `Build` check is gated behind Prepare/Detect Changes and routinely appears >60s after the merge commit lands (latest occurrence: gate gave up at 01:38:28Z, Build started 01:39:42Z)
- Result: `The requested check was never run against this ref` → **5 consecutive deploy-services failures** (Jun 4–10), all on the `Wait for CI` job — the source of the deploys degraded/unhealthy health flapping
- Fix: `checks-discovery-timeout: 600` — discovery only; once the check appears the action polls to completion as before

## Recovery
Failed run 27247254825 (PR #1974 merge commit) re-run with `--failed` — Build check now exists, deploy proceeding.

## Test plan
- [x] Verified `checks-discovery-timeout` input exists at the pinned action SHA (v1.7.0 action.yml)
- [x] All 5 recent deploy failures confirmed as `Wait for CI` job only (no real deploy/build defects)
- [ ] Next merge-commit deploy passes ci-gate without discovery timeout