### PR TITLE
fix(ci): start backend + health-gate before Hospitality E2E

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,7 @@ on:
       - "apps/hospitality/**"
       - "packages/rialto/**"
       - "services/reservations/**"
+      - "services/users/**"
       - "packages/database/**"
   workflow_dispatch:
 
@@ -22,6 +23,27 @@ jobs:
     name: Hospitality E2E
     runs-on: ubuntu-latest
     timeout-minutes: 20
+
+    # Postgres backs the reservations + users APIs the hospitality app proxies to.
+    # Without a live backend, the Vite dev-server proxy returns ECONNREFUSED for
+    # every /api/v1/* request and the SPA never finishes booting (see issue #2123).
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    env:
+      DATABASE_URL: postgresql://test:test@localhost:5432/test
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -43,6 +65,67 @@ jobs:
       - name: Install Playwright
         run: npx playwright install --with-deps chromium
 
+      # Apply migrations so the services boot against a real, up-to-date schema.
+      - name: Apply migrations (users)
+        run: pnpm --filter @mbe/users-service db:migrate:deploy
+
+      - name: Apply migrations (reservations)
+        run: pnpm --filter @mbe/reservations-service db:migrate:deploy
+
+      # The `dev` script loads config via `tsx watch --env-file=.env`, so each
+      # service needs a .env on disk. NODE_ENV stays unset (development), which
+      # keeps AUTH_AUTHORITY/AUTH_AUDIENCE optional — the services boot without
+      # real Auth0 config. DB liveness is what the readiness gate below verifies.
+      - name: Write service env files
+        run: |
+          cat > services/users/.env <<EOF
+          DATABASE_URL=${DATABASE_URL}
+          PORT=3001
+          HOST=0.0.0.0
+          LOG_LEVEL=warn
+          CORS_ORIGINS=http://localhost:3002
+          EOF
+          cat > services/reservations/.env <<EOF
+          DATABASE_URL=${DATABASE_URL}
+          PORT=3004
+          HOST=0.0.0.0
+          LOG_LEVEL=warn
+          CORS_ORIGINS=http://localhost:3002
+          EOF
+
+      - name: Start backend services
+        run: |
+          pnpm --filter @mbe/users-service dev > /tmp/users-api.log 2>&1 &
+          pnpm --filter @mbe/reservations-service dev > /tmp/reservations-api.log 2>&1 &
+
+      # Gate on the DB-backed health endpoints (NOT /health, which is liveness
+      # only). A 200 here means the process is listening AND Prisma can reach
+      # Postgres — the real readiness the Vite proxy needs before Playwright runs.
+      - name: Wait for backend health
+        run: |
+          wait_for_health() {
+            name="$1"
+            url="$2"
+            for i in $(seq 1 60); do
+              # `|| true` keeps the loop alive under `set -e` when curl exits
+              # non-zero (e.g. connection refused while the service is booting).
+              http_code=$(curl -s -o /dev/null -w "%{http_code}" "$url" || true)
+              if [ "$http_code" = "200" ]; then
+                echo "$name healthy ($url)"
+                return 0
+              fi
+              sleep 2
+            done
+            echo "::error::$name never became healthy ($url, last code: $http_code)"
+            return 1
+          }
+          wait_for_health "users-api" "http://localhost:3001/api/v1/users/health" || {
+            echo "----- users-api log -----"; cat /tmp/users-api.log || true; exit 1;
+          }
+          wait_for_health "reservations-api" "http://localhost:3004/api/v1/reservations/health" || {
+            echo "----- reservations-api log -----"; cat /tmp/reservations-api.log || true; exit 1;
+          }
+
       - name: Run E2E tests
         run: pnpm --dir apps/hospitality test:e2e
         env:
@@ -56,6 +139,12 @@ jobs:
           E2E_AUTH0_AUDIENCE: ${{ secrets.E2E_AUTH0_AUDIENCE }}
           E2E_AUTH_EMAIL: ${{ secrets.E2E_AUTH_EMAIL }}
           E2E_AUTH_PASSWORD: ${{ secrets.E2E_AUTH_PASSWORD }}
+
+      - name: Dump backend logs on failure
+        if: failure()
+        run: |
+          echo "----- users-api log -----"; cat /tmp/users-api.log || true
+          echo "----- reservations-api log -----"; cat /tmp/reservations-api.log || true
 
       - name: Upload failure artifacts
         if: failure()


### PR DESCRIPTION
Closes #2123

## Root cause

The `Hospitality E2E` workflow only started the Vite **frontend** dev server (`pnpm --filter @mbe/hospitality dev`). The reservations API (`:3004`) and users API (`:3001`) that the Vite proxy forwards `/api/v1/*` to were **never started**, and there was no Postgres/migrations and no readiness gate.

Result: every `/api/v1/*` request hit a dead proxy target → continuous `[vite] http proxy error … AggregateError [ECONNREFUSED]` for `/api/v1/venues?limit=100` and `/api/v1/events/stream`. The SPA could not finish booting on its initial data fetches — so even the **unauthenticated** `auth.spec.ts` test (which needs no backend) failed with `login-prompt` element-not-found, and many mocked specs flaked. The last failing run (27440145523) showed `25 passed` but exited 1 due to these failures. This is environmental, not a code regression.

## Fix

In `.github/workflows/e2e.yml`:
- **Postgres 15 service container** (mirrors the existing `ci.yml` "Validate Migrations" job) + job-level `DATABASE_URL`.
- **Apply migrations** for users + reservations (`db:migrate:deploy`).
- **Write `.env`** for each service — the `dev` script loads config via `tsx watch --env-file=.env`. `NODE_ENV` stays unset (development), so `@mbe/service-bootstrap` **skips the Auth0 plugin** (`create-service-app.ts`) and routes serve without a JWT — exactly what the E2E harness needs.
- **Start both services** in the background (`:3001`, `:3004` — the proxy targets in `apps/hospitality/vite.config.ts`).
- **Health-gate** before Playwright: poll the **DB-backed** `/api/v1/users/health` and `/api/v1/reservations/health` for HTTP 200 (process listening **and** Prisma connected) — NOT `/health`, which is liveness-only.
- **Dump service logs** on failure for diagnosis.
- Add `services/users/**` to the `paths:` filter since users is now a backend dependency.

The rialto build prerequisite (`pnpm build --filter @mattbutlerengineering/rialto`, required because the `/styles` export → `dist/lib/styles.css`) was already present and is retained.

## Verified locally
- YAML parses (`yaml.safe_load`).
- Health-gate bash function passes `bash -n` and a functional connection-refused smoke test.
- Referenced script targets exist: `dev` and `db:migrate:deploy` for both `@mbe/users-service` and `@mbe/reservations-service`.
- Health endpoint paths exist in source: `/api/v1/users/health` (`services/users/src/routes/health.ts`), `/api/v1/reservations/health` (`services/reservations/src/routes/health.ts`); both return HTTP 200 + `{status}` and 503 only on critical DB error.
- Route prefixes match the proxied paths: reservations serves `/api/v1/venues` and `/api/v1/events/stream` (`services/reservations/src/app.ts`).
- Auth plugin is skipped in dev/test mode (confirmed in `create-service-app.ts`), so protected endpoints serve real (empty-DB) data instead of 401 — no boot hang.
- Prisma client is committed to git, so no `prisma generate` step is needed; `prisma.config.ts` reads `DATABASE_URL` from env.
- No untrusted GitHub-event input used in `run:` steps; only `${{ secrets.* }}` and a static `DATABASE_URL`.

## NOT verified locally (only the CI E2E run can confirm)
- The full GH Actions E2E environment cannot be reproduced locally (no `actionlint` available either — install was blocked; manual review only).
- Whether both services reach health 200 within the 60×2s window on a cold CI runner.
- Whether, with a live empty-DB backend, every previously-mocked spec still passes end-to-end (the mocks should still intercept via `page.route`; the unauthenticated + setup paths now get real HTTP responses instead of ECONNREFUSED).

Opened as **draft** so the PR's own E2E run is the real validation before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)