### PR TITLE
refactor(gen): AppShell compound components replace 11-prop interface

### DIFF
--- a/apps/gen/src/components/AppShell.module.css
+++ b/apps/gen/src/components/AppShell.module.css
@@ -125,3 +125,85 @@
     display: none;
   }
 }
+
+/* ── Side panel wrapper (desktop) ─────────────── */
+
+.sidePanel {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-inline-size: 0;
+}
+
+/* ── Overlay backdrop (mobile/tablet) ─────────── */
+
+.backdrop {
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+  background-color: var(--rialto-overlay);
+  animation: fadeIn 200ms var(--rialto-ease-smooth);
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+/* ── Overlay panels (mobile/tablet) ───────────── */
+
+.overlayPanel {
+  position: absolute;
+  inset-block: 0;
+  z-index: 11;
+  inline-size: min(320px, 85vw);
+  background-color: var(--rialto-surface-default);
+  box-shadow: var(--rialto-shadow-lg);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.overlayStart {
+  inset-inline-start: 0;
+  animation: slideInStart 250ms var(--rialto-ease-smooth);
+}
+
+.overlayEnd {
+  inset-inline-end: 0;
+  animation: slideInEnd 250ms var(--rialto-ease-smooth);
+}
+
+@keyframes slideInStart {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes slideInEnd {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+/* ── Reduced motion ──────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .backdrop {
+    animation: none;
+  }
+
+  .overlayStart,
+  .overlayEnd {
+    animation: none;
+  }
+}

--- a/apps/gen/src/components/AppShell.test.tsx
+++ b/apps/gen/src/components/AppShell.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { AppShell } from "./AppShell.js";
+import { AppShell, useAppShellPanels } from "./AppShell.js";
 
 vi.mock("@mattbutlerengineering/rialto", () => ({
   AppBar: ({ logo, actions }: { logo: React.ReactNode; actions: React.ReactNode }) => (
@@ -67,6 +67,22 @@ vi.mock("../contexts/ThemeContext.js", () => ({
   useTheme: () => ({ theme: "light", toggleTheme: vi.fn() }),
 }));
 
+const mockToggleHistory = vi.fn();
+const mockToggleInspector = vi.fn();
+const mockCloseOverlays = vi.fn();
+let panelLayoutState = {
+  historyVisible: true,
+  inspectorVisible: true,
+  breakpoint: "desktop" as "mobile" | "tablet" | "desktop",
+  toggleHistory: mockToggleHistory,
+  toggleInspector: mockToggleInspector,
+  closeOverlays: mockCloseOverlays,
+};
+
+vi.mock("../hooks/usePanelLayout.js", () => ({
+  usePanelLayout: () => panelLayoutState,
+}));
+
 vi.mock("./AppShell.module.css", () => ({
   default: {
     shell: "shell",
@@ -80,16 +96,29 @@ vi.mock("./AppShell.module.css", () => ({
     actions: "actions",
     content: "content",
     skipLink: "skipLink",
+    sidePanel: "sidePanel",
+    overlayPanel: "overlayPanel",
+    overlayStart: "overlayStart",
+    overlayEnd: "overlayEnd",
+    backdrop: "backdrop",
   },
 }));
 
 const child = <div data-testid="child-content">Content</div>;
 
-describe("AppShell", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+beforeEach(() => {
+  vi.clearAllMocks();
+  panelLayoutState = {
+    historyVisible: true,
+    inspectorVisible: true,
+    breakpoint: "desktop",
+    toggleHistory: mockToggleHistory,
+    toggleInspector: mockToggleInspector,
+    closeOverlays: mockCloseOverlays,
+  };
+});
 
+describe("AppShell", () => {
   it("renders children inside the content area", () => {
     render(<AppShell>{child}</AppShell>);
     expect(screen.getByTestId("child-content")).toBeDefined();
@@ -113,38 +142,19 @@ describe("AppShell", () => {
     expect(onSignOut).toHaveBeenCalledTimes(1);
   });
 
-  it("shows panel toggle for history when onToggleHistory is provided", () => {
-    const onToggleHistory = vi.fn();
-    render(<AppShell onToggleHistory={onToggleHistory}>{child}</AppShell>);
-    expect(screen.getByRole("button", { name: /toggle history panel/i })).toBeDefined();
-  });
-
-  it("hides history panel toggle when onToggleHistory is not provided", () => {
+  it("renders avatar with user name", () => {
     render(<AppShell>{child}</AppShell>);
-    expect(screen.queryByRole("button", { name: /toggle history panel/i })).toBeNull();
+    expect(screen.getByTestId("avatar")).toBeDefined();
+    expect(screen.getByText("Test User")).toBeDefined();
   });
 
-  it("calls onToggleHistory when history toggle is clicked", () => {
-    const onToggleHistory = vi.fn();
-    render(<AppShell onToggleHistory={onToggleHistory}>{child}</AppShell>);
-    fireEvent.click(screen.getByRole("button", { name: /toggle history panel/i }));
-    expect(onToggleHistory).toHaveBeenCalledTimes(1);
-  });
-
-  it("shows inspector panel toggle when onToggleInspector is provided", () => {
-    const onToggleInspector = vi.fn();
-    render(<AppShell onToggleInspector={onToggleInspector}>{child}</AppShell>);
-    expect(screen.getByRole("button", { name: /toggle json inspector/i })).toBeDefined();
-  });
-
-  it("hides inspector panel toggle when onToggleInspector is not provided", () => {
+  it("renders the theme toggle", () => {
     render(<AppShell>{child}</AppShell>);
-    expect(screen.queryByRole("button", { name: /toggle json inspector/i })).toBeNull();
+    expect(screen.getByTestId("theme-toggle")).toBeDefined();
   });
 
   it("shows Templates button when onTemplatesOpen is provided", () => {
-    const onTemplatesOpen = vi.fn();
-    render(<AppShell onTemplatesOpen={onTemplatesOpen}>{child}</AppShell>);
+    render(<AppShell onTemplatesOpen={vi.fn()}>{child}</AppShell>);
     expect(screen.getByRole("button", { name: /templates/i })).toBeDefined();
   });
 
@@ -160,29 +170,180 @@ describe("AppShell", () => {
     expect(onTemplatesOpen).toHaveBeenCalledTimes(1);
   });
 
-  it("renders avatar with user name", () => {
+  it("calls onLogoClick when the logo is clicked", () => {
+    const onLogoClick = vi.fn();
+    render(<AppShell onLogoClick={onLogoClick}>{child}</AppShell>);
+    fireEvent.click(screen.getByRole("button", { name: /return to empty state/i }));
+    expect(onLogoClick).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("AppShell — shell-owned panel toggle state", () => {
+  it("always renders the history toggle (shell owns the state, no callback needed)", () => {
     render(<AppShell>{child}</AppShell>);
-    expect(screen.getByTestId("avatar")).toBeDefined();
-    expect(screen.getByText("Test User")).toBeDefined();
+    expect(screen.getByRole("button", { name: /toggle history panel/i })).toBeDefined();
   });
 
-  it("renders the theme toggle", () => {
+  it("always renders the inspector toggle (shell owns the state, no callback needed)", () => {
     render(<AppShell>{child}</AppShell>);
-    expect(screen.getByTestId("theme-toggle")).toBeDefined();
+    expect(screen.getByRole("button", { name: /toggle json inspector/i })).toBeDefined();
   });
 
-  it("renders CommandPalette when paletteOpen and commandItems are provided", () => {
-    const onPaletteOpenChange = vi.fn();
+  it("toggles history visibility through the shell-owned state", () => {
+    render(<AppShell>{child}</AppShell>);
+    fireEvent.click(screen.getByRole("button", { name: /toggle history panel/i }));
+    expect(mockToggleHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it("toggles inspector visibility through the shell-owned state", () => {
+    render(<AppShell>{child}</AppShell>);
+    fireEvent.click(screen.getByRole("button", { name: /toggle json inspector/i }));
+    expect(mockToggleInspector).toHaveBeenCalledTimes(1);
+  });
+
+  it("reflects history visibility in aria-pressed", () => {
+    render(<AppShell>{child}</AppShell>);
+    expect(
+      screen.getByRole("button", { name: /toggle history panel/i }).getAttribute("aria-pressed")
+    ).toBe("true");
+  });
+});
+
+describe("AppShell.HistoryRegion", () => {
+  it("renders panel content when history is visible", () => {
     render(
-      <AppShell paletteOpen={true} onPaletteOpenChange={onPaletteOpenChange} commandItems={[]}>
-        {child}
+      <AppShell>
+        <AppShell.HistoryRegion>
+          <div data-testid="history-content">history</div>
+        </AppShell.HistoryRegion>
+      </AppShell>
+    );
+    expect(screen.getByTestId("history-content")).toBeDefined();
+  });
+
+  it("renders nothing when history is hidden", () => {
+    panelLayoutState = { ...panelLayoutState, historyVisible: false };
+    render(
+      <AppShell>
+        <AppShell.HistoryRegion>
+          <div data-testid="history-content">history</div>
+        </AppShell.HistoryRegion>
+      </AppShell>
+    );
+    expect(screen.queryByTestId("history-content")).toBeNull();
+  });
+
+  it("renders nothing when fullscreen even if history is visible", () => {
+    render(
+      <AppShell isFullscreen>
+        <AppShell.HistoryRegion>
+          <div data-testid="history-content">history</div>
+        </AppShell.HistoryRegion>
+      </AppShell>
+    );
+    expect(screen.queryByTestId("history-content")).toBeNull();
+  });
+});
+
+describe("AppShell.InspectorRegion", () => {
+  it("renders panel content when inspector is visible", () => {
+    render(
+      <AppShell>
+        <AppShell.InspectorRegion>
+          <div data-testid="inspector-content">inspector</div>
+        </AppShell.InspectorRegion>
+      </AppShell>
+    );
+    expect(screen.getByTestId("inspector-content")).toBeDefined();
+  });
+
+  it("renders nothing when inspector is hidden", () => {
+    panelLayoutState = { ...panelLayoutState, inspectorVisible: false };
+    render(
+      <AppShell>
+        <AppShell.InspectorRegion>
+          <div data-testid="inspector-content">inspector</div>
+        </AppShell.InspectorRegion>
+      </AppShell>
+    );
+    expect(screen.queryByTestId("inspector-content")).toBeNull();
+  });
+});
+
+describe("AppShell.CommandPalette", () => {
+  it("renders the command palette as a composable child", () => {
+    render(
+      <AppShell>
+        <AppShell.CommandPalette items={[]} />
       </AppShell>
     );
     expect(screen.getByTestId("command-palette")).toBeDefined();
   });
 
-  it("does not render CommandPalette when paletteOpen is undefined", () => {
+  it("does not render a command palette when the child is not composed", () => {
     render(<AppShell>{child}</AppShell>);
     expect(screen.queryByTestId("command-palette")).toBeNull();
+  });
+});
+
+describe("useAppShellPanels", () => {
+  function Probe() {
+    const panels = useAppShellPanels();
+    return (
+      <div>
+        <span data-testid="history-visible">{String(panels.historyVisible)}</span>
+        <span data-testid="inspector-visible">{String(panels.inspectorVisible)}</span>
+        <span data-testid="breakpoint">{panels.breakpoint}</span>
+        <button type="button" onClick={() => panels.openPalette()}>
+          open palette
+        </button>
+        <button type="button" onClick={() => panels.closeOverlays()}>
+          close overlays
+        </button>
+      </div>
+    );
+  }
+
+  it("exposes the shell-owned panel state to the page body", () => {
+    render(
+      <AppShell>
+        <Probe />
+      </AppShell>
+    );
+    expect(screen.getByTestId("history-visible").textContent).toBe("true");
+    expect(screen.getByTestId("inspector-visible").textContent).toBe("true");
+    expect(screen.getByTestId("breakpoint").textContent).toBe("desktop");
+  });
+
+  it("opens the command palette through the exposed control", () => {
+    render(
+      <AppShell>
+        <AppShell.CommandPalette items={[]} />
+        <Probe />
+      </AppShell>
+    );
+    expect(screen.getByTestId("command-palette").getAttribute("data-open")).toBe("false");
+    fireEvent.click(screen.getByText("open palette"));
+    expect(screen.getByTestId("command-palette").getAttribute("data-open")).toBe("true");
+  });
+
+  it("delegates closeOverlays to the panel layout", () => {
+    render(
+      <AppShell>
+        <Probe />
+      </AppShell>
+    );
+    fireEvent.click(screen.getByText("close overlays"));
+    expect(mockCloseOverlays).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when used outside an AppShell", () => {
+    function Orphan() {
+      useAppShellPanels();
+      return null;
+    }
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => render(<Orphan />)).toThrow(/AppShell/);
+    spy.mockRestore();
   });
 });

--- a/apps/gen/src/components/AppShell.tsx
+++ b/apps/gen/src/components/AppShell.tsx
@@ -1,3 +1,4 @@
+import { createContext, useContext, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 import {
   AppBar,
@@ -11,41 +12,115 @@ import {
 import type { CommandItem } from "@mattbutlerengineering/rialto";
 import { useAuth } from "@mbe/auth/react";
 import { useTheme } from "../contexts/ThemeContext.js";
+import { usePanelLayout } from "../hooks/usePanelLayout.js";
 import styles from "./AppShell.module.css";
 
-export interface AppShellProps {
-  children: ReactNode;
-  onSignOut?: () => void;
-  historyVisible?: boolean;
-  inspectorVisible?: boolean;
-  onToggleHistory?: () => void;
-  onToggleInspector?: () => void;
-  onLogoClick?: () => void;
-  onTemplatesOpen?: () => void;
-  paletteOpen?: boolean;
-  onPaletteOpenChange?: (open: boolean) => void;
-  commandItems?: CommandItem[];
+type Breakpoint = "mobile" | "tablet" | "desktop";
+
+/**
+ * State exposed by the shell to the page body. The shell owns panel
+ * visibility (history / inspector) and the command-palette open flag; pages
+ * read this through {@link useAppShellPanels} instead of threading callbacks
+ * and paired flags through props.
+ */
+interface AppShellPanels {
+  historyVisible: boolean;
+  inspectorVisible: boolean;
+  breakpoint: Breakpoint;
+  isFullscreen: boolean;
+  toggleHistory: () => void;
+  toggleInspector: () => void;
+  closeOverlays: () => void;
+  openPalette: () => void;
+  closePalette: () => void;
+}
+
+interface AppShellContextValue extends AppShellPanels {
+  paletteOpen: boolean;
+  setPaletteOpen: (open: boolean) => void;
+}
+
+const AppShellContext = createContext<AppShellContextValue | null>(null);
+
+function useAppShellContext(): AppShellContextValue {
+  const ctx = useContext(AppShellContext);
+  if (!ctx) {
+    throw new Error("AppShell compound components must be used within <AppShell>");
+  }
+  return ctx;
 }
 
 /**
- * Top-level layout shell with AppBar (panel toggles, theme toggle, user avatar, logout)
- * and a content area below.
+ * Read the shell-owned panel state from inside an {@link AppShell}.
+ * Use this in the page body to drive responsive layout classes and
+ * overlay-dismissal behaviour without re-deriving panel state.
+ */
+export function useAppShellPanels(): AppShellPanels {
+  const {
+    historyVisible,
+    inspectorVisible,
+    breakpoint,
+    isFullscreen,
+    toggleHistory,
+    toggleInspector,
+    closeOverlays,
+    openPalette,
+    closePalette,
+  } = useAppShellContext();
+  return {
+    historyVisible,
+    inspectorVisible,
+    breakpoint,
+    isFullscreen,
+    toggleHistory,
+    toggleInspector,
+    closeOverlays,
+    openPalette,
+    closePalette,
+  };
+}
+
+export interface AppShellProps {
+  children: ReactNode;
+  /** Genuinely per-page: how to sign the user out. Defaults to auth signOut. */
+  onSignOut?: () => void;
+  /** Genuinely per-page: clicking the logo returns to the empty state. */
+  onLogoClick?: () => void;
+  /** Genuinely per-page: open the templates gallery. Omit to hide the button. */
+  onTemplatesOpen?: () => void;
+  /** Genuinely per-page: fullscreen suppresses the side panels. */
+  isFullscreen?: boolean;
+}
+
+interface RegionProps {
+  children: ReactNode;
+}
+
+/**
+ * Top-level layout shell. Owns panel toggle state (history / inspector) and
+ * the command-palette open flag internally via {@link usePanelLayout}, exposing
+ * them through context. Compose {@link AppShell.HistoryRegion},
+ * {@link AppShell.InspectorRegion}, and {@link AppShell.CommandPalette} as
+ * children instead of wiring callbacks and paired visibility flags.
  */
 export function AppShell({
   children,
   onSignOut,
-  historyVisible = true,
-  inspectorVisible = true,
-  onToggleHistory,
-  onToggleInspector,
   onLogoClick,
   onTemplatesOpen,
-  paletteOpen,
-  onPaletteOpenChange,
-  commandItems,
+  isFullscreen = false,
 }: AppShellProps) {
   const { theme, toggleTheme } = useTheme();
   const { user, signOut } = useAuth();
+  const {
+    historyVisible,
+    inspectorVisible,
+    breakpoint,
+    toggleHistory,
+    toggleInspector,
+    closeOverlays,
+  } = usePanelLayout();
+  const [paletteOpen, setPaletteOpen] = useState(false);
 
   function handleSignOut() {
     if (onSignOut) {
@@ -55,79 +130,159 @@ export function AppShell({
     }
   }
 
+  const contextValue = useMemo<AppShellContextValue>(
+    () => ({
+      historyVisible,
+      inspectorVisible,
+      breakpoint,
+      isFullscreen,
+      toggleHistory,
+      toggleInspector,
+      closeOverlays,
+      openPalette: () => setPaletteOpen(true),
+      closePalette: () => setPaletteOpen(false),
+      paletteOpen,
+      setPaletteOpen,
+    }),
+    [
+      historyVisible,
+      inspectorVisible,
+      breakpoint,
+      isFullscreen,
+      toggleHistory,
+      toggleInspector,
+      closeOverlays,
+      paletteOpen,
+    ]
+  );
+
   return (
-    <div className={styles.shell}>
-      <a href="#main-content" className={styles.skipLink}>
-        Skip to main content
-      </a>
-      <AppBar
-        logo={
-          <div className={styles.logoGroup}>
-            {onToggleHistory && (
+    <AppShellContext.Provider value={contextValue}>
+      <div className={styles.shell}>
+        <a href="#main-content" className={styles.skipLink}>
+          Skip to main content
+        </a>
+        <AppBar
+          logo={
+            <div className={styles.logoGroup}>
               <Button
                 type="button"
                 className={`${styles.panelToggle} ${historyVisible ? styles.panelToggleActive : ""}`}
-                onClick={onToggleHistory}
+                onClick={toggleHistory}
                 aria-label="Toggle history panel"
                 aria-pressed={historyVisible}
               >
                 <Text aria-hidden="true">&#9776;</Text>
               </Button>
-            )}
-            <Button
-              type="button"
-              className={styles.logoButton}
-              onClick={onLogoClick}
-              aria-label="Return to empty state"
-            >
-              <Text className={styles.logoAccent} aria-hidden="true">
-                &#9670;
-              </Text>
-              <Text className={styles.logoText}>Gen Playground</Text>
-            </Button>
-            <Shortcut keys={["\u2318", "K"]} className={styles.shortcutHint} />
-          </div>
-        }
-        actions={
-          <div className={styles.actions}>
-            {onTemplatesOpen && (
-              <Button variant="ghost" size="sm" onClick={onTemplatesOpen}>
-                Templates
+              <Button
+                type="button"
+                className={styles.logoButton}
+                onClick={onLogoClick}
+                aria-label="Return to empty state"
+              >
+                <Text className={styles.logoAccent} aria-hidden="true">
+                  &#9670;
+                </Text>
+                <Text className={styles.logoText}>Gen Playground</Text>
               </Button>
-            )}
-            {onToggleInspector && (
+              <Shortcut keys={["⌘", "K"]} className={styles.shortcutHint} />
+            </div>
+          }
+          actions={
+            <div className={styles.actions}>
+              {onTemplatesOpen && (
+                <Button variant="ghost" size="sm" onClick={onTemplatesOpen}>
+                  Templates
+                </Button>
+              )}
               <Button
                 type="button"
                 className={`${styles.panelToggle} ${inspectorVisible ? styles.panelToggleActive : ""}`}
-                onClick={onToggleInspector}
+                onClick={toggleInspector}
                 aria-label="Toggle JSON inspector"
                 aria-pressed={inspectorVisible}
               >
                 <Text aria-hidden="true">{"{}"}</Text>
               </Button>
-            )}
-            <ThemeToggle theme={theme} onToggle={toggleTheme} />
-            {user && (
-              <Avatar src={user.picture} name={user.name ?? user.email ?? "User"} size="sm" />
-            )}
-            <Button variant="ghost" size="sm" onClick={handleSignOut}>
-              Sign out
-            </Button>
-          </div>
-        }
-      />
-      <div id="main-content" className={styles.content}>
-        {children}
-      </div>
-      {paletteOpen !== undefined && onPaletteOpenChange && commandItems && (
-        <CommandPalette
-          open={paletteOpen}
-          onOpenChange={onPaletteOpenChange}
-          items={commandItems}
-          groups={["Actions", "Panels", "Settings"]}
-          placeholder="Search commands..."
+              <ThemeToggle theme={theme} onToggle={toggleTheme} />
+              {user && (
+                <Avatar src={user.picture} name={user.name ?? user.email ?? "User"} size="sm" />
+              )}
+              <Button variant="ghost" size="sm" onClick={handleSignOut}>
+                Sign out
+              </Button>
+            </div>
+          }
         />
-      )}
-    </div>
+        <div id="main-content" className={styles.content}>
+          {children}
+        </div>
+      </div>
+    </AppShellContext.Provider>
   );
 }
+
+/**
+ * Wraps the history panel. Renders nothing when history is hidden or the page
+ * is fullscreen. Applies the responsive side-panel / overlay chrome and an
+ * overlay backdrop on mobile/tablet.
+ */
+function HistoryRegion({ children }: RegionProps) {
+  const { historyVisible, isFullscreen, breakpoint, closeOverlays } = useAppShellContext();
+  if (isFullscreen || !historyVisible) return null;
+  const isOverlay = breakpoint !== "desktop";
+  return (
+    <>
+      {isOverlay && <div className={styles.backdrop} onClick={closeOverlays} aria-hidden="true" />}
+      <div
+        className={isOverlay ? `${styles.overlayPanel} ${styles.overlayStart}` : styles.sidePanel}
+      >
+        {children}
+      </div>
+    </>
+  );
+}
+
+/**
+ * Wraps the JSON inspector panel. Renders nothing when the inspector is hidden
+ * or the page is fullscreen. Applies the responsive side-panel / overlay chrome
+ * and an overlay backdrop on mobile/tablet.
+ */
+function InspectorRegion({ children }: RegionProps) {
+  const { inspectorVisible, isFullscreen, breakpoint, closeOverlays } = useAppShellContext();
+  if (isFullscreen || !inspectorVisible) return null;
+  const isOverlay = breakpoint !== "desktop";
+  return (
+    <>
+      {isOverlay && <div className={styles.backdrop} onClick={closeOverlays} aria-hidden="true" />}
+      <div className={isOverlay ? `${styles.overlayPanel} ${styles.overlayEnd}` : styles.sidePanel}>
+        {children}
+      </div>
+    </>
+  );
+}
+
+interface ShellCommandPaletteProps {
+  items: CommandItem[];
+}
+
+/**
+ * Command palette wired to the shell-owned open state. Open it with
+ * {@link useAppShellPanels}'s `openPalette`.
+ */
+function ShellCommandPalette({ items }: ShellCommandPaletteProps) {
+  const { paletteOpen, setPaletteOpen } = useAppShellContext();
+  return (
+    <CommandPalette
+      open={paletteOpen}
+      onOpenChange={setPaletteOpen}
+      items={items}
+      groups={["Actions", "Panels", "Settings"]}
+      placeholder="Search commands..."
+    />
+  );
+}
+
+AppShell.HistoryRegion = HistoryRegion;
+AppShell.InspectorRegion = InspectorRegion;
+AppShell.CommandPalette = ShellCommandPalette;

--- a/apps/gen/src/pages/PlaygroundPage.module.css
+++ b/apps/gen/src/pages/PlaygroundPage.module.css
@@ -30,76 +30,6 @@
   overflow: hidden;
 }
 
-/* ── Side panel wrapper (desktop) ─────────────── */
-
-.sidePanel {
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  min-inline-size: 0;
-}
-
-/* ── Overlay backdrop (mobile/tablet) ─────────── */
-
-.backdrop {
-  position: absolute;
-  inset: 0;
-  z-index: 10;
-  background-color: var(--rialto-overlay);
-  animation: fadeIn 200ms var(--rialto-ease-smooth);
-}
-
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-/* ── Overlay panels (mobile/tablet) ───────────── */
-
-.overlayPanel {
-  position: absolute;
-  inset-block: 0;
-  z-index: 11;
-  inline-size: min(320px, 85vw);
-  background-color: var(--rialto-surface-default);
-  box-shadow: var(--rialto-shadow-lg);
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-}
-
-.overlayStart {
-  inset-inline-start: 0;
-  animation: slideInStart 250ms var(--rialto-ease-smooth);
-}
-
-.overlayEnd {
-  inset-inline-end: 0;
-  animation: slideInEnd 250ms var(--rialto-ease-smooth);
-}
-
-@keyframes slideInStart {
-  from {
-    transform: translateX(-100%);
-  }
-  to {
-    transform: translateX(0);
-  }
-}
-
-@keyframes slideInEnd {
-  from {
-    transform: translateX(100%);
-  }
-  to {
-    transform: translateX(0);
-  }
-}
-
 /* ── Tablet: 2-column default ─────────────────── */
 
 @media (min-width: 768px) and (max-width: 1024px) {
@@ -132,17 +62,5 @@
   .layout[data-inspector="true"],
   .layout[data-history="true"][data-inspector="true"] {
     grid-template-columns: 1fr;
-  }
-}
-
-/* ── Reduced motion ──────────────────────────── */
-@media (prefers-reduced-motion: reduce) {
-  .backdrop {
-    animation: none;
-  }
-
-  .overlayStart,
-  .overlayEnd {
-    animation: none;
   }
 }

--- a/apps/gen/src/pages/PlaygroundPage.test.tsx
+++ b/apps/gen/src/pages/PlaygroundPage.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable mbe-local/prefer-rialto-components */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 
@@ -61,23 +60,14 @@ vi.mock("../hooks/useSpecsApi.js", () => ({
   }),
 }));
 
-vi.mock("../hooks/usePanelLayout.js", () => ({
-  usePanelLayout: () => ({
-    historyVisible: true,
-    inspectorVisible: true,
-    breakpoint: "desktop",
-    toggleHistory: mockToggleHistory,
-    toggleInspector: mockToggleInspector,
-    closeOverlays: mockCloseOverlays,
-  }),
-}));
-
 vi.mock("../contexts/ThemeContext.js", () => ({
   useTheme: () => ({ theme: "light", toggleTheme: mockToggleTheme }),
 }));
 
-vi.mock("../components/AppShell.js", () => ({
-  AppShell: ({
+// AppShell now owns panel toggle state and exposes it via context. The mock
+// provides the compound children and the useAppShellPanels hook the page reads.
+vi.mock("../components/AppShell.js", () => {
+  function AppShell({
     children,
     onSignOut,
     onLogoClick,
@@ -87,15 +77,43 @@ vi.mock("../components/AppShell.js", () => ({
     onSignOut?: () => void;
     onLogoClick?: () => void;
     onTemplatesOpen?: () => void;
-  }) => (
-    <div data-testid="app-shell">
-      {onSignOut && <button onClick={onSignOut}>Sign Out</button>}
-      {onLogoClick && <button onClick={onLogoClick}>Logo</button>}
-      {onTemplatesOpen && <button onClick={onTemplatesOpen}>Templates</button>}
-      {children}
-    </div>
-  ),
-}));
+  }) {
+    return (
+      <div data-testid="app-shell">
+        {onSignOut && <button onClick={onSignOut}>Sign Out</button>}
+        {onLogoClick && <button onClick={onLogoClick}>Logo</button>}
+        {onTemplatesOpen && <button onClick={onTemplatesOpen}>Templates</button>}
+        {children}
+      </div>
+    );
+  }
+  function HistoryRegion({ children }: { children: React.ReactNode }) {
+    return <>{children}</>;
+  }
+  function InspectorRegion({ children }: { children: React.ReactNode }) {
+    return <>{children}</>;
+  }
+  function CommandPalette() {
+    return null;
+  }
+  AppShell.HistoryRegion = HistoryRegion;
+  AppShell.InspectorRegion = InspectorRegion;
+  AppShell.CommandPalette = CommandPalette;
+  return {
+    AppShell,
+    useAppShellPanels: () => ({
+      historyVisible: true,
+      inspectorVisible: true,
+      breakpoint: "desktop",
+      isFullscreen: false,
+      toggleHistory: mockToggleHistory,
+      toggleInspector: mockToggleInspector,
+      closeOverlays: mockCloseOverlays,
+      openPalette: vi.fn(),
+      closePalette: vi.fn(),
+    }),
+  };
+});
 
 vi.mock("../components/HistoryPanel.js", () => ({
   HistoryPanel: ({

--- a/apps/gen/src/pages/PlaygroundPage.tsx
+++ b/apps/gen/src/pages/PlaygroundPage.tsx
@@ -5,15 +5,15 @@ import type { CommandItem } from "@mattbutlerengineering/rialto";
 import type { Spec } from "@json-render/react";
 import { useGenStream } from "../hooks/useGenStream.js";
 import { useSpecsApi } from "../hooks/useSpecsApi.js";
-import { usePanelLayout } from "../hooks/usePanelLayout.js";
 import { useTheme } from "../contexts/ThemeContext.js";
-import { AppShell } from "../components/AppShell.js";
+import { AppShell, useAppShellPanels } from "../components/AppShell.js";
 import { HistoryPanel } from "../components/HistoryPanel.js";
 import { PreviewPane } from "../components/PreviewPane.js";
 import { JsonInspector } from "../components/JsonInspector.js";
 import { PromptBar } from "../components/PromptBar.js";
 import { TemplateGallery } from "../components/TemplateGallery.js";
 import { KeyboardShortcuts, HelpButton } from "../components/KeyboardShortcuts.js";
+import type { StoredSpec } from "../types.js";
 import styles from "./PlaygroundPage.module.css";
 
 /**
@@ -22,6 +22,11 @@ import styles from "./PlaygroundPage.module.css";
  * History is database-backed via useSpecsApi — survives page refresh.
  * Three-column layout: HistoryPanel | PreviewPane | JsonInspector
  * with AppShell wrapping the top bar and PromptBar at the bottom.
+ *
+ * Panel open/close state (history / inspector / command palette) is owned by
+ * AppShell; this page reads it through useAppShellPanels and composes the
+ * AppShell.HistoryRegion / AppShell.InspectorRegion / AppShell.CommandPalette
+ * compound children instead of threading toggle callbacks and paired flags.
  *
  * Responsive behavior:
  * - Desktop (>1024px): 3-column grid
@@ -37,20 +42,11 @@ export function PlaygroundPage() {
   const { toast } = useToast();
   const { toggleTheme } = useTheme();
   const { specs, isLoading, saveSpec, toggleFavorite, deleteSpec } = useSpecsApi();
-  const {
-    historyVisible,
-    inspectorVisible,
-    breakpoint,
-    toggleHistory,
-    toggleInspector,
-    closeOverlays,
-  } = usePanelLayout();
 
   const [activeId, setActiveId] = useState<string | null>(null);
   const [filter, setFilter] = useState<"all" | "favorites">("all");
   const [mode, setMode] = useState<"generate" | "refine">("generate");
   const [isFullscreen, setIsFullscreen] = useState(false);
-  const [paletteOpen, setPaletteOpen] = useState(false);
   const [galleryOpen, setGalleryOpen] = useState(false);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
 
@@ -84,6 +80,160 @@ export function PlaygroundPage() {
     }
   }, [error, toast]);
 
+  function handleSignOut() {
+    setActiveId(null);
+    setMode("generate");
+    void signOut();
+  }
+
+  const handleLogoClick = useCallback(() => {
+    setActiveId(null);
+    setMode("generate");
+  }, []);
+
+  function handleTemplatesOpen() {
+    setGalleryOpen(true);
+  }
+
+  // Keyboard shortcut: Cmd+T / Ctrl+T to open template gallery
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "t") {
+        e.preventDefault();
+        setGalleryOpen((prev) => !prev);
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, []);
+
+  // Keyboard shortcut: "?" to open shortcuts help (only when no input is focused)
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== "?") return;
+      const tag = (e.target as HTMLElement)?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+      if ((e.target as HTMLElement)?.isContentEditable) return;
+      e.preventDefault();
+      setShortcutsOpen((prev) => !prev);
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, []);
+
+  return (
+    <AppShell
+      isFullscreen={isFullscreen}
+      onSignOut={handleSignOut}
+      onLogoClick={handleLogoClick}
+      onTemplatesOpen={handleTemplatesOpen}
+    >
+      <PlaygroundBody
+        specs={specs}
+        isLoading={isLoading}
+        activeId={activeId}
+        setActiveId={setActiveId}
+        filter={filter}
+        setFilter={setFilter}
+        mode={mode}
+        setMode={setMode}
+        isFullscreen={isFullscreen}
+        setIsFullscreen={setIsFullscreen}
+        galleryOpen={galleryOpen}
+        setGalleryOpen={setGalleryOpen}
+        shortcutsOpen={shortcutsOpen}
+        setShortcutsOpen={setShortcutsOpen}
+        promptRef={promptRef}
+        spec={spec}
+        isStreaming={isStreaming}
+        error={error}
+        rawLines={rawLines}
+        send={send}
+        stop={stop}
+        toggleFavorite={toggleFavorite}
+        deleteSpec={deleteSpec}
+        toggleTheme={toggleTheme}
+        onSignOut={handleSignOut}
+        toast={toast}
+      />
+    </AppShell>
+  );
+}
+
+interface PlaygroundBodyProps {
+  specs: StoredSpec[];
+  isLoading: boolean;
+  activeId: string | null;
+  setActiveId: React.Dispatch<React.SetStateAction<string | null>>;
+  filter: "all" | "favorites";
+  setFilter: React.Dispatch<React.SetStateAction<"all" | "favorites">>;
+  mode: "generate" | "refine";
+  setMode: React.Dispatch<React.SetStateAction<"generate" | "refine">>;
+  isFullscreen: boolean;
+  setIsFullscreen: React.Dispatch<React.SetStateAction<boolean>>;
+  galleryOpen: boolean;
+  setGalleryOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  shortcutsOpen: boolean;
+  setShortcutsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  promptRef: React.MutableRefObject<string>;
+  spec: Spec | null;
+  isStreaming: boolean;
+  error: Error | null;
+  rawLines: string[];
+  send: (prompt: string) => Promise<void> | void;
+  stop: () => void;
+  toggleFavorite: (id: string) => Promise<void>;
+  deleteSpec: (id: string) => Promise<void>;
+  toggleTheme: () => void;
+  onSignOut: () => void;
+  toast: ReturnType<typeof useToast>["toast"];
+}
+
+/**
+ * The playground content rendered inside AppShell. Reads shell-owned panel
+ * state (history / inspector visibility, breakpoint, palette controls) via
+ * useAppShellPanels and composes the AppShell panel regions + command palette.
+ */
+function PlaygroundBody({
+  specs,
+  isLoading,
+  activeId,
+  setActiveId,
+  filter,
+  setFilter,
+  mode,
+  setMode,
+  isFullscreen,
+  setIsFullscreen,
+  galleryOpen,
+  setGalleryOpen,
+  shortcutsOpen,
+  setShortcutsOpen,
+  promptRef,
+  spec,
+  isStreaming,
+  error,
+  rawLines,
+  send,
+  stop,
+  toggleFavorite,
+  deleteSpec,
+  toggleTheme,
+  onSignOut,
+  toast,
+}: PlaygroundBodyProps) {
+  const {
+    historyVisible,
+    inspectorVisible,
+    breakpoint,
+    toggleHistory,
+    toggleInspector,
+    closeOverlays,
+    closePalette,
+  } = useAppShellPanels();
+
+  const isMobileOrTablet = breakpoint !== "desktop";
+
   // ---------------------------------------------------------------------------
   // Display logic — live streaming vs. history review mode
   // ---------------------------------------------------------------------------
@@ -102,8 +252,6 @@ export function PlaygroundPage() {
 
   // activeSpecId for Share/Refine: only set when viewing a non-streaming saved entry
   const activeSpecId = !isStreaming && activeId ? activeId : null;
-
-  const isMobileOrTablet = breakpoint !== "desktop";
 
   // ---------------------------------------------------------------------------
   // Handlers
@@ -175,12 +323,6 @@ export function PlaygroundPage() {
     void send(retryPrompt);
   }
 
-  function handleSignOut() {
-    setActiveId(null);
-    setMode("generate");
-    void signOut();
-  }
-
   function handleEnterRefinement() {
     setMode("refine");
   }
@@ -197,49 +339,14 @@ export function PlaygroundPage() {
     // onShare is called after clipboard write in PreviewPane; no additional action needed here
   }
 
-  const handleLogoClick = useCallback(() => {
-    setActiveId(null);
-    setMode("generate");
-  }, []);
-
   function handleTemplateSelect(prompt: string) {
     toast({ title: "Generating from template...", variant: "accent", duration: 2000 });
     handleSubmit(prompt);
   }
 
-  function handleTemplatesOpen() {
-    setGalleryOpen(true);
-  }
-
   function handleGalleryClose() {
     setGalleryOpen(false);
   }
-
-  // Keyboard shortcut: Cmd+T / Ctrl+T to open template gallery
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === "t") {
-        e.preventDefault();
-        setGalleryOpen((prev) => !prev);
-      }
-    };
-    document.addEventListener("keydown", handler);
-    return () => document.removeEventListener("keydown", handler);
-  }, []);
-
-  // Keyboard shortcut: "?" to open shortcuts help (only when no input is focused)
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key !== "?") return;
-      const tag = (e.target as HTMLElement)?.tagName;
-      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
-      if ((e.target as HTMLElement)?.isContentEditable) return;
-      e.preventDefault();
-      setShortcutsOpen((prev) => !prev);
-    };
-    document.addEventListener("keydown", handler);
-    return () => document.removeEventListener("keydown", handler);
-  }, []);
 
   // ---------------------------------------------------------------------------
   // Command palette items
@@ -249,9 +356,9 @@ export function PlaygroundPage() {
       id: "new-generation",
       label: "New Generation",
       group: "Actions",
-      shortcut: ["\u2318", "N"],
+      shortcut: ["⌘", "N"],
       onSelect: () => {
-        setPaletteOpen(false);
+        closePalette();
         setActiveId(null);
         setMode("generate");
       },
@@ -260,9 +367,9 @@ export function PlaygroundPage() {
       id: "toggle-fullscreen",
       label: "Toggle Fullscreen",
       group: "Actions",
-      shortcut: ["\u2318", "F"],
+      shortcut: ["⌘", "F"],
       onSelect: () => {
-        setPaletteOpen(false);
+        closePalette();
         setIsFullscreen((prev) => !prev);
       },
     },
@@ -274,7 +381,7 @@ export function PlaygroundPage() {
             group: "Actions",
             shortcut: ["Esc"],
             onSelect: () => {
-              setPaletteOpen(false);
+              closePalette();
               stop();
             },
           },
@@ -284,9 +391,9 @@ export function PlaygroundPage() {
       id: "open-templates",
       label: "Browse Templates",
       group: "Actions",
-      shortcut: ["\u2318", "T"],
+      shortcut: ["⌘", "T"],
       onSelect: () => {
-        setPaletteOpen(false);
+        closePalette();
         setGalleryOpen(true);
       },
     },
@@ -297,7 +404,7 @@ export function PlaygroundPage() {
             label: "Download Spec as JSON",
             group: "Export",
             onSelect: () => {
-              setPaletteOpen(false);
+              closePalette();
               const json = JSON.stringify(displaySpec, null, 2);
               const blob = new Blob([json], { type: "application/json" });
               const url = URL.createObjectURL(blob);
@@ -313,7 +420,7 @@ export function PlaygroundPage() {
             label: "Copy Spec JSON",
             group: "Export",
             onSelect: () => {
-              setPaletteOpen(false);
+              closePalette();
               const json = JSON.stringify(displaySpec, null, 2);
               void navigator.clipboard.writeText(json);
             },
@@ -324,9 +431,9 @@ export function PlaygroundPage() {
       id: "toggle-history",
       label: "Toggle History Panel",
       group: "Panels",
-      shortcut: ["\u2318", "1"],
+      shortcut: ["⌘", "1"],
       onSelect: () => {
-        setPaletteOpen(false);
+        closePalette();
         toggleHistory();
       },
     },
@@ -334,9 +441,9 @@ export function PlaygroundPage() {
       id: "toggle-inspector",
       label: "Toggle JSON Inspector",
       group: "Panels",
-      shortcut: ["\u2318", "2"],
+      shortcut: ["⌘", "2"],
       onSelect: () => {
-        setPaletteOpen(false);
+        closePalette();
         toggleInspector();
       },
     },
@@ -346,7 +453,7 @@ export function PlaygroundPage() {
       group: "Settings",
       shortcut: ["?"],
       onSelect: () => {
-        setPaletteOpen(false);
+        closePalette();
         setShortcutsOpen(true);
       },
     },
@@ -355,7 +462,7 @@ export function PlaygroundPage() {
       label: "Toggle Theme",
       group: "Settings",
       onSelect: () => {
-        setPaletteOpen(false);
+        closePalette();
         toggleTheme();
       },
     },
@@ -364,63 +471,40 @@ export function PlaygroundPage() {
       label: "Sign Out",
       group: "Settings",
       onSelect: () => {
-        setPaletteOpen(false);
-        handleSignOut();
+        closePalette();
+        onSignOut();
       },
     },
   ];
 
   // Build layout data attributes for CSS-driven responsive grid
   const layoutClassName = isFullscreen ? styles.layoutFullscreen : styles.layout;
-  const showHistoryPanel = !isFullscreen && historyVisible;
-  const showInspectorPanel = !isFullscreen && inspectorVisible;
 
   return (
-    <AppShell
-      onSignOut={handleSignOut}
-      historyVisible={historyVisible}
-      inspectorVisible={inspectorVisible}
-      onToggleHistory={toggleHistory}
-      onToggleInspector={toggleInspector}
-      onLogoClick={handleLogoClick}
-      onTemplatesOpen={handleTemplatesOpen}
-      paletteOpen={paletteOpen}
-      onPaletteOpenChange={setPaletteOpen}
-      commandItems={commandItems}
-    >
+    <>
       <div
         className={layoutClassName}
         data-history={historyVisible}
         data-inspector={inspectorVisible}
       >
-        {/* Backdrop for mobile/tablet overlays */}
-        {isMobileOrTablet && (showHistoryPanel || showInspectorPanel) && (
-          <div className={styles.backdrop} onClick={closeOverlays} aria-hidden="true" />
-        )}
-
-        {showHistoryPanel && (
-          <div
-            className={
-              isMobileOrTablet ? `${styles.overlayPanel} ${styles.overlayStart}` : styles.sidePanel
-            }
-          >
-            <HistoryPanel
-              entries={specs}
-              activeId={activeId}
-              filter={filter}
-              isLoading={isLoading}
-              onSelect={handleSelectHistory}
-              onReplay={handleReplay}
-              onToggleFavorite={handleToggleFavorite}
-              onDelete={handleDelete}
-              onFilterChange={setFilter}
-            />
-          </div>
-        )}
+        <AppShell.HistoryRegion>
+          <HistoryPanel
+            entries={specs}
+            activeId={activeId}
+            filter={filter}
+            isLoading={isLoading}
+            onSelect={handleSelectHistory}
+            onReplay={handleReplay}
+            onToggleFavorite={handleToggleFavorite}
+            onDelete={handleDelete}
+            onFilterChange={setFilter}
+          />
+        </AppShell.HistoryRegion>
 
         <ErrorBoundary
           fallback={
             <div style={{ padding: "var(--rialto-space-lg)", textAlign: "center" }}>
+              {/* eslint-disable mbe-local/prefer-rialto-components -- rialto unavailable inside an ErrorBoundary fallback */}
               <p>Preview failed to render.</p>
               <button
                 type="button"
@@ -437,6 +521,7 @@ export function PlaygroundPage() {
               >
                 Retry
               </button>
+              {/* eslint-enable mbe-local/prefer-rialto-components */}
             </div>
           }
         >
@@ -455,38 +540,34 @@ export function PlaygroundPage() {
           />
         </ErrorBoundary>
 
-        {showInspectorPanel && (
-          <div
-            className={
-              isMobileOrTablet ? `${styles.overlayPanel} ${styles.overlayEnd}` : styles.sidePanel
+        <AppShell.InspectorRegion>
+          <ErrorBoundary
+            fallback={
+              <div style={{ padding: "var(--rialto-space-lg)", textAlign: "center" }}>
+                {/* eslint-disable mbe-local/prefer-rialto-components -- rialto unavailable inside an ErrorBoundary fallback */}
+                <p>Inspector failed to render.</p>
+                <button
+                  type="button"
+                  onClick={() => window.location.reload()}
+                  style={{
+                    marginBlockStart: "var(--rialto-space-sm)",
+                    padding: "var(--rialto-space-xs) var(--rialto-space-sm)",
+                    borderRadius: "var(--rialto-radius-default)",
+                    border: "1px solid var(--rialto-border)",
+                    background: "var(--rialto-surface-elevated)",
+                    color: "var(--rialto-text-primary)",
+                    cursor: "pointer",
+                  }}
+                >
+                  Retry
+                </button>
+                {/* eslint-enable mbe-local/prefer-rialto-components */}
+              </div>
             }
           >
-            <ErrorBoundary
-              fallback={
-                <div style={{ padding: "var(--rialto-space-lg)", textAlign: "center" }}>
-                  <p>Inspector failed to render.</p>
-                  <button
-                    type="button"
-                    onClick={() => window.location.reload()}
-                    style={{
-                      marginBlockStart: "var(--rialto-space-sm)",
-                      padding: "var(--rialto-space-xs) var(--rialto-space-sm)",
-                      borderRadius: "var(--rialto-radius-default)",
-                      border: "1px solid var(--rialto-border)",
-                      background: "var(--rialto-surface-elevated)",
-                      color: "var(--rialto-text-primary)",
-                      cursor: "pointer",
-                    }}
-                  >
-                    Retry
-                  </button>
-                </div>
-              }
-            >
-              <JsonInspector rawLines={displayRawLines} isStreaming={isStreaming} />
-            </ErrorBoundary>
-          </div>
-        )}
+            <JsonInspector rawLines={displayRawLines} isStreaming={isStreaming} />
+          </ErrorBoundary>
+        </AppShell.InspectorRegion>
       </div>
       <PromptBar
         onSubmit={handleSubmit}
@@ -503,6 +584,7 @@ export function PlaygroundPage() {
       />
       <KeyboardShortcuts open={shortcutsOpen} onClose={() => setShortcutsOpen(false)} />
       <HelpButton onClick={() => setShortcutsOpen(true)} />
-    </AppShell>
+      <AppShell.CommandPalette items={commandItems} />
+    </>
   );
 }


### PR DESCRIPTION
## Summary

Inverts the gen app's `AppShell` from an 11-prop pass-through interface (8 optional callbacks plus paired state flags, with an implementation that was mostly `if (onToggleX)` conditional renders) into **compound components with shell-owned panel state**.

The shell now owns the panel toggle state machine instead of having it threaded through prop plumbing from the page.

## What changed

- **Shell owns panel state.** `AppShell` calls `usePanelLayout()` internally and exposes it through a new `AppShellContext`. The history/inspector toggle buttons and the command-palette open flag are no longer threaded from pages.
- **Compound children** replace the callback props:
  - `AppShell.HistoryRegion` / `AppShell.InspectorRegion` — gate visibility (hidden when not visible or fullscreen) and apply the responsive side-panel / overlay chrome + backdrop. Each is testable in isolation.
  - `AppShell.CommandPalette` — wired to the shell-owned palette open state.
- **`useAppShellPanels()` hook** exposes shell-owned state (`historyVisible`, `inspectorVisible`, `breakpoint`, `isFullscreen`, `toggleHistory`, `toggleInspector`, `closeOverlays`, `openPalette`, `closePalette`) to the page body for the CSS-driven responsive grid and overlay-dismiss behaviour.
- **Props collapse** to `children` + genuinely-per-page values: `onSignOut`, `onLogoClick`, `onTemplatesOpen`, `isFullscreen` (all optional).
- **PlaygroundPage migrated** with no behavior change — the body is extracted into a `PlaygroundBody` rendered inside the shell that composes the regions + palette. This is the only consumer of `AppShell`.
- **Panel-region CSS** (`sidePanel` / `overlayPanel` / `overlayStart` / `overlayEnd` / `backdrop` + keyframes + reduced-motion) moved from `PlaygroundPage.module.css` into `AppShell.module.css`, alongside the regions that own it. The `.layout` grid stays in the page.
- **Shell test no longer needs the 11-prop fixture** — panels are covered as isolated compound components.

## Acceptance criteria

- [x] AppShell exposes compound children for the panels; consumers compose what they need
- [x] Panel open/close state owned inside the shell, not threaded from pages
- [x] PlaygroundPage (the only consumer) migrated; no behavior change in the rendered app
- [x] Each panel testable in isolation; shell test no longer needs an 11-prop fixture
- [x] `pnpm typecheck`, lint, and tests green in apps/gen

## Test plan

- `pnpm --dir apps/gen lint` — PASS (0 errors)
- `pnpm --dir apps/gen typecheck` — PASS
- `pnpm --dir apps/gen test` — 188 passed (16 files)
- `pnpm turbo typecheck --filter='...[origin/main]'` — 20 tasks PASS
- `pnpm --dir apps/gen build` — PASS

Closes #2083

🤖 Generated with [Claude Code](https://claude.com/claude-code)