### PR TITLE
feat(skills): add /gotcha-harvest to mine CI-feedback lessons from loops

### DIFF
--- a/.claude/rules/gotchas.md
+++ b/.claude/rules/gotchas.md
@@ -2,6 +2,8 @@
 
 Project-specific traps that have bitten me before. Read these before diving into pre-commit, release, or deploy work.
 
+> **Adding entries:** after an autonomous loop (`/implement-queue`, `/ship-loop`), run `/gotcha-harvest` to mine the session for `CI failed → fix → passed` arcs and recurring tool-errors — it proposes new bullets here (and cross-repo facts to memory) with human review. `/reflect` only captures *human corrections*, so loop-discovered gotchas land here via `/gotcha-harvest`, not `/reflect`.
+
 ## Pre-commit / lint
 
 - Pre-commit hook runs `eslint --fix` + `check-adr` + `pack-changed` (the last one regenerates `llms.txt` / `llms-full.txt` in affected packages — expect them to appear in `git status` after your commit lands)

--- a/.claude/skills/gotcha-harvest/SKILL.md
+++ b/.claude/skills/gotcha-harvest/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: gotcha-harvest
+description: "Harvest discovery-driven lessons from autonomous loops. Scans a session (or --days N of history) for 'CI/check failed → fix → passed' arcs and recurring tool-errors, then proposes entries for .claude/rules/gotchas.md (repo-specific) or your frontmatter-per-fact memory (cross-repo). Use after /implement-queue or /ship-loop runs, or invoke /gotcha-harvest. Complements /reflect, which is correction-driven and misses these."
+user-invocable: true
+allowed-tools: Read, Edit, Write, Glob, Grep, Bash, AskUserQuestion, TodoWrite
+---
+
+# Gotcha Harvest
+
+`/reflect` captures **corrections** — places where a human told the agent "no, do X." Autonomous loops (`/implement-queue`, `/ship-loop`) rarely produce those; their lessons are **discovery-driven**: a CI check fails, the agent diagnoses and fixes it, the check passes. That arc is the richest source of reusable gotchas and `/reflect` structurally never sees it. This skill harvests it.
+
+**Output is a proposal, never a silent write.** Always show findings and get a human decision before editing any file.
+
+## Arguments
+
+- (none) — scan the **current session** transcript only.
+- `--days N` — scan all project session files modified in the last N days (default 7 when the flag is bare).
+- `--dry-run` — show proposals, write nothing.
+
+## Process
+
+### Step 0: Track the run
+
+Use TodoWrite with: locate transcripts → detect arcs → synthesize gotchas → dedupe → route → review → apply.
+
+### Step 1: Locate transcripts
+
+```bash
+# current project's session folder (paths have / replaced by -)
+ls ~/.claude/projects/ | grep -i "$(basename "$(pwd)" | tr '_' '-')"
+```
+
+- No flag → the most recent non-`agent-*` `.jsonl` (current session).
+- `--days N` → every `*.jsonl` (including `agent-*.jsonl` — workers hit the recurring drift/typecheck failures) modified within N days.
+
+### Step 2: Detect failure→fix→pass arcs
+
+Scan the transcript(s) for this shape, in order:
+
+1. **A signal of a check failing** — a tool result or assistant line containing CI/build feedback. Anchor patterns (case-insensitive):
+   - `❌`, `FAIL`, `exit code 1`, `ELIFECYCLE`, `Process completed with exit code`
+   - named checks: `CI Gate`, `Integrity`, `Build`, `typecheck`, `lint`, `instruction rot`, `dependency-graph.md is stale`, `llms.txt … out of sync`, `frozen-lockfile`, `check-adr`, `check-deps`
+2. **An action taken in response** — an Edit/Write/Bash between the failure and the recovery (regenerate, rebase, add a step, change a value).
+3. **A recovery signal** — a later "all pass" / green / merged / "✓" for the same check.
+
+Also collect **recurring tool-errors**: the same error class (e.g. `@mbe/agent-core … not built`, `vitest: command not found`, lockfile desync) appearing **2+ times** across the scanned scope — these are gotchas even without a clean arc.
+
+Discard one-off transient failures with no fix and no recurrence.
+
+### Step 3: Synthesize a one-line gotcha per arc
+
+Imperative, cause→fix, ≤2 lines. Mirror the existing `gotchas.md` voice (terse, concrete, command-bearing). Example shapes:
+
+- "Deleting a workspace package drifts the **root** llms.txt — `pnpm pack-changed` misses it; regenerate with `node tools/cli/dist/index.js pack .` and run `detect-instruction-rot.mjs`."
+- "Worktree agents must `pnpm build --filter @mbe/agent-core...` before `tools/cli` typecheck — fresh checkouts have no dist."
+
+### Step 4: Dedupe against existing knowledge
+
+```bash
+grep -niE "<keyword>" .claude/rules/gotchas.md
+```
+
+If a near-match exists, propose **merge/refine** rather than a new bullet. Also skip lessons **already encoded this session** into a skill/agent/PR (check `git log --oneline origin/main..HEAD` and the session for edits that already fixed it) — re-proposing what you just shipped is noise.
+
+### Step 5: Route each gotcha
+
+| Kind of lesson | Destination | How |
+| --- | --- | --- |
+| Repo CI / build / pre-commit / drift / release / deploy / Prisma | `.claude/rules/gotchas.md` | append a bullet under the matching `## ` section (Pre-commit / Pre-push / Build / CI / Dependencies / Releases / Tooling / Auth0 · E2E / Prisma · DO migrate) |
+| Cross-repo Claude Code / harness / tooling fact (true outside this repo) | frontmatter-per-fact memory | see **Memory schema** below |
+| Workflow/process correction tied to a specific skill | that skill's `SKILL.md` | only when it changes how the skill should behave |
+
+If no `## ` section fits a repo gotcha, propose a new section header.
+
+### Step 6: Review, then apply
+
+Present a compact table (`#`, gotcha, destination, new/merge), then `AskUserQuestion`: Apply all / Select / Skip. On `--dry-run`, stop here. Apply with `Edit` (stage specific files only — never `git add -A`). Report what landed where.
+
+## Memory schema (cross-repo facts)
+
+Cross-repo facts go to `~/.claude/projects/<project>/memory/` as **one file per fact** with this frontmatter — the same schema as `MEMORY.md`, so the manual memory protocol, this skill, and any future `/reflect` auto-memory all converge on one format (resolves the two-schema split in that directory):
+
+```markdown
+---
+name: <short-kebab-case-slug>
+description: <one-line summary used for recall>
+metadata:
+  type: feedback | reference
+---
+
+<the fact. **Why:** … **How to apply:** … Link related facts with [[their-name]].>
+```
+
+After writing the file, add one index line to `MEMORY.md`: `- [Title](file.md) — hook`. Never put fact bodies in `MEMORY.md`.
+
+## Relationship to `/reflect`
+
+- `/reflect` → human corrections, routed to CLAUDE.md / rules / skills. Run it for interactive sessions.
+- `/gotcha-harvest` → agent-discovered CI/build lessons, routed to `gotchas.md` / memory. Run it after autonomous loops.
+
+They are complementary; running both loses nothing because each dedupes against the shared targets.

--- a/.claude/skills/gotcha-harvest/SKILL.md
+++ b/.claude/skills/gotcha-harvest/SKILL.md
@@ -14,8 +14,17 @@ allowed-tools: Read, Edit, Write, Glob, Grep, Bash, AskUserQuestion, TodoWrite
 ## Arguments
 
 - (none) — scan the **current session** transcript only.
-- `--days N` — scan all project session files modified in the last N days (default 7 when the flag is bare).
+- `--days N` — scan the last N days (default 7 when the flag is bare).
+- `--source transcript|github|auto` — where to mine from (default `auto`).
 - `--dry-run` — show proposals, write nothing.
+
+## Source modes
+
+The failure→fix→pass arc lives in two places; pick by where you're running:
+
+- **`transcript`** — local session `.jsonl` files. Richest signal (the agent's own reasoning + the exact commands), but only exists on the machine that ran the loop, and Claude Code prunes sessions after 30 days. Use locally.
+- **`github`** — the repo's merged-PR + CI-run history via `gh`. Durable and available **in a cloud/CI checkout with no local files** — this is the mode a scheduled cloud routine must use. Lower fidelity (you see the failed check and the fixing commit, not the deliberation), but the arc is still recoverable.
+- **`auto`** (default) — `transcript` if local session files for this project exist, else `github`.
 
 ## Process
 
@@ -23,19 +32,27 @@ allowed-tools: Read, Edit, Write, Glob, Grep, Bash, AskUserQuestion, TodoWrite
 
 Use TodoWrite with: locate transcripts → detect arcs → synthesize gotchas → dedupe → route → review → apply.
 
-### Step 1: Locate transcripts
+### Step 1: Locate the source
+
+**Resolve the mode** (`--source`, default `auto`):
 
 ```bash
-# current project's session folder (paths have / replaced by -)
+# transcript candidates for this project (paths have / replaced by -)
 ls ~/.claude/projects/ | grep -i "$(basename "$(pwd)" | tr '_' '-')"
 ```
 
-- No flag → the most recent non-`agent-*` `.jsonl` (current session).
-- `--days N` → every `*.jsonl` (including `agent-*.jsonl` — workers hit the recurring drift/typecheck failures) modified within N days.
+- If candidates exist (or `--source transcript`) → **transcript mode**: no flag = most recent non-`agent-*` `.jsonl`; `--days N` = every `*.jsonl` (incl. `agent-*.jsonl` — workers hit the recurring drift/typecheck failures) modified within N days.
+- If none exist (cloud/CI) or `--source github` → **github mode**: gather the window's history (the `date` math below; BSD/macOS `date -v`, GNU `date -d`):
+
+  ```bash
+  SINCE=$(date -u -v-7d +%F 2>/dev/null || date -u -d '7 days ago' +%F)
+  gh pr list --state merged --search "merged:>=$SINCE" --json number,title,mergedAt --limit 50
+  gh run list --created ">=$SINCE" --status failure --json databaseId,headBranch,workflowName --limit 50
+  ```
 
 ### Step 2: Detect failure→fix→pass arcs
 
-Scan the transcript(s) for this shape, in order:
+**Transcript mode** — scan for this shape, in order:
 
 1. **A signal of a check failing** — a tool result or assistant line containing CI/build feedback. Anchor patterns (case-insensitive):
    - `❌`, `FAIL`, `exit code 1`, `ELIFECYCLE`, `Process completed with exit code`
@@ -46,6 +63,22 @@ Scan the transcript(s) for this shape, in order:
 Also collect **recurring tool-errors**: the same error class (e.g. `@mbe/agent-core … not built`, `vitest: command not found`, lockfile desync) appearing **2+ times** across the scanned scope — these are gotchas even without a clean arc.
 
 Discard one-off transient failures with no fix and no recurrence.
+
+**GitHub mode** — reconstruct the arc from history:
+
+1. For each failed run from Step 1, read its failing job log for the anchor patterns above:
+   ```bash
+   gh run view <databaseId> --log-failed | grep -iE 'error|fail|drift|stale|out of sync|rot|exit code'
+   ```
+2. Find the **fix**: the next commit/PR on that branch that turned the same check green — inspect its diff and message:
+   ```bash
+   gh pr view <N> --json commits,files
+   gh pr diff <N> --name-only
+   ```
+   Commits like `chore: regenerate …`, `fix: … drift`, follow-up pushes after a red check are the fix signal.
+3. A check that failed on a PR and passed after a specific commit **is** an arc — the failing log gives the cause, the fixing diff gives the remedy. Cluster identical failures across PRs (e.g. the same llms.txt drift on 3 PRs) into one recurring-gotcha.
+
+Lower fidelity than transcripts (no agent reasoning), so when the cause is ambiguous from the log alone, mark the proposal `needs-confirmation` rather than asserting it.
 
 ### Step 3: Synthesize a one-line gotcha per arc
 
@@ -74,7 +107,12 @@ If no `## ` section fits a repo gotcha, propose a new section header.
 
 ### Step 6: Review, then apply
 
-Present a compact table (`#`, gotcha, destination, new/merge), then `AskUserQuestion`: Apply all / Select / Skip. On `--dry-run`, stop here. Apply with `Edit` (stage specific files only — never `git add -A`). Report what landed where.
+Always present a compact table first (`#`, gotcha, destination, new/merge, confidence).
+
+- **Interactive (local)** → `AskUserQuestion`: Apply all / Select / Skip. Apply with `Edit` (stage specific files only — never `git add -A`). Report what landed where.
+- **Unattended (cloud routine, no human to prompt)** → do **not** write to `main` and do **not** silently apply. Create a branch, apply the proposals, and open a PR titled `chore(gotchas): harvested from CI history (last N days)` with the proposal table in the body for human review. This is the conservative scheduled-run contract: propose via PR, never auto-commit to `main`. If there are zero proposals, exit quietly without a PR.
+
+On `--dry-run`, stop after the table regardless of mode.
 
 ## Memory schema (cross-repo facts)
 


### PR DESCRIPTION
## Why

`/reflect` is **correction-driven** — it captures places a human said "no, do X." Autonomous loops (`/implement-queue`, `/ship-loop`) rarely produce corrections; their lessons are **discovery-driven**: a CI check fails → the agent diagnoses and fixes it → the check passes. That arc is the richest source of reusable gotchas and `/reflect` structurally never sees it.

This session is the proof: 9 PRs merged, repeated llms.txt/dep-graph drift failures diagnosed and fixed, the `Agent(model:)` tier-only finding — **zero** of it was a human correction, so `/reflect` would have captured none of the high-value lessons.

## What

A project-local `/gotcha-harvest` skill that:
- scans the current session (or `--days N` of history, incl. `agent-*.jsonl` workers) for `failed → fix → passed` arcs and recurring tool-errors (2+ occurrences)
- synthesizes terse, imperative gotchas in the existing `gotchas.md` voice
- dedupes against existing `gotchas.md` bullets and skips lessons already encoded this session
- routes: repo CI/build/drift/release → `.claude/rules/gotchas.md` (matching section); cross-repo Claude Code/tooling facts → frontmatter-per-fact memory (same schema as `MEMORY.md`, converging the two memory formats in that dir)
- **always proposes with human review** — never a silent write; `--dry-run` supported

Documents the routing convention at the top of `gotchas.md`.

## Scope notes
- Does not (and cannot) modify the third-party `claude-reflect` plugin; it aligns the side we control and is explicitly complementary — both dedupe against shared targets, so running both is safe.
- Cadence (a Friday `--days 7` run) is being set up separately as a scheduled routine.

## Test plan
- [x] Markdown-only skill; no code paths to unit-test
- [ ] Dogfood: run `/gotcha-harvest` against this very session — it should surface the package-deletion drift + `Agent(model:)` tier findings and route them correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)