### PR TITLE
fix: remove duplicate test:contract task in turbo.json

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -64,15 +64,6 @@
       "dependsOn": ["^build"],
       "inputs": ["src/**", "package.json", "vitest.config.ts"]
     },
-    "test:contract": {
-      "dependsOn": ["^build"],
-      "inputs": [
-        "src/**",
-        "package.json",
-        "vitest.config.ts",
-        "../../packages/types/src/schemas/**"
-      ]
-    },
     "test:coverage": {
       "dependsOn": ["^build"],
       "outputs": ["coverage/**"],


### PR DESCRIPTION
## Summary

Fixed duplicate definition of the `test:contract` task in turbo.json. The task was defined twice (lines 67-74 and 101-102), with the second definition's `cache: false` being silently overridden by the first definition.

**Kept configuration:** Cache disabled (`cache: false`)
**Removed:** First definition with `dependsOn` and `inputs` (lines 67-74)

## Verification

- Validated JSON syntax
- Confirmed `test:contract` task resolved with `"cache": false` via `turbo run test:contract --dry-run`

Closes #2017

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>