### PR TITLE
docs(packages): currency sweep for 6 package CLAUDE.md files

### DIFF
--- a/packages/api-client/CLAUDE.md
+++ b/packages/api-client/CLAUDE.md
@@ -6,16 +6,19 @@ Typed HTTP client for the MBE platform API. Wraps `fetch` with auth token inject
 
 ```
 src/
+├── agent-sessions.ts  # AgentSessionsClient
+├── availability.ts    # AvailabilityClient, HoldsClient
 ├── client.ts          # ApiClient base class, retry, timeout, errors
 ├── client.test.ts     # Core client tests
-├── index.ts           # createApiClient factory + re-exports
-├── users.ts           # UsersClient
-├── reservations.ts    # ReservationsClient
-├── venues.ts          # VenuesClient, VenueGroupsClient
-├── tables.ts          # TablesClient
-├── guests.ts          # GuestsClient
 ├── floor-plans.ts     # FloorPlansClient
-└── availability.ts    # AvailabilityClient, HoldsClient
+├── guests.ts          # GuestsClient
+├── health.ts          # HealthClient
+├── index.ts           # createApiClient factory + re-exports
+├── reservations.ts    # ReservationsClient
+├── streaming.ts       # StreamingClient (SSE event streams)
+├── tables.ts          # TablesClient
+├── users.ts           # UsersClient
+└── venues.ts          # VenuesClient, VenueGroupsClient
 ```
 
 ## Quick Start
@@ -121,8 +124,9 @@ const client = new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 0 })
 ## Commands
 
 ```bash
-pnpm build        # Compile TypeScript
-pnpm test         # Run tests
-pnpm lint         # ESLint
-pnpm typecheck    # Type check
+pnpm build          # Compile TypeScript
+pnpm test           # Run tests
+pnpm test:contract  # Run contract tests only
+pnpm lint           # ESLint
+pnpm typecheck      # Type check
 ```

--- a/packages/config/CLAUDE.md
+++ b/packages/config/CLAUDE.md
@@ -7,9 +7,10 @@ Shared configuration presets for the workspace. Centralizes ESLint, TypeScript, 
 ```
 .
 ├── eslint/
-│   ├── base.js    # Shared linting rules
-│   ├── node.js    # Node-specific rules
-│   └── react.js   # React-specific rules
+│   ├── base.js         # Shared linting rules
+│   ├── local-rules.js  # Custom architectural lint rules (import restrictions, etc.)
+│   ├── node.js         # Node-specific rules
+│   └── react.js        # React-specific rules
 ├── prettier/
 │   └── index.js   # Shared formatting rules
 └── typescript/
@@ -32,8 +33,6 @@ Shared configuration presets for the workspace. Centralizes ESLint, TypeScript, 
 
 ## Commands
 
-No build required (pure config files).
+No per-package scripts (pure config files). Lint rules are consumed by `pnpm lint` in workspace packages that extend from `@mbe/config/eslint/*`.
 
-```bash
-pnpm lint         # Run linting on this package
-```
+Custom architectural rules live in `eslint/local-rules.js` — they enforce import boundaries, prevent cross-package coupling violations, and ensure monorepo structure compliance.

--- a/packages/mcp-server/CLAUDE.md
+++ b/packages/mcp-server/CLAUDE.md
@@ -13,6 +13,7 @@ src/
     ├── deploy_status.ts  # deploy_status — DigitalOcean App Platform status
     ├── git.ts            # git_workflow_status — branch, uncommitted changes, CI
     ├── health.ts         # service_health_check — backend service health
+    ├── logs.ts           # check_logs — recent backend service logs
     └── pulumi.ts         # pulumi_stack_outputs — Pulumi stack exports
 ```
 
@@ -23,6 +24,7 @@ src/
 | `pulumi_stack_outputs` | List all outputs from the Pulumi production stack       |
 | `service_health_check` | Check health of users, reservations, agent services     |
 | `ci_run_status`        | Get latest GitHub Actions run status for all workflows  |
+| `check_logs`           | Read recent logs from backend services                  |
 | `deploy_status`        | Get current DigitalOcean App Platform deployment status |
 | `git_workflow_status`  | Current branch, uncommitted changes, CI status          |
 | `db_list_tables`       | List all tables in the database                         |
@@ -58,8 +60,9 @@ Uses `StdioServerTransport` from `@modelcontextprotocol/sdk`. Configured in `.mc
 ## Commands
 
 ```bash
-pnpm build       # Compile TypeScript
-pnpm lint        # ESLint
-pnpm typecheck   # Type check
-pnpm start       # Run server (stdio)
+pnpm build         # Compile TypeScript
+pnpm typecheck     # Type check
+pnpm test          # Run tests
+pnpm test:coverage # Run tests with coverage report
+pnpm start         # Run server (stdio)
 ```

--- a/packages/rialto-catalog/CLAUDE.md
+++ b/packages/rialto-catalog/CLAUDE.md
@@ -35,16 +35,17 @@ const catalog = await getCatalog();
 
 ## Patterns
 
-- **Static Analysis**: Uses TypeScript Compiler API (via `scripts/generate.ts`) to extract types without executing code.
+- **Static Analysis**: Uses TypeScript Compiler API (via `scripts/generate-catalog.ts`) to extract types without executing code.
 - **JSON Output**: The generated catalog is serialized to JSON for consumption by web apps.
 - **Sync**: The `mbe pack` command (or `pnpm generate`) should be run after modifying Rialto components to keep the catalog in sync.
 
 ## Commands
 
 ```bash
-pnpm generate     # Regenerate catalog from @mbe/rialto
-pnpm build        # Compile TypeScript
-pnpm lint         # ESLint
-pnpm typecheck    # TypeScript check
-pnpm test         # Vitest unit tests
+pnpm generate       # Regenerate catalog from @mbe/rialto
+pnpm build          # Compile TypeScript
+pnpm lint           # ESLint
+pnpm typecheck      # TypeScript check
+pnpm test           # Vitest unit tests
+pnpm test:drift     # Check catalog drift — fails if catalog is stale
 ```

--- a/packages/rialto/CLAUDE.md
+++ b/packages/rialto/CLAUDE.md
@@ -179,6 +179,16 @@ llms-full.txt covers consuming the library in an application.
 - `pnpm test` — Run unit tests
 - `pnpm typecheck` — Type-check without emitting
 
+## Exports Map
+
+The `exports` field in `package.json` is auto-generated. Running `pnpm manifest` generates `dist/manifest.json` (component list), and `pnpm exports` rewrites the `exports` map in `package.json` to match the manifest. After adding a new component:
+
+1. Wire it up in `src/components/index.ts` (barrel export)
+2. Run `pnpm build` — which runs `vite build && pnpm manifest && pnpm exports` in sequence, regenerating both the manifest and the exports map
+3. If the exports map gets out of sync with the source (a common drift gotcha), run `pnpm exports` standalone to fix it
+
+`pnpm exports:check` validates the exports map without overwriting — useful in CI to catch drift.
+
 ## Publishing
 
 - Publishes to **GitHub Packages** (`npm.pkg.github.com`), not npm — `npm view @mattbutlerengineering/rialto` returns 404

--- a/packages/types/CLAUDE.md
+++ b/packages/types/CLAUDE.md
@@ -8,6 +8,7 @@ Shared TypeScript type definitions and Zod schemas for the workspace.
 src/
 ├── index.ts            # Barrel export
 ├── agent.ts            # Agent session and event types
+├── schemas.test.ts     # Schema validation tests
 ├── api.ts              # API request/response and error types (RFC 9457)
 ├── availability.ts     # Time slot and availability types
 ├── date.ts             # Date/time utility types


### PR DESCRIPTION
Closes #2191

**Changes:**

### packages/config
- Remove phantom `pnpm lint` command (package has zero scripts)
- Document `eslint/local-rules.js` in the structure block

### packages/mcp-server
- Remove phantom `pnpm lint` from Commands
- Add `logs.ts` to the tools structure and `check_logs` to the tools table
- Add `pnpm test` and `pnpm test:coverage` to Commands

### packages/api-client
- Add `agent-sessions.ts`, `health.ts`, `streaming.ts` to the structure block
- Add `pnpm test:contract` to Commands

### packages/rialto-catalog
- Fix internal contradiction: `scripts/generate.ts` → `scripts/generate-catalog.ts`
- Add `pnpm test:drift` to Commands

### packages/types
- Add `schemas.test.ts` to the structure block

### packages/rialto
- Add Exports Map section documenting `pnpm manifest` / `pnpm exports` regeneration (ties to the exports-map drift gotcha)