### PR TITLE
refactor(reservations): inject BookingNotifier via buildApp, delete module singletons

### DIFF
--- a/services/reservations/llms-full.txt
+++ b/services/reservations/llms-full.txt
@@ -364,7 +364,9 @@
           const venue = reservation.venueId ? await venueService.getById(reservation.venueId) : null;
     
           // Cancel any pending reminder jobs for this reservation
-          cancelBookingReminders(reservation.id).catch(() => {});
+          fastify.bookingNotifier
+            .cancelBookingReminders(reservation.id)
+            .catch((err) => fastify.log.error({ err }, "Failed to cancel booking reminders"));
     
           if (reservation.guestEmail && venue) {
             const preference =
@@ -2195,7 +2197,9 @@
           // Reschedule reminder jobs if time changed
           const timeChanged = date !== undefined || startTime !== undefined || endTime !== undefined;
           if (timeChanged) {
-            rescheduleBookingReminders(updated, token).catch(() => {});
+            fastify.bookingNotifier
+              .rescheduleBookingReminders(updated, token)
+              .catch((err) => fastify.log.error({ err }, "Failed to reschedule booking reminders"));
           }
     
           if (updated.guestEmail && venue) {
@@ -5181,6 +5185,7 @@
   <file path="src/app.ts">
     export interface ReservationsAppOptions extends AppOptions {
       notificationPort?: NotificationDispatcher;
+      bookingNotifier?: BookingNotifier;
     }
     export async function buildApp(options: ReservationsAppOptions = {}): Promise<FastifyInstance> {
       const fastify = await createServiceApp(
@@ -5198,6 +5203,10 @@
       // Wire notification port (injected or default Resend-backed)
       const notificationPort = options.notificationPort ?? createNotificationPort();
       fastify.decorate("notificationPort", notificationPort);
+    
+      // Wire booking notifier (injected or default Resend + BullMQ backed)
+      const bookingNotifier = options.bookingNotifier ?? createDefaultBookingNotifier();
+      fastify.decorate("bookingNotifier", bookingNotifier);
     
       // Register routes
       await fastify.register(healthRoutes);

--- a/services/reservations/llms.txt
+++ b/services/reservations/llms.txt
@@ -528,6 +528,7 @@
     <item priority="low">
       interface ReservationsAppOptions {
         notificationPort?: NotificationDispatcher;
+        bookingNotifier?: BookingNotifier;
       }
     </item>
     <item priority="high">

--- a/services/reservations/src/app.ts
+++ b/services/reservations/src/app.ts
@@ -26,6 +26,10 @@ import { publicDepositRoutes } from "./routes/public-deposits.js";
 import { stripeWebhookRoutes } from "./routes/stripe-webhook.js";
 import { waitlistRoutes } from "./routes/waitlist.js";
 import { createNotificationPort } from "./notifications.js";
+import {
+  createDefaultBookingNotifier,
+  type BookingNotifier,
+} from "./services/booking-notifications.js";
 import { createLapsedGuestMonitor } from "./services/lapsed-guest-cron.js";
 import { runLapsedGuestScan } from "./services/lapsed-guest-scan.js";
 import { emitLapsingGuests } from "./services/events.js";
@@ -33,6 +37,7 @@ import { prisma } from "./services/database.js";
 
 export interface ReservationsAppOptions extends AppOptions {
   notificationPort?: NotificationDispatcher;
+  bookingNotifier?: BookingNotifier;
 }
 
 /**
@@ -54,6 +59,10 @@ export async function buildApp(options: ReservationsAppOptions = {}): Promise<Fa
   // Wire notification port (injected or default Resend-backed)
   const notificationPort = options.notificationPort ?? createNotificationPort();
   fastify.decorate("notificationPort", notificationPort);
+
+  // Wire booking notifier (injected or default Resend + BullMQ backed)
+  const bookingNotifier = options.bookingNotifier ?? createDefaultBookingNotifier();
+  fastify.decorate("bookingNotifier", bookingNotifier);
 
   // Register routes
   await fastify.register(healthRoutes);
@@ -128,5 +137,6 @@ export async function buildApp(options: ReservationsAppOptions = {}): Promise<Fa
 declare module "fastify" {
   interface FastifyInstance {
     notificationPort: NotificationDispatcher;
+    bookingNotifier: BookingNotifier;
   }
 }

--- a/services/reservations/src/routes/cancel-reservation.test.ts
+++ b/services/reservations/src/routes/cancel-reservation.test.ts
@@ -3,6 +3,7 @@ import { buildApp } from "../app.js";
 import type { FastifyInstance } from "fastify";
 import { generateManageToken } from "./public-reservations.js";
 import type { NotificationDispatcher } from "@mbe/notifications";
+import type { BookingNotifier } from "../services/booking-notifications.js";
 
 vi.mock("../services/reservation.js", () => ({
   reservationService: {
@@ -231,5 +232,37 @@ describe("DELETE /public/v1/reservations/manage", () => {
     });
 
     expect(response.statusCode).toBe(404);
+  });
+
+  it("cancels reminder jobs via injected bookingNotifier", async () => {
+    const stubNotifier: BookingNotifier = {
+      scheduleBookingNotifications: vi.fn().mockResolvedValue(undefined),
+      cancelBookingReminders: vi.fn().mockResolvedValue(undefined),
+      rescheduleBookingReminders: vi.fn().mockResolvedValue(undefined),
+    };
+    const stubApp = await buildApp({
+      logger: false,
+      notificationPort: createStubNotificationDispatcher() as never,
+      bookingNotifier: stubNotifier,
+    });
+    await stubApp.ready();
+
+    const token = generateManageToken("res_1", "jane@example.com");
+    vi.mocked(reservationService.getById).mockResolvedValueOnce(mockReservation as never);
+    vi.mocked(reservationService.update).mockResolvedValueOnce({
+      ...mockReservation,
+      status: "CANCELLED",
+    } as never);
+    vi.mocked(venueService.getById).mockResolvedValueOnce(mockVenue as never);
+
+    const response = await stubApp.inject({
+      method: "DELETE",
+      url: `/public/v1/reservations/manage?token=${token}`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(stubNotifier.cancelBookingReminders).toHaveBeenCalledWith("res_1");
+
+    await stubApp.close();
   });
 });

--- a/services/reservations/src/routes/cancel-reservation.ts
+++ b/services/reservations/src/routes/cancel-reservation.ts
@@ -2,7 +2,6 @@ import type { FastifyPluginAsync } from "fastify";
 import { verifyManageToken } from "./public-reservations.js";
 import { reservationService } from "../services/reservation.js";
 import { venueService } from "../services/venue.js";
-import { cancelBookingReminders } from "../services/booking-notifications.js";
 
 export const cancelReservationRoutes: FastifyPluginAsync = async (fastify) => {
   fastify.delete<{ Querystring: { token?: string } }>(
@@ -88,7 +87,9 @@ export const cancelReservationRoutes: FastifyPluginAsync = async (fastify) => {
       const venue = reservation.venueId ? await venueService.getById(reservation.venueId) : null;
 
       // Cancel any pending reminder jobs for this reservation
-      cancelBookingReminders(reservation.id).catch(() => {});
+      fastify.bookingNotifier
+        .cancelBookingReminders(reservation.id)
+        .catch((err) => fastify.log.error({ err }, "Failed to cancel booking reminders"));
 
       if (reservation.guestEmail && venue) {
         const preference =

--- a/services/reservations/src/routes/modify-reservation.test.ts
+++ b/services/reservations/src/routes/modify-reservation.test.ts
@@ -3,6 +3,7 @@ import { buildApp } from "../app.js";
 import type { FastifyInstance } from "fastify";
 import { generateManageToken } from "./public-reservations.js";
 import type { NotificationDispatcher } from "@mbe/notifications";
+import type { BookingNotifier } from "../services/booking-notifications.js";
 
 vi.mock("../services/reservation.js", () => ({
   reservationService: {
@@ -287,5 +288,40 @@ describe("PATCH /public/v1/reservations/manage", () => {
 
     expect(response.statusCode).toBe(200);
     expect(response.json().data.reservation.notes).toBe("No peanuts please");
+  });
+
+  it("reschedules reminder jobs via injected bookingNotifier when time changes", async () => {
+    const stubNotifier: BookingNotifier = {
+      scheduleBookingNotifications: vi.fn().mockResolvedValue(undefined),
+      cancelBookingReminders: vi.fn().mockResolvedValue(undefined),
+      rescheduleBookingReminders: vi.fn().mockResolvedValue(undefined),
+    };
+    const stubApp = await buildApp({
+      logger: false,
+      notificationPort: createStubNotificationDispatcher() as never,
+      bookingNotifier: stubNotifier,
+    });
+    await stubApp.ready();
+
+    const token = generateManageToken("res_1", "jane@example.com");
+    const updatedReservation = { ...mockReservation, startTime: "20:00" };
+
+    vi.mocked(reservationService.getById).mockResolvedValueOnce(mockReservation as never);
+    vi.mocked(reservationService.updateWithConflictCheck).mockResolvedValueOnce({
+      success: true,
+      reservation: updatedReservation,
+    } as never);
+    vi.mocked(venueService.getById).mockResolvedValueOnce(mockVenue as never);
+
+    const response = await stubApp.inject({
+      method: "PATCH",
+      url: `/public/v1/reservations/manage?token=${token}`,
+      payload: { startTime: "20:00" },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(stubNotifier.rescheduleBookingReminders).toHaveBeenCalledWith(updatedReservation, token);
+
+    await stubApp.close();
   });
 });

--- a/services/reservations/src/routes/modify-reservation.ts
+++ b/services/reservations/src/routes/modify-reservation.ts
@@ -2,7 +2,6 @@ import type { FastifyPluginAsync } from "fastify";
 import { verifyManageToken } from "./public-reservations.js";
 import { reservationService } from "../services/reservation.js";
 import { venueService } from "../services/venue.js";
-import { rescheduleBookingReminders } from "../services/booking-notifications.js";
 
 interface ModifyBody {
   date?: string;
@@ -135,7 +134,9 @@ export const modifyReservationRoutes: FastifyPluginAsync = async (fastify) => {
       // Reschedule reminder jobs if time changed
       const timeChanged = date !== undefined || startTime !== undefined || endTime !== undefined;
       if (timeChanged) {
-        rescheduleBookingReminders(updated, token).catch(() => {});
+        fastify.bookingNotifier
+          .rescheduleBookingReminders(updated, token)
+          .catch((err) => fastify.log.error({ err }, "Failed to reschedule booking reminders"));
       }
 
       if (updated.guestEmail && venue) {

--- a/services/reservations/src/routes/public-reservations.test.ts
+++ b/services/reservations/src/routes/public-reservations.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
 import { buildApp } from "../app.js";
 import type { FastifyInstance } from "fastify";
+import type { BookingNotifier } from "../services/booking-notifications.js";
 import { generateManageToken, verifyManageToken } from "./public-reservations.js";
 
 vi.mock("../services/venue.js", () => ({
@@ -197,6 +198,39 @@ describe("POST /public/v1/venues/:slug/reservations", () => {
     });
 
     expect(response.statusCode).toBe(409);
+  });
+});
+
+describe("bookingNotifier injection", () => {
+  it("calls injected bookingNotifier.scheduleBookingNotifications with reservation and manage token", async () => {
+    const stubNotifier: BookingNotifier = {
+      scheduleBookingNotifications: vi.fn().mockResolvedValue(undefined),
+      cancelBookingReminders: vi.fn().mockResolvedValue(undefined),
+      rescheduleBookingReminders: vi.fn().mockResolvedValue(undefined),
+    };
+    const stubApp = await buildApp({ logger: false, bookingNotifier: stubNotifier });
+    await stubApp.ready();
+
+    vi.mocked(venueService.getBySlug).mockResolvedValueOnce(mockVenue);
+    vi.mocked(confirmHold).mockResolvedValueOnce({
+      success: true,
+      reservation: mockReservation,
+    });
+
+    const response = await stubApp.inject({
+      method: "POST",
+      url: "/public/v1/venues/the-oak-table/reservations",
+      payload: { holdId: "hold_1", guestName: "Jane Doe", guestEmail: "jane@example.com" },
+    });
+
+    expect(response.statusCode).toBe(201);
+    const { manageToken } = response.json().data;
+    expect(stubNotifier.scheduleBookingNotifications).toHaveBeenCalledWith(
+      mockReservation,
+      manageToken
+    );
+
+    await stubApp.close();
   });
 });
 

--- a/services/reservations/src/routes/public-reservations.ts
+++ b/services/reservations/src/routes/public-reservations.ts
@@ -5,7 +5,6 @@ import { venueService } from "../services/venue.js";
 import { confirmHold } from "../services/confirm-hold.js";
 import { publicRateLimitHook } from "../middleware/public-rate-limit.js";
 import { decrementHoldCount } from "../middleware/public-rate-limit.js";
-import { scheduleBookingNotifications } from "../services/booking-notifications.js";
 
 const TOKEN_SECRET = process.env.MANAGE_TOKEN_SECRET || "dev-secret-do-not-use-in-prod";
 
@@ -115,7 +114,9 @@ export const publicReservationRoutes: FastifyPluginAsync = async (fastify) => {
       const manageToken = generateManageToken(result.reservation.id, guestEmail);
 
       // Fire-and-forget: send confirmation + schedule reminders (non-blocking)
-      scheduleBookingNotifications(result.reservation, manageToken).catch(() => {});
+      fastify.bookingNotifier
+        .scheduleBookingNotifications(result.reservation, manageToken)
+        .catch((err) => fastify.log.error({ err }, "Failed to schedule booking notifications"));
 
       return reply.status(201).send({
         data: {

--- a/services/reservations/src/services/booking-notifications.test.ts
+++ b/services/reservations/src/services/booking-notifications.test.ts
@@ -1,70 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
-// Hoisted mocks
-const { mockSchedule, mockCancel } = vi.hoisted(() => ({
-  mockSchedule: vi.fn().mockResolvedValue("job-id"),
-  mockCancel: vi.fn().mockResolvedValue(undefined),
-}));
-
-vi.mock("@mbe/jobs", () => {
-  class MockJobScheduler {
-    schedule = mockSchedule;
-    cancel = mockCancel;
-  }
-  return {
-    JobScheduler: MockJobScheduler,
-    JOB_TYPES: {
-      BOOKING_REMINDER: "booking-reminder",
-      DAY_OF_REMINDER: "day-of-reminder",
-    },
-  };
-});
-
-const { mockSendConfirmation } = vi.hoisted(() => ({
-  mockSendConfirmation: vi.fn().mockResolvedValue(undefined),
-}));
-
-vi.mock("@mbe/notifications", () => {
-  class MockResendNotificationAdapter {
-    sendBookingConfirmation = mockSendConfirmation;
-    sendBookingReminder = vi.fn().mockResolvedValue(undefined);
-    sendBookingModified = vi.fn().mockResolvedValue(undefined);
-    sendBookingCancelled = vi.fn().mockResolvedValue(undefined);
-  }
-  class MockTwilioSmsAdapter {}
-  class MockNotificationDispatcher {
-    sendBookingConfirmation = vi.fn().mockResolvedValue(undefined);
-    sendBookingReminder = vi.fn().mockResolvedValue(undefined);
-    sendBookingModified = vi.fn().mockResolvedValue(undefined);
-    sendBookingCancelled = vi.fn().mockResolvedValue(undefined);
-  }
-  return {
-    ResendNotificationAdapter: MockResendNotificationAdapter,
-    TwilioSmsAdapter: MockTwilioSmsAdapter,
-    NotificationDispatcher: MockNotificationDispatcher,
-  };
-});
-
-vi.mock("resend", () => ({
-  Resend: vi.fn().mockImplementation(() => ({
-    emails: { send: vi.fn().mockResolvedValue({ id: "email_1" }) },
-  })),
-}));
-
-vi.mock("../services/venue.js", () => ({
-  venueService: {
-    getById: vi.fn(),
-  },
-}));
-
-import {
-  scheduleBookingNotifications,
-  cancelBookingReminders,
-  rescheduleBookingReminders,
-  createBookingNotifier,
-} from "./booking-notifications.js";
+import { createBookingNotifier, createDefaultBookingNotifier } from "./booking-notifications.js";
 import type { BookingNotifierDeps } from "./booking-notifications.js";
-import { venueService } from "./venue.js";
 
 const mockVenue = {
   id: "venue-1",
@@ -103,191 +40,13 @@ function makeReservation(overrides: Record<string, unknown> = {}) {
   };
 }
 
-describe("scheduleBookingNotifications", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    vi.mocked(venueService.getById).mockResolvedValue(mockVenue as never);
-  });
+describe("createDefaultBookingNotifier", () => {
+  it("returns a BookingNotifier without constructing deps (no Redis connection at build time)", () => {
+    const notifier = createDefaultBookingNotifier();
 
-  it("sends confirmation email when guest has email and venue exists", async () => {
-    const reservation = makeReservation();
-    const manageToken = "token-abc";
-
-    await scheduleBookingNotifications(reservation as never, manageToken);
-
-    expect(mockSendConfirmation).toHaveBeenCalledWith(
-      expect.objectContaining({
-        reservationId: "res-1",
-        guestEmail: "jane@example.com",
-        venueName: "The Oak Table",
-        manageToken: "token-abc",
-        partySize: 2,
-      })
-    );
-  });
-
-  it("skips confirmation when guestEmail is null", async () => {
-    const reservation = makeReservation({ guestEmail: null });
-
-    await scheduleBookingNotifications(reservation as never, "token");
-
-    expect(mockSendConfirmation).not.toHaveBeenCalled();
-  });
-
-  it("skips confirmation when venue not found", async () => {
-    vi.mocked(venueService.getById).mockResolvedValue(null);
-    const reservation = makeReservation();
-
-    await scheduleBookingNotifications(reservation as never, "token");
-
-    expect(mockSendConfirmation).not.toHaveBeenCalled();
-  });
-
-  it("schedules day-before reminder 24h before startTime", async () => {
-    const startMs = Date.now() + 30 * 60 * 60 * 1000; // 30h from now
-    const startTime = new Date(startMs).toISOString();
-    const reservation = makeReservation({ startTime });
-
-    await scheduleBookingNotifications(reservation as never, "token");
-
-    const dayBeforeDelayMs = startMs - Date.now() - 24 * 60 * 60 * 1000;
-
-    expect(mockSchedule).toHaveBeenCalledWith(
-      "booking-reminder",
-      expect.objectContaining({ reservationId: "res-1" }),
-      expect.closeTo(dayBeforeDelayMs, -2) // within 1s
-    );
-  });
-
-  it("schedules day-of reminder 2h before startTime", async () => {
-    const startMs = Date.now() + 30 * 60 * 60 * 1000; // 30h from now
-    const startTime = new Date(startMs).toISOString();
-    const reservation = makeReservation({ startTime });
-
-    await scheduleBookingNotifications(reservation as never, "token");
-
-    const dayOfDelayMs = startMs - Date.now() - 2 * 60 * 60 * 1000;
-
-    expect(mockSchedule).toHaveBeenCalledWith(
-      "day-of-reminder",
-      expect.objectContaining({ reservationId: "res-1" }),
-      expect.closeTo(dayOfDelayMs, -2)
-    );
-  });
-
-  it("skips day-before reminder when startTime is less than 24h away", async () => {
-    const startMs = Date.now() + 10 * 60 * 60 * 1000; // 10h from now (< 24h)
-    const reservation = makeReservation({ startTime: new Date(startMs).toISOString() });
-
-    await scheduleBookingNotifications(reservation as never, "token");
-
-    expect(mockSchedule).not.toHaveBeenCalledWith(
-      "booking-reminder",
-      expect.anything(),
-      expect.anything()
-    );
-  });
-
-  it("skips day-of reminder when startTime is less than 2h away", async () => {
-    const startMs = Date.now() + 1 * 60 * 60 * 1000; // 1h from now (< 2h)
-    const reservation = makeReservation({ startTime: new Date(startMs).toISOString() });
-
-    await scheduleBookingNotifications(reservation as never, "token");
-
-    expect(mockSchedule).not.toHaveBeenCalledWith(
-      "day-of-reminder",
-      expect.anything(),
-      expect.anything()
-    );
-  });
-
-  it("skips all reminders for walk-ins (startTime in the past)", async () => {
-    const reservation = makeReservation({ startTime: new Date(Date.now() - 1000).toISOString() });
-
-    await scheduleBookingNotifications(reservation as never, "token");
-
-    expect(mockSchedule).not.toHaveBeenCalled();
-  });
-
-  it("passes channel=both when guestPhone and guestEmail present", async () => {
-    const reservation = makeReservation();
-
-    await scheduleBookingNotifications(reservation as never, "token");
-
-    expect(mockSchedule).toHaveBeenCalledWith(
-      "booking-reminder",
-      expect.objectContaining({ channel: "both" }),
-      expect.any(Number)
-    );
-  });
-
-  it("passes channel=email when only guestEmail present", async () => {
-    const reservation = makeReservation({ guestPhone: null });
-
-    await scheduleBookingNotifications(reservation as never, "token");
-
-    expect(mockSchedule).toHaveBeenCalledWith(
-      "booking-reminder",
-      expect.objectContaining({ channel: "email" }),
-      expect.any(Number)
-    );
-  });
-
-  it("skips reminders when venueId is null", async () => {
-    const reservation = makeReservation({ venueId: null });
-
-    await scheduleBookingNotifications(reservation as never, "token");
-
-    expect(mockSchedule).not.toHaveBeenCalled();
-  });
-});
-
-describe("cancelBookingReminders", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it("cancels both reminder jobs", async () => {
-    await cancelBookingReminders("res-1");
-
-    expect(mockCancel).toHaveBeenCalledWith("booking-reminder:res-1");
-    expect(mockCancel).toHaveBeenCalledWith("day-of-reminder:res-1");
-  });
-
-  it("does not throw when jobs do not exist", async () => {
-    mockCancel.mockRejectedValueOnce(new Error("Job not found"));
-    mockCancel.mockRejectedValueOnce(new Error("Job not found"));
-
-    await expect(cancelBookingReminders("res-1")).resolves.not.toThrow();
-  });
-});
-
-describe("rescheduleBookingReminders", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    vi.mocked(venueService.getById).mockResolvedValue(mockVenue as never);
-  });
-
-  it("cancels old jobs then schedules new ones", async () => {
-    const reservation = makeReservation();
-
-    await rescheduleBookingReminders(reservation as never, "token");
-
-    // Should cancel old jobs
-    expect(mockCancel).toHaveBeenCalledWith("booking-reminder:res-1");
-    expect(mockCancel).toHaveBeenCalledWith("day-of-reminder:res-1");
-
-    // Should schedule new jobs
-    expect(mockSchedule).toHaveBeenCalledWith(
-      "booking-reminder",
-      expect.any(Object),
-      expect.any(Number)
-    );
-    expect(mockSchedule).toHaveBeenCalledWith(
-      "day-of-reminder",
-      expect.any(Object),
-      expect.any(Number)
-    );
+    expect(typeof notifier.scheduleBookingNotifications).toBe("function");
+    expect(typeof notifier.cancelBookingReminders).toBe("function");
+    expect(typeof notifier.rescheduleBookingReminders).toBe("function");
   });
 });
 
@@ -364,6 +123,66 @@ describe("createBookingNotifier", () => {
     expect(deps.notificationAdapter.sendBookingConfirmation).not.toHaveBeenCalled();
   });
 
+  it("scheduleBookingNotifications skips confirmation when guestEmail is null", async () => {
+    const deps = makeDeps();
+    const notifier = createBookingNotifier(deps);
+    const reservation = makeReservation({ guestEmail: null });
+
+    await notifier.scheduleBookingNotifications(reservation as never, "token");
+
+    expect(deps.notificationAdapter.sendBookingConfirmation).not.toHaveBeenCalled();
+  });
+
+  it("scheduleBookingNotifications skips reminders when venueId is null", async () => {
+    const deps = makeDeps();
+    const notifier = createBookingNotifier(deps);
+    const reservation = makeReservation({ venueId: null });
+
+    await notifier.scheduleBookingNotifications(reservation as never, "token");
+
+    expect(deps.scheduler.schedule).not.toHaveBeenCalled();
+  });
+
+  it("scheduleBookingNotifications skips all reminders for walk-ins (startTime in the past)", async () => {
+    const deps = makeDeps();
+    const notifier = createBookingNotifier(deps);
+    const reservation = makeReservation({ startTime: new Date(Date.now() - 1000).toISOString() });
+
+    await notifier.scheduleBookingNotifications(reservation as never, "token");
+
+    expect(deps.scheduler.schedule).not.toHaveBeenCalled();
+  });
+
+  it("scheduleBookingNotifications skips day-before reminder when startTime is less than 24h away", async () => {
+    const deps = makeDeps();
+    const notifier = createBookingNotifier(deps);
+    const startMs = Date.now() + 10 * 60 * 60 * 1000; // 10h from now (< 24h)
+    const reservation = makeReservation({ startTime: new Date(startMs).toISOString() });
+
+    await notifier.scheduleBookingNotifications(reservation as never, "token");
+
+    expect(deps.scheduler.schedule).not.toHaveBeenCalledWith(
+      "booking-reminder",
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it("scheduleBookingNotifications skips day-of reminder when startTime is less than 2h away", async () => {
+    const deps = makeDeps();
+    const notifier = createBookingNotifier(deps);
+    const startMs = Date.now() + 1 * 60 * 60 * 1000; // 1h from now (< 2h)
+    const reservation = makeReservation({ startTime: new Date(startMs).toISOString() });
+
+    await notifier.scheduleBookingNotifications(reservation as never, "token");
+
+    expect(deps.scheduler.schedule).not.toHaveBeenCalledWith(
+      "day-of-reminder",
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
   it("scheduleBookingNotifications schedules both reminders for future booking", async () => {
     const deps = makeDeps();
     const notifier = createBookingNotifier(deps);
@@ -372,15 +191,18 @@ describe("createBookingNotifier", () => {
 
     await notifier.scheduleBookingNotifications(reservation as never, "token");
 
+    const dayBeforeDelayMs = startMs - Date.now() - 24 * 60 * 60 * 1000;
+    const dayOfDelayMs = startMs - Date.now() - 2 * 60 * 60 * 1000;
+
     expect(deps.scheduler.schedule).toHaveBeenCalledWith(
       "booking-reminder",
       expect.objectContaining({ reservationId: "res-1" }),
-      expect.any(Number)
+      expect.closeTo(dayBeforeDelayMs, -2) // within 1s
     );
     expect(deps.scheduler.schedule).toHaveBeenCalledWith(
       "day-of-reminder",
       expect.objectContaining({ reservationId: "res-1" }),
-      expect.any(Number)
+      expect.closeTo(dayOfDelayMs, -2)
     );
   });
 

--- a/services/reservations/src/services/booking-notifications.ts
+++ b/services/reservations/src/services/booking-notifications.ts
@@ -121,70 +121,47 @@ export function createBookingNotifier(deps: BookingNotifierDeps): BookingNotifie
   return { scheduleBookingNotifications, cancelBookingReminders, rescheduleBookingReminders };
 }
 
-// ─── Module-level singletons (kept for backward compat with existing routes) ─
+// ─── Default notifier (env-backed deps, constructed per app instance) ────────
 
-// Lazy scheduler
-let _scheduler: JobScheduler | null = null;
-function getScheduler(): JobScheduler {
-  if (!_scheduler) {
-    _scheduler = new JobScheduler({ redisUrl: REDIS_URL });
+/**
+ * Creates the production BookingNotifier backed by Resend + BullMQ.
+ * Dep construction is deferred to first use: JobScheduler opens a Redis
+ * connection in its constructor, and buildApp() must stay side-effect-free
+ * for tests that don't inject a stub.
+ */
+export function createDefaultBookingNotifier(): BookingNotifier {
+  let notifier: BookingNotifier | null = null;
+
+  function getNotifier(): BookingNotifier {
+    if (!notifier) {
+      const resendClient = process.env.RESEND_API_KEY
+        ? (new Resend(process.env.RESEND_API_KEY) as unknown as {
+            emails: {
+              send(payload: Record<string, unknown>): Promise<{ id: string }>;
+            };
+          })
+        : null;
+
+      const notificationAdapter: NotificationPort = new ResendNotificationAdapter({
+        resend: resendClient,
+        fromAddress: process.env.EMAIL_FROM ?? "reservations@mattbutlerengineering.com",
+        manageBaseUrl: MANAGE_BASE_URL,
+      });
+
+      notifier = createBookingNotifier({
+        notificationAdapter,
+        scheduler: new JobScheduler({ redisUrl: REDIS_URL }),
+        getVenue: (venueId) => venueService.getById(venueId),
+      });
+    }
+    return notifier;
   }
-  return _scheduler;
-}
 
-function createDefaultNotificationAdapter(): NotificationPort {
-  const resendClient = process.env.RESEND_API_KEY
-    ? (new Resend(process.env.RESEND_API_KEY) as unknown as {
-        emails: {
-          send(payload: Record<string, unknown>): Promise<{ id: string }>;
-        };
-      })
-    : null;
-
-  return new ResendNotificationAdapter({
-    resend: resendClient,
-    fromAddress: process.env.EMAIL_FROM ?? "reservations@mattbutlerengineering.com",
-    manageBaseUrl: MANAGE_BASE_URL,
-  });
-}
-
-let _defaultNotifier: BookingNotifier | null = null;
-
-function getDefaultNotifier(): BookingNotifier {
-  if (!_defaultNotifier) {
-    _defaultNotifier = createBookingNotifier({
-      notificationAdapter: createDefaultNotificationAdapter(),
-      scheduler: getScheduler(),
-      getVenue: (venueId) => venueService.getById(venueId),
-    });
-  }
-  return _defaultNotifier;
-}
-
-/**
- * Send booking confirmation and schedule day-before + day-of reminder jobs.
- * Walk-ins (startTime in the past) skip reminders.
- */
-export async function scheduleBookingNotifications(
-  reservation: Reservation,
-  manageToken: string
-): Promise<void> {
-  return getDefaultNotifier().scheduleBookingNotifications(reservation, manageToken);
-}
-
-/**
- * Cancel pending reminder jobs for a reservation (on cancellation).
- */
-export async function cancelBookingReminders(reservationId: string): Promise<void> {
-  return getDefaultNotifier().cancelBookingReminders(reservationId);
-}
-
-/**
- * Cancel existing reminders and reschedule to new times (on rescheduling).
- */
-export async function rescheduleBookingReminders(
-  reservation: Reservation,
-  manageToken: string
-): Promise<void> {
-  return getDefaultNotifier().rescheduleBookingReminders(reservation, manageToken);
+  return {
+    scheduleBookingNotifications: (reservation, manageToken) =>
+      getNotifier().scheduleBookingNotifications(reservation, manageToken),
+    cancelBookingReminders: (reservationId) => getNotifier().cancelBookingReminders(reservationId),
+    rescheduleBookingReminders: (reservation, manageToken) =>
+      getNotifier().rescheduleBookingReminders(reservation, manageToken),
+  };
 }


### PR DESCRIPTION
## Summary
Closes #1938

- `bookingNotifier?: BookingNotifier` added to `ReservationsAppOptions`; constructed in `buildApp` and decorated on the Fastify instance
- Routes (`public-reservations`, `cancel-reservation`, `modify-reservation`) call `fastify.bookingNotifier.*` — module-level imports removed
- Module-level singletons (`_scheduler`, `_defaultNotifier`, `getScheduler`, `getDefaultNotifier`, `createDefaultNotificationAdapter`) and the three wrapper exports deleted
- New `createDefaultBookingNotifier()` defers Resend/JobScheduler construction to first call — `JobScheduler`'s constructor opens a Redis connection, and bare `buildApp()` in tests must stay side-effect-free
- Route tests inject a 3-`vi.fn()` stub via `buildApp({ bookingNotifier })` — no `vi.mock("@mbe/notifications")` / `vi.mock("resend")` / `vi.mock("@mbe/jobs")` needed
- Wrapper-path test block deleted; uncovered edge cases (null email/venueId, walk-ins, <24h/<2h windows, exact reminder-delay `closeTo` assertions) ported to the injection-clean factory suite
- Fire-and-forget `.catch(() => {})` on the rewritten lines now logs via `fastify.log.error`

### Deviation from issue text
The issue suggested reusing the already-wired `notificationPort` as the notifier's adapter. Not type-possible: `NotificationDispatcher.sendBookingConfirmation(input, preference)` (2 args) doesn't satisfy `NotificationPort.sendBookingConfirmation(input)` (1 arg). Kept a dedicated Resend adapter inside the default factory — identical to prior production behavior.

### Follow-up candidate
Per-app `JobScheduler` has no `onClose` teardown (pre-existing: the old singleton was never closed either). Worth a small follow-up to dispose the scheduler on app close.

## Test plan
- [x] 642 tests passing in services/reservations (TDD: stub-injection tests written RED first)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] Code review passed (Standards + Spec, parallel subagents)