### PR TITLE
fix: derive Swagger server URL from API_BASE_URL origin in production

### DIFF
--- a/packages/service-bootstrap/src/create-service-app.test.ts
+++ b/packages/service-bootstrap/src/create-service-app.test.ts
@@ -76,6 +76,7 @@ describe("createServiceApp", () => {
     delete process.env.AUTH_AUDIENCE;
     delete process.env.CORS_ORIGINS;
     delete process.env.NODE_ENV;
+    delete process.env.API_BASE_URL;
   });
 
   afterEach(async () => {
@@ -150,6 +151,67 @@ describe("createServiceApp", () => {
     expect(openapi.info.title).toBe("My Custom API");
     expect(openapi.info.description).toBe("Custom description");
     expect(openapi.servers).toEqual([{ url: "http://localhost:4000" }]);
+  });
+
+  it("uses the origin of API_BASE_URL as the swagger server URL in production", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.AUTH_AUTHORITY = "https://auth.example.com";
+    process.env.AUTH_AUDIENCE = "https://api.example.com";
+    process.env.API_BASE_URL = "https://api.example.com/api";
+    const swagger = await import("@fastify/swagger");
+    app = await createServiceApp(
+      createTestConfig({
+        swagger: {
+          title: "My Custom API",
+          description: "Custom description",
+          serverUrl: "http://localhost:4000",
+        },
+      })
+    );
+    const opts = getPluginOpts(vi.mocked(swagger.default)) as {
+      openapi: { servers: { url: string }[] };
+    };
+    expect(opts.openapi.servers).toEqual([{ url: "https://api.example.com" }]);
+  });
+
+  it("ignores API_BASE_URL outside production (agent service sets it to another port in dev)", async () => {
+    process.env.NODE_ENV = "development";
+    process.env.API_BASE_URL = "http://localhost:3000";
+    const swagger = await import("@fastify/swagger");
+    app = await createServiceApp(
+      createTestConfig({
+        swagger: {
+          title: "My Custom API",
+          description: "Custom description",
+          serverUrl: "http://localhost:4000",
+        },
+      })
+    );
+    const opts = getPluginOpts(vi.mocked(swagger.default)) as {
+      openapi: { servers: { url: string }[] };
+    };
+    expect(opts.openapi.servers).toEqual([{ url: "http://localhost:4000" }]);
+  });
+
+  it("falls back to the configured serverUrl when API_BASE_URL is malformed", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.AUTH_AUTHORITY = "https://auth.example.com";
+    process.env.AUTH_AUDIENCE = "https://api.example.com";
+    process.env.API_BASE_URL = "not-a-valid-url";
+    const swagger = await import("@fastify/swagger");
+    app = await createServiceApp(
+      createTestConfig({
+        swagger: {
+          title: "My Custom API",
+          description: "Custom description",
+          serverUrl: "http://localhost:4000",
+        },
+      })
+    );
+    const opts = getPluginOpts(vi.mocked(swagger.default)) as {
+      openapi: { servers: { url: string }[] };
+    };
+    expect(opts.openapi.servers).toEqual([{ url: "http://localhost:4000" }]);
   });
 
   it("registers swagger-ui at /docs", async () => {

--- a/packages/service-bootstrap/src/create-service-app.ts
+++ b/packages/service-bootstrap/src/create-service-app.ts
@@ -74,6 +74,26 @@ export function validateCorsOrigins(origins: string[]): string[] {
 }
 
 /**
+ * Resolves the OpenAPI server URL for Swagger "Try it out".
+ * In production, API_BASE_URL (set on every DO service) overrides the
+ * configured serverUrl. Routes register their full public path prefix
+ * (e.g. /api/v1/users), so only the URL's origin is used — API_BASE_URL
+ * carries an /api path suffix that would double up if used verbatim.
+ * Production-only because the agent service sets API_BASE_URL to a
+ * different port in local dev (gen-app links, not this service's origin).
+ */
+function resolveSwaggerServerUrl(fallbackUrl: string, log: FastifyInstance["log"]): string {
+  const base = process.env.API_BASE_URL;
+  if (process.env.NODE_ENV !== "production" || !base) return fallbackUrl;
+  try {
+    return new URL(base).origin;
+  } catch {
+    log.warn({ apiBaseUrl: base, fallbackUrl }, "API_BASE_URL is not a valid URL; using fallback");
+    return fallbackUrl;
+  }
+}
+
+/**
  * Creates a Fastify application with all shared plugins pre-registered:
  * CORS, request-ID, error-rate tracking, rate-limiting, Swagger/Scalar,
  * Auth0, Sentry, and API versioning.
@@ -166,7 +186,7 @@ export async function createServiceApp(
         description: config.swagger.description,
         version: swaggerVersion,
       },
-      servers: [{ url: config.swagger.serverUrl }],
+      servers: [{ url: resolveSwaggerServerUrl(config.swagger.serverUrl, fastify.log) }],
       components: {
         securitySchemes: {
           bearerAuth: {


### PR DESCRIPTION
## Summary
Closes #1956

- `createServiceApp` (service-bootstrap) now resolves the OpenAPI server URL from `API_BASE_URL` in production — already set to `https://api.<domain>/api` on all three DO services by Pulumi, so no infra change needed.
- Only the URL's **origin** is used: routes register their full public path prefix (`/api/v1/users` etc. with `preservePathPrefix: true`), so using `API_BASE_URL` verbatim would double the `/api` segment.
- Production-scoped on purpose: the agent service sets `API_BASE_URL=http://localhost:3000` in local dev (gen-app links), which would otherwise hijack its Swagger docs onto the wrong port. Dev keeps each service's localhost fallback.
- Malformed `API_BASE_URL` logs a structured warning and falls back.
- One seam in service-bootstrap fixes all three services; the per-service `app.ts` files are untouched (their localhost values are now the dev fallback).

Known pre-existing gap (out of scope, surfaced during review): reservations' `/public/v1/*` and the bare `/health`–`/ready` paths have no DO ingress rule and fall through to the `/` catch-all (users-api), so Try-it-out against those specific endpoints still 404s regardless of server URL. Ingress fix would belong in `infrastructure/pulumi/index.ts`.

## Test plan
- [x] 74 tests passing in @mbe/service-bootstrap (3 new: prod override, dev ignore, malformed fallback)
- [x] users (133), agent (240), reservations suites green locally
- [x] ESLint clean, tsc --noEmit clean (pre-push: 18 turbo tasks green)
- [x] Dual-axis review (Standards + Spec) — findings fixed: production scoping, unexported helper, structured log