### PR TITLE
fix: add split-screen-exit showcase page to sitemap.xml

### DIFF
--- a/apps/marketing/public/sitemap.xml
+++ b/apps/marketing/public/sitemap.xml
@@ -349,6 +349,11 @@
     <lastmod>2026-03-31</lastmod>
     <priority>0.5</priority>
   </url>
+  <url>
+    <loc>https://mattbutlerengineering.com/rialto/components/split-screen-exit</loc>
+    <lastmod>2026-05-25</lastmod>
+    <priority>0.5</priority>
+  </url>
 
   <!-- Rialto Tokens -->
   <url>


### PR DESCRIPTION
## Summary
Closes #1957

- Adds the missing `/rialto/components/split-screen-exit` entry to `apps/marketing/public/sitemap.xml` (Layout section), `lastmod: 2026-05-25` (the date the route shipped), `priority: 0.5` matching sibling component entries.
- Narrow on purpose: the stale `lastmod` dates across the rest of the sitemap and the proposed sitemap generator are tracked separately in #1959.

## Test plan
- [x] xmllint validates sitemap.xml
- [x] Entry format matches existing component entries