### PR TITLE
fix(scripts): drop deleted feature-flags from llms-txt manifest; add llms-full.txt coverage

### DIFF
--- a/scripts/__tests__/regen-manifest.test.mjs
+++ b/scripts/__tests__/regen-manifest.test.mjs
@@ -39,7 +39,6 @@ describe("regen-manifest", () => {
 
   it("llms-txt outputs include all workspace packages with llms.txt", () => {
     const llms = FAMILIES.find((f) => f.id === "llms-txt");
-    const workspaceOutputs = llms.outputs.filter((o) => o !== "llms.txt");
     // At least the main app and service packages
     const expected = [
       "apps/hospitality/llms.txt",
@@ -49,9 +48,10 @@ describe("regen-manifest", () => {
     for (const e of expected) {
       expect(llms.outputs, `expected ${e}`).toContain(e);
     }
-    // All workspace outputs end with /llms.txt
+    // All workspace outputs end with /llms.txt or /llms-full.txt
+    const workspaceOutputs = llms.outputs.filter((o) => o !== "llms.txt" && o !== "llms-full.txt");
     for (const o of workspaceOutputs) {
-      expect(o).toMatch(/\/llms\.txt$/);
+      expect(o).toMatch(/\/llms(?:-full)?\.txt$/);
     }
   });
 
@@ -66,10 +66,11 @@ describe("regen-manifest", () => {
     }
   });
 
-  it("llmsPackages() length matches llms-txt outputs", () => {
+  it("llmsPackages() length matches llms-txt llms.txt entries (not llms-full.txt)", () => {
     const llms = FAMILIES.find((f) => f.id === "llms-txt");
+    const txtCount = llms.outputs.filter((o) => o === "llms.txt" || o.endsWith("/llms.txt")).length;
     const pkgs = llmsPackages();
-    expect(pkgs.length).toBe(llms.outputs.length);
+    expect(pkgs.length).toBe(txtCount);
   });
 
   it("rialto-registry command references the correct filter", () => {
@@ -88,5 +89,21 @@ describe("regen-manifest", () => {
     expect(md.outputs[0]).toContain(".md");
     expect(json.outputs[0]).toContain(".json");
     expect(md.outputs[0]).not.toBe(json.outputs[0]);
+  });
+
+  it("llms-txt outputs do NOT include deleted packages/feature-flags", () => {
+    const llms = FAMILIES.find((f) => f.id === "llms-txt");
+    expect(llms.outputs).not.toContain("packages/feature-flags/llms.txt");
+    expect(llms.outputs).not.toContain("packages/feature-flags/llms-full.txt");
+  });
+
+  it("llms-txt outputs include llms-full.txt alongside every llms.txt", () => {
+    const llms = FAMILIES.find((f) => f.id === "llms-txt");
+    const txts = llms.outputs.filter((o) => o.endsWith("/llms.txt") || o === "llms.txt");
+    for (const txt of txts) {
+      const fullTxt =
+        txt === "llms.txt" ? "llms-full.txt" : txt.replace(/\/llms\.txt$/, "/llms-full.txt");
+      expect(llms.outputs, `expected ${fullTxt} alongside ${txt}`).toContain(fullTxt);
+    }
   });
 });

--- a/scripts/regen-manifest.mjs
+++ b/scripts/regen-manifest.mjs
@@ -68,28 +68,49 @@ export const FAMILIES = [
     command: "pnpm --filter @mbe/cli start pack-all",
     outputs: [
       "llms.txt",
+      "llms-full.txt",
       "apps/gen/llms.txt",
+      "apps/gen/llms-full.txt",
       "apps/hospitality/llms.txt",
+      "apps/hospitality/llms-full.txt",
       "apps/marketing/llms.txt",
+      "apps/marketing/llms-full.txt",
       "apps/rialto-web/llms.txt",
+      "apps/rialto-web/llms-full.txt",
       "packages/agent-core/llms.txt",
+      "packages/agent-core/llms-full.txt",
       "packages/agent-test-utils/llms.txt",
+      "packages/agent-test-utils/llms-full.txt",
       "packages/api-client/llms.txt",
+      "packages/api-client/llms-full.txt",
       "packages/auth/llms.txt",
+      "packages/auth/llms-full.txt",
       "packages/database/llms.txt",
-      "packages/feature-flags/llms.txt",
+      "packages/database/llms-full.txt",
       "packages/jobs/llms.txt",
+      "packages/jobs/llms-full.txt",
       "packages/mcp-server/llms.txt",
+      "packages/mcp-server/llms-full.txt",
       "packages/notifications/llms.txt",
+      "packages/notifications/llms-full.txt",
       "packages/observability/llms.txt",
+      "packages/observability/llms-full.txt",
       "packages/rialto/llms.txt",
+      "packages/rialto/llms-full.txt",
       "packages/rialto-catalog/llms.txt",
+      "packages/rialto-catalog/llms-full.txt",
       "packages/sentry/llms.txt",
+      "packages/sentry/llms-full.txt",
       "packages/service-bootstrap/llms.txt",
+      "packages/service-bootstrap/llms-full.txt",
       "packages/types/llms.txt",
+      "packages/types/llms-full.txt",
       "services/agent/llms.txt",
+      "services/agent/llms-full.txt",
       "services/reservations/llms.txt",
+      "services/reservations/llms-full.txt",
       "services/users/llms.txt",
+      "services/users/llms-full.txt",
     ],
   },
   {
@@ -124,9 +145,9 @@ export const FAMILIES = [
 
 /** All workspace directories that carry an llms.txt (relative to root). */
 export function llmsPackages() {
-  return FAMILIES.find((f) => f.id === "llms-txt").outputs.map((o) =>
-    o === "llms.txt" ? "." : o.replace(/\/llms\.txt$/, "")
-  );
+  return FAMILIES.find((f) => f.id === "llms-txt")
+    .outputs.filter((o) => o === "llms.txt" || o.endsWith("/llms.txt"))
+    .map((o) => (o === "llms.txt" ? "." : o.replace(/\/llms\.txt$/, "")));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Remove `packages/feature-flags/llms.txt` from the `llms-txt` family outputs — `@mbe/feature-flags` was deleted in #2135 (inlined into service-bootstrap); the stale entry caused `llmsPackages()` to try packing a non-existent package
- Add `llms-full.txt` alongside every `llms.txt` in the `llms-txt` outputs array — `regen --check` previously could not detect `llms-full.txt` drift (root + rialto-catalog were stale and uncaught, as observed in PR #2173)
- Update `llmsPackages()` to filter only `llms.txt` entries when deriving directory list — `llms-full.txt` entries are companion outputs, not separate packages
- Update tests: adjust the 1:1 length assertion to count only `llms.txt` entries; add two dedicated tests asserting feature-flags absence and `llms-full.txt` coverage invariant

## Test plan

- [x] TDD: wrote two failing tests first (feature-flags absent, llms-full.txt present alongside each llms.txt), confirmed RED, implemented fix, confirmed GREEN
- [x] All 13 regen-manifest tests pass
- [x] `pnpm --filter @mbe/cli start check-adr` — no violations
- [x] `pnpm --filter @mbe/cli start check-deps` — all dependencies consistent
- [x] `node scripts/detect-instruction-rot.mjs` — no instruction rot
- [x] `node scripts/regen-manifest.mjs --check` — llms-txt family is clean; the 3 stale families (rialto-registry, rialto-catalog-schemas, dep-graph-md) are pre-existing and unrelated
- [x] Pre-push hook: 19/19 tasks successful across 10 packages
- [x] No lingering `packages/feature-flags/` directory in this worktree

Closes #2196