### PR TITLE
fix(reservations): eliminate double-booking write-skew in hold confirmation

### DIFF
--- a/services/reservations/llms-full.txt
+++ b/services/reservations/llms-full.txt
@@ -4762,11 +4762,8 @@
   </file>
   <file path="src/services/confirm-hold.ts">
     type ConfirmHoldErrorCode = "NOT_FOUND" | "EXPIRED" | "SESSION_MISMATCH" | "CONFLICT";
-    export interface ConfirmHoldInput {
-      holdId: string;
-      sessionId?: string;
-      guestDetails: ConfirmHoldRequest;
-      userId?: string;
+    export function tableAdvisoryLockSql(tableId: string): Prisma.Sql {
+      return Prisma.sql`SELECT pg_advisory_xact_lock(hashtext(${tableId})::bigint)`;
     }
   </file>
   <file path="src/services/database.ts">

--- a/services/reservations/llms.txt
+++ b/services/reservations/llms.txt
@@ -244,13 +244,8 @@
     <item priority="high">
       type ConfirmHoldErrorCode = "NOT_FOUND" | "EXPIRED" | "SESSION_MISMATCH" | "CONFLICT";
     </item>
-    <item priority="low">
-      interface ConfirmHoldInput {
-        holdId: string;
-        sessionId?: string;
-        guestDetails: ConfirmHoldRequest;
-        userId?: string;
-      }
+    <item priority="high">
+      export function tableAdvisoryLockSql(tableId: string): Prisma.Sql { /* ... */ }
     </item>
   </file>
   <file path="src/services/database.ts">

--- a/services/reservations/src/services/confirm-hold.test.ts
+++ b/services/reservations/src/services/confirm-hold.test.ts
@@ -110,6 +110,7 @@ describe("confirmHold", () => {
       vi.mocked(prisma.$transaction).mockImplementationOnce(
         async (fn: (tx: any) => Promise<unknown>) => {
           const tx = {
+            $executeRaw: vi.fn().mockResolvedValue(0),
             reservation: {
               findFirst: vi.fn().mockResolvedValue(null),
               create: vi.fn().mockResolvedValue(reservation),
@@ -159,11 +160,30 @@ describe("confirmHold", () => {
   });
 
   describe("Slice 3: Hold expired", () => {
-    it("returns EXPIRED and cleans up expired hold", async () => {
+    it("returns EXPIRED and deletes expired hold inside the transaction (no reservation created)", async () => {
       vi.mocked(prisma.reservationHold.findUnique).mockResolvedValueOnce(
         makePrismaHold({ expiresAt: FIVE_MIN_AGO }) as never
       );
-      vi.mocked(prisma.reservationHold.delete).mockResolvedValueOnce(undefined as never);
+
+      const holdDelete = vi.fn().mockResolvedValue(undefined);
+      const reservationCreate = vi.fn();
+
+      vi.mocked(prisma.$transaction).mockImplementationOnce(
+        async (fn: (tx: any) => Promise<unknown>) => {
+          const tx = {
+            $executeRaw: vi.fn().mockResolvedValue(0),
+            reservation: {
+              findFirst: vi.fn().mockResolvedValue(null),
+              create: reservationCreate,
+            },
+            reservationHold: {
+              findFirst: vi.fn().mockResolvedValue(null),
+              delete: holdDelete,
+            },
+          };
+          return fn(tx);
+        }
+      );
 
       const result = await confirmHold({
         holdId: "hold-1",
@@ -176,9 +196,67 @@ describe("confirmHold", () => {
         expect(result.error).toContain("expired");
       }
 
-      expect(prisma.reservationHold.delete).toHaveBeenCalledWith({
-        where: { id: "hold-1" },
+      // Expired hold deleted, but NO reservation created and no event emitted.
+      expect(holdDelete).toHaveBeenCalledWith({ where: { id: "hold-1" } });
+      expect(reservationCreate).not.toHaveBeenCalled();
+      expect(emitHoldConfirmed).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Slice 8: Advisory lock serializes conflict-checked writes", () => {
+    it("acquires the table advisory lock BEFORE any conflict check", async () => {
+      const hold = makePrismaHold();
+      const reservation = makeReservationResult(hold);
+
+      vi.mocked(prisma.reservationHold.findUnique).mockResolvedValueOnce(hold as never);
+
+      const callOrder: string[] = [];
+      const executeRaw = vi.fn().mockImplementation((sql: any) => {
+        callOrder.push("lock");
+        // The SQL must take the advisory lock keyed on the table id, and must
+        // bind tableId as a parameter (never string-interpolated).
+        expect(sql.sql ?? String(sql)).toContain("pg_advisory_xact_lock");
+        expect(sql.values).toContain("table-1");
+        return Promise.resolve(0);
       });
+      const reservationFindFirst = vi.fn().mockImplementation(() => {
+        callOrder.push("reservation.findFirst");
+        return Promise.resolve(null);
+      });
+      const holdFindFirst = vi.fn().mockImplementation(() => {
+        callOrder.push("hold.findFirst");
+        return Promise.resolve(null);
+      });
+
+      vi.mocked(prisma.$transaction).mockImplementationOnce(
+        async (fn: (tx: any) => Promise<unknown>) => {
+          const tx = {
+            $executeRaw: executeRaw,
+            reservation: {
+              findFirst: reservationFindFirst,
+              create: vi.fn().mockResolvedValue(reservation),
+            },
+            reservationHold: {
+              findFirst: holdFindFirst,
+              delete: vi.fn().mockResolvedValue(undefined),
+            },
+          };
+          return fn(tx);
+        }
+      );
+
+      const result = await confirmHold({
+        holdId: "hold-1",
+        sessionId: "session-abc",
+        guestDetails: { guestName: "Jane Doe" },
+      });
+
+      expect(result.success).toBe(true);
+      // Lock acquired first, before BOTH conflict checks.
+      expect(executeRaw).toHaveBeenCalledTimes(1);
+      expect(callOrder[0]).toBe("lock");
+      expect(callOrder.indexOf("lock")).toBeLessThan(callOrder.indexOf("reservation.findFirst"));
+      expect(callOrder.indexOf("lock")).toBeLessThan(callOrder.indexOf("hold.findFirst"));
     });
   });
 
@@ -208,6 +286,7 @@ describe("confirmHold", () => {
       vi.mocked(prisma.$transaction).mockImplementationOnce(
         async (fn: (tx: any) => Promise<unknown>) => {
           const tx = {
+            $executeRaw: vi.fn().mockResolvedValue(0),
             reservation: {
               findFirst: vi.fn().mockResolvedValue({ id: "conflict-res" }),
               create: vi.fn(),
@@ -243,6 +322,7 @@ describe("confirmHold", () => {
       vi.mocked(prisma.$transaction).mockImplementationOnce(
         async (fn: (tx: any) => Promise<unknown>) => {
           const tx = {
+            $executeRaw: vi.fn().mockResolvedValue(0),
             reservation: {
               findFirst: vi.fn().mockResolvedValue(null),
               create: vi.fn(),
@@ -279,6 +359,7 @@ describe("confirmHold", () => {
       vi.mocked(prisma.$transaction).mockImplementationOnce(
         async (fn: (tx: any) => Promise<unknown>) => {
           const tx = {
+            $executeRaw: vi.fn().mockResolvedValue(0),
             reservation: {
               findFirst: vi.fn().mockResolvedValue(null),
               create: vi.fn().mockResolvedValue(reservation),
@@ -314,6 +395,7 @@ describe("confirmHold", () => {
       vi.mocked(prisma.$transaction).mockImplementationOnce(
         async (fn: (tx: any) => Promise<unknown>) => {
           const tx = {
+            $executeRaw: vi.fn().mockResolvedValue(0),
             reservation: {
               findFirst: vi.fn().mockResolvedValue(null),
               create: vi.fn().mockResolvedValue(reservation),

--- a/services/reservations/src/services/confirm-hold.ts
+++ b/services/reservations/src/services/confirm-hold.ts
@@ -6,10 +6,28 @@ import {
   type Table,
   type TableShapeMetadata,
 } from "@mbe/types";
+import { Prisma } from "../generated/prisma/index.js";
 import { prisma } from "./database.js";
 import { emitHoldConfirmed } from "./events.js";
 
 type ConfirmHoldErrorCode = "NOT_FOUND" | "EXPIRED" | "SESSION_MISMATCH" | "CONFLICT";
+
+/**
+ * Builds a transaction-scoped advisory lock statement keyed on the table id.
+ *
+ * Serializes every conflict-checked write for a given table so that concurrent
+ * confirmations (or a confirm racing a walk-in create) cannot both pass their
+ * conflict checks under read-committed isolation and both commit a reservation
+ * (write-skew double-booking). `hashtext` maps the table id to an int4 which is
+ * cast to bigint for the single-key `pg_advisory_xact_lock` overload.
+ *
+ * The table id is bound as a parameter (never string-interpolated) to prevent
+ * SQL injection. The lock auto-releases when the transaction commits or rolls
+ * back.
+ */
+export function tableAdvisoryLockSql(tableId: string): Prisma.Sql {
+  return Prisma.sql`SELECT pg_advisory_xact_lock(hashtext(${tableId})::bigint)`;
+}
 
 export interface ConfirmHoldInput {
   holdId: string;
@@ -109,11 +127,16 @@ function mapReservationResult(result: {
  *
  * Steps:
  * 1. Look up hold by ID
- * 2. Check expiry (+ cleanup expired hold)
- * 3. If sessionId provided, validate it matches
- * 4. Transaction: conflict check -> create reservation -> delete hold
- * 5. Emit hold:confirmed event
- * 6. Return reservation
+ * 2. If sessionId provided, validate it matches
+ * 3. Transaction: advisory lock -> expiry check -> conflict check -> create
+ *    reservation -> delete hold
+ * 4. Emit hold:confirmed event
+ * 5. Return reservation
+ *
+ * The advisory lock and expiry check live inside the transaction so two
+ * concurrent confirmations (or a confirm racing a walk-in create) on the same
+ * table serialize on the lock key and cannot both pass their conflict checks
+ * and commit (write-skew double-booking).
  */
 export async function confirmHold(input: ConfirmHoldInput): Promise<ConfirmHoldResult> {
   const { holdId, sessionId, guestDetails, userId } = input;
@@ -127,13 +150,7 @@ export async function confirmHold(input: ConfirmHoldInput): Promise<ConfirmHoldR
     return { success: false, error: "Hold not found", errorCode: "NOT_FOUND" };
   }
 
-  // Step 2: Check expiry
-  if (hold.expiresAt < new Date()) {
-    await prisma.reservationHold.delete({ where: { id: holdId } }).catch(() => {});
-    return { success: false, error: "Hold has expired", errorCode: "EXPIRED" };
-  }
-
-  // Step 3: Session validation (only when sessionId is provided — internal path)
+  // Step 2: Session validation (only when sessionId is provided — internal path)
   if (sessionId !== undefined && hold.sessionId !== sessionId) {
     return {
       success: false,
@@ -142,8 +159,21 @@ export async function confirmHold(input: ConfirmHoldInput): Promise<ConfirmHoldR
     };
   }
 
-  // Step 4: Transaction — conflict check + create reservation + delete hold
+  // Step 3: Transaction — advisory lock + expiry check + conflict check +
+  // create reservation + delete hold
   const txResult = await prisma.$transaction(async (tx: PrismaTransactionClient) => {
+    // Serialize conflict-checked writes per table BEFORE any conflict check so
+    // concurrent confirmations cannot both pass and double-book. The lock is
+    // released automatically when the transaction ends.
+    await tx.$executeRaw(tableAdvisoryLockSql(hold.tableId));
+
+    // Re-check expiry inside the transaction so an expired hold never produces a
+    // reservation, even if it expired between the lookup and acquiring the lock.
+    if (hold.expiresAt < new Date()) {
+      await tx.reservationHold.delete({ where: { id: holdId } });
+      return { outcome: "expired" as const };
+    }
+
     // Check for conflicting reservations
     const conflictingReservation = await tx.reservation.findFirst({
       where: {
@@ -157,7 +187,7 @@ export async function confirmHold(input: ConfirmHoldInput): Promise<ConfirmHoldR
 
     if (conflictingReservation) {
       await tx.reservationHold.delete({ where: { id: holdId } });
-      return { conflict: true as const };
+      return { outcome: "conflict" as const };
     }
 
     // Check for conflicting holds
@@ -174,7 +204,7 @@ export async function confirmHold(input: ConfirmHoldInput): Promise<ConfirmHoldR
 
     if (conflictingHold) {
       await tx.reservationHold.delete({ where: { id: holdId } });
-      return { conflict: true as const };
+      return { outcome: "conflict" as const };
     }
 
     // Create the reservation
@@ -200,10 +230,14 @@ export async function confirmHold(input: ConfirmHoldInput): Promise<ConfirmHoldR
     // Delete the hold
     await tx.reservationHold.delete({ where: { id: holdId } });
 
-    return { conflict: false as const, reservation };
+    return { outcome: "created" as const, reservation };
   });
 
-  if (txResult.conflict) {
+  if (txResult.outcome === "expired") {
+    return { success: false, error: "Hold has expired", errorCode: "EXPIRED" };
+  }
+
+  if (txResult.outcome === "conflict") {
     return {
       success: false,
       error: "Time slot is no longer available",
@@ -211,10 +245,10 @@ export async function confirmHold(input: ConfirmHoldInput): Promise<ConfirmHoldR
     };
   }
 
-  // Step 5: Map to domain type
+  // Step 4: Map to domain type
   const reservation = mapReservationResult(txResult.reservation);
 
-  // Step 6: Emit event
+  // Step 5: Emit event
   emitHoldConfirmed(reservation);
 
   return { success: true, reservation };
@@ -222,6 +256,7 @@ export async function confirmHold(input: ConfirmHoldInput): Promise<ConfirmHoldR
 
 // Transaction client type — matches the subset used in the transaction callback
 type PrismaTransactionClient = {
+  $executeRaw: typeof prisma.$executeRaw;
   reservation: {
     findFirst: typeof prisma.reservation.findFirst;
     create: typeof prisma.reservation.create;

--- a/services/reservations/src/services/reservation.test.ts
+++ b/services/reservations/src/services/reservation.test.ts
@@ -539,6 +539,7 @@ describe("reservationService", () => {
       vi.mocked(prisma.$transaction).mockImplementationOnce(
         async (fn: (tx: any) => Promise<unknown>) => {
           const tx = {
+            $executeRaw: vi.fn().mockResolvedValue(0),
             reservation: {
               findFirst: vi.fn().mockResolvedValue(null),
               create: vi.fn().mockResolvedValue(walkInReservation),
@@ -564,6 +565,7 @@ describe("reservationService", () => {
       vi.mocked(prisma.$transaction).mockImplementationOnce(
         async (fn: (tx: any) => Promise<unknown>) => {
           const tx = {
+            $executeRaw: vi.fn().mockResolvedValue(0),
             reservation: {
               findFirst: vi.fn().mockResolvedValue(null),
               create: vi.fn().mockImplementation((args) => {
@@ -592,6 +594,7 @@ describe("reservationService", () => {
       vi.mocked(prisma.$transaction).mockImplementationOnce(
         async (fn: (tx: any) => Promise<unknown>) => {
           const tx = {
+            $executeRaw: vi.fn().mockResolvedValue(0),
             reservation: {
               findFirst: vi.fn().mockResolvedValue(null),
               create: vi.fn().mockImplementation((args) => {
@@ -635,6 +638,7 @@ describe("reservationService", () => {
       vi.mocked(prisma.$transaction).mockImplementationOnce(
         async (fn: (tx: any) => Promise<unknown>) => {
           const tx = {
+            $executeRaw: vi.fn().mockResolvedValue(0),
             reservation: {
               findFirst: vi.fn().mockResolvedValue({ id: "conflict" }),
               create: vi.fn(),
@@ -660,6 +664,7 @@ describe("reservationService", () => {
       vi.mocked(prisma.$transaction).mockImplementationOnce(
         async (fn: (tx: any) => Promise<unknown>) => {
           const tx = {
+            $executeRaw: vi.fn().mockResolvedValue(0),
             reservation: {
               findFirst: vi.fn().mockResolvedValue(null),
               create: vi.fn().mockImplementation((args) => {
@@ -680,6 +685,46 @@ describe("reservationService", () => {
         tableId: "table-1",
         venueId: "venue-1",
       });
+    });
+
+    it("acquires the table advisory lock BEFORE the in-transaction conflict check", async () => {
+      vi.mocked(availabilityService.checkTableConflict).mockReturnValueOnce(false);
+
+      const callOrder: string[] = [];
+      const executeRaw = vi.fn().mockImplementation((sql: any) => {
+        callOrder.push("lock");
+        expect(sql.sql ?? String(sql)).toContain("pg_advisory_xact_lock");
+        // tableId bound as a parameter, never string-interpolated.
+        expect(sql.values).toContain("table-1");
+        return Promise.resolve(0);
+      });
+
+      vi.mocked(prisma.$transaction).mockImplementationOnce(
+        async (fn: (tx: any) => Promise<unknown>) => {
+          const tx = {
+            $executeRaw: executeRaw,
+            reservation: {
+              findFirst: vi.fn().mockImplementation(() => {
+                callOrder.push("reservation.findFirst");
+                return Promise.resolve(null);
+              }),
+              create: vi.fn().mockResolvedValue(makePrismaReservation({ status: "CONFIRMED" })),
+            },
+          };
+          return fn(tx);
+        }
+      );
+
+      const result = await reservationService.createWalkIn({
+        partySize: 2,
+        tableId: "table-1",
+        venueId: "venue-1",
+      });
+
+      expect(result.success).toBe(true);
+      expect(executeRaw).toHaveBeenCalledTimes(1);
+      expect(callOrder[0]).toBe("lock");
+      expect(callOrder.indexOf("lock")).toBeLessThan(callOrder.indexOf("reservation.findFirst"));
     });
   });
 

--- a/services/reservations/src/services/reservation.ts
+++ b/services/reservations/src/services/reservation.ts
@@ -18,6 +18,7 @@ import type {
 } from "../generated/prisma/index.js";
 import { prisma } from "./database.js";
 import { availabilityService } from "./availability.js";
+import { tableAdvisoryLockSql } from "./confirm-hold.js";
 
 function isPrismaNotFound(err: unknown): boolean {
   return (
@@ -430,6 +431,12 @@ export const reservationService = {
     }
 
     const reservation = await prisma.$transaction(async (tx) => {
+      // Serialize conflict-checked writes per table BEFORE the conflict check so
+      // a walk-in create and a concurrent hold confirmation on the same table
+      // cannot both pass and double-book. Shares the same lock key as
+      // confirmHold. Released automatically when the transaction ends.
+      await tx.$executeRaw(tableAdvisoryLockSql(data.tableId));
+
       // Re-check for conflicting reservations inside the transaction
       const conflicting = await tx.reservation.findFirst({
         where: {


### PR DESCRIPTION
## Problem

`confirmHold` checked for conflicting reservations/holds inside `prisma.$transaction`, but at default read-committed isolation two concurrent confirmations (or a confirm racing a walk-in create) cannot see each other's uncommitted reservations — both conflict checks pass and both reservations commit: a **double-booking write-skew**. The hold-expiry check also ran outside the transaction.

## Fix

- Take a transaction-scoped Postgres advisory lock keyed on the table id — `SELECT pg_advisory_xact_lock(hashtext($tableId)::bigint)` — as the **first statement inside the transaction**, before any conflict check.
- Applied the same lock (shared key helper `tableAdvisoryLockSql`) in the walk-in / standard reservation-create conflict-check path (`reservationService.createWalkIn`), so confirm-vs-walkin races serialize on the same key.
- Moved the hold-expiry check **inside** the transaction: an expired hold is deleted and never produces a reservation, even if it expires between the lookup and acquiring the lock.

`tableId` is bound as a **parameter** via `Prisma.sql` (never string-interpolated) — no SQL injection.

## Tests (TDD)

- New ordering test in `confirm-hold.test.ts` (Slice 8) asserts the advisory lock is acquired **before** both conflict checks; verified RED (fails without the lock) then GREEN.
- New ordering test in `reservation.test.ts` for the walk-in path.
- Updated the expiry test to assert delete-inside-transaction with no reservation created and no event emitted.
- The suite is fully mocked (no real Postgres / testcontainers in this service), so this is a **unit lock-before-check ordering test**, not a live two-parallel-confirmHold integration test.

## Gates

- `pnpm --dir services/reservations lint` — pass
- `pnpm --dir services/reservations typecheck` — pass
- `pnpm --dir services/reservations test` — pass (644 tests)

Closes #2104

🤖 Generated with [Claude Code](https://claude.com/claude-code)