### PR TITLE
refactor(jobs): add jobId param to schedule() — fix silent cancel no-op

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -13463,7 +13463,8 @@
       async schedule<T extends JobType>(
         jobType: T,
         payload: JobPayloadMap[T],
-        delayMs: number
+        delayMs: number,
+        jobId?: string
       ): Promise<string> {
         const job = await this.queue.add(jobType, payload, {
           delay: delayMs,
@@ -13474,6 +13475,7 @@
           },
           removeOnComplete: { count: 100 },
           removeOnFail: { count: 50 },
+          ...(jobId !== undefined ? { jobId } : {}),
         });
         return job.id as string;
       }

--- a/packages/jobs/llms-full.txt
+++ b/packages/jobs/llms-full.txt
@@ -40,7 +40,8 @@
       async schedule<T extends JobType>(
         jobType: T,
         payload: JobPayloadMap[T],
-        delayMs: number
+        delayMs: number,
+        jobId?: string
       ): Promise<string> {
         const job = await this.queue.add(jobType, payload, {
           delay: delayMs,
@@ -51,6 +52,7 @@
           },
           removeOnComplete: { count: 100 },
           removeOnFail: { count: 50 },
+          ...(jobId !== undefined ? { jobId } : {}),
         });
         return job.id as string;
       }

--- a/packages/jobs/src/scheduler.test.ts
+++ b/packages/jobs/src/scheduler.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // Use vi.hoisted so mocks are available before vi.mock hoisting
 const mocks = vi.hoisted(() => ({
   add: vi.fn().mockResolvedValue({ id: "job_123" }),
+  remove: vi.fn().mockResolvedValue(undefined),
   upsertJobScheduler: vi.fn().mockResolvedValue({ id: "sched_123" }),
   close: vi.fn().mockResolvedValue(undefined),
   redisQuit: vi.fn().mockResolvedValue("OK"),
@@ -11,6 +12,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("bullmq", () => {
   class MockQueue {
     add = mocks.add;
+    remove = mocks.remove;
     upsertJobScheduler = mocks.upsertJobScheduler;
     close = mocks.close;
     constructor(_name: string, _opts?: unknown) {
@@ -51,6 +53,7 @@ const lapsedPayload: LapsedGuestScanPayload = {
 describe("JobScheduler", () => {
   beforeEach(() => {
     mocks.add.mockClear();
+    mocks.remove.mockClear();
     mocks.upsertJobScheduler.mockClear();
     mocks.close.mockClear();
     mocks.redisQuit.mockClear();
@@ -115,5 +118,41 @@ describe("JobScheduler", () => {
     const result = await scheduler.schedule(JOB_TYPES.BOOKING_REMINDER, bookingPayload, 5000);
 
     expect(result).toBe("job_456");
+  });
+
+  it("schedule() passes jobId as opts.jobId when provided", async () => {
+    const scheduler = new JobScheduler({ redisUrl: "redis://localhost:6379" });
+    const knownId = "booking-reminder:res_abc";
+
+    await scheduler.schedule(JOB_TYPES.BOOKING_REMINDER, bookingPayload, 3600000, knownId);
+
+    const [, , opts] = mocks.add.mock.calls[0];
+    expect(opts).toMatchObject({ jobId: knownId });
+  });
+
+  it("schedule() returns the provided jobId when one is given", async () => {
+    const knownId = "booking-reminder:res_abc";
+    mocks.add.mockResolvedValueOnce({ id: knownId });
+    const scheduler = new JobScheduler({ redisUrl: "redis://localhost:6379" });
+
+    const result = await scheduler.schedule(
+      JOB_TYPES.BOOKING_REMINDER,
+      bookingPayload,
+      3600000,
+      knownId
+    );
+
+    expect(result).toBe(knownId);
+  });
+
+  it("cancel() round-trip: schedule with known id → cancel calls queue.remove with that id", async () => {
+    const knownId = "booking-reminder:res_abc";
+    mocks.add.mockResolvedValueOnce({ id: knownId });
+    const scheduler = new JobScheduler({ redisUrl: "redis://localhost:6379" });
+
+    await scheduler.schedule(JOB_TYPES.BOOKING_REMINDER, bookingPayload, 3600000, knownId);
+    await scheduler.cancel(knownId);
+
+    expect(mocks.remove).toHaveBeenCalledWith(knownId);
   });
 });

--- a/packages/jobs/src/scheduler.ts
+++ b/packages/jobs/src/scheduler.ts
@@ -33,7 +33,8 @@ export class JobScheduler {
   async schedule<T extends JobType>(
     jobType: T,
     payload: JobPayloadMap[T],
-    delayMs: number
+    delayMs: number,
+    jobId?: string
   ): Promise<string> {
     const job = await this.queue.add(jobType, payload, {
       delay: delayMs,
@@ -44,6 +45,7 @@ export class JobScheduler {
       },
       removeOnComplete: { count: 100 },
       removeOnFail: { count: 50 },
+      ...(jobId !== undefined ? { jobId } : {}),
     });
     return job.id as string;
   }

--- a/services/reservations/src/services/booking-notifications.test.ts
+++ b/services/reservations/src/services/booking-notifications.test.ts
@@ -197,12 +197,14 @@ describe("createBookingNotifier", () => {
     expect(deps.scheduler.schedule).toHaveBeenCalledWith(
       "booking-reminder",
       expect.objectContaining({ reservationId: "res-1" }),
-      expect.closeTo(dayBeforeDelayMs, -2) // within 1s
+      expect.closeTo(dayBeforeDelayMs, -2), // within 1s
+      "booking-reminder:res-1"
     );
     expect(deps.scheduler.schedule).toHaveBeenCalledWith(
       "day-of-reminder",
       expect.objectContaining({ reservationId: "res-1" }),
-      expect.closeTo(dayOfDelayMs, -2)
+      expect.closeTo(dayOfDelayMs, -2),
+      "day-of-reminder:res-1"
     );
   });
 
@@ -255,7 +257,8 @@ describe("createBookingNotifier", () => {
     expect(deps.scheduler.schedule).toHaveBeenCalledWith(
       "booking-reminder",
       expect.objectContaining({ channel: "email" }),
-      expect.any(Number)
+      expect.any(Number),
+      "booking-reminder:res-1"
     );
   });
 
@@ -274,7 +277,8 @@ describe("createBookingNotifier", () => {
     expect(deps.scheduler.schedule).toHaveBeenCalledWith(
       "booking-reminder",
       expect.objectContaining({ channel: "both" }),
-      expect.any(Number)
+      expect.any(Number),
+      "booking-reminder:res-1"
     );
   });
 });

--- a/services/reservations/src/services/booking-notifications.ts
+++ b/services/reservations/src/services/booking-notifications.ts
@@ -33,7 +33,10 @@ function resolveChannel(
 
 export interface BookingNotifierDeps {
   notificationAdapter: NotificationPort;
-  scheduler: { schedule(...args: unknown[]): Promise<unknown>; cancel(id: string): Promise<void> };
+  scheduler: {
+    schedule(jobType: string, payload: unknown, delayMs: number, jobId?: string): Promise<unknown>;
+    cancel(id: string): Promise<void>;
+  };
   getVenue: (venueId: string) => Promise<Venue | null>;
 }
 
@@ -89,7 +92,8 @@ export function createBookingNotifier(deps: BookingNotifierDeps): BookingNotifie
       await scheduler.schedule(
         JOB_TYPES.BOOKING_REMINDER,
         { reservationId: id, guestEmail, guestPhone: guestPhone ?? null, venueId, channel },
-        dayBeforeDelay
+        dayBeforeDelay,
+        reminderJobId(JOB_TYPES.BOOKING_REMINDER, id)
       );
     }
 
@@ -98,7 +102,8 @@ export function createBookingNotifier(deps: BookingNotifierDeps): BookingNotifie
       await scheduler.schedule(
         JOB_TYPES.DAY_OF_REMINDER,
         { reservationId: id, guestEmail, guestPhone: guestPhone ?? null, venueId, channel },
-        dayOfDelay
+        dayOfDelay,
+        reminderJobId(JOB_TYPES.DAY_OF_REMINDER, id)
       );
     }
   }


### PR DESCRIPTION
## Summary

- `JobScheduler.schedule()` now accepts an optional 4th `jobId?: string` parameter, passed as `opts.jobId` to `queue.add()` so BullMQ registers jobs with a deterministic canonical ID
- `booking-notifications.ts` passes `reminderJobId(jobType, reservationId)` to both `BOOKING_REMINDER` and `DAY_OF_REMINDER` schedule calls, so the ID is round-trippable through `cancel()`
- Previously `cancelBookingReminders()` built the correct ID string but BullMQ never knew about it — cancelled reservations could still fire reminders

## Test plan

- [x] RED: new tests in `packages/jobs/src/scheduler.test.ts` — `schedule()` passes `opts.jobId`, returned id equals provided jobId, cancel round-trip calls `queue.remove` with same id
- [x] GREEN: all 3 new tests pass; existing 20 scheduler tests pass
- [x] Updated 3 existing assertions in `booking-notifications.test.ts` to include 4th arg; all 663 reservations tests pass
- [x] `pnpm typecheck` on `packages/jobs` — clean
- [x] `pnpm typecheck` on `services/reservations` — clean
- [x] `pnpm lint` on both packages — clean
- [x] `check-adr` — no violations
- [x] `check-deps` — no violations
- [x] `detect-instruction-rot.mjs` — no rot detected

Closes #2145