### PR TITLE
docs(reservations): add Deposits/Stripe/Waitlist/FloorPlan + fix Guest interface

### DIFF
--- a/services/reservations/CLAUDE.md
+++ b/services/reservations/CLAUDE.md
@@ -16,6 +16,10 @@ VenueGroup (1) ──────< Venue (many)
                      └────< Guest (many)
                      │
                      └────< ReservationHold (many)
+                     │
+                     └────< FloorPlan (many)
+                     │
+                     └────< WaitlistEntry (many)
 ```
 
 ### VenueGroup
@@ -34,7 +38,7 @@ interface VenueGroup {
 
 ### Venue
 
-Individual restaurant location.
+Individual restaurant location. Also holds the deposit policy configuration.
 
 ```typescript
 interface Venue {
@@ -46,6 +50,29 @@ interface Venue {
   currencyCode: string; // default: "USD"
   operatingHours: Record<string, unknown> | null; // JSON — structure at app level
   settings: Record<string, unknown> | null; // JSON
+  // Deposit policy
+  depositEnabled: boolean; // default: false
+  depositType: "flat" | "per_person" | null;
+  depositAmountCents: number | null;
+  freeCancellationHours: number | null;
+  lateCancellationFeePercent: number | null;
+  noShowFeePercent: number | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+```
+
+### FloorPlan
+
+Visual layout of a venue. One floor plan per venue is active at a time.
+
+```typescript
+interface FloorPlan {
+  id: string;
+  venueId: string;
+  name: string;
+  isActive: boolean; // default: false
+  layoutJson: Record<string, unknown>; // editor canvas layout
   createdAt: Date;
   updatedAt: Date;
 }
@@ -106,6 +133,8 @@ interface Reservation {
   partySize: number;
   status: ReservationStatus;
   notes: string | null;
+  occasion: Occasion | null;
+  seatingPreference: SeatingPreference | null;
   cancellationReason: string | null;
   cancellationNote: string | null;
   createdAt: Date;
@@ -118,11 +147,15 @@ type ReservationStatus =
   | "COMPLETED" // Dining finished
   | "CANCELLED" // Cancelled by guest or staff
   | "NO_SHOW"; // Guest didn't arrive
+
+type Occasion = "birthday" | "anniversary" | "business" | "date_night" | "other" | "none";
+
+type SeatingPreference = "booth" | "patio" | "bar" | "window" | "quiet" | "no_preference";
 ```
 
 ### Guest
 
-Guest CRM entity.
+Guest CRM entity. Full type is defined in `@mbe/types` (`packages/types/src/guest.ts`).
 
 ```typescript
 interface Guest {
@@ -133,12 +166,82 @@ interface Guest {
   name: string;
   notes: string | null;
   visitCount: number;
-  lifetimeSpend: number | null;
-  lastVisit: Date | null;
-  tags: Record<string, unknown> | null;
+  lifetimeSpend: string | null; // Decimal as string for precision
+  lastVisit: string | null;
+  tags: string[] | null;
+  dietaryRestrictions: string[] | null; // e.g. ["gluten-free", "vegan", "nut-allergy"]
+  communicationPreference: CommunicationPreference; // default: "both"
+  staffNotes: StaffNote[]; // staff-only, never returned in public API responses
+  createdAt: string;
+  updatedAt: string;
+}
+
+type CommunicationPreference = "email_only" | "sms_only" | "both" | "transactional_only";
+
+interface StaffNote {
+  text: string;
+  createdBy: string; // authenticated user id
+  createdAt: string;
+}
+```
+
+### Deposit
+
+Payment hold associated with a reservation. One deposit per reservation (`reservationId` is unique).
+
+```typescript
+interface Deposit {
+  id: string;
+  reservationId: string; // unique — one deposit per reservation
+  amountCents: number;
+  currency: string; // ISO code, lowercase (e.g. "usd")
+  status: DepositStatus;
+  stripePaymentIntentId: string | null;
+  stripeCustomerId: string | null;
+  heldAt: Date | null;
+  appliedAt: Date | null;
+  refundedAt: Date | null;
+  forfeitedAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
 }
+
+type DepositStatus = "pending" | "held" | "applied" | "refunded" | "forfeited";
+
+type DepositType = "flat" | "per_person"; // stored on Venue.depositType
+```
+
+**Lifecycle:**
+
+```
+pending ──(payment_intent.succeeded webhook)──> held
+held    ──(capture / no-show)──> applied | forfeited
+held    ──(cancellation)──> refunded
+```
+
+Stripe PaymentIntents are created with **manual capture** (authorize-only hold). The webhook transitions `pending → held` when the payment is authorized. Staff actions then capture (`held → applied`), refund (`held → refunded`), or forfeit (`held → forfeited`).
+
+### WaitlistEntry
+
+Walk-in queue entry for a venue.
+
+```typescript
+interface WaitlistEntry {
+  id: string;
+  venueId: string;
+  partySize: number;
+  guestName: string;
+  guestPhone: string;
+  position: number;
+  estimatedWaitMinutes: number;
+  status: WaitlistStatus;
+  notifiedAt: Date | null;
+  expiresAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+type WaitlistStatus = "waiting" | "notified" | "seated" | "expired" | "cancelled";
 ```
 
 ## API Routes
@@ -162,6 +265,22 @@ interface Guest {
 | PUT    | `/api/v1/tables/:id/status` | Update table status             |
 | DELETE | `/api/v1/tables/:id`        | Delete table                    |
 
+### Floor Plans
+
+| Method | Path                                         | Description                              |
+| ------ | -------------------------------------------- | ---------------------------------------- |
+| GET    | `/api/v1/floor-plans`                        | List floor plans (filterable by venueId) |
+| GET    | `/api/v1/floor-plans/:id`                    | Get floor plan by ID                     |
+| GET    | `/api/v1/floor-plans/venue/:venueId/active`  | Get active floor plan for venue          |
+| POST   | `/api/v1/floor-plans`                        | Create floor plan                        |
+| POST   | `/api/v1/floor-plans/:id/clone`              | Clone floor plan (copies all tables)     |
+| POST   | `/api/v1/floor-plans/:id/activate`           | Set as active (deactivates others)       |
+| PATCH  | `/api/v1/floor-plans/:id`                    | Update floor plan metadata               |
+| DELETE | `/api/v1/floor-plans/:id`                    | Delete floor plan                        |
+| POST   | `/api/v1/floor-plans/tables/positions`       | Bulk update table positions              |
+| POST   | `/api/v1/floor-plans/tables/:tableId/assign` | Assign table to floor plan               |
+| POST   | `/api/v1/floor-plans/tables/:tableId/remove` | Remove table from floor plan             |
+
 ### Reservations
 
 | Method | Path                                | Description                          |
@@ -182,19 +301,71 @@ interface Guest {
 | POST   | `/api/v1/holds`             | Create reservation hold (5 min) |
 | PUT    | `/api/v1/holds/:id/confirm` | Confirm hold → reservation      |
 
+### Guests
+
+| Method | Path                            | Description                                     |
+| ------ | ------------------------------- | ----------------------------------------------- |
+| GET    | `/api/v1/guests`                | List guests for venue                           |
+| GET    | `/api/v1/guests/search`         | Search guests by name/email/phone/tags          |
+| GET    | `/api/v1/guests/segments`       | Get guest segments (VIP, At Risk, Lapsed, etc.) |
+| GET    | `/api/v1/guests/lapsing`        | On-demand lapse detection scan                  |
+| GET    | `/api/v1/guests/:id`            | Get guest by ID                                 |
+| POST   | `/api/v1/guests`                | Create guest (accepts `dietaryRestrictions`)    |
+| POST   | `/api/v1/guests/find-or-create` | Identity resolution — find or create            |
+| PATCH  | `/api/v1/guests/:id`            | Update guest (accepts `dietaryRestrictions`)    |
+| POST   | `/api/v1/guests/:id/notes`      | Append staff note                               |
+| POST   | `/api/v1/guests/:id/win-back`   | Send win-back message to lapsing guest          |
+| DELETE | `/api/v1/guests/:id`            | Delete guest (fails if guest has reservations)  |
+
+`dietaryRestrictions` is a `string[]` field accepted on create, update, and `find-or-create`. It is stored as JSON on the `Guest` model. Tests for dietary-restriction flows live in `src/routes/guests-dietary.test.ts`.
+
+### Deposits (authenticated)
+
+| Method | Path                           | Description                        |
+| ------ | ------------------------------ | ---------------------------------- |
+| POST   | `/api/v1/deposits`             | Create deposit in `pending` state  |
+| GET    | `/api/v1/deposits/:id`         | Get deposit by ID                  |
+| POST   | `/api/v1/deposits/:id/capture` | Apply (capture) a `held` deposit   |
+| POST   | `/api/v1/deposits/:id/refund`  | Refund a `held` deposit            |
+| POST   | `/api/v1/deposits/:id/forfeit` | Forfeit a `held` deposit (no-show) |
+
+### Stripe Webhook (unauthenticated)
+
+| Method | Path                     | Description                                            |
+| ------ | ------------------------ | ------------------------------------------------------ |
+| POST   | `/api/v1/stripe/webhook` | Receive Stripe events; verifies signature via raw body |
+
+Handled event types: `payment_intent.succeeded` (`pending → held`), `payment_intent.canceled` (`held → refunded`), `charge.refunded` (`held → refunded`).
+
+Raw body access is required for HMAC signature verification — this route must be registered before any JSON body parsers.
+
+### Waitlist
+
+| Method | Path                          | Description                    |
+| ------ | ----------------------------- | ------------------------------ |
+| POST   | `/api/v1/waitlist`            | Add guest to waitlist          |
+| GET    | `/api/v1/waitlist`            | List waiting entries for venue |
+| GET    | `/api/v1/waitlist/:id`        | Get single waitlist entry      |
+| PUT    | `/api/v1/waitlist/:id/seat`   | Mark guest as seated           |
+| PUT    | `/api/v1/waitlist/:id/cancel` | Cancel waitlist entry          |
+| PUT    | `/api/v1/waitlist/:id/expire` | Mark entry as expired          |
+
 ### Public Booking Widget (no auth)
 
-| Method | Path                                    | Description                         |
-| ------ | --------------------------------------- | ----------------------------------- |
-| GET    | `/public/v1/venues/:slug`               | Get public venue info               |
-| GET    | `/public/v1/venues/:slug/availability`  | Get available slots (public)        |
-| POST   | `/public/v1/venues/:slug/holds`         | Create hold (public)                |
-| DELETE | `/public/v1/venues/:slug/holds/:holdId` | Release hold (public)               |
-| POST   | `/public/v1/venues/:slug/reservations`  | Confirm hold → reservation (public) |
-| GET    | `/public/v1/reservations/manage`        | Get reservation via manage token    |
-| PATCH  | `/public/v1/reservations/manage`        | Modify reservation via manage token |
-| DELETE | `/public/v1/reservations/manage`        | Cancel reservation via manage token |
-| GET    | `/public/v1/reservations/confirm`       | Confirm attendance via token        |
+| Method | Path                                              | Description                             |
+| ------ | ------------------------------------------------- | --------------------------------------- |
+| GET    | `/public/v1/venues/:slug`                         | Get public venue info                   |
+| GET    | `/public/v1/venues/:slug/availability`            | Get available slots (public)            |
+| POST   | `/public/v1/venues/:slug/holds`                   | Create hold (public)                    |
+| DELETE | `/public/v1/venues/:slug/holds/:holdId`           | Release hold (public)                   |
+| POST   | `/public/v1/venues/:slug/reservations`            | Confirm hold → reservation (public)     |
+| POST   | `/public/v1/venues/:slug/deposits/payment-intent` | Create Stripe PaymentIntent for deposit |
+| GET    | `/public/v1/reservations/manage`                  | Get reservation via manage token        |
+| PATCH  | `/public/v1/reservations/manage`                  | Modify reservation via manage token     |
+| DELETE | `/public/v1/reservations/manage`                  | Cancel reservation via manage token     |
+| GET    | `/public/v1/reservations/confirm`                 | Confirm attendance via token            |
+
+The public deposit route creates a Stripe PaymentIntent (manual capture) and a `Deposit` record in `pending` state, returning the `clientSecret` for Stripe.js to confirm on the frontend.
 
 ### Events (SSE)
 
@@ -294,13 +465,14 @@ Hospitality UI ──> Reservations API ──> SSE ──> Hospitality UI (upda
 Booking Widget ──> GET /availability ──> Time slots
                ──> POST /holds ──> Hold created (5 min)
                ──> PUT /holds/:id/confirm ──> Reservation created
+               ──> POST /public/v1/venues/:slug/deposits/payment-intent ──> Stripe PaymentIntent (if deposit enabled)
 ```
 
 ### Auth Flow
 
 Authenticated routes (require JWT): all `/api/v1/*` routes except `/api/v1/availability`.
 
-Unauthenticated routes: `/health`, `/ready`, `/api/v1/availability`, and all `/public/v1/*` routes (public booking widget, manage/cancel/modify reservation by token, confirm attendance).
+Unauthenticated routes: `/health`, `/ready`, `/api/v1/availability`, `/api/v1/stripe/webhook`, and all `/public/v1/*` routes (public booking widget, manage/cancel/modify reservation by token, confirm attendance).
 
 ```typescript
 // Routes use @mbe/auth plugin
@@ -363,34 +535,41 @@ it("broadcasts reservation:created event", async () => {
 ## Commands
 
 ```bash
-pnpm dev              # Hot-reload dev server (port 3004)
-pnpm build            # Compile TypeScript
-pnpm test             # Run all tests
-pnpm test:watch       # Watch mode
-pnpm test:coverage    # Coverage report
-pnpm lint             # ESLint
-pnpm typecheck        # TypeScript type check
-pnpm db:generate      # Generate Prisma client
-pnpm db:push          # Push schema (dev only)
-pnpm db:migrate       # Create + apply migrations
+pnpm dev               # Hot-reload dev server (port 3004)
+pnpm start             # Run compiled output (production)
+pnpm build             # Compile TypeScript
+pnpm build:openapi     # Generate openapi.json from live app
+pnpm test              # Run all tests
+pnpm test:contract     # Run contract tests only
+pnpm test:watch        # Watch mode
+pnpm test:coverage     # Coverage report
+pnpm lint              # ESLint
+pnpm typecheck         # TypeScript type check
+pnpm db:generate       # Generate Prisma client
+pnpm db:push           # Push schema (dev only)
+pnpm db:migrate        # Create + apply migrations
 pnpm db:migrate:deploy # Apply migrations (production)
+pnpm db:migrate:status # Show migration status
+pnpm db:studio         # Open Prisma Studio
 ```
 
 ## Environment Variables
 
-| Variable              | Required   | Description                                             |
-| --------------------- | ---------- | ------------------------------------------------------- |
-| `PORT`                | No         | Service port (default: 3004)                            |
-| `LOG_LEVEL`           | No         | Logging level (default: info)                           |
-| `CORS_ORIGINS`        | No         | Comma-separated allowed origins                         |
-| `AUTH_AUTHORITY`      | Yes (prod) | Auth0 domain                                            |
-| `AUTH_AUDIENCE`       | Yes (prod) | Auth0 API identifier                                    |
-| `DATABASE_URL`        | Yes        | Postgres connection                                     |
-| `MANAGE_TOKEN_SECRET` | Yes (prod) | HMAC secret for self-service manage/cancel tokens       |
-| `RESEND_API_KEY`      | No         | Resend API key — enables email notifications when set   |
-| `EMAIL_FROM`          | No         | From address for emails (default: reservations@m...com) |
-| `MANAGE_BASE_URL`     | No         | Base URL for manage/cancel links in emails              |
-| `SENTRY_DSN`          | No         | Sentry DSN for error tracking                           |
+| Variable                | Required   | Description                                             |
+| ----------------------- | ---------- | ------------------------------------------------------- |
+| `PORT`                  | No         | Service port (default: 3004)                            |
+| `LOG_LEVEL`             | No         | Logging level (default: info)                           |
+| `CORS_ORIGINS`          | No         | Comma-separated allowed origins                         |
+| `AUTH_AUTHORITY`        | Yes (prod) | Auth0 domain                                            |
+| `AUTH_AUDIENCE`         | Yes (prod) | Auth0 API identifier                                    |
+| `DATABASE_URL`          | Yes        | Postgres connection                                     |
+| `MANAGE_TOKEN_SECRET`   | Yes (prod) | HMAC secret for self-service manage/cancel tokens       |
+| `RESEND_API_KEY`        | No         | Resend API key — enables email notifications when set   |
+| `EMAIL_FROM`            | No         | From address for emails (default: reservations@m...com) |
+| `MANAGE_BASE_URL`       | No         | Base URL for manage/cancel links in emails              |
+| `SENTRY_DSN`            | No         | Sentry DSN for error tracking                           |
+| `STRIPE_SECRET_KEY`     | Yes (prod) | Stripe secret key — required when deposits are enabled  |
+| `STRIPE_WEBHOOK_SECRET` | Yes (prod) | Stripe webhook signing secret for HMAC verification     |
 
 ## Related Documentation
 


### PR DESCRIPTION
Closes #2185

## Summary

- Document the **Deposits + Stripe subsystem**: `Deposit` model with `DepositStatus`/`DepositType` enums, all 5 `/api/v1/deposits` routes (`create`, `get`, `capture`, `refund`, `forfeit`), the Stripe webhook route at `/api/v1/stripe/webhook`, the public deposit route `POST /public/v1/venues/:slug/deposits/payment-intent`, the `hold→applied/refunded/forfeited` lifecycle, and both `STRIPE_SECRET_KEY`/`STRIPE_WEBHOOK_SECRET` env vars (names only — no values)
- Document the **Waitlist subsystem**: `WaitlistEntry` model with `WaitlistStatus` enum (`waiting/notified/seated/expired/cancelled`) and all 6 `/api/v1/waitlist` routes
- Document the **FloorPlan** model and all 11 `/api/v1/floor-plans` routes (list, get, active, create, clone, activate, update, delete, bulk positions, assign, remove)
- Fix the **Guest interface**: add `dietaryRestrictions`, `communicationPreference`, `staffNotes`; note `guests-dietary.test.ts`; remove the stale shape (`lifetimeSpend: number`, `tags: Record`)
- Fix the **Reservation interface**: add `occasion` (`Occasion` enum) and `seatingPreference` (`SeatingPreference` enum) which were in the Prisma schema but missing from the doc
- Fix the **Venue interface**: add deposit policy fields (`depositEnabled`, `depositType`, `depositAmountCents`, `freeCancellationHours`, `lateCancellationFeePercent`, `noShowFeePercent`)
- Add omitted scripts: `start`, `build:openapi`, `test:contract`, `db:migrate:status`, `db:studio`
- Update entity hierarchy diagram to include `FloorPlan` and `WaitlistEntry`

## Verification

Every claim was verified against source before writing:
- Routes verified against `services/reservations/src/routes/*.ts` and `src/app.ts` registrations
- Models verified against `services/reservations/prisma/schema.prisma`
- Scripts verified against `services/reservations/package.json`
- Guest fields verified against `packages/types/src/guest.ts`
- Reservation fields verified against `packages/types/src/reservation.ts`

## Test plan

- [x] `pnpm lint` — passes (markdown-only change, no source touched)
- [x] `pnpm test` on reservations service — 47 test files, 663 tests, all pass
- [x] `pnpm --filter @mbe/cli start check-adr` — no violations
- [x] `pnpm --filter @mbe/cli start check-deps` — no violations
- [x] `node scripts/detect-instruction-rot.mjs` — no rot detected
- [x] `pnpm regen --check` — 3 stale artifacts are pre-existing (rialto registry, rialto-catalog schemas, dep-graph), not caused by this change
- [x] PR base ref verified as `main`