### PR TITLE
fix(ci): don't overwrite deploy health KV when no deploy was attempted

### DIFF
--- a/.github/workflows/deploy-services.yml
+++ b/.github/workflows/deploy-services.yml
@@ -172,6 +172,13 @@ jobs:
           DEPLOY_RESULT: ${{ needs.deploy.result }}
           VERIFY_RESULT: ${{ needs.verify.result }}
         run: |
+          # No deploy attempted (circuit-blocked) — leave the previous
+          # deploy/services KV state in place rather than writing a false
+          # "success" for a run that deployed nothing
+          if [ "$DEPLOY_RESULT" = "skipped" ]; then
+            echo "No service deploy attempted; preserving previous deploy/services status"
+            exit 0
+          fi
           CONCLUSION="success"
           if [ "$DEPLOY_RESULT" = "failure" ] || [ "$VERIFY_RESULT" = "failure" ]; then
             CONCLUSION="failure"

--- a/.github/workflows/deploy-static.yml
+++ b/.github/workflows/deploy-static.yml
@@ -285,16 +285,26 @@ jobs:
           GH_SHA: ${{ github.sha }}
           VERIFY_RESULT: ${{ needs.verify.result }}
           ROLLBACK_RESULT: ${{ needs.rollback.result }}
+          MARKETING_RESULT: ${{ needs.deploy-marketing.result }}
+          HOSPITALITY_RESULT: ${{ needs.deploy-hospitality.result }}
+          RIALTO_RESULT: ${{ needs.deploy-rialto-web.result }}
           MARKETING_DEPLOYED: ${{ needs.detect-changes.outputs.marketing }}
           HOSPITALITY_DEPLOYED: ${{ needs.detect-changes.outputs.hospitality }}
           RIALTO_DEPLOYED: ${{ needs.detect-changes.outputs.rialto-web }}
         run: |
+          # No deploy attempted (circuit-blocked or no app changes) — leave the
+          # previous deploy/static KV state in place instead of poisoning it
+          # with a "cancelled" that the health worker reads as unhealthy
+          if [ "$MARKETING_RESULT" = "skipped" ] && [ "$HOSPITALITY_RESULT" = "skipped" ] && [ "$RIALTO_RESULT" = "skipped" ]; then
+            echo "No static deploy attempted; preserving previous deploy/static status"
+            exit 0
+          fi
           CONCLUSION="success"
           if [ "$ROLLBACK_RESULT" = "success" ]; then
             CONCLUSION="rolled_back"
-          elif [ "$VERIFY_RESULT" = "failure" ]; then
+          elif [ "$MARKETING_RESULT" = "failure" ] || [ "$HOSPITALITY_RESULT" = "failure" ] || [ "$RIALTO_RESULT" = "failure" ] || [ "$VERIFY_RESULT" = "failure" ]; then
             CONCLUSION="failure"
-          elif [ "$VERIFY_RESULT" = "cancelled" ] || [ "$VERIFY_RESULT" = "skipped" ]; then
+          elif [ "$VERIFY_RESULT" = "cancelled" ]; then
             CONCLUSION="cancelled"
           fi
           PAYLOAD=$(jq -n \

--- a/.github/workflows/pulumi-up.yml
+++ b/.github/workflows/pulumi-up.yml
@@ -140,10 +140,17 @@ jobs:
           GH_SHA: ${{ github.sha }}
           DEPLOY_RESULT: ${{ needs.deploy.result }}
         run: |
+          # No deploy attempted (job skipped) — leave the previous
+          # deploy/infrastructure KV state in place instead of writing a
+          # "cancelled" that the health worker reads as unhealthy
+          if [ "$DEPLOY_RESULT" = "skipped" ]; then
+            echo "No infrastructure deploy attempted; preserving previous deploy/infrastructure status"
+            exit 0
+          fi
           CONCLUSION="success"
           if [ "$DEPLOY_RESULT" = "failure" ]; then
             CONCLUSION="failure"
-          elif [ "$DEPLOY_RESULT" = "cancelled" ] || [ "$DEPLOY_RESULT" = "skipped" ]; then
+          elif [ "$DEPLOY_RESULT" = "cancelled" ]; then
             CONCLUSION="cancelled"
           fi
           PAYLOAD=$(jq -n \


### PR DESCRIPTION
## Summary
Final layer of tonight's deploys-unhealthy saga (#1977).

After the ci-gate timeout fix (#1981) and the Dockerfile fix (#1982), `/health/system` still reported deploys unhealthy. Cause: at 02:06 the circuit breaker (opened by the two earlier failures) blocked both deploy workflows, and their `report-health` jobs **wrote KV anyway**:

- `deploy-static` → `conclusion: cancelled` (verify skipped) — the edge-router worker counts any non-success as **unhealthy**, and the key stays poisoned until the next real static deploy (could be days)
- `deploy-services` → `conclusion: success` — false positive, nothing was deployed
- `pulumi-up` → would write `cancelled` for skipped deploys (same class)

## Fix
All three `report-health` jobs now exit early without writing when the deploy job was `skipped` — the KV keeps the last real deploy state. Bonus: `deploy-static` now reports `failure` when a deploy job itself fails (previously mislabelled `cancelled` since `verify` gets skipped).

## Recovery
`deploy/static` KV key manually restored to the last real static deploy (run 27236081615, sha dff48d9d, success @ 2026-06-09T21:13:49Z).

## Test plan
- [x] Only trusted `needs.*.result` values interpolated (no untrusted input)
- [ ] Workflow lint (actionlint in CI) passes
- [ ] Next circuit-blocked or no-change run leaves KV untouched