### PR TITLE
docs(rialto-plugin): fix phantom skills + lint script in CLAUDE.md

### DIFF
--- a/packages/rialto-plugin/CLAUDE.md
+++ b/packages/rialto-plugin/CLAUDE.md
@@ -7,32 +7,44 @@ Claude Code plugin for the Rialto design system. Enhances agent productivity whe
 ```
 .
 ├── agents/        # Rialto-specialized sub-agents
-├── hooks/         # Pre-commit/Pre-push validation hooks
-├── scripts/       # Plugin lifecycle and build scripts
-├── skills/        # Specialized Claude Code skills (e.g. /rialto-review)
-└── .claude-plugin # Plugin manifest and configuration
+├── generated/     # Auto-generated component reference (committed artifact)
+├── hooks/         # PostToolUse validation hook
+├── scripts/       # Build scripts
+└── skills/        # Specialized Claude Code skill
 ```
 
 ## Skills
 
-- `/rialto-review`: Analyzes UI code for proper token usage and component selection.
-- `/rialto-docs`: Returns the latest documentation for a specific component from the catalog.
+- `skills/rialto/SKILL.md` — invoked as `/rialto`. Use when building UI with the Rialto design system: choosing components, applying design tokens, composing layouts, or authoring new Rialto components.
+
+## Agents
+
+- `agents/rialto-ui-builder.md` — autonomous UI builder; generates complete page sections, forms, and layouts with correct component selection, token usage, accessibility, and motion.
 
 ## Validation Hooks
 
-- **Token Guard**: Scans CSS and JS for hardcoded colors/spacing; suggests Rialto variables.
-- **Component Guard**: Discourages the use of raw HTML elements when a Rialto equivalent exists.
+`hooks/hooks.json` wires a `PostToolUse` hook on every `Write` or `Edit` call. `hooks/validate-rialto.mjs` runs and emits advisory stderr warnings (never blocking) for:
 
-## Patterns
+- **Hardcoded hex colors** — suggests `var(--rialto-*)` token instead
+- **Subpath imports** — `rialto/components/…` should be the `"rialto"` barrel
+- **Physical CSS properties** — `margin-left` → `margin-inline-start`, etc.
+- **Raw `cubic-bezier()`** — use `var(--rialto-ease-*)` token
+- **`<img>` without `alt`** — basic a11y check in `.tsx`/`.jsx` files
 
-- **Catalog Integration**: Uses `@mbe/rialto-catalog` to provide context to Claude Code.
-- **Zero-Touch**: Aims to automate the "Review" phase of the RIPER workflow for UI tasks.
-- **MCP Sync**: Updates local `.mcp.json` with Rialto-specific server configurations.
+Only fires on `.tsx`, `.jsx`, `.ts`, `.js`, or `.css` files that contain `"rialto"` or `"--rialto-"`.
 
 ## Commands
 
 ```bash
-pnpm build        # Build plugin assets
-pnpm lint         # ESLint
-pnpm typecheck    # TypeScript check
+pnpm build        # Alias for pnpm generate — runs scripts/generate-reference.ts
+                  # → writes generated/component-reference.md
+pnpm typecheck    # TypeScript check (tsc --noEmit)
 ```
+
+> There is no `pnpm lint` script in this package.
+
+## Patterns
+
+- **Catalog Integration**: Uses `@mattbutlerengineering/rialto` (workspace dep) to provide component context to Claude Code.
+- **Zero-Touch Validation**: PostToolUse hook auto-reviews UI code for token/import/a11y violations without requiring a manual step.
+- **Generated Reference**: `pnpm build` regenerates `generated/component-reference.md` with per-component props, slots, and character limits from the live Rialto source.


### PR DESCRIPTION
## Summary

- Remove non-existent `/rialto-review` and `/rialto-docs` skills; document the real skill (`skills/rialto/SKILL.md`, invoked as `/rialto`) and the real agent (`agents/rialto-ui-builder.md`)
- Remove the phantom `pnpm lint` script (no such script in `package.json`)
- Fix build description: `build` is an alias for `pnpm generate` which runs `scripts/generate-reference.ts` → `generated/component-reference.md`, not generic "build plugin assets"
- Document `hooks/hooks.json` + `hooks/validate-rialto.mjs` with accurate descriptions of all 5 validation rules (hardcoded hex, subpath imports, physical CSS props, raw cubic-bezier, img without alt)
- Every command/skill/path verified against the actual source tree before writing

## Gate results

- `pnpm typecheck` (rialto-plugin): pass
- `pnpm --filter @mbe/cli start check-adr`: no violations
- `pnpm --filter @mbe/cli start check-deps`: no mismatches
- `node scripts/detect-instruction-rot.mjs`: no rot detected
- Pre-push hook (typecheck + tests across all affected packages): pass

Closes #2189