### PR TITLE
refactor(agent-core): retry seam for worktree cleanup failures

### DIFF
--- a/packages/agent-core/llms-full.txt
+++ b/packages/agent-core/llms-full.txt
@@ -2087,10 +2087,19 @@
                   } catch (cleanupErr) {
                     const cleanupMsg =
                       cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr);
+                    // Record the error in the result (unchanged behavior)
                     cleanupErrors.push(cleanupMsg);
                     console.warn(`Worktree cleanup failed: ${cleanupMsg}`);
                     emitEvent(onEvent, "session:cleanup_warning", {
                       message: `Worktree cleanup failed: ${cleanupMsg}`,
+                    });
+                    // Schedule a bounded retry so the worktree is reclaimed instead of
+                    // persisting until a human notices. Reap exhaustion logs at error
+                    // level (never silent) and is not treated as a session failure.
+                    await scheduleWorktreeReap({
+                      repoPath: effectiveConfig.repoPath,
+                      worktreePath: ctx.worktree.path,
+                      mode: ctx.worktree.mode,
                     });
                   }
                 }
@@ -2459,6 +2468,29 @@
           `Invalid ${label}: "${path}" — must not contain shell metacharacters (${String(UNSAFE_PATH_CHARS)})`
         );
       }
+    }
+  </file>
+  <file path="src/worktree-reaper.ts">
+    export interface ReaperLogger {
+      readonly error: (message: string) => void;
+    }
+    export interface ScheduleWorktreeReapOptions {
+      readonly repoPath: string;
+      readonly worktreePath: string;
+      /** Worktree isolation mode — passed through to removal. Defaults to 'full'. */
+      readonly mode?: WorktreeMode;
+      /** Max retry attempts after the initial failure. Default: 3. */
+      readonly maxRetries?: number;
+      /** Base backoff delay in ms. Default: 1000. */
+      readonly baseDelayMs?: number;
+      /** Removal function (injectable for testing). Defaults to worktree-manager.removeWorktree. */
+      readonly removeFn?: (
+        repoPath: string,
+        worktreePath: string,
+        mode?: WorktreeMode
+      ) => Promise<void>;
+      /** Error-level logger (injectable for testing). Defaults to console.error. */
+      readonly logger?: ReaperLogger;
     }
   </file>
   </section>

--- a/packages/agent-core/llms.txt
+++ b/packages/agent-core/llms.txt
@@ -748,5 +748,21 @@
       export function validatePath(path: string, label: string): void { /* ... */ }
     </item>
   </file>
+  <file path="src/worktree-reaper.ts">
+    <item priority="low">
+      interface ReaperLogger {
+        error: (message: string) => void;
+      }
+    </item>
+    <item priority="low">
+      interface ScheduleWorktreeReapOptions {
+        repoPath: string;
+        worktreePath: string;
+        mode?: WorktreeMode;
+        maxRetries?: number;
+        baseDelayMs?: number;
+      }
+    </item>
+  </file>
   </section>
 </codebase>

--- a/packages/agent-core/src/__tests__/session-runner.test.ts
+++ b/packages/agent-core/src/__tests__/session-runner.test.ts
@@ -77,6 +77,10 @@ vi.mock("@langfuse/tracing", () => ({
   updateActiveObservation: vi.fn(),
 }));
 
+vi.mock("../worktree-reaper.js", () => ({
+  scheduleWorktreeReap: vi.fn().mockResolvedValue({ succeeded: true, attempts: 2 }),
+}));
+
 vi.mock("../retry.js", async () => {
   const actual = (await vi.importActual("../retry.js")) as Record<string, unknown>;
   return {
@@ -105,6 +109,7 @@ import { loadMemory, queryPastFailures, buildFailureContext } from "../failure-m
 import { buildSystemPrompt } from "../prompt-builder.js";
 import { createToolPermissionHandler } from "../tool-permissions.js";
 import { withRetry } from "../retry.js";
+import { scheduleWorktreeReap } from "../worktree-reaper.js";
 import {
   startActiveObservation,
   startObservation,
@@ -164,6 +169,9 @@ describe("runSession", () => {
       const value = await fn();
       return { value, attempts: 1 };
     });
+
+    // Reset reaper to default success
+    vi.mocked(scheduleWorktreeReap).mockResolvedValue({ succeeded: true, attempts: 2 });
 
     vi.mocked(createWorktree).mockResolvedValue({
       path: "/repo/.agent-worktrees/agent-fix-bug-abc123",
@@ -393,6 +401,58 @@ describe("runSession", () => {
 
     expect(result.status).toBe("succeeded");
     expect(result.cleanupErrors).toBeUndefined();
+  });
+
+  it("schedules a worktree reap retry when removeWorktree fails", async () => {
+    const mockResult = createMockResultMessage();
+
+    vi.mocked(query).mockReturnValue(mockQueryGenerator([mockResult]) as ReturnType<typeof query>);
+    vi.mocked(hasChanges).mockResolvedValue(true);
+    vi.mocked(commitChanges).mockResolvedValue("abc123");
+    vi.mocked(pushBranch).mockResolvedValue(undefined);
+    vi.mocked(buildPrTitle).mockReturnValue("feat: test");
+    vi.mocked(buildPrBody).mockReturnValue("body");
+    vi.mocked(createPullRequest).mockResolvedValue({
+      url: "https://github.com/repo/pull/1",
+      number: 1,
+    });
+    vi.mocked(removeWorktree).mockRejectedValue(new Error("fatal: worktree is locked"));
+
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = await runSession(BASE_CONFIG);
+
+    // Error is still recorded in the result (unchanged behavior)
+    expect(result.cleanupErrors).toEqual(["fatal: worktree is locked"]);
+    // And a follow-up reap retry is scheduled for the same worktree
+    expect(scheduleWorktreeReap).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoPath: "/repo",
+        worktreePath: "/repo/.agent-worktrees/agent-fix-bug-abc123",
+      })
+    );
+
+    vi.restoreAllMocks();
+  });
+
+  it("does not schedule a reap when removeWorktree succeeds first try", async () => {
+    const mockResult = createMockResultMessage();
+
+    vi.mocked(query).mockReturnValue(mockQueryGenerator([mockResult]) as ReturnType<typeof query>);
+    vi.mocked(hasChanges).mockResolvedValue(true);
+    vi.mocked(commitChanges).mockResolvedValue("abc123");
+    vi.mocked(pushBranch).mockResolvedValue(undefined);
+    vi.mocked(buildPrTitle).mockReturnValue("feat: test");
+    vi.mocked(buildPrBody).mockReturnValue("body");
+    vi.mocked(createPullRequest).mockResolvedValue({
+      url: "https://github.com/repo/pull/1",
+      number: 1,
+    });
+    vi.mocked(removeWorktree).mockResolvedValue(undefined);
+
+    const result = await runSession(BASE_CONFIG);
+
+    expect(result.status).toBe("succeeded");
+    expect(scheduleWorktreeReap).not.toHaveBeenCalled();
   });
 
   it("handles createWorktree failure gracefully", async () => {

--- a/packages/agent-core/src/__tests__/worktree-reaper.test.ts
+++ b/packages/agent-core/src/__tests__/worktree-reaper.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from "vitest";
+import { scheduleWorktreeReap } from "../worktree-reaper.js";
+
+const BASE_OPTS = {
+  repoPath: "/repo",
+  worktreePath: "/repo/.agent-worktrees/agent-fix-bug-abc123",
+  mode: "full" as const,
+  // No real delays in tests.
+  baseDelayMs: 0,
+  maxRetries: 3,
+};
+
+describe("scheduleWorktreeReap", () => {
+  it("retries worktree removal and resolves when a retry succeeds", async () => {
+    // First attempt throws (lock contention), second succeeds.
+    const removeFn = vi
+      .fn<
+        (repoPath: string, worktreePath: string, mode?: "full" | "lightweight") => Promise<void>
+      >()
+      .mockRejectedValueOnce(new Error("fatal: worktree is locked"))
+      .mockResolvedValueOnce(undefined);
+
+    const outcome = await scheduleWorktreeReap({ ...BASE_OPTS, removeFn });
+
+    expect(outcome.succeeded).toBe(true);
+    expect(outcome.attempts).toBe(2);
+    // Removal was retried with the same isolation target (ADR-005: same worktree, no new model).
+    expect(removeFn).toHaveBeenCalledTimes(2);
+    expect(removeFn).toHaveBeenLastCalledWith(
+      "/repo",
+      "/repo/.agent-worktrees/agent-fix-bug-abc123",
+      "full"
+    );
+  });
+
+  it("surfaces exhaustion at error level with the worktree path", async () => {
+    const removeFn = vi
+      .fn<
+        (repoPath: string, worktreePath: string, mode?: "full" | "lightweight") => Promise<void>
+      >()
+      .mockRejectedValue(new Error("fatal: worktree is locked"));
+    const errorLog = vi.fn();
+
+    const outcome = await scheduleWorktreeReap({
+      ...BASE_OPTS,
+      removeFn,
+      logger: { error: errorLog },
+    });
+
+    expect(outcome.succeeded).toBe(false);
+    // maxRetries: 3 → 1 initial + 3 retries = 4 attempts.
+    expect(removeFn).toHaveBeenCalledTimes(4);
+    expect(errorLog).toHaveBeenCalledTimes(1);
+    const [message] = errorLog.mock.calls[0];
+    expect(message).toContain("/repo/.agent-worktrees/agent-fix-bug-abc123");
+    expect(message).toContain("fatal: worktree is locked");
+  });
+
+  it("does not log an error when the first retry succeeds", async () => {
+    const removeFn = vi
+      .fn<
+        (repoPath: string, worktreePath: string, mode?: "full" | "lightweight") => Promise<void>
+      >()
+      .mockRejectedValueOnce(new Error("fatal: worktree is locked"))
+      .mockResolvedValueOnce(undefined);
+    const errorLog = vi.fn();
+
+    const outcome = await scheduleWorktreeReap({
+      ...BASE_OPTS,
+      removeFn,
+      logger: { error: errorLog },
+    });
+
+    expect(outcome.succeeded).toBe(true);
+    expect(errorLog).not.toHaveBeenCalled();
+  });
+
+  it("defaults to the lightweight mode target when given lightweight", async () => {
+    const removeFn = vi
+      .fn<
+        (repoPath: string, worktreePath: string, mode?: "full" | "lightweight") => Promise<void>
+      >()
+      .mockResolvedValue(undefined);
+
+    const outcome = await scheduleWorktreeReap({
+      ...BASE_OPTS,
+      mode: "lightweight",
+      removeFn,
+    });
+
+    expect(outcome.succeeded).toBe(true);
+    expect(removeFn).toHaveBeenCalledWith(
+      "/repo",
+      "/repo/.agent-worktrees/agent-fix-bug-abc123",
+      "lightweight"
+    );
+  });
+});

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -41,6 +41,10 @@ export type {
   VerificationResult as PrePushVerification,
 } from "./worktree-manager.js";
 
+// Worktree cleanup-failure reaper
+export { scheduleWorktreeReap } from "./worktree-reaper.js";
+export type { ScheduleWorktreeReapOptions, ReapOutcome, ReaperLogger } from "./worktree-reaper.js";
+
 // PR creation
 export { createPullRequest, buildPrTitle, buildPrBody, buildFailurePrBody } from "./pr-creator.js";
 

--- a/packages/agent-core/src/session-runner.ts
+++ b/packages/agent-core/src/session-runner.ts
@@ -2,6 +2,7 @@ import { trace, SpanStatusCode } from "@opentelemetry/api";
 import type { SessionConfig, SessionResult, SessionEventCallback } from "./types.js";
 import { buildSessionResult } from "./cost-tracker.js";
 import { hasChanges, commitChanges, pushBranch, removeWorktree } from "./worktree-manager.js";
+import { scheduleWorktreeReap } from "./worktree-reaper.js";
 import { createPullRequest, buildFailurePrBody } from "./pr-creator.js";
 import { recordFailure } from "./failure-memory.js";
 import { withRetry } from "./retry.js";
@@ -158,10 +159,19 @@ export async function runSession(
               } catch (cleanupErr) {
                 const cleanupMsg =
                   cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr);
+                // Record the error in the result (unchanged behavior)
                 cleanupErrors.push(cleanupMsg);
                 console.warn(`Worktree cleanup failed: ${cleanupMsg}`);
                 emitEvent(onEvent, "session:cleanup_warning", {
                   message: `Worktree cleanup failed: ${cleanupMsg}`,
+                });
+                // Schedule a bounded retry so the worktree is reclaimed instead of
+                // persisting until a human notices. Reap exhaustion logs at error
+                // level (never silent) and is not treated as a session failure.
+                await scheduleWorktreeReap({
+                  repoPath: effectiveConfig.repoPath,
+                  worktreePath: ctx.worktree.path,
+                  mode: ctx.worktree.mode,
                 });
               }
             }

--- a/packages/agent-core/src/worktree-reaper.ts
+++ b/packages/agent-core/src/worktree-reaper.ts
@@ -1,0 +1,93 @@
+/**
+ * In-process worktree reaper.
+ *
+ * Session cleanup removes the agent worktree in the `runSession` `finally`
+ * block. When that removal fails (git lock contention, transient disk error),
+ * the error is recorded in the session result but the worktree would otherwise
+ * persist until a human notices. This reaper schedules a bounded retry of the
+ * removal so the same isolation target (ADR-005) is reclaimed without a new
+ * isolation model — it is hygiene only.
+ *
+ * We use a lightweight in-process retry rather than the reservations-domain
+ * `@mbe/jobs` scheduler: cleanup runs inside a single long-lived `runSession`
+ * process, the operation is a fire-and-forget filesystem retry, and agent-core
+ * already owns the `withRetry` backoff helper. Pulling in a Prisma-backed,
+ * off-domain job queue would be disproportionate.
+ */
+
+import { withRetry } from "./retry.js";
+import { removeWorktree as defaultRemoveWorktree } from "./worktree-manager.js";
+import type { WorktreeMode } from "./types.js";
+
+/** Minimal error-level logger seam (console.error by default). */
+export interface ReaperLogger {
+  readonly error: (message: string) => void;
+}
+
+export interface ScheduleWorktreeReapOptions {
+  readonly repoPath: string;
+  readonly worktreePath: string;
+  /** Worktree isolation mode — passed through to removal. Defaults to 'full'. */
+  readonly mode?: WorktreeMode;
+  /** Max retry attempts after the initial failure. Default: 3. */
+  readonly maxRetries?: number;
+  /** Base backoff delay in ms. Default: 1000. */
+  readonly baseDelayMs?: number;
+  /** Removal function (injectable for testing). Defaults to worktree-manager.removeWorktree. */
+  readonly removeFn?: (
+    repoPath: string,
+    worktreePath: string,
+    mode?: WorktreeMode
+  ) => Promise<void>;
+  /** Error-level logger (injectable for testing). Defaults to console.error. */
+  readonly logger?: ReaperLogger;
+}
+
+export interface ReapOutcome {
+  readonly succeeded: boolean;
+  /** Total removal attempts made (initial + retries). */
+  readonly attempts: number;
+}
+
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_BASE_DELAY_MS = 1_000;
+
+/**
+ * Retry a failed worktree removal with exponential backoff.
+ *
+ * Resolves once removal succeeds. If all retries are exhausted, logs at error
+ * level with the worktree path (never silent) and resolves with
+ * `succeeded: false` — the caller has already recorded the original error and
+ * must not treat reap exhaustion as a session failure.
+ */
+export async function scheduleWorktreeReap(
+  options: ScheduleWorktreeReapOptions
+): Promise<ReapOutcome> {
+  const {
+    repoPath,
+    worktreePath,
+    mode = "full",
+    maxRetries = DEFAULT_MAX_RETRIES,
+    baseDelayMs = DEFAULT_BASE_DELAY_MS,
+    removeFn = defaultRemoveWorktree,
+    logger = { error: (message: string) => console.error(message) },
+  } = options;
+
+  try {
+    const { attempts } = await withRetry(() => removeFn(repoPath, worktreePath, mode), {
+      maxRetries,
+      baseDelayMs,
+      // Cleanup failures (lock contention, disk) are all worth retrying — the
+      // operation is idempotent and the worktree must be reclaimed regardless
+      // of the specific error class.
+      isRetryable: () => true,
+    });
+    return { succeeded: true, attempts };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error(
+      `Worktree reap exhausted after ${maxRetries} retries; worktree not removed: ${worktreePath} (${message})`
+    );
+    return { succeeded: false, attempts: maxRetries + 1 };
+  }
+}


### PR DESCRIPTION
Closes #2084

## What changed

Session cleanup recorded worktree-removal failures into the result's `cleanupErrors` field but never acted on them — a worktree that failed to remove (git lock contention, transient disk error) persisted until a human noticed.

This adds an in-process **reaper** (`scheduleWorktreeReap`) invoked from `runSession`'s cleanup `catch` block. When `removeWorktree` throws, the original error is still recorded in the result (**unchanged behavior**) and a bounded retry of the removal is scheduled with exponential backoff. On retry success the worktree is reclaimed. On exhaustion it logs at **error level with the worktree path** (never silent). No behavior change when cleanup succeeds first try.

## Retry mechanism choice: in-process reaper (not `@mbe/jobs`)

The issue let the implementer choose between the existing jobs scheduler and a lightweight in-process reaper. I chose **in-process**:

- Cleanup runs inside a single long-lived `runSession` process, in its `finally` block. A bounded retry with backoff is the minimal seam that fits that lifecycle.
- `@mbe/jobs` is a **Prisma-backed, reservations-domain** scheduler (booking reminders, waitlist expiry). It has zero presence in `agent-core` (which depends only on `@mbe/api-client`, `@mbe/types`, langfuse, otel, zod). Wiring it in would add a heavyweight, off-domain dependency for a fire-and-forget filesystem retry.
- `agent-core` already owns the `withRetry` backoff helper — the reaper reuses it with `isRetryable: () => true` (every cleanup failure is worth retrying; the removal is idempotent).

## ADR-005 (worktree isolation)

This adds **hygiene only**. The reaper retries removal of the **same worktree** the session already created — no new isolation model, no change to how worktrees are created or isolated. ADR check passes.

## Tests (TDD — RED then GREEN)

New `worktree-reaper.test.ts`:
- retry success removes the worktree (throws once → succeeds on retry, 2 attempts)
- exhaustion surfaced at error level with the worktree path + error message
- no error log when first retry succeeds
- mode pass-through (full / lightweight)

`session-runner.test.ts` additions:
- `removeWorktree` fails → error still in `cleanupErrors` **and** `scheduleWorktreeReap` called with the worktree path
- `removeWorktree` succeeds first try → reap **not** scheduled

## Gate results

- `pnpm --dir packages/agent-core lint` — clean
- `pnpm --dir packages/agent-core typecheck` — clean
- `pnpm --dir packages/agent-core test` — 58 suites / 1052 tests pass
- `pnpm turbo typecheck --filter='...[origin/main]'` — 23/23 tasks pass (incl. `@mbe/agent-service`)

No service changes needed — the reaper is internal to `runSession` (no signature changes); the new `scheduleWorktreeReap` is exported from the package index for reuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)