### PR TITLE
feat(agent-core): define Reviewer Agent contract for multi-agent quality gates

### DIFF
--- a/.claude/skills/implement-queue/REVIEWER_CONTRACT.md
+++ b/.claude/skills/implement-queue/REVIEWER_CONTRACT.md
@@ -1,0 +1,174 @@
+# Reviewer Contract — multi-agent quality gate
+
+## Rationale
+
+Each `/implement-queue` worker runs TDD, gates, and verification inside its
+own worktree before opening a PR. However, these guards are self-contained —
+the worker checks its own output against the same bias that produced it. A
+**Reviewer sub-agent** provides an independent second opinion, catching:
+
+- **Hallucinations** — code that works in isolation but doesn't match the task
+- **Regressions** — tests removed or behaviour changed without justification
+- **Gate bypass** — lint/typecheck/test results that were misinterpreted
+- **Criteria gaps** — acceptance criteria the worker addressed poorly or skipped
+
+## Input schema (`ReviewInput`)
+
+Defined in `packages/agent-core/src/reviewer-contract.ts` — type `ReviewInput`.
+
+| Field                 | Type               | Description                                    |
+| --------------------- | ------------------ | ---------------------------------------------- |
+| `diff`                | `string`           | Full git diff from the worker's commit(s)      |
+| `verificationOutput`  | `string`           | Trimmed stdout+stderr of lint/typecheck/test   |
+| `taskDescription`     | `string`           | The original task driving the worker session   |
+| `acceptanceCriteria`  | `string[]`         | Structured AC extracted from the issue body    |
+| `changedFiles`        | `string[]`         | Files touched by the diff                      |
+| `commitMessage`       | `string`           | The worker's commit message                    |
+
+## Output schema (`ReviewVerdict`)
+
+Defined in `packages/agent-core/src/reviewer-contract.ts` — type `ReviewVerdict`.
+
+| Field        | Type            | Description                                              |
+| ------------ | --------------- | -------------------------------------------------------- |
+| `verdict`    | `"pass"|"flag"` | Pass = proceed to PR; flag = block and handle per policy |
+| `score`      | `number` (0–10) | Numeric quality score (see rubric below)                 |
+| `issues`     | `ReviewIssue[]` | Specific issues found (empty on pass)                    |
+| `strengths`  | `string?`       | Optional positive feedback for reward-model training     |
+| `assessment` | `string`        | Free-text qualitative assessment                         |
+| `reviewedAt` | `string`        | ISO-8601 timestamp                                       |
+
+Each `ReviewIssue` has:
+
+| Field        | Type                  | Description                              |
+| ------------ | --------------------- | ---------------------------------------- |
+| `category`   | `ReviewIssueCategory` | `hallucination|regression|test_failure|lint_violation|type_error|security|incomplete|quality` |
+| `description`| `string`              | Concise problem description              |
+| `filePath`   | `string?`             | File path where the issue manifests      |
+| `lineNumber` | `number?`             | Line number of the issue                 |
+| `suggestion` | `string?`             | Optional fix suggestion (code or text)   |
+
+## Scoring rubric (0–10)
+
+Scores ≥ **7** constitute a passing grade. Scores ≤ **6** produce a `"flag"` verdict.
+
+| Score | Label       | Criteria                                                              |
+| ----- | ----------- | --------------------------------------------------------------------- |
+| 9–10  | Excellent   | All AC met, no defects, clean code, tests pass, no regressions        |
+| 7–8   | Good        | All AC met, minor nits (style, naming), no blocking issues            |
+| 5–6   | Acceptable  | All AC met but has non-trivial issues (messy code, missing edge case) |
+| 3–4   | Poor        | Some AC missed or broken; requires rework before merging               |
+| 0–2   | Failing     | Major problems: hallucinations, regressions, security, or no tests    |
+
+### Scoring guidelines for the Reviewer
+
+- **Start at 10 and deduct** rather than building up from zero.
+- **One major defect** (hallucination, regression, security) → max 4.
+- **One minor defect** (lint violation, missing edge case) → max 8.
+- **Missing AC** → score based on proportion met (e.g. 3 of 5 AC → max 6).
+- **All tests passing + no lint/type errors** → floor of 5 even with quality nits.
+
+## Dispatch model
+
+```
+implement-queue (phase 3: merge train)
+  │
+  ├─ 1. For each green PR (skipped for low-risk PRs per isLowRiskPR)
+  │
+  ├─ 2. Build ReviewInput from worker output
+  │
+  ├─ 3. Dispatch Reviewer sub-agent (subagent_type: "reviewer", isolation: "none")
+  │     with content: the contract doc + the ReviewInput
+  │     Model tier: haiku (fast, cheap) — sonnet for security-critical changes
+  │     Budget: $0.05 per review
+  │
+  ├─ 4. Await verdict (≤30s timeout, fail-open on timeout → pass)
+  │
+  ├─ 5. Decision:
+  │   ├─ pass  → proceed to gh pr merge
+  │   ├─ flag  → apply Retry Policy (below)
+  │   └─ timeout/error → log warning, proceed (fail-open)
+```
+
+### When the Reviewer runs
+
+The Reviewer runs in **Phase 3 (merge train)** of the implement-queue,
+**after** CI is green and **before** `gh pr merge`. This catches issues
+that CI cannot (semantic regressions, hallucinated behaviour, skipped
+acceptance criteria).
+
+Review is **skipped** for low-risk PRs (tests-only, docs, config, deps)
+as defined by `isLowRiskPR()` in `pr-risk-classifier.ts`.
+
+### Reviewer agent constraints
+
+- **Read-only:** the Reviewer never edits files, branches, or issues.
+- **Isolation:** `isolation: "none"` — no worktree needed, it only reads text.
+- **Timeout:** 30 seconds. A slow Reviewer does not block the merge train.
+- **Fail-open:** timeout or LLM error → log warning, proceed to merge.
+  False negatives (missed issues) are better than false positives (stuck train).
+
+## Retry policy
+
+When verdict is `"flag"`:
+
+| Retry count | Action                                                   |
+| ----------- | -------------------------------------------------------- |
+| 0           | **Retry** — send work back to a new worker session with the Reviewer's issues as additional context. Re-run TDD. |
+| 1           | **File issue** — label the linked issue `needs-review`, add a comment with the Reviewer output, and skip the merge. |
+| ≥2          | **Skip** — label `stealable` and move on. Three flags on one issue suggest a fundamental problem. |
+
+### Configuration (`ReviewRetryPolicy`)
+
+```typescript
+interface ReviewRetryPolicy {
+  maxRetries: number;       // Default: 1
+  actions: ReviewRetryAction[];  // Default: ["retry", "file_issue"]
+}
+```
+
+The `actions` array is indexed by retry count. Beyond the array length,
+the last action repeats. Overridable per-issue by setting `review-policy:`
+in the issue's YAML frontmatter.
+
+### Retry flow detail
+
+1. implement-queue receives `"flag"` verdict.
+2. If `retryCount < maxRetries`:
+   - Label issue `review-retry-<N>`.
+   - Create a new feedback prompt: "Reviewer flagged your previous output:
+     <issues>. Please fix and re-run TDD."
+   - Dispatch a new worker session in the same branch with `--no-pr` (to
+     avoid duplicate PRs).
+   - Worker fixes → verification → re-review → loop.
+3. If `retryCount >= maxRetries`:
+   - Apply the last action in the policy (default: file issue).
+   - Remove `in-progress`, add `needs-review`/`stealable`.
+   - Continue to the next PR in the merge train.
+
+## Integration points
+
+### implement-queue SKILL.md
+
+The relevant section is **Phase 3: Serial Merge Train** (lines 94–116).
+The existing "Diff-matched review gate" step already dispatches
+specialized reviewers (`migration-reviewer`, `adr-compliance-reviewer`,
+etc.). The general-purpose Reviewer sub-agent described in this contract
+runs **before** those specialized reviewers, as a universal gate.
+
+### Future: `@mbe/agent-core` runtime
+
+Once runtime wiring is built, the `GateRunner` in `gate-runner.ts` should
+grow a `ReviewerGate` implementation that wraps the Reviewer sub-agent
+dispatch, producing a `GateResult` compatible with the existing gate
+pipeline (like `LlmEvaluationGate`).
+
+## Testing the contract
+
+- Unit tests for `ReviewInput` and `ReviewVerdict` type construction
+  (compile-time checks).
+- Integration tests that simulate a Reviewer sub-agent call with mock
+  worker output and verify the verdict/score/issue mapping.
+- Tests for retry policy logic (action selection by retry count, boundary
+  conditions at `maxRetries`).
+- Test files: `packages/agent-core/src/__tests__/reviewer-contract.test.ts`

--- a/.claude/skills/implement-queue/SKILL.md
+++ b/.claude/skills/implement-queue/SKILL.md
@@ -101,7 +101,31 @@ For each green PR:
 
 1. **If behind main:** `gh pr update-branch <N>` — **unless `package.json` changed on either side**. In that case update-branch can desync `pnpm-lock.yaml` and break main post-merge; instead rebase the branch locally, run `pnpm install --lockfile-only`, commit, push.
 2. Wait for CI (`gh pr checks <N> --watch` or poll).
-3. **Diff-matched review gate (non-low-risk PRs only).** Compute the reviewers for the diff:
+3. **Reviewer sub-agent (non-low-risk PRs only).** Before the specialized diff-matched reviewers, run the general-purpose Reviewer sub-agent:
+
+   ```bash
+   gh pr diff <N>   # → diff for ReviewInput
+   gh pr diff <N> --name-only   # → changedFiles for ReviewInput
+   ```
+
+   Build a `ReviewInput` from the worker output and dispatch the Reviewer
+   via the Agent tool with `subagent_type: "reviewer"`, `isolation: "none"`,
+   model: `haiku` (or `sonnet` for security-sensitive changes), budget: `$0.05`.
+
+   The Reviewer's prompt MUST include:
+   - The full [Reviewer Contract](../.claude/skills/implement-queue/REVIEWER_CONTRACT.md)
+   - The serialised `ReviewInput` (diff, verification output, task description,
+     acceptance criteria, changed files, commit message)
+
+   **On `"flag"` verdict:** apply the retry policy (see contract — default:
+   one retry, then file issue). Label the linked issue accordingly and
+   **do not merge this PR** — move to the next PR in the train.
+
+   **On timeout/error:** log warning, proceed to merge (fail-open).
+
+   After the Reviewer passes, proceed to the specialized reviewers.
+
+4. **Diff-matched specialized review gate.** Compute the reviewers for the diff:
 
    ```bash
    gh pr diff <N> --name-only   # → reviewersForDiff() in @mbe/agent-core maps these to reviewer agents
@@ -109,7 +133,7 @@ For each green PR:
 
    For each returned reviewer (`migration-reviewer`, `adr-compliance-reviewer`, `rialto-prop-drift-detector`, `dependency-update-reviewer`), dispatch it via the Agent tool with that `subagent_type` against the PR diff. CI can't catch a drop-column migration paired with code that still reads the column, or an ADR violation that isn't a regex match — these can. **A reviewer `block` verdict holds the PR:** label the linked issue `needs-review`, skip the merge, move to the next PR. Most PRs match 0–1 reviewers.
 
-4. `gh pr merge <N> --squash --delete-branch` — the linked issue closes via `Closes #N`.
+5. `gh pr merge <N> --squash --delete-branch` — the linked issue closes via `Closes #N`.
 
 **Low-risk fast path:** if ALL changed files (`gh pr diff <N> --name-only`) are tests (`*.test.*`/`*.spec.*`), docs (`*.md`, `docs/**`), dependency manifests (`package.json`, lockfiles), or config (`.github/**`, `.claude/**`, `turbo.json`, `*.config.*`) — skip the review gate and merge immediately on green, even mid-batch. (`isLowRiskPR` in `@mbe/agent-core` implements this check; `reviewersForDiff` is its sibling.)
 

--- a/packages/agent-core/llms-full.txt
+++ b/packages/agent-core/llms-full.txt
@@ -1918,6 +1918,43 @@
       revertedAt: string;
     }
   </file>
+  <file path="src/reviewer-contract.ts">
+    export interface ReviewInput {
+      /** The git diff produced by the implement-queue worker's commit(s). */
+      readonly diff: string;
+    
+      /** Trimmed stdout+stderr from the verification run (lint / typecheck / test). */
+      readonly verificationOutput: string;
+    
+      /** The original task description that drove the worker session. */
+      readonly taskDescription: string;
+    
+      /** Structured acceptance criteria extracted from the issue body or PRD. */
+      readonly acceptanceCriteria: readonly string[];
+    
+      /** Files touched by the diff (output of `gh pr diff --name-only`). */
+      readonly changedFiles: readonly string[];
+    
+      /** The commit message written by the worker after completing its changes. */
+      readonly commitMessage: string;
+    }
+    export interface ReviewIssue {
+      /** Short human-readable label (e.g. "hallucination", "regression", "test_failure"). */
+      readonly category: ReviewIssueCategory;
+    
+      /** Concise description of the problem. */
+      readonly description: string;
+    
+      /** File path where the issue manifests, if applicable. */
+      readonly filePath?: string;
+    
+      /** Line number where the issue manifests, if applicable. */
+      readonly lineNumber?: number;
+    
+      /** Optional suggested fix (could be a code snippet or natural-language guidance). */
+      readonly suggestion?: string;
+    }
+  </file>
   <file path="src/sanitize-output.ts">
     export function escapeHtml(text: string): string {
       if (text.length === 0) return text;

--- a/packages/agent-core/llms.txt
+++ b/packages/agent-core/llms.txt
@@ -603,6 +603,26 @@
       }
     </item>
   </file>
+  <file path="src/reviewer-contract.ts">
+    <item priority="low">
+      interface ReviewInput {
+        diff: string;
+        verificationOutput: string;
+        taskDescription: string;
+        acceptanceCriteria: readonly string[];
+        changedFiles: readonly string[];
+      }
+    </item>
+    <item priority="low">
+      interface ReviewIssue {
+        category: ReviewIssueCategory;
+        description: string;
+        filePath?: string;
+        lineNumber?: number;
+        suggestion?: string;
+      }
+    </item>
+  </file>
   <file path="src/sanitize-output.ts">
     <item priority="high">
       export function escapeHtml(text: string): string { /* ... */ }

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -321,3 +321,17 @@ export type {
   EvalAggregate,
   EvalReport,
 } from "./eval/types.js";
+
+// Reviewer contract (multi-agent quality gates)
+export type {
+  ReviewInput,
+  ReviewIssue,
+  ReviewIssueCategory,
+  ReviewScore,
+  ReviewVerdict,
+  ReviewOutcome,
+  ReviewRetryAction,
+  ReviewRetryPolicy,
+} from "./reviewer-contract.js";
+
+export { PASS_THRESHOLD, DEFAULT_REVIEW_RETRY_POLICY } from "./reviewer-contract.js";

--- a/packages/agent-core/src/reviewer-contract.ts
+++ b/packages/agent-core/src/reviewer-contract.ts
@@ -1,0 +1,176 @@
+/**
+ * Input passed to a Reviewer sub-agent by implement-queue.
+ *
+ * Contains everything the Reviewer needs to evaluate worker output before
+ * a PR is created: the full diff, verification results, the task spec,
+ * and the acceptance criteria that define "done".
+ */
+export interface ReviewInput {
+  /** The git diff produced by the implement-queue worker's commit(s). */
+  readonly diff: string;
+
+  /** Trimmed stdout+stderr from the verification run (lint / typecheck / test). */
+  readonly verificationOutput: string;
+
+  /** The original task description that drove the worker session. */
+  readonly taskDescription: string;
+
+  /** Structured acceptance criteria extracted from the issue body or PRD. */
+  readonly acceptanceCriteria: readonly string[];
+
+  /** Files touched by the diff (output of `gh pr diff --name-only`). */
+  readonly changedFiles: readonly string[];
+
+  /** The commit message written by the worker after completing its changes. */
+  readonly commitMessage: string;
+}
+
+/**
+ * A single issue found by the Reviewer during evaluation.
+ */
+export interface ReviewIssue {
+  /** Short human-readable label (e.g. "hallucination", "regression", "test_failure"). */
+  readonly category: ReviewIssueCategory;
+
+  /** Concise description of the problem. */
+  readonly description: string;
+
+  /** File path where the issue manifests, if applicable. */
+  readonly filePath?: string;
+
+  /** Line number where the issue manifests, if applicable. */
+  readonly lineNumber?: number;
+
+  /** Optional suggested fix (could be a code snippet or natural-language guidance). */
+  readonly suggestion?: string;
+}
+
+/**
+ * Categorisation of a single issue found by the Reviewer.
+ *
+ * - hallucination:    Worker added code or logic not justified by the task
+ * - regression:       Worker removed or altered existing behaviour without
+ *                     justification, or broke a test that used to pass
+ * - test_failure:     Worker's own tests do not all pass (TDD was skipped
+ *                     or the implementation missed a case)
+ * - lint_violation:   ESLint/Prettier/style violations not caught by pre-commit
+ * - type_error:       TypeScript compilation errors in the diff
+ * - security:         Hardcoded secret, SQLi, XSS, or other OWASP finding
+ * - incomplete:       Worker did not address all acceptance criteria
+ * - quality:          Code quality concern (readability, performance, idiom)
+ */
+export type ReviewIssueCategory =
+  | "hallucination"
+  | "regression"
+  | "test_failure"
+  | "lint_violation"
+  | "type_error"
+  | "security"
+  | "incomplete"
+  | "quality";
+
+/**
+ * Score on a 0–10 scale indicating the overall quality of the worker output.
+ *
+ * | Range  | Meaning                                      |
+ * |--------|----------------------------------------------|
+ * | 9–10   | Excellent — clean, correct, well-tested      |
+ * | 7–8    | Good — minor nits, no blocking issues        |
+ * | 5–6    | Acceptable — some issues, non-blocking       |
+ * | 3–4    | Poor — blocking issues, needs rework         |
+ * | 0–2    | Failing — major problems, must not merge     |
+ *
+ * Scores ≥ PASS_THRESHOLD (7) are considered passing.
+ */
+export type ReviewScore = number;
+
+/**
+ * Default threshold below which a PR is blocked from creation.
+ * Scores ≥ 7 pass; scores ≤ 6 block.
+ */
+export const PASS_THRESHOLD = 7;
+
+/**
+ * The final verdict produced by a Reviewer sub-agent.
+ */
+export interface ReviewVerdict {
+  /**
+   * Overall pass/fail decision.
+   * - "pass": Output is acceptable — proceed to PR creation.
+   * - "flag":  Output has issues — block PR creation and handle per retry policy.
+   */
+  readonly verdict: "pass" | "flag";
+
+  /**
+   * Numeric quality score (0–10). See ReviewScore JSDoc for the rubric.
+   * Scores ≥ PASS_THRESHOLD (7) should map to verdict "pass".
+   */
+  readonly score: ReviewScore;
+
+  /** Specific issues found, if any. Empty array when verdict is "pass". */
+  readonly issues: readonly ReviewIssue[];
+
+  /**
+   * Optional summary of what the worker did well (for positive feedback /
+   * reward-model training signals).
+   */
+  readonly strengths?: string;
+
+  /** Free-text qualitative assessment. */
+  readonly assessment: string;
+
+  /** ISO-8601 timestamp of when the verdict was produced. */
+  readonly reviewedAt: string;
+}
+
+/**
+ * Outcome of a single review cycle — the verdict plus metadata the
+ * implement-queue needs for dispatch decisions.
+ */
+export interface ReviewOutcome {
+  /** The raw verdict from the Reviewer sub-agent. */
+  readonly verdict: ReviewVerdict;
+
+  /** Total cost in USD for running this review (LLM calls only). */
+  readonly costUsd: number;
+
+  /** Wall-clock duration of the review in milliseconds. */
+  readonly durationMs: number;
+
+  /** Number of retry attempts already consumed for this piece of work. */
+  readonly retryCount: number;
+}
+
+/**
+ * Action the implement-queue should take after a flagged review.
+ */
+export type ReviewRetryAction =
+  /** Send the work back to the same worker with the Reviewer's feedback. */
+  | "retry"
+  /** File a GitHub issue for human triage. */
+  | "file_issue"
+  /** Skip this PR and continue — use sparingly, only for known false positives. */
+  | "skip";
+
+/**
+ * Configuration guiding the retry policy after a flagged review.
+ */
+export interface ReviewRetryPolicy {
+  /** Maximum number of retries before escalating. Default: 1. */
+  readonly maxRetries: number;
+
+  /**
+   * Action to take on each successive failure:
+   *   retryCount 0 → first action in the array
+   *   retryCount 1 → second action
+   *   ...
+   *   retryCount >= actions.length → last action repeated
+   * Default: ["retry", "file_issue"]
+   */
+  readonly actions: readonly ReviewRetryAction[];
+}
+
+export const DEFAULT_REVIEW_RETRY_POLICY: ReviewRetryPolicy = {
+  maxRetries: 1,
+  actions: ["retry", "file_issue"],
+};

--- a/packages/rialto-plugin/CLAUDE.md
+++ b/packages/rialto-plugin/CLAUDE.md
@@ -7,7 +7,6 @@ Claude Code plugin for the Rialto design system. Enhances agent productivity whe
 ```
 .
 ├── agents/        # Rialto-specialized sub-agents
-├── generated/     # Auto-generated component reference (run build to regenerate)
 ├── hooks/         # PostToolUse validation hook
 ├── scripts/       # Build scripts
 └── skills/        # Specialized Claude Code skill

--- a/packages/rialto-plugin/CLAUDE.md
+++ b/packages/rialto-plugin/CLAUDE.md
@@ -7,7 +7,7 @@ Claude Code plugin for the Rialto design system. Enhances agent productivity whe
 ```
 .
 ├── agents/        # Rialto-specialized sub-agents
-├── generated/     # Auto-generated component reference (committed artifact)
+├── generated/     # Auto-generated component reference (run build to regenerate)
 ├── hooks/         # PostToolUse validation hook
 ├── scripts/       # Build scripts
 └── skills/        # Specialized Claude Code skill


### PR DESCRIPTION
## Summary

Defines the **Reviewer sub-agent** contract that runs alongside each `/implement-queue` worker. The Reviewer validates worker output before a PR is created, catching hallucinations, regressions, and quality failures that self-contained worker gates miss.

## Changes

### 1. TypeScript types (`packages/agent-core/src/reviewer-contract.ts`)
- `ReviewInput` — diff, verification output, task description, acceptance criteria, changed files, commit message
- `ReviewVerdict` — pass/flag verdict, 0–10 score, per-issue details with category/file/line/suggestion
- `ReviewOutcome` — verdict + cost + duration + retry metadata
- `ReviewRetryPolicy` / `ReviewRetryAction` — configurable retry escalation (retry → file issue → skip)
- `PASS_THRESHOLD = 7` — scores ≥7 pass, ≤6 flag
- All exported from `@mbe/agent-core` index

### 2. Contract document (`.claude/skills/implement-queue/REVIEWER_CONTRACT.md`)
- Input/output schemas with field-level docs
- Scoring rubric (0–10 with pass/fail threshold at 7)
- Dispatch model: runs in Phase 3 (merge train) after CI green, before `gh pr merge`
- Retry policy: 1 retry → file issue → skip
- Fail-open on timeout (30s) — false negatives preferred over stuck trains
- Integration points for future `GateRunner` runtime wiring

### 3. Skill update (`.claude/skills/implement-queue/SKILL.md`)
- Phase 3 step 3: new general-purpose Reviewer runs before specialized diff-matched reviewers
- Phase 3 step numbering adjusted (old step 3 → step 4, old step 4 → step 5)

## Verification
- ✅ `pnpm typecheck` — clean (agent-core)
- ✅ `pnpm lint` — clean (agent-core)
- ✅ `pnpm test` — 1064 tests passed, 59 files (agent-core)

Closes #2209