### PR TITLE
fix: refresh stale sitemap lastmod dates from git history

### DIFF
--- a/apps/marketing/public/sitemap.xml
+++ b/apps/marketing/public/sitemap.xml
@@ -31,327 +31,327 @@
   <!-- Rialto Components: Forms -->
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/button</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/input</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/textarea</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/number-input</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/checkbox-radio</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/toggle</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/slider</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/select</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/pin-input</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/segmented-control</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/autocomplete</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/input-group</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
 
   <!-- Rialto Components: Data Display -->
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/card</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/table</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/badge</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/tag</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/avatar</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/stat</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/data-list</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/meter</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/kbd</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/flip-dot</loc>
-    <lastmod>2026-04-11</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/split-flap</loc>
-    <lastmod>2026-04-27</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/chalkboard</loc>
-    <lastmod>2026-04-27</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/ferrofluid</loc>
-    <lastmod>2026-04-27</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/tape-chart</loc>
-    <lastmod>2026-04-27</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
 
   <!-- Rialto Components: Navigation -->
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/tabs</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/breadcrumb</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/steps</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/pagination</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/navigation-menu</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/tree</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/sidebar</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/navbar</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
 
   <!-- Rialto Components: Feedback -->
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/toast</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/alert</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/banner</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/progress</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/spinner</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/skeleton</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/empty-state</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
 
   <!-- Rialto Components: Overlays -->
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/dialog</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/confirm-dialog</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/drawer</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/command-palette</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/tooltip</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/popover</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/hover-card</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/dropdown-menu</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/context-menu</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/disabled-tooltip</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
 
   <!-- Rialto Components: Layout -->
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/divider</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/text</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/stack</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/collapsible</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/accordion</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/aspect-ratio</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-04-13</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/scroll-area</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/timeline</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/hero</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/footer</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/page-header</loc>
-    <lastmod>2026-03-31</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://mattbutlerengineering.com/rialto/components/split-screen-exit</loc>
-    <lastmod>2026-05-25</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <priority>0.5</priority>
   </url>
 


### PR DESCRIPTION
## Summary
Closes #1959

- Refreshes `lastmod` on 63 rialto component entries in `apps/marketing/public/sitemap.xml`, deriving each date from `git log -1 --format=%as` on the component's showcase page file (mostly 2026-04-13 / 2026-05-16, replacing the stale 2026-03-31 dates).
- `split-screen-exit` moves 2026-05-25 → 2026-05-16: #1957 used the route-added date from the issue text; the page file's actual last commit is 05-16, and consistency with the other 62 git-derived entries wins.
- Token entries (motion, typography, color, spacing, radius, shadows, surfaces, icon-vocabulary) left untouched — they have no per-entry page files to derive from.

### Issue premise correction
#1959 lists 7 components added 2026-05-25 (AppBar, ChatPanel, StatusLED, GlobalNav, ImageUpload, Heading, SplitScreenExit). Only **SplitScreenExit** has a showcase page/route (handled in #1957). The other six exist in `packages/rialto` but have **no rialto-web pages**, so there are no URLs to add — adding sitemap entries for them would point crawlers at 404s. If showcase pages are wanted for those six, that's a feature issue, not a sitemap fix.

### Long-term generator
The suggested `pnpm generate:sitemap` automation is intentionally not included — kept data-only per surgical-change policy. Happy to file a follow-up issue if wanted.

## Test plan
- [x] xmllint validates sitemap.xml
- [x] 63 dates spot-checked against `git log` output (script-derived, deterministic)