### PR TITLE
feat: issue agent frontmatter parsed into mbe agent run overrides

### DIFF
--- a/.claude/skills/issue-worker/SKILL.md
+++ b/.claude/skills/issue-worker/SKILL.md
@@ -111,13 +111,25 @@ Use the issue labels and description to set the right budget:
 - `feature` or standard issues: `--max-budget 1.50`
 - Complex issues (multi-file, new service, architecture): `--max-budget 2.00`
 
+### Step 3c: Parse Agent Frontmatter
+
+Check the issue body for per-issue agent overrides (see `docs/agents/issue-tracker.md` → "Agent frontmatter"):
+
+```bash
+FRONTMATTER_FLAGS=$(gh issue view <NUMBER> --json body -q .body | mbe agent frontmatter)
+```
+
+The command prints `mbe agent run` flags (e.g. `--model claude-haiku-4-5-20251001 --max-budget 0.5`) or an empty line when the issue has no usable agent block. Warnings go to stderr; the command always exits 0, so this step can never break the loop.
+
 ### Step 4: Delegate to Agent
 
 Run the implementation in an isolated worktree:
 
 ```bash
-mbe agent run "<task description synthesized from issue>" --max-budget <budget from step 3b> --adapter auto
+mbe agent run "<task description synthesized from issue>" --max-budget <budget from step 3b> --adapter auto $FRONTMATTER_FLAGS
 ```
+
+`$FRONTMATTER_FLAGS` goes last — later flags win, so issue frontmatter overrides the step 3b budget heuristic and the default adapter.
 
 The `mbe agent run` command will:
 

--- a/.claude/skills/issue-worker/SKILL.md
+++ b/.claude/skills/issue-worker/SKILL.md
@@ -126,10 +126,12 @@ The command prints `mbe agent run` flags (e.g. `--model claude-haiku-4-5-2025100
 Run the implementation in an isolated worktree:
 
 ```bash
-mbe agent run "<task description synthesized from issue>" --max-budget <budget from step 3b> --adapter auto $FRONTMATTER_FLAGS
+eval "mbe agent run \"\$TASK_DESCRIPTION\" --max-budget <budget from step 3b> --adapter auto $FRONTMATTER_FLAGS"
 ```
 
 `$FRONTMATTER_FLAGS` goes last — later flags win, so issue frontmatter overrides the step 3b budget heuristic and the default adapter.
+
+The `eval` is required: this shell is zsh, which does NOT word-split an unquoted `$FRONTMATTER_FLAGS` — without eval the whole flag string is passed as one unknown option and commander exits 1. The eval is safe because `mbe agent frontmatter` only ever emits validated enum/numeric values, never raw issue text.
 
 The `mbe agent run` command will:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ mbe agent logs <id>                               # Stream SSE events
 mbe agent cancel <id>                             # Cancel running session
 mbe agent delete <id>                             # Delete session + cleanup
 mbe agent orchestrate "Big task"                  # Decompose → parallel sessions → PRs
+mbe agent frontmatter                             # stdin issue body → mbe agent run flags (yaml agent block)
 
 # Development
 mbe stats                                         # Agent performance metrics

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,47 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Agent frontmatter
+
+An issue body may carry a fenced yaml block tagged `agent` declaring per-issue overrides for `mbe agent run`. The issue-worker loop parses it via `mbe agent frontmatter`; invalid or missing blocks fall back to the model router.
+
+````markdown
+```yaml agent
+model: haiku # haiku | sonnet | opus — overrides the model router
+budget: 0.50 # max USD (capped at 5.00)
+max_turns: 30 # positive integer
+adapter: auto # claude | gemini | opencode | auto
+```
+````
+
+All fields are optional. Unknown keys are ignored with a warning. Malformed yaml or invalid values never fail the loop — valid fields are kept, invalid ones are dropped with a stderr warning.
+
+To resolve a body into flags:
+
+```bash
+gh issue view <number> --json body -q .body | mbe agent frontmatter
+# → --model claude-haiku-4-5-20251001 --max-budget 0.5 --max-turns 30 --adapter auto
+# → (empty line when no usable overrides)
+```
+
+Append the output to the end of the `mbe agent run` invocation — later flags win, so frontmatter overrides heuristic defaults.

--- a/tools/cli/CLAUDE.md
+++ b/tools/cli/CLAUDE.md
@@ -58,6 +58,15 @@ mbe agent cancel <id>      # Cancel running session
 mbe agent orchestrate "task"  # Decompose → parallel sessions → PRs
 ```
 
+### Issue frontmatter
+
+````bash
+gh issue view <n> --json body -q .body | mbe agent frontmatter
+# Parses the ```yaml agent block from an issue body into mbe agent run flags.
+# Empty output = no usable overrides (fall back to model router).
+# Warnings → stderr, always exits 0. Schema: docs/agents/issue-tracker.md
+````
+
 ### Context Management
 
 ```bash

--- a/tools/cli/src/__tests__/agent-frontmatter.test.ts
+++ b/tools/cli/src/__tests__/agent-frontmatter.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for the `mbe agent frontmatter` subcommand (#2021).
+ * Reads an issue body (--body-file or stdin), prints `mbe agent run` flags
+ * to stdout and warnings to stderr. Always exits 0 — the issue-worker loop
+ * must never crash on a bad agent block.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { frontmatterCommand } from "../commands/agent-frontmatter.js";
+
+describe("agent frontmatter subcommand", () => {
+  let tmpDir: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    tmpDir = mkdtempSync(join(tmpdir(), "frontmatter-test-"));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const writeBody = (content: string): string => {
+    const file = join(tmpDir, "body.md");
+    writeFileSync(file, content);
+    return file;
+  };
+
+  it("prints flags for a valid agent block", async () => {
+    const file = writeBody("## Task\n\n```yaml agent\nmodel: haiku\nbudget: 0.5\n```\n");
+    await frontmatterCommand.parseAsync(["--body-file", file], { from: "user" });
+    expect(logSpy).toHaveBeenCalledWith("--model claude-haiku-4-5-20251001 --max-budget 0.5");
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("prints an empty line when no agent block exists", async () => {
+    const file = writeBody("## Task\n\nNo block here.\n");
+    await frontmatterCommand.parseAsync(["--body-file", file], { from: "user" });
+    expect(logSpy).toHaveBeenCalledWith("");
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("warns to stderr and prints empty flags on malformed yaml", async () => {
+    const file = writeBody("```yaml agent\nmodel: [unclosed\n```\n");
+    await frontmatterCommand.parseAsync(["--body-file", file], { from: "user" });
+    expect(logSpy).toHaveBeenCalledWith("");
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("warns but still prints valid flags when some fields are invalid", async () => {
+    const file = writeBody("```yaml agent\nmodel: gpt-5\nadapter: auto\n```\n");
+    await frontmatterCommand.parseAsync(["--body-file", file], { from: "user" });
+    expect(logSpy).toHaveBeenCalledWith("--adapter auto");
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("warns and prints empty flags for an unreadable body file", async () => {
+    await frontmatterCommand.parseAsync(["--body-file", join(tmpDir, "missing.md")], {
+      from: "user",
+    });
+    expect(logSpy).toHaveBeenCalledWith("");
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});

--- a/tools/cli/src/__tests__/agent-frontmatter.test.ts
+++ b/tools/cli/src/__tests__/agent-frontmatter.test.ts
@@ -60,6 +60,35 @@ describe("agent frontmatter subcommand", () => {
     expect(warnSpy).toHaveBeenCalled();
   });
 
+  it("reads the issue body from piped stdin", async () => {
+    const { Readable } = await import("node:stream");
+    const fake = Readable.from(["```yaml agent\nmodel: opus\n```\n"]);
+    Object.defineProperty(fake, "isTTY", { value: false });
+    const original = Object.getOwnPropertyDescriptor(process, "stdin")!;
+    Object.defineProperty(process, "stdin", { value: fake, configurable: true });
+    try {
+      await frontmatterCommand.parseAsync([], { from: "user" });
+    } finally {
+      Object.defineProperty(process, "stdin", original);
+    }
+    expect(logSpy).toHaveBeenCalledWith("--model claude-opus-4-6");
+  });
+
+  it("warns and prints empty flags instead of hanging when stdin is a TTY", async () => {
+    const { Readable } = await import("node:stream");
+    const fake = Readable.from([]);
+    Object.defineProperty(fake, "isTTY", { value: true });
+    const original = Object.getOwnPropertyDescriptor(process, "stdin")!;
+    Object.defineProperty(process, "stdin", { value: fake, configurable: true });
+    try {
+      await frontmatterCommand.parseAsync([], { from: "user" });
+    } finally {
+      Object.defineProperty(process, "stdin", original);
+    }
+    expect(logSpy).toHaveBeenCalledWith("");
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
   it("warns and prints empty flags for an unreadable body file", async () => {
     await frontmatterCommand.parseAsync(["--body-file", join(tmpDir, "missing.md")], {
       from: "user",

--- a/tools/cli/src/__tests__/agent.test.ts
+++ b/tools/cli/src/__tests__/agent.test.ts
@@ -17,6 +17,14 @@ vi.mock("@mbe/agent-core", () => ({
   runEvalSuite: vi.fn(),
   resolveBudget: vi.fn(() => ({ budgetUsd: 1.0, maxTurns: 50 })),
   resolveModel: vi.fn(() => "claude-sonnet-4-6"),
+  resolveModelId: vi.fn(
+    (tier: string) =>
+      ({
+        haiku: "claude-haiku-4-5-20251001",
+        sonnet: "claude-sonnet-4-6",
+        opus: "claude-opus-4-6",
+      })[tier]
+  ),
   routeModelWithReason: vi.fn(() => ({
     tier: "standard",
     modelId: "claude-sonnet-4-6",
@@ -168,6 +176,33 @@ describe("agent command", () => {
       const config = (core.runSession as ReturnType<typeof vi.fn>).mock.calls[0][0];
       expect(config.maxBudgetUsd).toBe(1.0);
       expect(config.maxTurns).toBe(50);
+    });
+
+    it("honors an explicit --model even when it equals the default (frontmatter override, #2021)", async () => {
+      // Smart router would pick haiku; an explicit --model must pin the model
+      // even when the value matches DEFAULT_SESSION_CONFIG.model.
+      vi.mocked(core.resolveModel as ReturnType<typeof vi.fn>).mockReturnValue(
+        "claude-haiku-4-5-20251001"
+      );
+      vi.mocked(core.runSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+        status: "succeeded",
+        branchName: "b",
+        durationMs: 100,
+        costUsd: 0,
+        numTurns: 1,
+        tokenUsage: { inputTokens: 1, outputTokens: 1 },
+        prUrl: null,
+        errors: [],
+        resultText: null,
+      });
+
+      const { agentCommand } = await import("../commands/agent.js");
+      await agentCommand.parseAsync(["run", "Pinned task", "--model", "claude-sonnet-4-6"], {
+        from: "user",
+      });
+
+      const config = (core.runSession as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(config.model).toBe("claude-sonnet-4-6");
     });
 
     it("prints verbose agent events when --verbose flag is set", async () => {

--- a/tools/cli/src/__tests__/issue-frontmatter.test.ts
+++ b/tools/cli/src/__tests__/issue-frontmatter.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for issue agent frontmatter parsing (#2021).
+ * An issue body may carry a fenced ```yaml agent block with per-issue
+ * overrides for `mbe agent run`. Parsing must never throw — malformed
+ * input degrades to "no overrides" with warnings.
+ */
+import { describe, it, expect } from "vitest";
+import { parseAgentFrontmatter, flagsFromOverrides } from "../issue-frontmatter.js";
+
+const body = (block: string) => `## What to build
+
+Some feature.
+
+${block}
+
+## Acceptance criteria
+
+- [ ] works
+`;
+
+describe("parseAgentFrontmatter", () => {
+  it("returns no overrides when the body has no agent block", () => {
+    const result = parseAgentFrontmatter(body(""));
+    expect(result.overrides).toBeNull();
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("ignores plain yaml blocks without the agent tag", () => {
+    const result = parseAgentFrontmatter(body("```yaml\nmodel: haiku\n```"));
+    expect(result.overrides).toBeNull();
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("parses a full agent block", () => {
+    const result = parseAgentFrontmatter(
+      body("```yaml agent\nmodel: haiku\nbudget: 0.50\nmax_turns: 30\nadapter: auto\n```")
+    );
+    expect(result.warnings).toEqual([]);
+    expect(result.overrides).toEqual({
+      model: "haiku",
+      budget: 0.5,
+      maxTurns: 30,
+      adapter: "auto",
+    });
+  });
+
+  it("parses a partial agent block (only model)", () => {
+    const result = parseAgentFrontmatter(body("```yaml agent\nmodel: opus\n```"));
+    expect(result.warnings).toEqual([]);
+    expect(result.overrides).toEqual({ model: "opus" });
+  });
+
+  it("returns null overrides with a warning on malformed yaml", () => {
+    const result = parseAgentFrontmatter(body("```yaml agent\nmodel: [unclosed\n```"));
+    expect(result.overrides).toBeNull();
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  it("rejects an unknown model tier with a warning, keeps valid fields", () => {
+    const result = parseAgentFrontmatter(body("```yaml agent\nmodel: gpt-5\nbudget: 1.00\n```"));
+    expect(result.overrides).toEqual({ budget: 1.0 });
+    expect(result.warnings.some((w) => w.includes("model"))).toBe(true);
+  });
+
+  it("rejects an unknown adapter with a warning", () => {
+    const result = parseAgentFrontmatter(body("```yaml agent\nadapter: copilot\n```"));
+    expect(result.overrides).toBeNull();
+    expect(result.warnings.some((w) => w.includes("adapter"))).toBe(true);
+  });
+
+  it("rejects non-positive budget and max_turns", () => {
+    const result = parseAgentFrontmatter(body("```yaml agent\nbudget: -1\nmax_turns: 0\n```"));
+    expect(result.overrides).toBeNull();
+    expect(result.warnings.length).toBe(2);
+  });
+
+  it("caps budget at the safety ceiling with a warning", () => {
+    const result = parseAgentFrontmatter(body("```yaml agent\nbudget: 50\n```"));
+    expect(result.overrides).toEqual({ budget: 5 });
+    expect(result.warnings.some((w) => w.includes("capped"))).toBe(true);
+  });
+
+  it("warns on unknown keys without failing known ones", () => {
+    const result = parseAgentFrontmatter(
+      body("```yaml agent\nmodel: sonnet\nverify: pnpm test\n```")
+    );
+    expect(result.overrides).toEqual({ model: "sonnet" });
+    expect(result.warnings.some((w) => w.includes("verify"))).toBe(true);
+  });
+
+  it("uses only the first agent block when several exist", () => {
+    const result = parseAgentFrontmatter(
+      body("```yaml agent\nmodel: haiku\n```\n\n```yaml agent\nmodel: opus\n```")
+    );
+    expect(result.overrides).toEqual({ model: "haiku" });
+    expect(result.warnings.some((w) => w.includes("multiple"))).toBe(true);
+  });
+
+  it("never throws on adversarial input", () => {
+    for (const evil of ["```yaml agent", "```yaml agent\n```", " ", ""]) {
+      expect(() => parseAgentFrontmatter(evil)).not.toThrow();
+    }
+  });
+});
+
+describe("flagsFromOverrides", () => {
+  it("returns empty array for null overrides", () => {
+    expect(flagsFromOverrides(null)).toEqual([]);
+  });
+
+  it("maps tier names to full model ids", () => {
+    expect(flagsFromOverrides({ model: "haiku" })).toEqual([
+      "--model",
+      "claude-haiku-4-5-20251001",
+    ]);
+  });
+
+  it("maps all fields to mbe agent run flags", () => {
+    expect(
+      flagsFromOverrides({ model: "sonnet", budget: 0.5, maxTurns: 30, adapter: "auto" })
+    ).toEqual([
+      "--model",
+      "claude-sonnet-4-6",
+      "--max-budget",
+      "0.5",
+      "--max-turns",
+      "30",
+      "--adapter",
+      "auto",
+    ]);
+  });
+});

--- a/tools/cli/src/commands/agent-frontmatter.ts
+++ b/tools/cli/src/commands/agent-frontmatter.ts
@@ -14,7 +14,7 @@ import { parseAgentFrontmatter, flagsFromOverrides } from "../issue-frontmatter.
 async function readStdin(): Promise<string> {
   const chunks: Buffer[] = [];
   for await (const chunk of process.stdin) {
-    chunks.push(chunk as Buffer);
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
   }
   return Buffer.concat(chunks).toString("utf-8");
 }
@@ -25,6 +25,14 @@ export const frontmatterCommand = new Command("frontmatter")
   )
   .option("--body-file <path>", "Read the issue body from a file instead of stdin")
   .action(async (options: { bodyFile?: string }) => {
+    if (!options.bodyFile && process.stdin.isTTY) {
+      console.warn(
+        "frontmatter: stdin is a terminal and no --body-file given; pipe an issue body in"
+      );
+      console.log("");
+      return;
+    }
+
     let body: string;
     try {
       body = options.bodyFile ? readFileSync(options.bodyFile, "utf-8") : await readStdin();

--- a/tools/cli/src/commands/agent-frontmatter.ts
+++ b/tools/cli/src/commands/agent-frontmatter.ts
@@ -1,0 +1,42 @@
+/**
+ * `mbe agent frontmatter` — parse the yaml agent block from an issue body
+ * into `mbe agent run` flags (#2021).
+ *
+ * Reads the body from --body-file or stdin. Prints the flag string to
+ * stdout (empty when there are no usable overrides) and warnings to
+ * stderr. Always exits 0: the issue-worker loop falls back to the model
+ * router on empty output, so failure here must never crash the loop.
+ */
+import { Command } from "commander";
+import { readFileSync } from "node:fs";
+import { parseAgentFrontmatter, flagsFromOverrides } from "../issue-frontmatter.js";
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+export const frontmatterCommand = new Command("frontmatter")
+  .description(
+    "Parse the yaml agent block from an issue body (stdin or --body-file) into mbe agent run flags"
+  )
+  .option("--body-file <path>", "Read the issue body from a file instead of stdin")
+  .action(async (options: { bodyFile?: string }) => {
+    let body: string;
+    try {
+      body = options.bodyFile ? readFileSync(options.bodyFile, "utf-8") : await readStdin();
+    } catch (err) {
+      console.warn(`frontmatter: cannot read issue body: ${(err as Error).message}`);
+      console.log("");
+      return;
+    }
+
+    const { overrides, warnings } = parseAgentFrontmatter(body);
+    for (const warning of warnings) {
+      console.warn(`frontmatter: ${warning}`);
+    }
+    console.log(flagsFromOverrides(overrides).join(" "));
+  });

--- a/tools/cli/src/commands/agent.ts
+++ b/tools/cli/src/commands/agent.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import { resolve } from "node:path";
 import type { SessionConfig, SessionEvent } from "@mbe/agent-core";
 import { agentEvalCommand } from "./agent-eval.js";
+import { frontmatterCommand } from "./agent-frontmatter.js";
 import {
   runSession,
   DEFAULT_SESSION_CONFIG,
@@ -1032,3 +1033,6 @@ async function streamEvents(sessionId: string): Promise<void> {
 // Registered last so `agentCommand.commands[0]` remains the `run` command,
 // which tests address positionally.
 agentCommand.addCommand(agentEvalCommand);
+
+// ── Issue frontmatter: mbe agent frontmatter (#2021) ─────────────────────
+agentCommand.addCommand(frontmatterCommand);

--- a/tools/cli/src/commands/agent.ts
+++ b/tools/cli/src/commands/agent.ts
@@ -209,7 +209,8 @@ agentCommand
         adapter: string;
         pr: boolean;
         verbose: boolean;
-      }
+      },
+      command: Command
     ) => {
       const repoPath = resolve(process.cwd());
       const adapterType = options.adapter;
@@ -226,9 +227,12 @@ agentCommand
       const smartBudget = resolveBudget(task);
       const smartModel = resolveModel(task);
 
-      const isDefaultModel = options.model === DEFAULT_SESSION_CONFIG.model;
-      const isDefaultBudget = options.maxBudget === String(DEFAULT_SESSION_CONFIG.maxBudgetUsd);
-      const isDefaultTurns = options.maxTurns === String(DEFAULT_SESSION_CONFIG.maxTurns);
+      // Detect overrides by option SOURCE, not value-equality with defaults:
+      // an explicit --model equal to the default (e.g. from issue frontmatter,
+      // #2021) must pin the model instead of falling through to the router.
+      const isDefaultModel = command.getOptionValueSource("model") !== "cli";
+      const isDefaultBudget = command.getOptionValueSource("maxBudget") !== "cli";
+      const isDefaultTurns = command.getOptionValueSource("maxTurns") !== "cli";
 
       const resolvedModel = isDefaultModel ? smartModel : options.model;
       const resolvedMaxTurns = isDefaultTurns

--- a/tools/cli/src/issue-frontmatter.ts
+++ b/tools/cli/src/issue-frontmatter.ts
@@ -1,0 +1,131 @@
+/**
+ * Issue agent frontmatter (#2021).
+ *
+ * An issue body may carry a fenced ```yaml agent block declaring per-issue
+ * overrides for `mbe agent run`. Parsing never throws: malformed input
+ * degrades to null overrides plus warnings, so the issue-worker loop can
+ * always fall back to the model router.
+ */
+import { load } from "js-yaml";
+import { resolveModelId, type ModelTier } from "@mbe/agent-core";
+
+export type AdapterType = "auto" | "claude" | "gemini" | "opencode";
+
+export interface AgentOverrides {
+  model?: ModelTier;
+  budget?: number;
+  maxTurns?: number;
+  adapter?: AdapterType;
+}
+
+export interface ParseResult {
+  overrides: AgentOverrides | null;
+  warnings: string[];
+}
+
+const MODEL_TIERS: readonly string[] = ["haiku", "sonnet", "opus"];
+const ADAPTERS: readonly string[] = ["auto", "claude", "gemini", "opencode"];
+const KNOWN_KEYS: readonly string[] = ["model", "budget", "max_turns", "adapter"];
+/** Safety ceiling: a typo'd budget must not exceed the daily spend limit. */
+const MAX_BUDGET_USD = 5;
+
+const AGENT_BLOCK = /```yaml agent[ \t]*\n([\s\S]*?)```/g;
+
+export function parseAgentFrontmatter(issueBody: string): ParseResult {
+  const matches = [...issueBody.matchAll(AGENT_BLOCK)];
+  if (matches.length === 0) return { overrides: null, warnings: [] };
+
+  const warnings: string[] =
+    matches.length > 1 ? [`multiple agent blocks found; using the first of ${matches.length}`] : [];
+
+  let raw: unknown;
+  try {
+    raw = load(matches[0][1]);
+  } catch (err) {
+    return {
+      overrides: null,
+      warnings: [...warnings, `malformed yaml in agent block: ${(err as Error).message}`],
+    };
+  }
+
+  if (raw === null || raw === undefined) return { overrides: null, warnings };
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    return {
+      overrides: null,
+      warnings: [...warnings, "agent block must be a yaml mapping of key: value pairs"],
+    };
+  }
+
+  const entries = Object.entries(raw as Record<string, unknown>);
+  const fieldResults = entries.map(([key, value]) => validateField(key, value));
+  const allWarnings = [...warnings, ...fieldResults.flatMap((r) => r.warnings)];
+  const overrides = fieldResults.reduce<AgentOverrides>((acc, r) => ({ ...acc, ...r.fields }), {});
+
+  return {
+    overrides: Object.keys(overrides).length > 0 ? overrides : null,
+    warnings: allWarnings,
+  };
+}
+
+function validateField(
+  key: string,
+  value: unknown
+): { fields: AgentOverrides; warnings: string[] } {
+  switch (key) {
+    case "model":
+      if (typeof value === "string" && MODEL_TIERS.includes(value)) {
+        return { fields: { model: value as ModelTier }, warnings: [] };
+      }
+      return {
+        fields: {},
+        warnings: [`invalid model "${String(value)}"; expected one of: ${MODEL_TIERS.join(", ")}`],
+      };
+    case "budget": {
+      if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+        return {
+          fields: {},
+          warnings: [`invalid budget "${String(value)}"; expected a positive number (USD)`],
+        };
+      }
+      if (value > MAX_BUDGET_USD) {
+        return {
+          fields: { budget: MAX_BUDGET_USD },
+          warnings: [`budget ${value} capped at ${MAX_BUDGET_USD} USD`],
+        };
+      }
+      return { fields: { budget: value }, warnings: [] };
+    }
+    case "max_turns":
+      if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+        return {
+          fields: {},
+          warnings: [`invalid max_turns "${String(value)}"; expected a positive integer`],
+        };
+      }
+      return { fields: { maxTurns: value }, warnings: [] };
+    case "adapter":
+      if (typeof value === "string" && ADAPTERS.includes(value)) {
+        return { fields: { adapter: value as AdapterType }, warnings: [] };
+      }
+      return {
+        fields: {},
+        warnings: [`invalid adapter "${String(value)}"; expected one of: ${ADAPTERS.join(", ")}`],
+      };
+    default:
+      return {
+        fields: {},
+        warnings: [`unknown key "${key}" ignored (known: ${KNOWN_KEYS.join(", ")})`],
+      };
+  }
+}
+
+/** Map validated overrides to `mbe agent run` CLI flags. */
+export function flagsFromOverrides(overrides: AgentOverrides | null): string[] {
+  if (overrides === null) return [];
+  return [
+    ...(overrides.model ? ["--model", resolveModelId(overrides.model)] : []),
+    ...(overrides.budget !== undefined ? ["--max-budget", String(overrides.budget)] : []),
+    ...(overrides.maxTurns !== undefined ? ["--max-turns", String(overrides.maxTurns)] : []),
+    ...(overrides.adapter ? ["--adapter", overrides.adapter] : []),
+  ];
+}

--- a/tools/cli/src/issue-frontmatter.ts
+++ b/tools/cli/src/issue-frontmatter.ts
@@ -67,55 +67,56 @@ export function parseAgentFrontmatter(issueBody: string): ParseResult {
   };
 }
 
-function validateField(
-  key: string,
-  value: unknown
-): { fields: AgentOverrides; warnings: string[] } {
+type FieldResult = { fields: AgentOverrides; warnings: string[] };
+
+const invalid = (warning: string): FieldResult => ({ fields: {}, warnings: [warning] });
+
+function validateModel(value: unknown): FieldResult {
+  if (typeof value === "string" && MODEL_TIERS.includes(value)) {
+    return { fields: { model: value as ModelTier }, warnings: [] };
+  }
+  return invalid(`invalid model "${String(value)}"; expected one of: ${MODEL_TIERS.join(", ")}`);
+}
+
+function validateBudget(value: unknown): FieldResult {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return invalid(`invalid budget "${String(value)}"; expected a positive number (USD)`);
+  }
+  if (value > MAX_BUDGET_USD) {
+    return {
+      fields: { budget: MAX_BUDGET_USD },
+      warnings: [`budget ${value} capped at ${MAX_BUDGET_USD} USD`],
+    };
+  }
+  return { fields: { budget: value }, warnings: [] };
+}
+
+function validateMaxTurns(value: unknown): FieldResult {
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    return invalid(`invalid max_turns "${String(value)}"; expected a positive integer`);
+  }
+  return { fields: { maxTurns: value }, warnings: [] };
+}
+
+function validateAdapter(value: unknown): FieldResult {
+  if (typeof value === "string" && ADAPTERS.includes(value)) {
+    return { fields: { adapter: value as AdapterType }, warnings: [] };
+  }
+  return invalid(`invalid adapter "${String(value)}"; expected one of: ${ADAPTERS.join(", ")}`);
+}
+
+function validateField(key: string, value: unknown): FieldResult {
   switch (key) {
     case "model":
-      if (typeof value === "string" && MODEL_TIERS.includes(value)) {
-        return { fields: { model: value as ModelTier }, warnings: [] };
-      }
-      return {
-        fields: {},
-        warnings: [`invalid model "${String(value)}"; expected one of: ${MODEL_TIERS.join(", ")}`],
-      };
-    case "budget": {
-      if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
-        return {
-          fields: {},
-          warnings: [`invalid budget "${String(value)}"; expected a positive number (USD)`],
-        };
-      }
-      if (value > MAX_BUDGET_USD) {
-        return {
-          fields: { budget: MAX_BUDGET_USD },
-          warnings: [`budget ${value} capped at ${MAX_BUDGET_USD} USD`],
-        };
-      }
-      return { fields: { budget: value }, warnings: [] };
-    }
+      return validateModel(value);
+    case "budget":
+      return validateBudget(value);
     case "max_turns":
-      if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
-        return {
-          fields: {},
-          warnings: [`invalid max_turns "${String(value)}"; expected a positive integer`],
-        };
-      }
-      return { fields: { maxTurns: value }, warnings: [] };
+      return validateMaxTurns(value);
     case "adapter":
-      if (typeof value === "string" && ADAPTERS.includes(value)) {
-        return { fields: { adapter: value as AdapterType }, warnings: [] };
-      }
-      return {
-        fields: {},
-        warnings: [`invalid adapter "${String(value)}"; expected one of: ${ADAPTERS.join(", ")}`],
-      };
+      return validateAdapter(value);
     default:
-      return {
-        fields: {},
-        warnings: [`unknown key "${key}" ignored (known: ${KNOWN_KEYS.join(", ")})`],
-      };
+      return invalid(`unknown key "${key}" ignored (known: ${KNOWN_KEYS.join(", ")})`);
   }
 }
 


### PR DESCRIPTION
## Summary
Closes #2021

Issues can declare per-issue agent overrides in a fenced `yaml agent` block. issue-worker resolves them via the new `mbe agent frontmatter` subcommand and appends the flags to `mbe agent run` — frontmatter wins over budget heuristics and the default adapter.

- `tools/cli/src/issue-frontmatter.ts` — parser + validator (model tier → model id, budget capped at $5, never throws)
- `tools/cli/src/commands/agent-frontmatter.ts` — stdin/`--body-file` subcommand; warnings → stderr, always exits 0 so the loop can never crash
- `mbe agent run` now detects `--model`/`--max-budget`/`--max-turns` overrides via commander option SOURCE instead of value-equality — an explicit `--model claude-sonnet-4-6` previously fell through to the smart router
- issue-worker SKILL.md Step 3c (parse) + Step 4 (zsh-safe `eval` append — zsh does not word-split unquoted vars)
- `docs/agents/issue-tracker.md` created with the schema (also fixes the dangling reference from root CLAUDE.md)

## Test plan
- [x] 22 new tests (parse/override/fallback/stdin/TTY/default-collision paths)
- [x] 302/302 @mbe/cli tests, ESLint clean, tsc --noEmit clean
- [x] Smoke: piped issue body → flags; malformed yaml → stderr warning + exit 0
- [x] Dual-axis review (Standards + Spec) — all High findings fixed in second commit