### PR TITLE
fix(agents): add name field so implement-queue-worker is dispatchable

### DIFF
--- a/.claude/agents/implement-queue-worker.md
+++ b/.claude/agents/implement-queue-worker.md
@@ -1,4 +1,5 @@
 ---
+name: implement-queue-worker
 description: Implements a single GitHub issue in an isolated worktree via TDD. Installs deps, writes a failing test first, implements, runs lint/typecheck/test gates, commits, pushes, and opens a PR targeting main. Designed to be spawned by /implement-queue with isolation: worktree.
 tools:
   - Bash


### PR DESCRIPTION
## Summary

The `implement-queue-worker` agent (added in #2133) is missing the `name:` frontmatter field. The agent registry keys subagents by `name:`, not filename — so `subagent_type: "implement-queue-worker"` resolves to "not found", and `/implement-queue` Phase 2 cannot dispatch it.

Discovered live while running `/implement-queue`: the dispatch failed, forcing a fall back to `general-purpose` workers, which lack the worker's restricted tool set (`Bash/Read/Write/Edit/Glob/Grep/Skill` only) and its baked-in TDD + surgical-scope protocol. In that run, a general-purpose substitute committed out-of-scope component swaps that broke CI typecheck (held as draft #2139) — exactly the class of mistake the restricted worker is designed to avoid.

One-line fix: add `name: implement-queue-worker` to match every other agent in `.claude/agents/`.

## Test plan
- [x] Confirmed all sibling agents in `.claude/agents/` carry a `name:` field; this one didn't
- [ ] After merge: `subagent_type: "implement-queue-worker"` dispatches successfully in a fresh session (registry is snapshotted at session start, so it takes effect next session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)