### PR TITLE
fix(reservations): make walk-in create + table OCCUPIED atomic

### DIFF
--- a/services/reservations/llms-full.txt
+++ b/services/reservations/llms-full.txt
@@ -2837,16 +2837,20 @@
         },
         async (request, reply) => {
           const userId = request.user?.id;
+          // createWalkIn inserts the reservation AND flips the table to OCCUPIED in
+          // a single transaction. If the table update fails the whole thing rolls
+          // back and rejects, so we only reach the SSE emits below after a
+          // committed, consistent state.
           const result = await reservationService.createWalkIn(request.body, userId);
           if (!result.success || !result.reservation) {
             return reply
               .code(409)
               .send(createProblemDetails(409, "Conflict", result.error ?? "Table is not available"));
           }
-          const updatedTable = await tableService.updateStatus(request.body.tableId, "OCCUPIED");
+          // Emit only after the transaction has committed.
           emitReservationCreated(result.reservation);
-          if (updatedTable) {
-            emitTableUpdated(updatedTable);
+          if (result.table) {
+            emitTableUpdated(result.table);
           }
           return reply.code(201).send({ data: result.reservation });
         }
@@ -5053,7 +5057,7 @@
         (err as { code: string }).code === "P2025"
       );
     }
-    function mapPrismaTable(table: {
+    export function mapPrismaTable(table: {
       id: string;
       name: string;
       tableNumber: string | null;

--- a/services/reservations/llms.txt
+++ b/services/reservations/llms.txt
@@ -447,8 +447,8 @@
     <item priority="medium">
       function isPrismaNotFound(err: unknown): boolean { /* ... */ }
     </item>
-    <item priority="medium">
-      function mapPrismaTable(table: {
+    <item priority="high">
+      export function mapPrismaTable(table: {
         id: string;
         name: string;
         tableNumber: string | null;

--- a/services/reservations/src/routes/reservations.test.ts
+++ b/services/reservations/src/routes/reservations.test.ts
@@ -122,8 +122,7 @@ vi.mock("jose", () => ({
 }));
 
 import { reservationService } from "../services/reservation.js";
-import { tableService } from "../services/table.js";
-import { emitReservationCreated } from "../services/events.js";
+import { emitReservationCreated, emitTableUpdated } from "../services/events.js";
 import { jwtVerify } from "jose";
 
 describe("Reservation Routes", () => {
@@ -697,9 +696,28 @@ describe("Reservation Routes", () => {
         guestName: "Walk-in Guest",
       });
 
+      const occupiedTable = {
+        id: "table-123",
+        name: "Table 123",
+        tableNumber: "123",
+        capacity: 4,
+        minCovers: 1,
+        maxCovers: 6,
+        location: null,
+        isActive: true,
+        priority: 0,
+        status: "OCCUPIED" as const,
+        venueId: "venue-123",
+        floorPlanId: null,
+        shapeMetadata: null,
+        createdAt: "2026-05-05T18:00:00.000Z",
+        updatedAt: "2026-05-05T18:00:00.000Z",
+      };
+
       vi.mocked(reservationService.createWalkIn).mockResolvedValueOnce({
         success: true,
         reservation: walkInReservation,
+        table: occupiedTable,
       });
 
       const response = await app.inject({
@@ -718,8 +736,42 @@ describe("Reservation Routes", () => {
       expect(response.statusCode).toBe(201);
       const body = JSON.parse(response.body);
       expect(body.data.id).toBe("res-walkin");
-      expect(tableService.updateStatus).toHaveBeenCalledWith("table-123", "OCCUPIED");
+      // The route no longer issues a separate table status update; the service
+      // flips the table inside the same transaction and returns it. The route
+      // emits both SSE events only after that committed result comes back.
       expect(emitReservationCreated).toHaveBeenCalledWith(walkInReservation);
+      expect(emitTableUpdated).toHaveBeenCalledWith(occupiedTable);
+    });
+
+    it("does not emit SSE events when createWalkIn fails (rolled back)", async () => {
+      vi.mocked(jwtVerify).mockResolvedValueOnce({
+        payload: mockJWTPayload,
+        protectedHeader: { alg: "RS256" },
+      } as never);
+
+      // Simulated table-status-update failure inside the transaction surfaces
+      // as a rejected promise — no reservation committed, error response, and
+      // crucially NO SSE events emitted.
+      vi.mocked(reservationService.createWalkIn).mockRejectedValueOnce(
+        new Error("table update failed")
+      );
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/v1/reservations/walk-in",
+        headers: {
+          authorization: "Bearer valid-token",
+        },
+        payload: {
+          tableId: "table-123",
+          partySize: 2,
+          venueId: "venue-123",
+        },
+      });
+
+      expect(response.statusCode).toBe(500);
+      expect(emitReservationCreated).not.toHaveBeenCalled();
+      expect(emitTableUpdated).not.toHaveBeenCalled();
     });
 
     it("creates walk-in with custom guest name and duration", async () => {

--- a/services/reservations/src/routes/reservations.ts
+++ b/services/reservations/src/routes/reservations.ts
@@ -18,7 +18,6 @@ import {
   emitReservationCreated,
   emitTableUpdated,
 } from "../services/events.js";
-import { tableService } from "../services/table.js";
 
 export const reservationRoutes: FastifyPluginAsync = async (fastify) => {
   // List reservations
@@ -251,16 +250,20 @@ export const reservationRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (request, reply) => {
       const userId = request.user?.id;
+      // createWalkIn inserts the reservation AND flips the table to OCCUPIED in
+      // a single transaction. If the table update fails the whole thing rolls
+      // back and rejects, so we only reach the SSE emits below after a
+      // committed, consistent state.
       const result = await reservationService.createWalkIn(request.body, userId);
       if (!result.success || !result.reservation) {
         return reply
           .code(409)
           .send(createProblemDetails(409, "Conflict", result.error ?? "Table is not available"));
       }
-      const updatedTable = await tableService.updateStatus(request.body.tableId, "OCCUPIED");
+      // Emit only after the transaction has committed.
       emitReservationCreated(result.reservation);
-      if (updatedTable) {
-        emitTableUpdated(updatedTable);
+      if (result.table) {
+        emitTableUpdated(result.table);
       }
       return reply.code(201).send({ data: result.reservation });
     }

--- a/services/reservations/src/services/reservation.test.ts
+++ b/services/reservations/src/services/reservation.test.ts
@@ -544,6 +544,9 @@ describe("reservationService", () => {
               findFirst: vi.fn().mockResolvedValue(null),
               create: vi.fn().mockResolvedValue(walkInReservation),
             },
+            table: {
+              update: vi.fn().mockResolvedValue(makePrismaTable()),
+            },
           };
           return fn(tx);
         }
@@ -576,6 +579,9 @@ describe("reservationService", () => {
                 return makePrismaReservation({ status: "CONFIRMED" });
               }),
             },
+            table: {
+              update: vi.fn().mockResolvedValue(makePrismaTable()),
+            },
           };
           return fn(tx);
         }
@@ -604,6 +610,9 @@ describe("reservationService", () => {
                 expect(durationMs).toBe(60 * 60 * 1000);
                 return makePrismaReservation({ status: "CONFIRMED" });
               }),
+            },
+            table: {
+              update: vi.fn().mockResolvedValue(makePrismaTable()),
             },
           };
           return fn(tx);
@@ -643,6 +652,9 @@ describe("reservationService", () => {
               findFirst: vi.fn().mockResolvedValue({ id: "conflict" }),
               create: vi.fn(),
             },
+            table: {
+              update: vi.fn().mockResolvedValue(makePrismaTable()),
+            },
           };
           return fn(tx);
         }
@@ -674,6 +686,9 @@ describe("reservationService", () => {
                   guestName: "Walk-in",
                 });
               }),
+            },
+            table: {
+              update: vi.fn().mockResolvedValue(makePrismaTable()),
             },
           };
           return fn(tx);
@@ -710,6 +725,9 @@ describe("reservationService", () => {
               }),
               create: vi.fn().mockResolvedValue(makePrismaReservation({ status: "CONFIRMED" })),
             },
+            table: {
+              update: vi.fn().mockResolvedValue(makePrismaTable()),
+            },
           };
           return fn(tx);
         }
@@ -725,6 +743,82 @@ describe("reservationService", () => {
       expect(executeRaw).toHaveBeenCalledTimes(1);
       expect(callOrder[0]).toBe("lock");
       expect(callOrder.indexOf("lock")).toBeLessThan(callOrder.indexOf("reservation.findFirst"));
+    });
+
+    it("updates the table to OCCUPIED inside the same transaction and returns it", async () => {
+      vi.mocked(availabilityService.checkTableConflict).mockReturnValueOnce(false);
+
+      const tableUpdate = vi.fn().mockResolvedValue(makePrismaTable());
+      const reservationCreate = vi
+        .fn()
+        .mockResolvedValue(makePrismaReservation({ status: "CONFIRMED" }));
+
+      vi.mocked(prisma.$transaction).mockImplementationOnce(
+        async (fn: (tx: any) => Promise<unknown>) => {
+          const tx = {
+            $executeRaw: vi.fn().mockResolvedValue(0),
+            reservation: {
+              findFirst: vi.fn().mockResolvedValue(null),
+              create: reservationCreate,
+            },
+            table: { update: tableUpdate },
+          };
+          return fn(tx);
+        }
+      );
+
+      const result = await reservationService.createWalkIn({
+        partySize: 2,
+        tableId: "table-1",
+        venueId: "venue-1",
+      });
+
+      expect(result.success).toBe(true);
+      expect(tableUpdate).toHaveBeenCalledWith({
+        where: { id: "table-1" },
+        data: { status: "OCCUPIED" },
+      });
+      expect(result.table).toBeDefined();
+      expect(result.table!.id).toBe("table-1");
+    });
+
+    it("rolls back the reservation when the in-transaction table update fails", async () => {
+      vi.mocked(availabilityService.checkTableConflict).mockReturnValueOnce(false);
+
+      const reservationCreate = vi
+        .fn()
+        .mockResolvedValue(makePrismaReservation({ status: "CONFIRMED" }));
+      const tableUpdate = vi.fn().mockRejectedValue(new Error("table update failed"));
+
+      // Real Prisma rolls back the whole transaction when the callback throws.
+      // Model that here: if the callback throws, $transaction rejects and NO
+      // reservation row is persisted (the create call is part of the same
+      // aborted transaction).
+      vi.mocked(prisma.$transaction).mockImplementationOnce(
+        async (fn: (tx: any) => Promise<unknown>) => {
+          const tx = {
+            $executeRaw: vi.fn().mockResolvedValue(0),
+            reservation: {
+              findFirst: vi.fn().mockResolvedValue(null),
+              create: reservationCreate,
+            },
+            table: { update: tableUpdate },
+          };
+          return fn(tx);
+        }
+      );
+
+      await expect(
+        reservationService.createWalkIn({
+          partySize: 2,
+          tableId: "table-1",
+          venueId: "venue-1",
+        })
+      ).rejects.toThrow("table update failed");
+
+      // create was attempted inside the transaction, but because the callback
+      // threw afterwards the whole transaction aborts — no committed row.
+      expect(tableUpdate).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/services/reservations/src/services/reservation.ts
+++ b/services/reservations/src/services/reservation.ts
@@ -18,6 +18,7 @@ import type {
 } from "../generated/prisma/index.js";
 import { prisma } from "./database.js";
 import { availabilityService } from "./availability.js";
+import { mapPrismaTable } from "./table.js";
 import { tableAdvisoryLockSql } from "./confirm-hold.js";
 
 function isPrismaNotFound(err: unknown): boolean {
@@ -91,6 +92,13 @@ export interface ListReservationsOptions {
 export interface CreateReservationResult {
   success: boolean;
   reservation?: Reservation;
+  /**
+   * The table whose status was changed as part of creating the reservation.
+   * Set by {@link reservationService.createWalkIn} when it flips the table to
+   * OCCUPIED in the same transaction as the reservation insert, so the route
+   * can emit the `table:updated` SSE event only after the commit succeeds.
+   */
+  table?: Table;
   error?: string;
   conflict?: ConflictCheckResult;
   pacing?: PacingCheckResult;
@@ -430,7 +438,7 @@ export const reservationService = {
       }
     }
 
-    const reservation = await prisma.$transaction(async (tx) => {
+    const result = await prisma.$transaction(async (tx) => {
       // Serialize conflict-checked writes per table BEFORE the conflict check so
       // a walk-in create and a concurrent hold confirmation on the same table
       // cannot both pass and double-book. Shares the same lock key as
@@ -452,7 +460,11 @@ export const reservationService = {
         return null;
       }
 
-      return tx.reservation.create({
+      // Create the reservation AND flip the table to OCCUPIED in the SAME
+      // transaction so the two writes commit or roll back together. If the
+      // table update throws, the reservation insert is aborted with it — no
+      // orphaned reservation row, no table left showing AVAILABLE.
+      const createdReservation = await tx.reservation.create({
         data: {
           date: dateOnly,
           startTime: now,
@@ -470,16 +482,27 @@ export const reservationService = {
         },
         include: { table: true },
       });
+
+      const occupiedTable = await tx.table.update({
+        where: { id: data.tableId },
+        data: { status: "OCCUPIED" },
+      });
+
+      return { reservation: createdReservation, table: occupiedTable };
     });
 
-    if (!reservation) {
+    if (!result) {
       return {
         success: false,
         error: "Table is not available",
       };
     }
 
-    return { success: true, reservation: mapPrismaReservation(reservation) };
+    return {
+      success: true,
+      reservation: mapPrismaReservation(result.reservation),
+      table: mapPrismaTable(result.table),
+    };
   },
 
   async cancel(id: string, reason?: string, note?: string): Promise<Reservation | null> {

--- a/services/reservations/src/services/table.ts
+++ b/services/reservations/src/services/table.ts
@@ -20,7 +20,7 @@ function isPrismaNotFound(err: unknown): boolean {
 
 const VALID_TABLE_STATUSES: TableStatus[] = ["AVAILABLE", "OCCUPIED", "DIRTY", "READY"];
 
-function mapPrismaTable(table: {
+export function mapPrismaTable(table: {
   id: string;
   name: string;
   tableNumber: string | null;


### PR DESCRIPTION
## Problem

The walk-in route created the reservation via `reservationService.createWalkIn`, then **separately** awaited `tableService.updateStatus(tableId, "OCCUPIED")`. If that second write threw, the client got a 500 but the reservation was already committed and the table still showed `AVAILABLE` — inconsistent state, and a retry then `409`d because the reservation already existed.

## Change

- `createWalkIn` now flips the table to `OCCUPIED` **inside the same `$transaction`** as the reservation insert (composed into the existing advisory-lock transaction from #2122 — not a nested transaction). The reservation row and the table status now commit or roll back together.
- `createWalkIn` returns the updated table in `CreateReservationResult.table`.
- The route emits `reservation:created` and `table:updated` SSE events **only after** the committed result returns. The separate `tableService.updateStatus` call (and its now-orphaned import) were removed from the route.
- `mapPrismaTable` is exported from `table.ts` and reused in `reservation.ts` to map the in-transaction table result.

## Tests (TDD — written failing first)

Service layer (`reservation.test.ts`):
- Table updated to `OCCUPIED` inside the same transaction and returned in the result.
- **Rollback**: simulated in-transaction `table.update` failure rejects the whole `$transaction` — no committed reservation row.

Route layer (`reservations.test.ts`):
- Success path emits both SSE events with the table from the result (no separate `updateStatus` call).
- **Failure path**: `createWalkIn` rejection → 500 error response and **no** SSE events emitted.

## Gates

- `pnpm --dir services/reservations lint` ✅
- `pnpm --dir services/reservations typecheck` ✅
- `pnpm --dir services/reservations test` ✅ (47 files, 647 tests)

Closes #2105