### PR TITLE
refactor(agent): publish session events at addEvent seam, SSE subscribes

### DIFF
--- a/services/agent/llms-full.txt
+++ b/services/agent/llms-full.txt
@@ -559,7 +559,8 @@
             operationId: "streamSessionEvents",
             description:
               "Server-Sent Events stream for real-time session updates. " +
-              "Sends existing events immediately, then polls for new events until the session completes.",
+              "Replays existing events from the database on connect, then streams " +
+              "new events live via an in-process subscription until the session completes.",
             tags: ["Events"],
             params: {
               type: "object",
@@ -588,12 +589,8 @@
             "X-Accel-Buffering": "no",
           });
     
-          let lastEventId: string | undefined;
           let isOpen = true;
-    
-          request.raw.on("close", () => {
-            isOpen = false;
-          });
+          const sentEventIds = new Set<string>();
     
           const sendEvent = (type: string, data: unknown) => {
             if (!isOpen) return;
@@ -601,52 +598,70 @@
             reply.raw.write(`data: ${JSON.stringify(data)}\n\n`);
           };
     
-          // Send existing events first
-          const existingEvents = await sessionService.listEvents(session.id);
-          for (const event of existingEvents) {
-            sendEvent(event.type, event);
-            lastEventId = event.id;
-          }
-    
-          // If session is already terminal, close the stream
-          const terminalStatuses = new Set(["succeeded", "failed", "cancelled"]);
-          if (terminalStatuses.has(session.status)) {
-            sendEvent("stream:end", { reason: "session_complete" });
-            reply.raw.end();
-            return;
-          }
-    
-          // Poll for new events until session completes
-          const poll = async () => {
-            while (isOpen) {
-              await new Promise((resolve) => setTimeout(resolve, SSE_POLL_INTERVAL_MS));
-    
-              if (!isOpen) break;
-    
-              const newEvents = await sessionService.listEvents(session.id, lastEventId);
-              for (const event of newEvents) {
-                sendEvent(event.type, event);
-                lastEventId = event.id;
-              }
-    
-              // Check if session has completed
-              const current = await sessionService.getById(session.id);
-              if (current && terminalStatuses.has(current.status)) {
-                sendEvent("stream:end", { reason: "session_complete", status: current.status });
-                break;
-              }
-            }
-    
+          const closeStream = (reason: string, status?: string) => {
+            if (!isOpen) return;
+            sendEvent("stream:end", status ? { reason, status } : { reason });
+            isOpen = false;
             reply.raw.end();
           };
     
-          poll().catch((err) => {
-            fastify.log.error({ sessionId: session.id, err }, "SSE polling error");
-            if (isOpen) {
-              sendEvent("stream:error", { message: "Internal polling error" });
-              reply.raw.end();
+          const deliver = (event: AgentSessionEvent) => {
+            if (!isOpen || sentEventIds.has(event.id)) return;
+            sentEventIds.add(event.id);
+            sendEvent(event.type, event);
+            if (TERMINAL_EVENT_TYPES.has(event.type)) {
+              closeStream("session_complete", session.status);
+            }
+          };
+    
+          // Subscribe before the catch-up read so events added during catch-up are
+          // buffered, not lost. Buffered events flush (deduped by id) after replay.
+          const liveBuffer: AgentSessionEvent[] = [];
+          let replayed = false;
+          let unsubscribe: () => void = () => {};
+          unsubscribe = getSessionEventEmitter().subscribe(session.id, (event) => {
+            if (replayed) {
+              deliver(event);
+            } else {
+              liveBuffer.push(event);
             }
           });
+    
+          request.raw.on("close", () => {
+            isOpen = false;
+            unsubscribe();
+          });
+    
+          try {
+            // Catch-up: read persisted events once on connect (the only DB event read).
+            const existingEvents = await sessionService.listEvents(session.id);
+            for (const event of existingEvents) {
+              deliver(event);
+            }
+    
+            // Flush anything that arrived live during catch-up, then go fully live.
+            replayed = true;
+            for (const event of liveBuffer) {
+              deliver(event);
+            }
+    
+            // If the session was already terminal on connect, close after replay.
+            if (isOpen && TERMINAL_STATUSES.has(session.status)) {
+              closeStream("session_complete", session.status);
+            }
+          } catch (err) {
+            fastify.log.error({ sessionId: session.id, err }, "SSE catch-up error");
+            if (isOpen) {
+              sendEvent("stream:error", { message: "Internal stream error" });
+              isOpen = false;
+              reply.raw.end();
+            }
+            unsubscribe();
+          }
+    
+          if (!isOpen) {
+            unsubscribe();
+          }
         }
       );
     };
@@ -955,6 +970,18 @@
         )
         .map((block: Record<string, unknown>) => block.text as string)
         .join("\n");
+    }
+  </file>
+  <file path="src/services/session-event-emitter.ts">
+    export type SessionEventListener = (event: AgentSessionEvent) => void;
+    export interface SessionEventEmitter {
+      /** Publish a persisted event to all subscribers of its session. */
+      publish(event: AgentSessionEvent): void;
+      /**
+       * Subscribe to live events for a session.
+       * @returns an unsubscribe function.
+       */
+      subscribe(sessionId: string, listener: SessionEventListener): () => void;
     }
   </file>
   <file path="src/services/session-executor.ts">

--- a/services/agent/llms.txt
+++ b/services/agent/llms.txt
@@ -181,6 +181,16 @@
       function extractText(content: unknown): string { /* ... */ }
     </item>
   </file>
+  <file path="src/services/session-event-emitter.ts">
+    <item priority="low">
+      type SessionEventListener = (event: AgentSessionEvent) => void;
+    </item>
+    <item priority="low">
+      interface SessionEventEmitter {
+        
+      }
+    </item>
+  </file>
   <file path="src/services/session-executor.ts">
     <item priority="medium">
       function getRepoPath(): string { /* ... */ }

--- a/services/agent/src/routes/session-events.integration.test.ts
+++ b/services/agent/src/routes/session-events.integration.test.ts
@@ -1,12 +1,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { FastifyInstance } from "fastify";
+import type { AgentSessionEvent } from "@mbe/types";
 import { buildMinimalSuccessFixture } from "@mbe/agent-test-utils";
 
 /**
  * Integration tests for the session events SSE endpoint.
  *
- * Verifies the actual SSE wire format returned by the session events
- * endpoint — content-type headers, event structure, and JSON data lines.
+ * The endpoint replays persisted events from the database once on connect
+ * (catch-up), then streams new events live via the in-process subscription
+ * seam — no fixed-interval poll loop. These tests verify the wire format,
+ * catch-up, terminal close, live delivery without a poll timer, single DB
+ * read per connect, and shared fan-out across concurrent subscribers.
  */
 
 vi.mock("jose", () => ({
@@ -60,7 +64,22 @@ vi.mock("../services/session-executor.js", () => ({
 }));
 
 const { prisma } = await import("../services/database.js");
+const { getSessionEventEmitter } = await import("../services/session-event-emitter.js");
 const { buildApp } = await import("../app.js");
+
+function makeLiveEvent(
+  sessionId: string,
+  id: string,
+  type: string,
+  data: Record<string, unknown> = {}
+): AgentSessionEvent {
+  return { id, sessionId, type, data, createdAt: new Date().toISOString() };
+}
+
+/** Wait one macrotask so SSE writes flush before assertions. */
+function tick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
 
 describe("Session Events SSE Integration", () => {
   let app: FastifyInstance;
@@ -79,7 +98,6 @@ describe("Session Events SSE Integration", () => {
   });
 
   it("returns SSE content-type for event stream", async () => {
-    // Mock session exists
     vi.mocked(prisma.session.findUnique).mockResolvedValue({
       id: "session-1",
       status: "SUCCEEDED",
@@ -106,7 +124,6 @@ describe("Session Events SSE Integration", () => {
       sdkSessionId: null,
     } as unknown as never);
 
-    // Mock events
     const events = buildMinimalSuccessFixture({ sessionId: "session-1" }).map((e, i) => ({
       id: `evt-${i}`,
       sessionId: "session-1",
@@ -123,7 +140,6 @@ describe("Session Events SSE Integration", () => {
       headers: { "x-auth-bypass": "true" },
     });
 
-    // Should return SSE content type
     expect(response.headers["content-type"]).toContain("text/event-stream");
   });
 
@@ -139,82 +155,137 @@ describe("Session Events SSE Integration", () => {
     expect(response.statusCode).toBe(404);
   });
 
-  it("polls for new events until session completes", async () => {
-    vi.useFakeTimers();
-
-    const session = {
-      id: "session-3",
-      status: "RUNNING", // Not terminal
+  it("replays existing events on connect, then closes a terminal session", async () => {
+    vi.mocked(prisma.session.findUnique).mockResolvedValue({
+      id: "session-replay",
+      status: "SUCCEEDED",
       taskDescription: "test",
       createdAt: new Date(),
       updatedAt: new Date(),
-    };
+    } as unknown as never);
 
-    vi.mocked(prisma.session.findUnique)
-      .mockResolvedValueOnce(session as unknown as never) // Initial getById
-      .mockResolvedValueOnce(session as unknown as never) // First poll getById
-      .mockResolvedValueOnce({ ...session, status: "SUCCEEDED" } as unknown as never); // Second poll getById (terminal)
+    vi.mocked(prisma.sessionEvent.findMany).mockResolvedValue([
+      { id: "e1", sessionId: "session-replay", type: "t1", data: {}, createdAt: new Date() },
+      { id: "e2", sessionId: "session-replay", type: "t2", data: {}, createdAt: new Date() },
+    ] as unknown as never);
 
-    const initialEvent = { id: "e1", type: "t1", data: {}, createdAt: new Date() };
-    const newEvent = { id: "e2", type: "t2", data: {}, createdAt: new Date() };
-
-    vi.mocked(prisma.sessionEvent.findMany)
-      .mockResolvedValueOnce([initialEvent] as unknown as never) // Initial listEvents
-      .mockResolvedValueOnce([newEvent] as unknown as never) // First poll listEvents
-      .mockResolvedValueOnce([] as unknown as never); // Second poll listEvents
-
-    const injectPromise = app.inject({
+    const response = await app.inject({
       method: "GET",
-      url: "/v1/sessions/session-3/events",
+      url: "/v1/sessions/session-replay/events",
       headers: { "x-auth-bypass": "true" },
     });
 
-    // Advance timers to trigger polling
-    await vi.advanceTimersByTimeAsync(1500); // Trigger first poll
-    await vi.advanceTimersByTimeAsync(1500); // Trigger second poll
-
-    const response = await injectPromise;
-    const body = response.body;
-
-    expect(body).toContain("event: t1");
-    expect(body).toContain("event: t2");
-    expect(body).toContain("event: stream:end");
-    expect(body).toContain("session_complete");
-
-    vi.useRealTimers();
+    expect(response.body).toContain("event: t1");
+    expect(response.body).toContain("event: t2");
+    expect(response.body).toContain("event: stream:end");
+    expect(response.body).toContain("session_complete");
+    // Catch-up read happens exactly once; no poll loop.
+    expect(prisma.sessionEvent.findMany).toHaveBeenCalledTimes(1);
   });
 
-  it("handles polling errors", async () => {
-    vi.useFakeTimers();
+  it("delivers a live event via the subscription without advancing any poll timer", async () => {
+    // Real timers + a spy proves no setTimeout-based poll loop is relied upon.
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
 
-    const session = {
-      id: "session-5",
+    vi.mocked(prisma.session.findUnique).mockResolvedValue({
+      id: "session-live",
       status: "RUNNING",
       taskDescription: "test",
       createdAt: new Date(),
       updatedAt: new Date(),
-    };
-
-    vi.mocked(prisma.session.findUnique)
-      .mockResolvedValueOnce(session as unknown as never) // Initial getById
-      .mockRejectedValueOnce(new Error("Database failure")); // First poll getById throws
+    } as unknown as never);
 
     vi.mocked(prisma.sessionEvent.findMany).mockResolvedValue([] as unknown as never);
 
-    const injectPromise = app.inject({
+    const reply = app.inject({
       method: "GET",
-      url: "/v1/sessions/session-5/events",
+      url: "/v1/sessions/session-live/events",
       headers: { "x-auth-bypass": "true" },
     });
 
-    await vi.advanceTimersByTimeAsync(1500);
+    // Let the route subscribe and finish catch-up.
+    await tick();
 
-    const response = await injectPromise;
+    const dbCallsBeforeLive = vi.mocked(prisma.sessionEvent.findMany).mock.calls.length;
 
-    // Stream should contain error event
+    // Publish a live event, then a terminal one to close the stream.
+    getSessionEventEmitter().publish(makeLiveEvent("session-live", "live-1", "agent:message"));
+    getSessionEventEmitter().publish(
+      makeLiveEvent("session-live", "live-2", "session:complete", { status: "SUCCEEDED" })
+    );
+
+    const response = await reply;
+
+    expect(response.body).toContain("event: agent:message");
+    expect(response.body).toContain("event: session:complete");
+    expect(response.body).toContain("event: stream:end");
+    // No additional DB event-list read after connect — live path is the subscription.
+    expect(vi.mocked(prisma.sessionEvent.findMany).mock.calls.length).toBe(dbCallsBeforeLive);
+    expect(prisma.sessionEvent.findMany).toHaveBeenCalledTimes(1);
+
+    setTimeoutSpy.mockRestore();
+  });
+
+  it("shares a single emit across concurrent subscribers with one DB read each", async () => {
+    vi.mocked(prisma.session.findUnique).mockResolvedValue({
+      id: "session-multi",
+      status: "RUNNING",
+      taskDescription: "test",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as unknown as never);
+
+    vi.mocked(prisma.sessionEvent.findMany).mockResolvedValue([] as unknown as never);
+
+    const replyA = app.inject({
+      method: "GET",
+      url: "/v1/sessions/session-multi/events",
+      headers: { "x-auth-bypass": "true" },
+    });
+    const replyB = app.inject({
+      method: "GET",
+      url: "/v1/sessions/session-multi/events",
+      headers: { "x-auth-bypass": "true" },
+    });
+
+    await tick();
+
+    // Each subscriber read the DB once on connect (2 connects = 2 reads). No
+    // further reads happen for the live event below.
+    expect(prisma.sessionEvent.findMany).toHaveBeenCalledTimes(2);
+    const readsAfterConnect = vi.mocked(prisma.sessionEvent.findMany).mock.calls.length;
+
+    // A single publish fans out to both subscribers.
+    getSessionEventEmitter().publish(
+      makeLiveEvent("session-multi", "m-1", "session:complete", { status: "SUCCEEDED" })
+    );
+
+    const [responseA, responseB] = await Promise.all([replyA, replyB]);
+
+    expect(responseA.body).toContain("event: session:complete");
+    expect(responseB.body).toContain("event: session:complete");
+    // No per-client DB reads after connect.
+    expect(vi.mocked(prisma.sessionEvent.findMany).mock.calls.length).toBe(readsAfterConnect);
+  });
+
+  it("emits a stream:error if catch-up read fails", async () => {
+    vi.mocked(prisma.session.findUnique).mockResolvedValue({
+      id: "session-err",
+      status: "RUNNING",
+      taskDescription: "test",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as unknown as never);
+
+    vi.mocked(prisma.sessionEvent.findMany).mockRejectedValue(new Error("DB down"));
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/v1/sessions/session-err/events",
+      headers: { "x-auth-bypass": "true" },
+    });
+
     expect(response.body).toContain("event: stream:error");
-    expect(response.body).toContain("Internal polling error");
-
-    vi.useRealTimers();
+    expect(response.body).toContain("Internal stream error");
   });
 });

--- a/services/agent/src/routes/session-events.ts
+++ b/services/agent/src/routes/session-events.ts
@@ -1,9 +1,17 @@
 import type { FastifyPluginAsync } from "fastify";
-import { type ApiError, createProblemDetails } from "@mbe/types";
+import { type ApiError, type AgentSessionEvent, createProblemDetails } from "@mbe/types";
 import { requireAuth } from "@mbe/auth/fastify";
 import { sessionService } from "../services/session.js";
+import { getSessionEventEmitter } from "../services/session-event-emitter.js";
 
-const SSE_POLL_INTERVAL_MS = 1000;
+/**
+ * Event types that signal the session has reached a terminal state. When one of
+ * these is delivered, the SSE stream closes — no per-tick DB status poll needed.
+ */
+const TERMINAL_EVENT_TYPES = new Set(["session:complete", "session:error", "session:cancelled"]);
+
+/** Session statuses that are terminal on connect (replay-only, no live stream). */
+const TERMINAL_STATUSES = new Set(["succeeded", "failed", "cancelled"]);
 
 export const sessionEventsRoutes: FastifyPluginAsync = async (fastify) => {
   // GET /v1/sessions/:id/events — SSE stream of session events
@@ -19,7 +27,8 @@ export const sessionEventsRoutes: FastifyPluginAsync = async (fastify) => {
         operationId: "streamSessionEvents",
         description:
           "Server-Sent Events stream for real-time session updates. " +
-          "Sends existing events immediately, then polls for new events until the session completes.",
+          "Replays existing events from the database on connect, then streams " +
+          "new events live via an in-process subscription until the session completes.",
         tags: ["Events"],
         params: {
           type: "object",
@@ -48,12 +57,8 @@ export const sessionEventsRoutes: FastifyPluginAsync = async (fastify) => {
         "X-Accel-Buffering": "no",
       });
 
-      let lastEventId: string | undefined;
       let isOpen = true;
-
-      request.raw.on("close", () => {
-        isOpen = false;
-      });
+      const sentEventIds = new Set<string>();
 
       const sendEvent = (type: string, data: unknown) => {
         if (!isOpen) return;
@@ -61,52 +66,70 @@ export const sessionEventsRoutes: FastifyPluginAsync = async (fastify) => {
         reply.raw.write(`data: ${JSON.stringify(data)}\n\n`);
       };
 
-      // Send existing events first
-      const existingEvents = await sessionService.listEvents(session.id);
-      for (const event of existingEvents) {
-        sendEvent(event.type, event);
-        lastEventId = event.id;
-      }
-
-      // If session is already terminal, close the stream
-      const terminalStatuses = new Set(["succeeded", "failed", "cancelled"]);
-      if (terminalStatuses.has(session.status)) {
-        sendEvent("stream:end", { reason: "session_complete" });
-        reply.raw.end();
-        return;
-      }
-
-      // Poll for new events until session completes
-      const poll = async () => {
-        while (isOpen) {
-          await new Promise((resolve) => setTimeout(resolve, SSE_POLL_INTERVAL_MS));
-
-          if (!isOpen) break;
-
-          const newEvents = await sessionService.listEvents(session.id, lastEventId);
-          for (const event of newEvents) {
-            sendEvent(event.type, event);
-            lastEventId = event.id;
-          }
-
-          // Check if session has completed
-          const current = await sessionService.getById(session.id);
-          if (current && terminalStatuses.has(current.status)) {
-            sendEvent("stream:end", { reason: "session_complete", status: current.status });
-            break;
-          }
-        }
-
+      const closeStream = (reason: string, status?: string) => {
+        if (!isOpen) return;
+        sendEvent("stream:end", status ? { reason, status } : { reason });
+        isOpen = false;
         reply.raw.end();
       };
 
-      poll().catch((err) => {
-        fastify.log.error({ sessionId: session.id, err }, "SSE polling error");
-        if (isOpen) {
-          sendEvent("stream:error", { message: "Internal polling error" });
-          reply.raw.end();
+      const deliver = (event: AgentSessionEvent) => {
+        if (!isOpen || sentEventIds.has(event.id)) return;
+        sentEventIds.add(event.id);
+        sendEvent(event.type, event);
+        if (TERMINAL_EVENT_TYPES.has(event.type)) {
+          closeStream("session_complete", session.status);
+        }
+      };
+
+      // Subscribe before the catch-up read so events added during catch-up are
+      // buffered, not lost. Buffered events flush (deduped by id) after replay.
+      const liveBuffer: AgentSessionEvent[] = [];
+      let replayed = false;
+      let unsubscribe: () => void = () => {};
+      unsubscribe = getSessionEventEmitter().subscribe(session.id, (event) => {
+        if (replayed) {
+          deliver(event);
+        } else {
+          liveBuffer.push(event);
         }
       });
+
+      request.raw.on("close", () => {
+        isOpen = false;
+        unsubscribe();
+      });
+
+      try {
+        // Catch-up: read persisted events once on connect (the only DB event read).
+        const existingEvents = await sessionService.listEvents(session.id);
+        for (const event of existingEvents) {
+          deliver(event);
+        }
+
+        // Flush anything that arrived live during catch-up, then go fully live.
+        replayed = true;
+        for (const event of liveBuffer) {
+          deliver(event);
+        }
+
+        // If the session was already terminal on connect, close after replay.
+        if (isOpen && TERMINAL_STATUSES.has(session.status)) {
+          closeStream("session_complete", session.status);
+        }
+      } catch (err) {
+        fastify.log.error({ sessionId: session.id, err }, "SSE catch-up error");
+        if (isOpen) {
+          sendEvent("stream:error", { message: "Internal stream error" });
+          isOpen = false;
+          reply.raw.end();
+        }
+        unsubscribe();
+      }
+
+      if (!isOpen) {
+        unsubscribe();
+      }
     }
   );
 };

--- a/services/agent/src/services/session-event-emitter.test.ts
+++ b/services/agent/src/services/session-event-emitter.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from "vitest";
+import type { AgentSessionEvent } from "@mbe/types";
+import {
+  InProcessSessionEventEmitter,
+  getSessionEventEmitter,
+  setSessionEventEmitter,
+  type SessionEventEmitter,
+} from "./session-event-emitter.js";
+
+function makeEvent(sessionId: string, id: string): AgentSessionEvent {
+  return { id, sessionId, type: "test", data: {}, createdAt: new Date().toISOString() };
+}
+
+describe("InProcessSessionEventEmitter", () => {
+  it("delivers published events to a subscriber of the same session", () => {
+    const emitter = new InProcessSessionEventEmitter();
+    const listener = vi.fn();
+    emitter.subscribe("s1", listener);
+
+    const event = makeEvent("s1", "e1");
+    emitter.publish(event);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(event);
+  });
+
+  it("isolates events by session id", () => {
+    const emitter = new InProcessSessionEventEmitter();
+    const listener = vi.fn();
+    emitter.subscribe("s1", listener);
+
+    emitter.publish(makeEvent("s2", "e1"));
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("fans out a single publish to multiple concurrent subscribers", () => {
+    const emitter = new InProcessSessionEventEmitter();
+    const a = vi.fn();
+    const b = vi.fn();
+    emitter.subscribe("s1", a);
+    emitter.subscribe("s1", b);
+
+    const event = makeEvent("s1", "e1");
+    emitter.publish(event);
+
+    expect(a).toHaveBeenCalledWith(event);
+    expect(b).toHaveBeenCalledWith(event);
+  });
+
+  it("stops delivering after unsubscribe", () => {
+    const emitter = new InProcessSessionEventEmitter();
+    const listener = vi.fn();
+    const unsubscribe = emitter.subscribe("s1", listener);
+
+    unsubscribe();
+    emitter.publish(makeEvent("s1", "e1"));
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+describe("session event emitter seam", () => {
+  it("defaults to an in-process emitter", () => {
+    expect(getSessionEventEmitter()).toBeInstanceOf(InProcessSessionEventEmitter);
+  });
+
+  it("can be swapped for an alternate implementation", () => {
+    const original = getSessionEventEmitter();
+    const custom: SessionEventEmitter = {
+      publish: vi.fn(),
+      subscribe: vi.fn(() => () => {}),
+    };
+    try {
+      setSessionEventEmitter(custom);
+      expect(getSessionEventEmitter()).toBe(custom);
+    } finally {
+      setSessionEventEmitter(original);
+    }
+  });
+});

--- a/services/agent/src/services/session-event-emitter.ts
+++ b/services/agent/src/services/session-event-emitter.ts
@@ -1,0 +1,64 @@
+import { EventEmitter } from "node:events";
+import type { AgentSessionEvent } from "@mbe/types";
+
+/**
+ * Listener invoked with each event published for a session.
+ */
+export type SessionEventListener = (event: AgentSessionEvent) => void;
+
+/**
+ * Publish/subscribe seam for session events.
+ *
+ * `addEvent` publishes here after persisting; SSE connections subscribe for
+ * live delivery. Kept behind an interface so an out-of-process adapter (e.g.
+ * Redis pub/sub) can satisfy the same contract for multi-instance deployments.
+ */
+export interface SessionEventEmitter {
+  /** Publish a persisted event to all subscribers of its session. */
+  publish(event: AgentSessionEvent): void;
+  /**
+   * Subscribe to live events for a session.
+   * @returns an unsubscribe function.
+   */
+  subscribe(sessionId: string, listener: SessionEventListener): () => void;
+}
+
+/**
+ * In-process implementation backed by Node's EventEmitter. Single-instance
+ * only — every subscriber to a session shares one emit, so N watchers cost
+ * zero extra database reads after connect.
+ */
+export class InProcessSessionEventEmitter implements SessionEventEmitter {
+  private readonly emitter = new EventEmitter();
+
+  constructor() {
+    // SSE fan-out can exceed the default 10-listener warning threshold.
+    this.emitter.setMaxListeners(0);
+  }
+
+  publish(event: AgentSessionEvent): void {
+    this.emitter.emit(event.sessionId, event);
+  }
+
+  subscribe(sessionId: string, listener: SessionEventListener): () => void {
+    this.emitter.on(sessionId, listener);
+    return () => {
+      this.emitter.off(sessionId, listener);
+    };
+  }
+}
+
+/**
+ * Process-wide emitter seam. Defaults to the in-process implementation; can be
+ * swapped (e.g. for a Redis adapter or a test double) via
+ * {@link setSessionEventEmitter}.
+ */
+let sessionEventEmitter: SessionEventEmitter = new InProcessSessionEventEmitter();
+
+export function getSessionEventEmitter(): SessionEventEmitter {
+  return sessionEventEmitter;
+}
+
+export function setSessionEventEmitter(emitter: SessionEventEmitter): void {
+  sessionEventEmitter = emitter;
+}

--- a/services/agent/src/services/session.ts
+++ b/services/agent/src/services/session.ts
@@ -1,6 +1,7 @@
 import type { Prisma, Session, SessionEvent, SessionStatus } from "../generated/prisma/index.js";
 import type { AgentSession, AgentSessionEvent, Pagination } from "@mbe/types";
 import { prisma } from "./database.js";
+import { getSessionEventEmitter } from "./session-event-emitter.js";
 
 function isPrismaNotFound(err: unknown): boolean {
   return (
@@ -213,7 +214,10 @@ export const sessionService = {
     const event = await prisma.sessionEvent.create({
       data: { sessionId, type, data: data as Prisma.InputJsonValue },
     });
-    return mapPrismaEvent(event);
+    const mapped = mapPrismaEvent(event);
+    // Publish on the seam so SSE subscribers receive it live, without polling.
+    getSessionEventEmitter().publish(mapped);
+    return mapped;
   },
 
   async listEvents(sessionId: string, afterId?: string): Promise<AgentSessionEvent[]> {


### PR DESCRIPTION
## Summary

The agent service's session-events SSE route ran a 1-second busy-wait poll loop per connected client, re-querying events and session status from the database each tick — N watchers of one session cost ~2N queries/second regardless of event volume. There was no subscription seam: adding an event wrote to the DB and nothing could hear it.

This makes `addEvent` the publishing seam. Each persisted event is emitted on an injected in-process emitter; the SSE route subscribes for live events and reads the database only once on connect (catch-up). The database remains the source of truth for replay. The emitter sits behind an interface so a Redis pub/sub adapter can satisfy the same seam later.

## Changes

- **`services/agent/src/services/session-event-emitter.ts`** (new) — `SessionEventEmitter` interface + `InProcessSessionEventEmitter` (Node `EventEmitter`, `setMaxListeners(0)` for SSE fan-out). Swappable via `getSessionEventEmitter()` / `setSessionEventEmitter()` so a Redis adapter or test double can replace it.
- **`services/agent/src/services/session.ts`** — `addEvent` publishes the mapped event on the emitter after persisting.
- **`services/agent/src/routes/session-events.ts`** — subscribes before the catch-up read (events during catch-up are buffered, then flushed, deduped by id), streams live, closes on a terminal event type (`session:complete` / `session:error` / `session:cancelled`) or terminal status on connect. **No poll loop remains.**
- Tests for the emitter (unit) and the route (integration): live delivery without advancing any poll timer, single DB event-list read per connect, shared emit across concurrent subscribers, terminal close, catch-up replay, catch-up error path.

## Acceptance criteria

- [x] `addEvent` emits on an injected emitter after persisting; SSE route subscribes — no fixed-interval poll loop
- [x] On connect, missed events served from DB (catch-up), then live events stream from the subscription
- [x] Terminal session state still closes the stream
- [x] Integration test: event added → SSE frame delivered without advancing any poll timer; DB event-list query happens only on connect
- [x] Multiple concurrent subscribers to one session share the single emit (no per-client DB reads after connect)
- [x] `pnpm typecheck`, lint, tests green in agent service

## Gates

- `pnpm --dir services/agent lint` — 0 errors (1 pre-existing unrelated warning in `remediation.test.ts`)
- `pnpm --dir services/agent typecheck` — clean
- `pnpm --dir services/agent test` — 249 passed
- `pnpm turbo typecheck --filter='...[origin/main]'` — 20/20 packages clean

Closes #2080

🤖 Generated with [Claude Code](https://claude.com/claude-code)