### PR TITLE
chore(infra): add GITHUB_TOKEN + GITHUB_WEBHOOK_SECRET to .env.example (#2113)

### DIFF
--- a/infrastructure/.env.example
+++ b/infrastructure/.env.example
@@ -15,5 +15,11 @@ VITE_AUTH_CLIENT_ID=your_client_id
 VITE_AUTH_AUDIENCE=https://api.mattbutlerengineering.com
 VITE_AUTH_REDIRECT_URI=http://localhost:3000/callback
 
+# Agent container (docker-compose agent-api service)
+# Without GITHUB_TOKEN, PR creation and webhook operations silently fail; optional for non-agent dev
+GITHUB_TOKEN=
+# Without GITHUB_WEBHOOK_SECRET, incoming GitHub webhooks are not verified; optional for non-agent dev
+GITHUB_WEBHOOK_SECRET=
+
 # Production only
 ACME_EMAIL=admin@mattbutlerengineering.com


### PR DESCRIPTION
Both vars are passed into the `agent-api` container via `docker-compose.yml` lines 100-101 but were missing from `infrastructure/.env.example`. A developer following `.env.example` would get an agent container with empty values and silent failures on webhook/PR operations.

Added both with placeholder values and one-line comments noting what breaks without them and that they are optional for non-agent development.

- `node scripts/check-env-sync.js` passes

Closes #2113