### PR TITLE
feat(acmm): review-burden collector — testable, queryable, documented

### DIFF
--- a/docs/acmm/review-burden.md
+++ b/docs/acmm/review-burden.md
@@ -79,6 +79,75 @@ Auto-merge reduces the mechanical burden of clicking "merge" but does not reduce
 4. **Rotate reviewers**. No single person should be the default reviewer for all agent PRs. Distribute using GitHub's CODEOWNERS or round-robin assignment.
 5. **Scheduled review windows**. Instead of interrupting flow with each agent PR, batch reviews into 1-2 daily windows.
 
+## Automated collector
+
+The ad-hoc `gh` snippets above are for spot checks. The repeatable collector is
+[`scripts/acmm/review-burden-metrics.js`](../../scripts/acmm/review-burden-metrics.js).
+It fetches closed PRs from the GitHub API (via `gh pr list`, so it reuses your
+`gh auth` / `GITHUB_TOKEN` — no token is ever read or logged by the script) and
+computes, per reviewer:
+
+- **PRs reviewed** in the window (self-reviews excluded)
+- **Mean review turnaround** — minutes from PR open to that reviewer's first review
+- **Rubber-stamp ratio** — share of approvals submitted within the threshold (default < 5 min)
+
+### Running it
+
+```bash
+node scripts/acmm/review-burden-metrics.js               # 7-day window, appends to JSON
+node scripts/acmm/review-burden-metrics.js --days 30      # custom window
+node scripts/acmm/review-burden-metrics.js --threshold 10 # custom rubber-stamp minutes
+node scripts/acmm/review-burden-metrics.js --dry-run      # print only, no file write
+```
+
+### Where results live
+
+Each run appends one timestamped entry to **`docs/metrics/review-burden.json`**
+(an array, so trend-over-time is preserved). The script also prints a
+human-readable per-reviewer breakdown to stdout.
+
+### Reading the JSON
+
+```bash
+# Most recent run's per-reviewer load
+jq '.[-1].reviewers' docs/metrics/review-burden.json
+
+# Trend: overall rubber-stamp ratio across every run
+jq '[.[] | { ts: .timestamp, ratio: .summary.overall_rubber_stamp_ratio }]' \
+  docs/metrics/review-burden.json
+```
+
+Each entry's shape:
+
+```jsonc
+{
+  "timestamp": "2026-06-13T...Z",
+  "window_days": 7,
+  "rubber_stamp_threshold_minutes": 5,
+  "total_closed_prs": 73,
+  "reviewers": [
+    {
+      "login": "...",
+      "prs_reviewed": 4,
+      "mean_review_minutes": 12.5,
+      "approvals": 4,
+      "rubber_stamps": 0,
+      "rubber_stamp_ratio": 0,
+    },
+  ],
+  "summary": {
+    "total_reviewers": 3,
+    "total_reviews": 11,
+    "overall_rubber_stamp_ratio": 0.09,
+    "overall_rubber_stamps": 1,
+    "overall_approvals": 11,
+  },
+}
+```
+
+The metric math is unit-tested in
+[`scripts/__tests__/review-burden-metrics.test.mjs`](../../scripts/__tests__/review-burden-metrics.test.mjs).
+
 ## Integration with /progress-tracker
 
 The `/progress-tracker` skill already reports issue and PR metrics. Review burden extends this with:

--- a/docs/metrics/review-burden.json
+++ b/docs/metrics/review-burden.json
@@ -1,0 +1,25 @@
+[
+  {
+    "timestamp": "2026-06-14T04:52:03.798Z",
+    "window_days": 7,
+    "rubber_stamp_threshold_minutes": 5,
+    "total_closed_prs": 73,
+    "reviewers": [
+      {
+        "login": "github-advanced-security",
+        "prs_reviewed": 1,
+        "mean_review_minutes": 2.07,
+        "approvals": 0,
+        "rubber_stamps": 0,
+        "rubber_stamp_ratio": 0
+      }
+    ],
+    "summary": {
+      "total_reviewers": 1,
+      "total_reviews": 1,
+      "overall_rubber_stamp_ratio": 0,
+      "overall_rubber_stamps": 0,
+      "overall_approvals": 0
+    }
+  }
+]

--- a/scripts/__tests__/review-burden-metrics.test.mjs
+++ b/scripts/__tests__/review-burden-metrics.test.mjs
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import {
+  filterByWindow,
+  countPrsPerReviewer,
+  meanReviewTimePerReviewer,
+  rubberStampRatio,
+  buildEntry,
+} from "../acmm/review-burden-metrics.js";
+
+/**
+ * Fixture: three closed PRs with reviews.
+ *
+ * - PR by "alice", reviewed by "bob" (approved 30 min after open) and "carol".
+ * - PR by "bob", reviewed by "carol" (approved 2 min after open → rubber-stamp).
+ * - PR by "alice", reviewed by "bob" who is also the author of nothing here;
+ *   bob approves 120 min after open.
+ */
+const PRS = [
+  {
+    author: { login: "alice" },
+    createdAt: "2026-06-01T00:00:00Z",
+    closedAt: "2026-06-01T02:00:00Z",
+    reviews: [
+      { author: { login: "bob" }, submittedAt: "2026-06-01T00:30:00Z", state: "APPROVED" },
+      { author: { login: "carol" }, submittedAt: "2026-06-01T00:45:00Z", state: "COMMENTED" },
+    ],
+  },
+  {
+    author: { login: "bob" },
+    createdAt: "2026-06-02T00:00:00Z",
+    closedAt: "2026-06-02T00:10:00Z",
+    reviews: [
+      { author: { login: "carol" }, submittedAt: "2026-06-02T00:02:00Z", state: "APPROVED" },
+    ],
+  },
+  {
+    author: { login: "alice" },
+    createdAt: "2026-06-03T00:00:00Z",
+    closedAt: "2026-06-03T03:00:00Z",
+    reviews: [{ author: { login: "bob" }, submittedAt: "2026-06-03T02:00:00Z", state: "APPROVED" }],
+  },
+];
+
+describe("filterByWindow", () => {
+  it("keeps PRs closed at or after the window start", () => {
+    const sinceMs = new Date("2026-06-02T00:00:00Z").getTime();
+    const result = filterByWindow(PRS, sinceMs);
+    expect(result).toHaveLength(2);
+    expect(result.map((p) => p.author.login)).toEqual(["bob", "alice"]);
+  });
+
+  it("drops PRs with a null closedAt", () => {
+    const open = [{ author: { login: "x" }, createdAt: "2026-06-02T00:00:00Z", closedAt: null }];
+    expect(filterByWindow(open, 0)).toHaveLength(0);
+  });
+});
+
+describe("countPrsPerReviewer", () => {
+  it("counts each PR a reviewer touched, excluding self-reviews", () => {
+    const counts = countPrsPerReviewer(PRS);
+    // bob reviewed PR0 and PR2 → 2; carol reviewed PR0 and PR1 → 2
+    expect(counts).toEqual({ bob: 2, carol: 2 });
+  });
+
+  it("does not count an author reviewing their own PR", () => {
+    const selfReviewed = [
+      {
+        author: { login: "alice" },
+        createdAt: "2026-06-01T00:00:00Z",
+        closedAt: "2026-06-01T01:00:00Z",
+        reviews: [
+          { author: { login: "alice" }, submittedAt: "2026-06-01T00:05:00Z", state: "APPROVED" },
+        ],
+      },
+    ];
+    expect(countPrsPerReviewer(selfReviewed)).toEqual({});
+  });
+});
+
+describe("meanReviewTimePerReviewer", () => {
+  it("computes mean minutes from PR open to each reviewer's first review", () => {
+    const means = meanReviewTimePerReviewer(PRS);
+    // bob: PR0 30 min, PR2 120 min → mean 75
+    expect(means.bob).toBe(75);
+    // carol: PR0 45 min, PR1 2 min → mean 23.5
+    expect(means.carol).toBe(23.5);
+  });
+});
+
+describe("rubberStampRatio", () => {
+  it("flags approvals submitted within the threshold window", () => {
+    const result = rubberStampRatio(PRS, 5);
+    // carol approved PR1 2 min after open → rubber-stamp; bob's approvals are 30 & 120 min → clean
+    expect(result.perReviewer.carol).toEqual({ total: 1, rubberStamped: 1, ratio: 1 });
+    expect(result.perReviewer.bob).toEqual({ total: 2, rubberStamped: 0, ratio: 0 });
+    expect(result.overall).toEqual({ total: 3, rubberStamped: 1, ratio: 0.33 });
+  });
+
+  it("only counts APPROVED reviews, not COMMENTED", () => {
+    const commentOnly = [
+      {
+        author: { login: "alice" },
+        createdAt: "2026-06-01T00:00:00Z",
+        closedAt: "2026-06-01T01:00:00Z",
+        reviews: [
+          { author: { login: "bob" }, submittedAt: "2026-06-01T00:01:00Z", state: "COMMENTED" },
+        ],
+      },
+    ];
+    expect(rubberStampRatio(commentOnly, 5).overall.total).toBe(0);
+  });
+});
+
+describe("buildEntry", () => {
+  it("assembles a queryable entry with per-reviewer and summary blocks", () => {
+    const entry = buildEntry({ days: 30, thresholdMinutes: 5, prs: PRS });
+    expect(entry.window_days).toBe(30);
+    expect(entry.total_closed_prs).toBe(3);
+    expect(entry.summary.total_reviewers).toBe(2);
+    const bob = entry.reviewers.find((r) => r.login === "bob");
+    expect(bob).toMatchObject({ prs_reviewed: 2, mean_review_minutes: 75, approvals: 2 });
+    expect(typeof entry.timestamp).toBe("string");
+  });
+});

--- a/scripts/acmm/review-burden-metrics.js
+++ b/scripts/acmm/review-burden-metrics.js
@@ -397,4 +397,21 @@ function main() {
   persistEntry(entry);
 }
 
-main();
+/* ── Exports (pure metric functions, testable) ───────────── */
+
+export {
+  parseArgs,
+  filterByWindow,
+  countPrsPerReviewer,
+  meanReviewTimePerReviewer,
+  rubberStampRatio,
+  buildEntry,
+};
+
+/* Only run the collector when invoked directly, not when imported by tests. */
+const isMain =
+  process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+
+if (isMain) {
+  main();
+}


### PR DESCRIPTION
Closes #2182

## What the existing code already did
The repo already had a fully-functional `scripts/acmm/review-burden-metrics.js` (400 lines, committed earlier) that fetches closed PRs via `gh pr list` and computes PRs-per-reviewer, mean review turnaround, and rubber-stamp ratio. `docs/acmm/review-burden.md` also already existed with metric definitions, and the ACMM scanner already detects `acmm:review-burden` (any-of `docs/acmm/review-burden.md`). So detection was satisfied, but two acceptance-criteria gaps remained.

## What this PR changes
- **Testability (TDD):** the script called `main()` unconditionally and exported nothing, so importing it fired a `gh` subprocess and the metric math had zero coverage. Exported the pure functions (`filterByWindow`, `countPrsPerReviewer`, `meanReviewTimePerReviewer`, `rubberStampRatio`, `buildEntry`) and guarded `main()` with the repo's standard `isMain` pattern. Added `scripts/__tests__/review-burden-metrics.test.mjs` — 8 tests over fixture data (turnaround math, self-review exclusion, rubber-stamp windowing, APPROVED-only counting, entry assembly). Written test-first (RED → GREEN).
- **Queryability:** seeded `docs/metrics/review-burden.json` with a first real collector run, so the data is queryable immediately (matches the committed `docs/metrics/pr-acceptance.json` convention).
- **Docs:** added an *Automated collector* section to `review-burden.md` — how to run it, that results append to `docs/metrics/review-burden.json`, and `jq` recipes for per-reviewer load and the rubber-stamp trend.

No token is ever read or logged by the script; it reuses `gh auth` / `GITHUB_TOKEN`. Diff is surgical: script change is only the export block + main guard; doc change is purely additive.

## Gate results
- `scripts/__tests__/review-burden-metrics.test.mjs` — 8 passed
- ACMM detection: `acmm:review-burden` → `true`
- `pnpm regen --check` — all artifacts up to date
- `node scripts/detect-instruction-rot.mjs` — no rot
- `check-adr --staged` — no violations
- Collector standalone run still works (guard verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)