### PR TITLE
fix(auth): gate AUTH_BYPASS_IN_TESTS behind non-production check

### DIFF
--- a/packages/auth/llms-full.txt
+++ b/packages/auth/llms-full.txt
@@ -15,6 +15,17 @@
       const jwksUri = `${authority.replace(/\/$/, "")}/.well-known/jwks.json`;
       const JWKS = createRemoteJWKSet(new URL(jwksUri));
     
+      // Prominent startup warning when the test auth bypass is enabled. The bypass
+      // grants a hardcoded admin identity with no JWT validation, so it must never
+      // be active in production (enforced by the NODE_ENV guard in the onRequest hook).
+      if (process.env.AUTH_BYPASS_IN_TESTS === "true") {
+        fastify.log.warn(
+          "AUTH_BYPASS_IN_TESTS=true — auth bypass is ENABLED. Requests with 'x-auth-bypass: true' " +
+            "skip JWT validation and receive a hardcoded admin identity. This is structurally " +
+            "disabled when NODE_ENV=production. NEVER set AUTH_BYPASS_IN_TESTS in production."
+        );
+      }
+    
       // Warn if rate limiting has not been registered by the consuming service.
       // The auth plugin delegates rate limiting to consumers (e.g., @fastify/rate-limit).
       fastify.addHook("onReady", async () => {
@@ -31,7 +42,10 @@
       fastify.addHook("onRequest", async (request: FastifyRequest, reply: FastifyReply) => {
         // 1. Explicit Test Bypass
         // Check if bypass mode is enabled AND the request opted in via header.
+        // Structurally unreachable in production: the NODE_ENV guard ensures one bad
+        // deploy config cannot grant a hardcoded admin identity on a live service.
         if (
+          process.env.NODE_ENV !== "production" &&
           process.env.AUTH_BYPASS_IN_TESTS === "true" &&
           request.headers["x-auth-bypass"] === "true"
         ) {

--- a/packages/auth/src/fastify/plugin.test.ts
+++ b/packages/auth/src/fastify/plugin.test.ts
@@ -343,6 +343,109 @@ describe("Auth Plugin", () => {
     });
   });
 
+  describe("AUTH_BYPASS_IN_TESTS production guard", () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      process.env = { ...originalEnv };
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it("grants bypass identity in non-production when env var + header are set", async () => {
+      process.env.NODE_ENV = "test";
+      process.env.AUTH_BYPASS_IN_TESTS = "true";
+
+      const bypassApp = Fastify({ logger: false });
+      await bypassApp.register(testRoutesPlugin, { excludePaths: ["/health"] });
+      await bypassApp.ready();
+
+      const response = await bypassApp.inject({
+        method: "GET",
+        url: "/protected",
+        headers: { "x-auth-bypass": "true" },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.user?.id).toBe("auth0|user-123");
+      expect(mockJwtVerify).not.toHaveBeenCalled();
+
+      await bypassApp.close();
+    });
+
+    it("does NOT bypass in production: requireAuth route 401s without a token", async () => {
+      process.env.NODE_ENV = "production";
+      process.env.AUTH_BYPASS_IN_TESTS = "true";
+
+      const prodApp = Fastify({ logger: false });
+      const prodRoutesPlugin: FastifyPluginAsync = async (fastify) => {
+        await fastify.register(authPlugin, {
+          authority: "https://test.auth0.com",
+          audience: "https://api.example.com",
+        });
+        fastify.get("/guarded", { preHandler: requireAuth }, async (request) => {
+          return { user: request.user };
+        });
+      };
+
+      await prodApp.register(prodRoutesPlugin);
+      await prodApp.ready();
+
+      const response = await prodApp.inject({
+        method: "GET",
+        url: "/guarded",
+        headers: { "x-auth-bypass": "true" },
+      });
+
+      expect(response.statusCode).toBe(401);
+      const body = JSON.parse(response.body);
+      expect(body.title).toBe("Unauthorized");
+      expect(mockJwtVerify).not.toHaveBeenCalled();
+
+      await prodApp.close();
+    });
+
+    it("logs a prominent warning at registration when AUTH_BYPASS_IN_TESTS=true", async () => {
+      process.env.NODE_ENV = "test";
+      process.env.AUTH_BYPASS_IN_TESTS = "true";
+
+      const warnSpy = vi.fn();
+      const warnApp = Fastify({ logger: { level: "warn" } });
+      warnApp.log.warn = warnSpy;
+
+      await warnApp.register(testRoutesPlugin);
+      await warnApp.ready();
+
+      const bypassWarnings = warnSpy.mock.calls.filter(
+        (call: unknown[]) => typeof call[0] === "string" && call[0].includes("AUTH_BYPASS_IN_TESTS")
+      );
+      expect(bypassWarnings.length).toBeGreaterThan(0);
+
+      await warnApp.close();
+    });
+
+    it("does not log the bypass warning when AUTH_BYPASS_IN_TESTS is unset", async () => {
+      delete process.env.AUTH_BYPASS_IN_TESTS;
+
+      const warnSpy = vi.fn();
+      const warnApp = Fastify({ logger: { level: "warn" } });
+      warnApp.log.warn = warnSpy;
+
+      await warnApp.register(testRoutesPlugin);
+      await warnApp.ready();
+
+      const bypassWarnings = warnSpy.mock.calls.filter(
+        (call: unknown[]) => typeof call[0] === "string" && call[0].includes("AUTH_BYPASS_IN_TESTS")
+      );
+      expect(bypassWarnings).toHaveLength(0);
+
+      await warnApp.close();
+    });
+  });
+
   describe("hasPermission", () => {
     it("returns false when user is undefined", async () => {
       const { hasPermission } = await import("./plugin.js");

--- a/packages/auth/src/fastify/plugin.ts
+++ b/packages/auth/src/fastify/plugin.ts
@@ -33,6 +33,17 @@ async function authPluginImpl(fastify: FastifyInstance, options: AuthPluginOptio
   const jwksUri = `${authority.replace(/\/$/, "")}/.well-known/jwks.json`;
   const JWKS = createRemoteJWKSet(new URL(jwksUri));
 
+  // Prominent startup warning when the test auth bypass is enabled. The bypass
+  // grants a hardcoded admin identity with no JWT validation, so it must never
+  // be active in production (enforced by the NODE_ENV guard in the onRequest hook).
+  if (process.env.AUTH_BYPASS_IN_TESTS === "true") {
+    fastify.log.warn(
+      "AUTH_BYPASS_IN_TESTS=true — auth bypass is ENABLED. Requests with 'x-auth-bypass: true' " +
+        "skip JWT validation and receive a hardcoded admin identity. This is structurally " +
+        "disabled when NODE_ENV=production. NEVER set AUTH_BYPASS_IN_TESTS in production."
+    );
+  }
+
   // Warn if rate limiting has not been registered by the consuming service.
   // The auth plugin delegates rate limiting to consumers (e.g., @fastify/rate-limit).
   fastify.addHook("onReady", async () => {
@@ -49,7 +60,10 @@ async function authPluginImpl(fastify: FastifyInstance, options: AuthPluginOptio
   fastify.addHook("onRequest", async (request: FastifyRequest, reply: FastifyReply) => {
     // 1. Explicit Test Bypass
     // Check if bypass mode is enabled AND the request opted in via header.
+    // Structurally unreachable in production: the NODE_ENV guard ensures one bad
+    // deploy config cannot grant a hardcoded admin identity on a live service.
     if (
+      process.env.NODE_ENV !== "production" &&
       process.env.AUTH_BYPASS_IN_TESTS === "true" &&
       request.headers["x-auth-bypass"] === "true"
     ) {
@@ -158,7 +172,9 @@ export function hasPermission(user: AuthUser | undefined, permission: string): b
 
 export async function requireAuth(request: FastifyRequest, reply: FastifyReply) {
   const isBypassed =
-    process.env.AUTH_BYPASS_IN_TESTS === "true" && request.headers["x-auth-bypass"] === "true";
+    process.env.NODE_ENV !== "production" &&
+    process.env.AUTH_BYPASS_IN_TESTS === "true" &&
+    request.headers["x-auth-bypass"] === "true";
   if (!request.user && !isBypassed) {
     return reply
       .code(401)


### PR DESCRIPTION
## Summary

The Fastify auth plugin (`packages/auth/src/fastify/plugin.ts`) honored `AUTH_BYPASS_IN_TESTS=true` + `x-auth-bypass: true` header in **any** environment, granting a hardcoded admin identity with no JWT validation. One bad deploy config meant a full auth bypass on all three services.

This gates the bypass so it is structurally unreachable in production.

## Changes

- **NODE_ENV guard**: the bypass path now additionally requires `process.env.NODE_ENV !== "production"` — applied in both the `onRequest` hook and the `requireAuth` preHandler.
- **Startup warning**: the plugin logs a prominent warning at registration time whenever `AUTH_BYPASS_IN_TESTS=true`, naming the risk and the prod guard.

## Tests (TDD — written failing first)

- `NODE_ENV=production` + `AUTH_BYPASS_IN_TESTS=true` + bypass header → request is NOT bypassed, falls through to JWT validation, and `requireAuth` returns 401 without a token.
- Non-production bypass still grants the test identity (existing behavior preserved).
- Startup warning is emitted when bypass is enabled, and not emitted when unset.

## Gates

- `pnpm --dir packages/auth test` — 56 passed
- `pnpm --dir packages/auth typecheck` — clean
- `pnpm --dir packages/auth lint` — 0 errors (6 pre-existing `any` warnings, none from this change)

Closes #2102

🤖 Generated with [Claude Code](https://claude.com/claude-code)