### PR TITLE
refactor(feature-flags): expose FeatureContext as request decoration via Fastify plugin

### DIFF
--- a/docs/architecture/dependency-graph.md
+++ b/docs/architecture/dependency-graph.md
@@ -75,7 +75,6 @@ flowchart TD
   reservations_service --> database
   reservations_service --> service_bootstrap
   reservations_service --> jobs
-  reservations_service --> feature_flags
   reservations_service --> notifications
   reservations_service --> observability
   reservations_service --> sentry
@@ -114,6 +113,7 @@ flowchart TD
   sentry --> config
   service_bootstrap --> auth
   service_bootstrap --> database
+  service_bootstrap --> feature_flags
   service_bootstrap --> observability
   service_bootstrap --> sentry
   service_bootstrap --> config

--- a/infrastructure/worker/dep-graph.json
+++ b/infrastructure/worker/dep-graph.json
@@ -304,11 +304,6 @@
     },
     {
       "from": "@mbe/reservations-service",
-      "to": "@mbe/feature-flags",
-      "type": "dependency"
-    },
-    {
-      "from": "@mbe/reservations-service",
       "to": "@mbe/notifications",
       "type": "dependency"
     },
@@ -495,6 +490,11 @@
     {
       "from": "@mbe/service-bootstrap",
       "to": "@mbe/database",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/service-bootstrap",
+      "to": "@mbe/feature-flags",
       "type": "dependency"
     },
     {

--- a/packages/feature-flags/CLAUDE.md
+++ b/packages/feature-flags/CLAUDE.md
@@ -6,7 +6,8 @@ Lightweight feature flag evaluation library. Flags are stored in Cloudflare KV (
 
 ```
 src/
-└── index.ts   # Types, evaluation functions, header parsing
+├── index.ts    # Types, FeatureContext factory, evaluation helpers (private)
+└── plugin.ts   # Fastify plugin — decorates request.features
 ```
 
 ## API
@@ -19,32 +20,45 @@ interface FeatureFlag {
   percentage: number; // 0-100 rollout percentage
 }
 
-type FeatureFlagMap = Record<string, FeatureFlag>;
+interface FeatureContext {
+  check(flagName: string): boolean; // 100% rollout only
+  checkForUser(flagName: string, userId: string): boolean; // percentage rollout
+}
 ```
 
-### Functions
+### Exports
 
-| Function            | Signature                            | Purpose                                                             |
-| ------------------- | ------------------------------------ | ------------------------------------------------------------------- |
-| `isEnabled`         | `(flags, flagName) => boolean`       | Check if flag is enabled (100% rollout only)                        |
-| `isEnabledForSeed`  | `(flags, flagName, seed) => boolean` | Check with percentage rollout using consistent hashing              |
-| `parseFeatureFlags` | `(header) => FeatureFlagMap`         | Parse `X-Feature-Flags` JSON header (safe, returns `{}` on failure) |
+| Export                     | Signature                          | Purpose                                                              |
+| -------------------------- | ---------------------------------- | -------------------------------------------------------------------- |
+| `createFeatureFlagsPlugin` | `() => FastifyPluginAsync`         | Fastify plugin: parses the header once per request, sets `request.features` |
+| `createFeatureContext`     | `(header) => FeatureContext`       | Build a context from a raw header value (tests, non-Fastify callers) |
+| `FEATURE_FLAGS_HEADER`     | `"x-feature-flags"`                | Header name constant                                                  |
+
+Parsing is safe — missing, invalid, or repeated headers all evaluate to "flags disabled", never a throw.
 
 ### Percentage Rollout
 
-Uses a deterministic hash of the seed string (typically user IP or ID) to decide inclusion. The same seed always gets the same result for a given percentage, ensuring consistent user experience.
+`checkForUser` uses a deterministic hash of the seed string (typically user ID) to decide inclusion. The same seed always gets the same result for a given percentage, ensuring consistent user experience.
 
 ## Usage
 
 ### In Fastify services
 
-```typescript
-import { parseFeatureFlags, isEnabled } from "@mbe/feature-flags";
+The plugin is registered automatically by `createServiceApp` (`@mbe/service-bootstrap`) — routes need no imports:
 
-const flags = parseFeatureFlags(request.headers["x-feature-flags"]);
-if (isEnabled(flags, "new-booking-flow")) {
+```typescript
+if (request.features.check("new-booking-flow")) {
   // New behavior
 }
+```
+
+For non-Fastify callers or unit tests, build a context directly:
+
+```typescript
+import { createFeatureContext } from "@mbe/feature-flags";
+
+const features = createFeatureContext('{"new-booking-flow":{"enabled":true,"percentage":100}}');
+features.check("new-booking-flow"); // true
 ```
 
 ### Flag lifecycle
@@ -52,7 +66,7 @@ if (isEnabled(flags, "new-booking-flow")) {
 1. **Create/update**: `PUT /api/flags/<name>` on the edge router (requires `ADMIN_TOKEN`)
 2. **Storage**: Cloudflare KV (`HEALTH_STATE` namespace, key `flags/all`)
 3. **Distribution**: Edge router reads KV, evaluates per-request, sets `X-Feature-Flags` header
-4. **Consumption**: Services parse header with `parseFeatureFlags()`
+4. **Consumption**: `createServiceApp` registers the plugin; routes read `request.features`
 
 ## Commands
 
@@ -60,4 +74,5 @@ if (isEnabled(flags, "new-booking-flow")) {
 pnpm build       # Compile TypeScript
 pnpm lint        # ESLint
 pnpm typecheck   # Type check
+pnpm test        # Vitest
 ```

--- a/packages/feature-flags/llms-full.txt
+++ b/packages/feature-flags/llms-full.txt
@@ -10,5 +10,24 @@
       checkForUser(flagName: string, userId: string): boolean;
     }
   </file>
+  <file path="src/plugin.ts">
+    export const FEATURE_FLAGS_HEADER = "x-feature-flags";
+    export function createFeatureFlagsPlugin(): FastifyPluginAsync {
+      return fp(
+        async function featureFlagsPlugin(fastify) {
+          fastify.decorateRequest("features");
+          fastify.addHook("onRequest", async (request) => {
+            const raw = request.headers[FEATURE_FLAGS_HEADER];
+            // Headers are typed string | string[]; Node joins repeated headers
+            // into one comma-separated string (invalid JSON → flags disabled),
+            // the array branch only guards exotic clients
+            const header = Array.isArray(raw) ? raw[0] : raw;
+            request.features = createFeatureContext(header);
+          });
+        },
+        { name: "feature-flags" }
+      );
+    }
+  </file>
   </section>
 </codebase>

--- a/packages/feature-flags/llms.txt
+++ b/packages/feature-flags/llms.txt
@@ -13,5 +13,13 @@
       }
     </item>
   </file>
+  <file path="src/plugin.ts">
+    <item priority="high">
+      export const FEATURE_FLAGS_HEADER: unknown;
+    </item>
+    <item priority="high">
+      export function createFeatureFlagsPlugin(): FastifyPluginAsync { /* ... */ }
+    </item>
+  </file>
   </section>
 </codebase>

--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -22,5 +22,17 @@
     "@types/node": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
+  },
+  "dependencies": {
+    "fastify": "catalog:",
+    "fastify-plugin": "^6.0.0"
+  },
+  "peerDependencies": {
+    "fastify": "catalog:"
+  },
+  "peerDependenciesMeta": {
+    "fastify": {
+      "optional": true
+    }
   }
 }

--- a/packages/feature-flags/src/index.ts
+++ b/packages/feature-flags/src/index.ts
@@ -58,3 +58,4 @@ export function createFeatureContext(header: string | null | undefined): Feature
     },
   };
 }
+export { createFeatureFlagsPlugin, FEATURE_FLAGS_HEADER } from "./plugin.js";

--- a/packages/feature-flags/src/plugin.test.ts
+++ b/packages/feature-flags/src/plugin.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import Fastify from "fastify";
+import { createFeatureFlagsPlugin } from "./plugin.js";
+
+const FLAG_HEADER = '{"enhanced-validation":{"enabled":true,"percentage":100}}';
+
+async function buildApp() {
+  const app = Fastify({ logger: false });
+  await app.register(createFeatureFlagsPlugin());
+  app.get("/check", async (request) => ({
+    enabled: request.features.check("enhanced-validation"),
+  }));
+  app.get("/check-user", async (request) => ({
+    enabled: request.features.checkForUser("enhanced-validation", "user-123"),
+  }));
+  return app;
+}
+
+describe("createFeatureFlagsPlugin", () => {
+  it("decorates request.features and evaluates flags from the header", async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "GET",
+      url: "/check",
+      headers: { "x-feature-flags": FLAG_HEADER },
+    });
+    expect(res.json()).toEqual({ enabled: true });
+  });
+
+  it("returns false for all flags when the header is missing", async () => {
+    const app = await buildApp();
+    const res = await app.inject({ method: "GET", url: "/check" });
+    expect(res.json()).toEqual({ enabled: false });
+  });
+
+  it("returns false for all flags when the header is invalid JSON", async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "GET",
+      url: "/check",
+      headers: { "x-feature-flags": "not-json" },
+    });
+    expect(res.json()).toEqual({ enabled: false });
+  });
+
+  it("degrades to disabled flags when the header is sent multiple times", async () => {
+    // Node joins repeated headers into a comma-separated string, which is
+    // not valid JSON — flags disable gracefully instead of throwing
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "GET",
+      url: "/check",
+      headers: { "x-feature-flags": [FLAG_HEADER, "{}"] },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ enabled: false });
+  });
+
+  it("exposes checkForUser for percentage rollouts", async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: "GET",
+      url: "/check-user",
+      headers: {
+        "x-feature-flags": '{"enhanced-validation":{"enabled":true,"percentage":100}}',
+      },
+    });
+    expect(res.json()).toEqual({ enabled: true });
+  });
+});

--- a/packages/feature-flags/src/plugin.ts
+++ b/packages/feature-flags/src/plugin.ts
@@ -1,0 +1,33 @@
+import type { FastifyPluginAsync } from "fastify";
+import fp from "fastify-plugin";
+import { createFeatureContext, type FeatureContext } from "./index.js";
+
+export const FEATURE_FLAGS_HEADER = "x-feature-flags";
+
+/**
+ * Fastify plugin that parses the x-feature-flags header once per request and
+ * decorates the request with a ready-to-use FeatureContext. Routes call
+ * `request.features.check("flag-name")` directly — no header access, no cast.
+ */
+export function createFeatureFlagsPlugin(): FastifyPluginAsync {
+  return fp(
+    async function featureFlagsPlugin(fastify) {
+      fastify.decorateRequest("features");
+      fastify.addHook("onRequest", async (request) => {
+        const raw = request.headers[FEATURE_FLAGS_HEADER];
+        // Headers are typed string | string[]; Node joins repeated headers
+        // into one comma-separated string (invalid JSON → flags disabled),
+        // the array branch only guards exotic clients
+        const header = Array.isArray(raw) ? raw[0] : raw;
+        request.features = createFeatureContext(header);
+      });
+    },
+    { name: "feature-flags" }
+  );
+}
+
+declare module "fastify" {
+  interface FastifyRequest {
+    features: FeatureContext;
+  }
+}

--- a/packages/service-bootstrap/package.json
+++ b/packages/service-bootstrap/package.json
@@ -24,6 +24,7 @@
     "@fastify/swagger-ui": "^6.0.0",
     "@mbe/auth": "workspace:*",
     "@mbe/database": "workspace:*",
+    "@mbe/feature-flags": "workspace:*",
     "@mbe/observability": "workspace:*",
     "@mbe/sentry": "workspace:*",
     "@scalar/fastify-api-reference": "^1.59.2",

--- a/packages/service-bootstrap/src/create-service-app.test.ts
+++ b/packages/service-bootstrap/src/create-service-app.test.ts
@@ -387,3 +387,48 @@ describe("validateCorsOrigins", () => {
     expect(result).toEqual([]);
   });
 });
+
+describe("feature flags plugin", () => {
+  let app: FastifyInstance;
+
+  afterEach(async () => {
+    if (app) await app.close();
+    vi.clearAllMocks();
+  });
+
+  it("decorates request.features so routes can check flags without header parsing", async () => {
+    app = await createServiceApp({
+      swagger: {
+        title: "Test API",
+        description: "Test API description",
+        serverUrl: "http://localhost:9999",
+      },
+    });
+    app.get("/flag-check", async (request) => ({
+      enabled: request.features.check("enhanced-validation"),
+    }));
+    const res = await app.inject({
+      method: "GET",
+      url: "/flag-check",
+      headers: {
+        "x-feature-flags": '{"enhanced-validation":{"enabled":true,"percentage":100}}',
+      },
+    });
+    expect(res.json()).toEqual({ enabled: true });
+  });
+
+  it("request.features reports flags disabled when no header is sent", async () => {
+    app = await createServiceApp({
+      swagger: {
+        title: "Test API",
+        description: "Test API description",
+        serverUrl: "http://localhost:9999",
+      },
+    });
+    app.get("/flag-check", async (request) => ({
+      enabled: request.features.check("enhanced-validation"),
+    }));
+    const res = await app.inject({ method: "GET", url: "/flag-check" });
+    expect(res.json()).toEqual({ enabled: false });
+  });
+});

--- a/packages/service-bootstrap/src/create-service-app.ts
+++ b/packages/service-bootstrap/src/create-service-app.ts
@@ -5,6 +5,7 @@ import swagger from "@fastify/swagger";
 import swaggerUi from "@fastify/swagger-ui";
 import ScalarApiReference from "@scalar/fastify-api-reference";
 import { authPlugin, getAuthPluginOptionsFromEnv } from "@mbe/auth/fastify";
+import { createFeatureFlagsPlugin } from "@mbe/feature-flags";
 import {
   createRequestIdMiddleware,
   errorRatePlugin_,
@@ -137,6 +138,9 @@ export async function createServiceApp(
 
   // Track per-endpoint error rates (exposed via health check)
   await fastify.register(errorRatePlugin_);
+
+  // Parse x-feature-flags once per request; routes use request.features
+  await fastify.register(createFeatureFlagsPlugin());
 
   const rateLimitMonitor = createRateLimitMonitor();
   fastify.decorate("rateLimitMonitor", rateLimitMonitor);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -723,6 +723,13 @@ importers:
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/feature-flags:
+    dependencies:
+      fastify:
+        specifier: 'catalog:'
+        version: 5.8.5
+      fastify-plugin:
+        specifier: ^6.0.0
+        version: 6.0.0
     devDependencies:
       '@mbe/config':
         specifier: workspace:*
@@ -1115,6 +1122,9 @@ importers:
       '@mbe/database':
         specifier: workspace:*
         version: link:../database
+      '@mbe/feature-flags':
+        specifier: workspace:*
+        version: link:../feature-flags
       '@mbe/observability':
         specifier: workspace:*
         version: link:../observability
@@ -1286,9 +1296,6 @@ importers:
       '@mbe/database':
         specifier: workspace:*
         version: link:../../packages/database
-      '@mbe/feature-flags':
-        specifier: workspace:*
-        version: link:../../packages/feature-flags
       '@mbe/jobs':
         specifier: workspace:*
         version: link:../../packages/jobs
@@ -15602,7 +15609,7 @@ snapshots:
       process-warning: 5.0.0
       rfdc: 1.4.1
       secure-json-parse: 4.1.0
-      semver: 7.8.0
+      semver: 7.8.2
       toad-cache: 3.7.0
 
   fastq@1.20.1:

--- a/services/reservations/llms-full.txt
+++ b/services/reservations/llms-full.txt
@@ -3026,10 +3026,7 @@
         async (request, reply) => {
           const userId = request.user?.id;
     
-          const features = createFeatureContext(
-            request.headers["x-feature-flags"] as string | undefined
-          );
-          const useEnhancedValidation = features.check("enhanced-validation");
+          const useEnhancedValidation = request.features.check("enhanced-validation");
     
           if (useEnhancedValidation && request.body.partySize > 20) {
             return reply

--- a/services/reservations/package.json
+++ b/services/reservations/package.json
@@ -30,7 +30,6 @@
     "@mbe/database": "workspace:*",
     "@mbe/service-bootstrap": "workspace:*",
     "@mbe/jobs": "workspace:*",
-    "@mbe/feature-flags": "workspace:*",
     "@mbe/notifications": "workspace:^",
     "@mbe/observability": "workspace:*",
     "@mbe/sentry": "workspace:*",

--- a/services/reservations/src/routes/reservations.test.ts
+++ b/services/reservations/src/routes/reservations.test.ts
@@ -304,6 +304,50 @@ describe("Reservation Routes", () => {
       expect(body.data.id).toBe(mockReservation.id);
     });
 
+    it("rejects party size over 20 when enhanced-validation flag is enabled", async () => {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/v1/reservations",
+        headers: {
+          "x-feature-flags": '{"enhanced-validation":{"enabled":true,"percentage":100}}',
+        },
+        payload: {
+          date: "2026-02-15",
+          startTime: "2026-02-15T18:00:00.000Z",
+          endTime: "2026-02-15T20:00:00.000Z",
+          partySize: 25,
+          tableId: "table-123",
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      // NOTE: the Error schema serializes {error,message,statusCode} while the
+      // route sends ProblemDetails — the detail text is stripped (pre-existing),
+      // so only the status code is asserted here
+      expect(reservationService.createWithConflictCheck).not.toHaveBeenCalled();
+    });
+
+    it("allows party size over 20 when enhanced-validation flag is absent", async () => {
+      vi.mocked(reservationService.createWithConflictCheck).mockResolvedValueOnce({
+        success: true,
+        reservation: createMockReservation({ partySize: 25 }),
+      });
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/v1/reservations",
+        payload: {
+          date: "2026-02-15",
+          startTime: "2026-02-15T18:00:00.000Z",
+          endTime: "2026-02-15T20:00:00.000Z",
+          partySize: 25,
+          tableId: "table-123",
+        },
+      });
+
+      expect(response.statusCode).toBe(201);
+    });
+
     it("creates a guest reservation without auth", async () => {
       vi.mocked(reservationService.createWithConflictCheck).mockResolvedValueOnce({
         success: true,

--- a/services/reservations/src/routes/reservations.ts
+++ b/services/reservations/src/routes/reservations.ts
@@ -12,7 +12,6 @@ import type {
 import { createProblemDetails } from "@mbe/types";
 import { requireAuth, optionalAuth, hasPermission } from "@mbe/auth/fastify";
 import { parseListQuery } from "@mbe/database";
-import { createFeatureContext } from "@mbe/feature-flags";
 import { reservationService } from "../services/reservation.js";
 import {
   emitReservationCancelled,
@@ -440,10 +439,7 @@ export const reservationRoutes: FastifyPluginAsync = async (fastify) => {
     async (request, reply) => {
       const userId = request.user?.id;
 
-      const features = createFeatureContext(
-        request.headers["x-feature-flags"] as string | undefined
-      );
-      const useEnhancedValidation = features.check("enhanced-validation");
+      const useEnhancedValidation = request.features.check("enhanced-validation");
 
       if (useEnhancedValidation && request.body.partySize > 20) {
         return reply


### PR DESCRIPTION
## Summary
Closes #1937

- `createFeatureFlagsPlugin()` exported from `@mbe/feature-flags` — parses `x-feature-flags` once per request in an `onRequest` hook and decorates `request.features: FeatureContext`
- Registered in `createServiceApp` (`@mbe/service-bootstrap` — the issue named `packages/database`, but #1974 moved that file; registration follows the spec's intent), so every service gets flag access automatically
- `services/reservations` route now uses `request.features.check("enhanced-validation")` — `createFeatureContext` import and the `as string | undefined` header cast deleted
- `@mbe/feature-flags` dep moved reservations → service-bootstrap (orphan cleanup); dep-graph regenerated
- `packages/feature-flags/CLAUDE.md` refreshed (was stale even pre-change — documented private helpers as exports)
- Characterization tests added for the previously-untested enhanced-validation route path (flag on → 400, flag absent → 201)

## Review notes
- Dual-axis review (Standards + Spec) run pre-commit; findings fixed: stale package CLAUDE.md, misleading array-handling comment, missing `peerDependenciesMeta` (now mirrors `@mbe/observability`)
- Pre-existing finding filed as #1984: `Error#` response schema strips ProblemDetails fields
- `checkForUser` (percentage rollout, zero callers) now reachable via `request.features` per the issue's testing-impact note

## Test plan
- [x] TDD red-green per slice (plugin → bootstrap registration → route swap)
- [x] 19 + 71 + 652 tests passing (feature-flags / service-bootstrap / reservations)
- [x] `pnpm typecheck` + `pnpm lint` clean on all three packages
- [x] `pnpm generate:dep-graph` committed (26 nodes, 82 edges)