### PR TITLE
refactor(rialto): useCombobox hook — extract the listbox state machine, Select adopts

### DIFF
--- a/packages/rialto/llms-full.txt
+++ b/packages/rialto/llms-full.txt
@@ -116,6 +116,24 @@
       return { style: { scale: springScale }, onMouseEnter, onMouseLeave };
     }
   </file>
+  <file path="src/hooks/useCombobox.ts">
+    export interface ComboboxItem {
+      value: string;
+      label: string;
+      disabled?: boolean;
+    }
+    export interface UseComboboxOptions {
+      items: ComboboxItem[];
+      /** Currently selected value — drives the initial focused index on open. */
+      value?: string;
+      /** Invoked when an item is committed (click, Enter, or closed type-ahead). */
+      onSelect?: (value: string) => void;
+      /** Wrapper element used to detect outside mousedown. */
+      containerRef?: RefObject<HTMLElement | null>;
+      /** Called after close/select so the consumer can return focus to its trigger. */
+      onRequestTriggerFocus?: () => void;
+    }
+  </file>
   <file path="src/hooks/useDirection.ts">
     type Direction = "ltr" | "rtl";
     export function useDirection(ref: RefObject<HTMLElement | null>): Direction {

--- a/packages/rialto/llms.txt
+++ b/packages/rialto/llms.txt
@@ -85,6 +85,24 @@
       } { /* ... */ }
     </item>
   </file>
+  <file path="src/hooks/useCombobox.ts">
+    <item priority="low">
+      interface ComboboxItem {
+        value: string;
+        label: string;
+        disabled?: boolean;
+      }
+    </item>
+    <item priority="low">
+      interface UseComboboxOptions {
+        items: ComboboxItem[];
+        value?: string;
+        onSelect?: (value: string) => void;
+        containerRef?: RefObject<HTMLElement | null>;
+        onRequestTriggerFocus?: () => void;
+      }
+    </item>
+  </file>
   <file path="src/hooks/useDirection.ts">
     <item priority="high">
       type Direction = "ltr" | "rtl";

--- a/packages/rialto/src/components/Select/Select.tsx
+++ b/packages/rialto/src/components/Select/Select.tsx
@@ -1,16 +1,9 @@
-import {
-  forwardRef,
-  useId,
-  useState,
-  useRef,
-  useEffect,
-  useCallback,
-  type KeyboardEvent,
-} from "react";
+import { forwardRef, useId, useRef, useEffect, type KeyboardEvent } from "react";
 import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import { Lock } from "lucide-react";
 import { springGentle } from "../../tokens/motion";
 import { DisabledTooltip } from "../DisabledTooltip/DisabledTooltip";
+import { useCombobox } from "../../hooks/useCombobox";
 import styles from "./Select.module.css";
 
 /* ── Types ───────────────────────────────────── */
@@ -55,7 +48,7 @@ export const Select = forwardRef<HTMLDivElement, SelectProps>(
       options,
       value,
       onChange,
-      placeholder = "Select\u2026",
+      placeholder = "Select…",
       label,
       disabled,
       disabledReason,
@@ -68,146 +61,20 @@ export const Select = forwardRef<HTMLDivElement, SelectProps>(
     const listboxId = `${baseId}-listbox`;
     const optionId = (index: number) => `${baseId}-option-${index}`;
 
-    const [open, setOpen] = useState(false);
-    const [focusedIndex, setFocusedIndex] = useState(-1);
+    const wrapperRef = useRef<HTMLDivElement>(null);
     const triggerRef = useRef<HTMLButtonElement>(null);
     const listRef = useRef<HTMLDivElement>(null);
-    const typeaheadRef = useRef("");
-    const typeaheadTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
     const shouldReduceMotion = useReducedMotion();
 
+    const { open, focusedIndex, toggle, select, setFocusedIndex, handleKeyDown } = useCombobox({
+      items: options,
+      value,
+      onSelect: onChange,
+      containerRef: wrapperRef,
+      onRequestTriggerFocus: () => triggerRef.current?.focus(),
+    });
+
     const selectedOption = options.find((o) => o.value === value);
-
-    // Close on outside click
-    useEffect(() => {
-      if (!open) return;
-      const handler = (e: MouseEvent) => {
-        const wrapper =
-          (ref as React.RefObject<HTMLDivElement>)?.current ?? triggerRef.current?.parentElement;
-        if (wrapper && !wrapper.contains(e.target as Node)) {
-          setOpen(false);
-        }
-      };
-      document.addEventListener("mousedown", handler);
-      return () => document.removeEventListener("mousedown", handler);
-    }, [open, ref]);
-
-    // Compute the initial focused index for when the dropdown opens
-    const openWithFocus = useCallback(() => {
-      const idx = value ? options.findIndex((o) => o.value === value) : 0;
-      setFocusedIndex(idx >= 0 ? idx : 0);
-      setOpen(true);
-    }, [value, options]);
-
-    const select = useCallback(
-      (optionValue: string) => {
-        onChange?.(optionValue);
-        setOpen(false);
-        triggerRef.current?.focus();
-      },
-      [onChange]
-    );
-
-    // Type-ahead: match option labels by typed characters
-    const handleTypeahead = useCallback(
-      (char: string) => {
-        clearTimeout(typeaheadTimerRef.current);
-        typeaheadRef.current += char.toLowerCase();
-        typeaheadTimerRef.current = setTimeout(() => (typeaheadRef.current = ""), 500);
-
-        const query = typeaheadRef.current;
-        const startIndex = open ? focusedIndex + 1 : 0;
-
-        // Search from current position, then wrap around
-        for (let i = 0; i < options.length; i++) {
-          const idx = (startIndex + i) % options.length;
-          const opt = options[idx];
-          if (opt && !opt.disabled && opt.label.toLowerCase().startsWith(query)) {
-            if (open) {
-              setFocusedIndex(idx);
-            } else {
-              // When closed, type-ahead selects directly
-              select(opt.value);
-            }
-            return;
-          }
-        }
-      },
-      [open, focusedIndex, options, select]
-    );
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      // Type-ahead for printable single characters
-      if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
-        e.preventDefault();
-        handleTypeahead(e.key);
-        if (!open) openWithFocus();
-        return;
-      }
-
-      if (!open) {
-        if (e.key === "ArrowDown" || e.key === "ArrowUp" || e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          openWithFocus();
-          return;
-        }
-        return;
-      }
-
-      switch (e.key) {
-        case "ArrowDown": {
-          e.preventDefault();
-          setFocusedIndex((prev) => {
-            let next = prev + 1;
-            while (next < options.length && options[next]?.disabled) next++;
-            return next < options.length ? next : prev;
-          });
-          break;
-        }
-        case "ArrowUp": {
-          e.preventDefault();
-          setFocusedIndex((prev) => {
-            let next = prev - 1;
-            while (next >= 0 && options[next]?.disabled) next--;
-            return next >= 0 ? next : prev;
-          });
-          break;
-        }
-        case "Home": {
-          e.preventDefault();
-          const first = options.findIndex((o) => !o.disabled);
-          if (first >= 0) setFocusedIndex(first);
-          break;
-        }
-        case "End": {
-          e.preventDefault();
-          for (let i = options.length - 1; i >= 0; i--) {
-            if (!options[i]?.disabled) {
-              setFocusedIndex(i);
-              break;
-            }
-          }
-          break;
-        }
-        case "Enter":
-        case " ": {
-          e.preventDefault();
-          const focused = options[focusedIndex];
-          if (focused && !focused.disabled) {
-            select(focused.value);
-          }
-          break;
-        }
-        case "Tab":
-          setOpen(false);
-          break;
-        case "Escape":
-          e.preventDefault();
-          setOpen(false);
-          triggerRef.current?.focus();
-          break;
-      }
-    };
 
     // Scroll focused option into view
     useEffect(() => {
@@ -218,16 +85,18 @@ export const Select = forwardRef<HTMLDivElement, SelectProps>(
       el?.scrollIntoView({ block: "nearest" });
     }, [open, focusedIndex]);
 
-    // Clean up typeahead timer
-    useEffect(() => {
-      const timer = typeaheadTimerRef;
-      return () => clearTimeout(timer.current);
-    }, []);
+    const onTriggerKeyDown = (e: KeyboardEvent) => handleKeyDown(e);
 
     const focusedOption = focusedIndex >= 0 ? options[focusedIndex] : undefined;
 
+    const mergeRef = (node: HTMLDivElement | null) => {
+      wrapperRef.current = node;
+      if (typeof ref === "function") ref(node);
+      else if (ref) ref.current = node;
+    };
+
     return (
-      <div ref={ref} className={[styles.wrapper, className].filter(Boolean).join(" ")}>
+      <div ref={mergeRef} className={[styles.wrapper, className].filter(Boolean).join(" ")}>
         {label && (
           <label htmlFor={triggerId} className={styles.label}>
             {label}
@@ -237,7 +106,7 @@ export const Select = forwardRef<HTMLDivElement, SelectProps>(
           <button
             ref={triggerRef}
             id={triggerId}
-            onKeyDown={disabled ? undefined : handleKeyDown}
+            onKeyDown={disabled ? undefined : onTriggerKeyDown}
             className={styles.trigger}
             type="button"
             role="combobox"
@@ -247,9 +116,7 @@ export const Select = forwardRef<HTMLDivElement, SelectProps>(
             aria-activedescendant={open && focusedOption ? optionId(focusedIndex) : undefined}
             aria-disabled={disabled || undefined}
             data-open={open}
-            onClick={
-              disabled ? (e) => e.preventDefault() : () => (open ? setOpen(false) : openWithFocus())
-            }
+            onClick={disabled ? (e) => e.preventDefault() : () => toggle()}
           >
             <span className={`${styles.triggerText} ${!selectedOption ? styles.placeholder : ""}`}>
               {selectedOption?.label ?? placeholder}
@@ -301,7 +168,7 @@ export const Select = forwardRef<HTMLDivElement, SelectProps>(
                   data-focused={index === focusedIndex}
                   data-disabled={option.disabled || undefined}
                   onClick={option.disabled ? undefined : () => select(option.value)}
-                  onKeyDown={handleKeyDown}
+                  onKeyDown={onTriggerKeyDown}
                   onMouseEnter={() => setFocusedIndex(index)}
                 >
                   <svg

--- a/packages/rialto/src/hooks/index.ts
+++ b/packages/rialto/src/hooks/index.ts
@@ -4,3 +4,5 @@ export { useScrollReveal } from "./useScrollReveal";
 export { useTilt } from "./useTilt";
 export { useThemeState, resolveTheme } from "./useThemeState";
 export type { ThemePreference, ThemeState } from "./useThemeState";
+export { useCombobox } from "./useCombobox";
+export type { ComboboxItem, UseComboboxOptions, UseComboboxResult } from "./useCombobox";

--- a/packages/rialto/src/hooks/useCombobox.test.ts
+++ b/packages/rialto/src/hooks/useCombobox.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useCombobox, type ComboboxItem } from "./useCombobox";
+
+const items: ComboboxItem[] = [
+  { value: "us", label: "United States" },
+  { value: "ca", label: "Canada" },
+  { value: "mx", label: "Mexico" },
+];
+
+const withDisabled: ComboboxItem[] = [
+  { value: "a", label: "Alpha" },
+  { value: "b", label: "Beta", disabled: true },
+  { value: "c", label: "Gamma" },
+];
+
+/** Build a KeyboardEvent-like object the hook's handler can consume. */
+function keyEvent(key: string, mods: Partial<KeyboardEvent> = {}) {
+  return {
+    key,
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    preventDefault: vi.fn(),
+    ...mods,
+  } as unknown as React.KeyboardEvent;
+}
+
+describe("useCombobox", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("open/close", () => {
+    it("starts closed with no focused item", () => {
+      const { result } = renderHook(() => useCombobox({ items }));
+      expect(result.current.open).toBe(false);
+      expect(result.current.focusedIndex).toBe(-1);
+    });
+
+    it("openWithFocus opens and focuses index 0 when no value", () => {
+      const { result } = renderHook(() => useCombobox({ items }));
+      act(() => result.current.openWithFocus());
+      expect(result.current.open).toBe(true);
+      expect(result.current.focusedIndex).toBe(0);
+    });
+
+    it("openWithFocus focuses the selected value's index", () => {
+      const { result } = renderHook(() => useCombobox({ items, value: "mx" }));
+      act(() => result.current.openWithFocus());
+      expect(result.current.focusedIndex).toBe(2);
+    });
+
+    it("close closes the menu", () => {
+      const { result } = renderHook(() => useCombobox({ items }));
+      act(() => result.current.openWithFocus());
+      act(() => result.current.close());
+      expect(result.current.open).toBe(false);
+    });
+
+    it("toggle flips open state", () => {
+      const { result } = renderHook(() => useCombobox({ items }));
+      act(() => result.current.toggle());
+      expect(result.current.open).toBe(true);
+      act(() => result.current.toggle());
+      expect(result.current.open).toBe(false);
+    });
+  });
+
+  describe("arrow navigation", () => {
+    it("ArrowDown moves focus down", () => {
+      const { result } = renderHook(() => useCombobox({ items }));
+      act(() => result.current.openWithFocus());
+      act(() => result.current.handleKeyDown(keyEvent("ArrowDown")));
+      expect(result.current.focusedIndex).toBe(1);
+    });
+
+    it("ArrowUp moves focus up", () => {
+      const { result } = renderHook(() => useCombobox({ items }));
+      act(() => result.current.openWithFocus());
+      act(() => result.current.handleKeyDown(keyEvent("ArrowDown")));
+      act(() => result.current.handleKeyDown(keyEvent("ArrowUp")));
+      expect(result.current.focusedIndex).toBe(0);
+    });
+
+    it("ArrowDown does not move past the last item", () => {
+      const { result } = renderHook(() => useCombobox({ items }));
+      act(() => result.current.openWithFocus());
+      act(() => result.current.handleKeyDown(keyEvent("ArrowDown")));
+      act(() => result.current.handleKeyDown(keyEvent("ArrowDown")));
+      act(() => result.current.handleKeyDown(keyEvent("ArrowDown")));
+      expect(result.current.focusedIndex).toBe(2);
+    });
+
+    it("ArrowDown skips disabled items", () => {
+      const { result } = renderHook(() => useCombobox({ items: withDisabled }));
+      act(() => result.current.openWithFocus()); // index 0
+      act(() => result.current.handleKeyDown(keyEvent("ArrowDown")));
+      // index 1 is disabled, so should land on 2
+      expect(result.current.focusedIndex).toBe(2);
+    });
+
+    it("ArrowUp skips disabled items", () => {
+      const { result } = renderHook(() => useCombobox({ items: withDisabled }));
+      act(() => result.current.openWithFocus());
+      act(() => result.current.handleKeyDown(keyEvent("End"))); // index 2
+      act(() => result.current.handleKeyDown(keyEvent("ArrowUp")));
+      // index 1 disabled, so should land on 0
+      expect(result.current.focusedIndex).toBe(0);
+    });
+
+    it("opens on ArrowDown when closed", () => {
+      const { result } = renderHook(() => useCombobox({ items }));
+      act(() => result.current.handleKeyDown(keyEvent("ArrowDown")));
+      expect(result.current.open).toBe(true);
+    });
+  });
+
+  describe("Home/End navigation", () => {
+    it("Home focuses the first enabled item", () => {
+      const { result } = renderHook(() => useCombobox({ items }));
+      act(() => result.current.openWithFocus());
+      act(() => result.current.handleKeyDown(keyEvent("End")));
+      act(() => result.current.handleKeyDown(keyEvent("Home")));
+      expect(result.current.focusedIndex).toBe(0);
+    });
+
+    it("End focuses the last enabled item", () => {
+      const { result } = renderHook(() => useCombobox({ items }));
+      act(() => result.current.openWithFocus());
+      act(() => result.current.handleKeyDown(keyEvent("End")));
+      expect(result.current.focusedIndex).toBe(2);
+    });
+
+    it("End skips a trailing disabled item", () => {
+      const trailing: ComboboxItem[] = [
+        { value: "a", label: "Alpha" },
+        { value: "b", label: "Beta" },
+        { value: "c", label: "Gamma", disabled: true },
+      ];
+      const { result } = renderHook(() => useCombobox({ items: trailing }));
+      act(() => result.current.openWithFocus());
+      act(() => result.current.handleKeyDown(keyEvent("End")));
+      expect(result.current.focusedIndex).toBe(1);
+    });
+  });
+
+  describe("type-ahead", () => {
+    it("focuses a matching item when open", () => {
+      const { result } = renderHook(() => useCombobox({ items }));
+      act(() => result.current.openWithFocus());
+      act(() => result.current.handleKeyDown(keyEvent("c")));
+      expect(result.current.focusedIndex).toBe(1); // Canada
+    });
+
+    it("matches multi-character queries before the timeout resets", () => {
+      const { result } = renderHook(() => useCombobox({ items }));
+      act(() => result.current.openWithFocus());
+      act(() => result.current.handleKeyDown(keyEvent("m")));
+      act(() => result.current.handleKeyDown(keyEvent("e")));
+      expect(result.current.focusedIndex).toBe(2); // Mexico ("me")
+    });
+
+    it("resets the query after the timeout", () => {
+      const { result } = renderHook(() => useCombobox({ items }));
+      act(() => result.current.openWithFocus());
+      act(() => result.current.handleKeyDown(keyEvent("m"))); // Mexico
+      act(() => vi.advanceTimersByTime(600)); // query resets
+      act(() => result.current.handleKeyDown(keyEvent("c"))); // Canada, not "mc"
+      expect(result.current.focusedIndex).toBe(1);
+    });
+
+    it("selects directly when closed", () => {
+      const onSelect = vi.fn();
+      const { result } = renderHook(() => useCombobox({ items, onSelect }));
+      act(() => result.current.handleKeyDown(keyEvent("c")));
+      expect(onSelect).toHaveBeenCalledWith("ca");
+    });
+  });
+
+  describe("selection", () => {
+    it("Enter selects the focused item", () => {
+      const onSelect = vi.fn();
+      const { result } = renderHook(() => useCombobox({ items, onSelect }));
+      act(() => result.current.openWithFocus()); // index 0
+      act(() => result.current.handleKeyDown(keyEvent("Enter")));
+      expect(onSelect).toHaveBeenCalledWith("us");
+    });
+
+    it("Enter does not select a disabled item", () => {
+      const onSelect = vi.fn();
+      const { result } = renderHook(() => useCombobox({ items: withDisabled, onSelect }));
+      act(() => result.current.openWithFocus());
+      // force focus onto disabled index 1
+      act(() => result.current.setFocusedIndex(1));
+      act(() => result.current.handleKeyDown(keyEvent("Enter")));
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it("select() invokes onSelect and closes", () => {
+      const onSelect = vi.fn();
+      const { result } = renderHook(() => useCombobox({ items, onSelect }));
+      act(() => result.current.openWithFocus());
+      act(() => result.current.select("ca"));
+      expect(onSelect).toHaveBeenCalledWith("ca");
+      expect(result.current.open).toBe(false);
+    });
+  });
+
+  describe("Escape and Tab", () => {
+    it("Escape closes the menu", () => {
+      const { result } = renderHook(() => useCombobox({ items }));
+      act(() => result.current.openWithFocus());
+      act(() => result.current.handleKeyDown(keyEvent("Escape")));
+      expect(result.current.open).toBe(false);
+    });
+
+    it("Tab closes the menu", () => {
+      const { result } = renderHook(() => useCombobox({ items }));
+      act(() => result.current.openWithFocus());
+      act(() => result.current.handleKeyDown(keyEvent("Tab")));
+      expect(result.current.open).toBe(false);
+    });
+  });
+
+  describe("click-outside", () => {
+    it("closes when a mousedown lands outside the container", () => {
+      const container = document.createElement("div");
+      document.body.appendChild(container);
+      const { result } = renderHook(() =>
+        useCombobox({ items, containerRef: { current: container } })
+      );
+      act(() => result.current.openWithFocus());
+      expect(result.current.open).toBe(true);
+
+      const outside = document.createElement("div");
+      document.body.appendChild(outside);
+      act(() => {
+        outside.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+      });
+      expect(result.current.open).toBe(false);
+
+      document.body.removeChild(container);
+      document.body.removeChild(outside);
+    });
+
+    it("stays open when mousedown lands inside the container", () => {
+      const container = document.createElement("div");
+      const inner = document.createElement("button");
+      container.appendChild(inner);
+      document.body.appendChild(container);
+      const { result } = renderHook(() =>
+        useCombobox({ items, containerRef: { current: container } })
+      );
+      act(() => result.current.openWithFocus());
+      act(() => {
+        inner.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+      });
+      expect(result.current.open).toBe(true);
+
+      document.body.removeChild(container);
+    });
+  });
+});

--- a/packages/rialto/src/hooks/useCombobox.ts
+++ b/packages/rialto/src/hooks/useCombobox.ts
@@ -1,0 +1,231 @@
+import {
+  useState,
+  useRef,
+  useEffect,
+  useCallback,
+  type KeyboardEvent,
+  type RefObject,
+} from "react";
+
+/**
+ * A single item in the combobox listbox. `value` is the stable identity,
+ * `label` is matched by type-ahead, and `disabled` items are skipped by
+ * navigation and are not selectable.
+ */
+export interface ComboboxItem {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
+export interface UseComboboxOptions {
+  items: ComboboxItem[];
+  /** Currently selected value — drives the initial focused index on open. */
+  value?: string;
+  /** Invoked when an item is committed (click, Enter, or closed type-ahead). */
+  onSelect?: (value: string) => void;
+  /** Wrapper element used to detect outside mousedown. */
+  containerRef?: RefObject<HTMLElement | null>;
+  /** Called after close/select so the consumer can return focus to its trigger. */
+  onRequestTriggerFocus?: () => void;
+}
+
+export interface UseComboboxResult {
+  readonly open: boolean;
+  readonly focusedIndex: number;
+  /** Open the listbox, focusing the selected value (or the first item). */
+  readonly openWithFocus: () => void;
+  readonly close: () => void;
+  readonly toggle: () => void;
+  /** Commit a value: fires onSelect, closes, and requests trigger focus. */
+  readonly select: (value: string) => void;
+  readonly setFocusedIndex: (index: number) => void;
+  readonly handleKeyDown: (e: KeyboardEvent) => void;
+}
+
+const TYPEAHEAD_RESET_MS = 500;
+
+/**
+ * Listbox state machine shared by combobox-style widgets (Select, Autocomplete).
+ *
+ * Owns: open/close state, focused-item index, ArrowUp/ArrowDown navigation with
+ * disabled-item skipping, Home/End, printable-character type-ahead with a
+ * timeout reset, click-outside via a document `mousedown` listener, and
+ * Escape/Tab close. Rendering and ARIA wiring stay with the consumer.
+ *
+ * Follows the rialto rule of never calling setState in a `useEffect` body:
+ * state transitions happen in event handlers, and the click-outside effect only
+ * (de)registers a listener.
+ */
+export function useCombobox({
+  items,
+  value,
+  onSelect,
+  containerRef,
+  onRequestTriggerFocus,
+}: UseComboboxOptions): UseComboboxResult {
+  const [open, setOpen] = useState(false);
+  const [focusedIndex, setFocusedIndex] = useState(-1);
+
+  const typeaheadRef = useRef("");
+  const typeaheadTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const close = useCallback(() => setOpen(false), []);
+
+  const openWithFocus = useCallback(() => {
+    const idx = value ? items.findIndex((o) => o.value === value) : 0;
+    setFocusedIndex(idx >= 0 ? idx : 0);
+    setOpen(true);
+  }, [value, items]);
+
+  const toggle = useCallback(() => {
+    if (open) {
+      setOpen(false);
+    } else {
+      openWithFocus();
+    }
+  }, [open, openWithFocus]);
+
+  const select = useCallback(
+    (optionValue: string) => {
+      onSelect?.(optionValue);
+      setOpen(false);
+      onRequestTriggerFocus?.();
+    },
+    [onSelect, onRequestTriggerFocus]
+  );
+
+  // Type-ahead: match item labels by typed characters.
+  const handleTypeahead = useCallback(
+    (char: string) => {
+      clearTimeout(typeaheadTimerRef.current);
+      typeaheadRef.current += char.toLowerCase();
+      typeaheadTimerRef.current = setTimeout(() => (typeaheadRef.current = ""), TYPEAHEAD_RESET_MS);
+
+      const query = typeaheadRef.current;
+      const startIndex = open ? focusedIndex + 1 : 0;
+
+      // Search from current position, then wrap around.
+      for (let i = 0; i < items.length; i++) {
+        const idx = (startIndex + i) % items.length;
+        const opt = items[idx];
+        if (opt && !opt.disabled && opt.label.toLowerCase().startsWith(query)) {
+          if (open) {
+            setFocusedIndex(idx);
+          } else {
+            // When closed, type-ahead selects directly.
+            select(opt.value);
+          }
+          return;
+        }
+      }
+    },
+    [open, focusedIndex, items, select]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      // Type-ahead for printable single characters.
+      if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        e.preventDefault();
+        handleTypeahead(e.key);
+        if (!open) openWithFocus();
+        return;
+      }
+
+      if (!open) {
+        if (e.key === "ArrowDown" || e.key === "ArrowUp" || e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          openWithFocus();
+        }
+        return;
+      }
+
+      switch (e.key) {
+        case "ArrowDown": {
+          e.preventDefault();
+          setFocusedIndex((prev) => {
+            let next = prev + 1;
+            while (next < items.length && items[next]?.disabled) next++;
+            return next < items.length ? next : prev;
+          });
+          break;
+        }
+        case "ArrowUp": {
+          e.preventDefault();
+          setFocusedIndex((prev) => {
+            let next = prev - 1;
+            while (next >= 0 && items[next]?.disabled) next--;
+            return next >= 0 ? next : prev;
+          });
+          break;
+        }
+        case "Home": {
+          e.preventDefault();
+          const first = items.findIndex((o) => !o.disabled);
+          if (first >= 0) setFocusedIndex(first);
+          break;
+        }
+        case "End": {
+          e.preventDefault();
+          for (let i = items.length - 1; i >= 0; i--) {
+            if (!items[i]?.disabled) {
+              setFocusedIndex(i);
+              break;
+            }
+          }
+          break;
+        }
+        case "Enter":
+        case " ": {
+          e.preventDefault();
+          const focused = items[focusedIndex];
+          if (focused && !focused.disabled) {
+            select(focused.value);
+          }
+          break;
+        }
+        case "Tab":
+          setOpen(false);
+          break;
+        case "Escape":
+          e.preventDefault();
+          setOpen(false);
+          onRequestTriggerFocus?.();
+          break;
+      }
+    },
+    [open, focusedIndex, items, handleTypeahead, openWithFocus, select, onRequestTriggerFocus]
+  );
+
+  // Close on outside mousedown. Effect only (de)registers the listener — the
+  // setState happens inside the event handler, never in the effect body.
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      const wrapper = containerRef?.current;
+      if (wrapper && !wrapper.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open, containerRef]);
+
+  // Clean up the type-ahead timer on unmount.
+  useEffect(() => {
+    const timer = typeaheadTimerRef;
+    return () => clearTimeout(timer.current);
+  }, []);
+
+  return {
+    open,
+    focusedIndex,
+    openWithFocus,
+    close,
+    toggle,
+    select,
+    setFocusedIndex,
+    handleKeyDown,
+  };
+}


### PR DESCRIPTION
## What & why

`Select` (332 lines) and `Autocomplete` (261 lines) independently reimplemented the same listbox state machine. This PR extracts a `useCombobox` hook that owns the machine and refactors `Select` to consume it. Autocomplete adoption is a deliberate follow-up slice (the second adapter that makes the seam real).

## What the hook owns

- Open/close state (`openWithFocus`, `close`, `toggle`)
- ArrowUp/ArrowDown navigation with disabled-item skipping
- Home/End navigation
- Printable-character type-ahead with 500ms timeout reset (and closed-state direct selection)
- Click-outside via a `document` `mousedown` listener (consumer passes a `containerRef`)
- Escape/Tab close
- Selection (`select`, Enter/Space), with `onSelect` + `onRequestTriggerFocus` callbacks

Rendering and ARIA wiring stay with the consumer. State transitions happen in event handlers — **never `setState` in a `useEffect` body** — per the rialto design-system rule. The click-outside effect only (de)registers the listener; the cleanup effect only clears the type-ahead timer.

## Files changed

- `packages/rialto/src/hooks/useCombobox.ts` — new hook (state machine)
- `packages/rialto/src/hooks/useCombobox.test.ts` — new test suite (25 tests)
- `packages/rialto/src/hooks/index.ts` — export hook + types
- `packages/rialto/src/components/Select/Select.tsx` — consume hook, delete inline state machine
- `packages/rialto/llms.txt` / `llms-full.txt` — regenerated by pre-commit `pack-changed` hook

## Behavior parity

Select's inline machine was deleted and replaced by the hook with no behavioral change. The one structural difference: the old click-outside logic resolved its wrapper as `(forwardedRef ?? triggerRef.parentElement)`; the refactor passes a dedicated internal `wrapperRef` (merged with the forwarded ref) as the hook's `containerRef`, which is strictly more reliable.

## Existing Select tests

**All 25 existing Select tests pass unmodified** — `Select.test.tsx` was not touched.

## Test plan / gates (all green)

- [x] `pnpm --dir packages/rialto lint` — 0 errors (pre-existing warnings only; no new warnings on `useCombobox.*`)
- [x] `pnpm --dir packages/rialto typecheck` — clean
- [x] `pnpm --dir packages/rialto build` — built (requires `@mbe/api-client` built first; verified via `turbo --filter='...'`)
- [x] `pnpm --dir packages/rialto test` — 1637 passed / 98 files (includes a11y)
- [x] `useCombobox.test.ts` — 25 passed (covers open/close, arrow + Home/End nav, type-ahead w/ timeout reset, click-outside via document mousedown, Escape)
- [x] `pnpm turbo typecheck --filter='...[origin/main]'` — 20/20 tasks pass (downstream apps clean)
- [x] `@mbe/rialto-catalog` drift-check — 100 passed

Closes #2081

🤖 Generated with [Claude Code](https://claude.com/claude-code)