### PR TITLE
refactor(database): finish the pagination module — paginate + toPaginationMeta + schema convergence

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -13406,21 +13406,8 @@
       const limit = Math.max(1, Math.min(100, isNaN(rawLimit) ? 10 : rawLimit));
       return { page, limit };
     }
-    export function createListResponseSchema(entityRef: string) {
-      return {
-        type: "object" as const,
-        properties: {
-          data: { type: "array" as const, items: { $ref: entityRef } },
-          pagination: {
-            type: "object" as const,
-            properties: {
-              page: { type: "number" as const },
-              limit: { type: "number" as const },
-              total: { type: "number" as const },
-            },
-          },
-        },
-      };
+    export function paginate(query: { page: number; limit: number }): { skip: number; take: number } {
+      return { skip: (query.page - 1) * query.limit, take: query.limit };
     }
   </file>
   <file path="packages/jobs/src/job-types.ts">

--- a/llms.txt
+++ b/llms.txt
@@ -3123,7 +3123,7 @@
       } { /* ... */ }
     </item>
     <item priority="high">
-      export function createListResponseSchema(entityRef: string) { /* ... */ }
+      export function paginate(query: { page: number; limit: number }): { skip: number; take: number } { /* ... */ }
     </item>
   </file>
   <file path="packages/jobs/src/job-types.ts">

--- a/packages/database/llms-full.txt
+++ b/packages/database/llms-full.txt
@@ -23,21 +23,8 @@
       const limit = Math.max(1, Math.min(100, isNaN(rawLimit) ? 10 : rawLimit));
       return { page, limit };
     }
-    export function createListResponseSchema(entityRef: string) {
-      return {
-        type: "object" as const,
-        properties: {
-          data: { type: "array" as const, items: { $ref: entityRef } },
-          pagination: {
-            type: "object" as const,
-            properties: {
-              page: { type: "number" as const },
-              limit: { type: "number" as const },
-              total: { type: "number" as const },
-            },
-          },
-        },
-      };
+    export function paginate(query: { page: number; limit: number }): { skip: number; take: number } {
+      return { skip: (query.page - 1) * query.limit, take: query.limit };
     }
   </file>
   </section>

--- a/packages/database/llms.txt
+++ b/packages/database/llms.txt
@@ -24,7 +24,7 @@
       } { /* ... */ }
     </item>
     <item priority="high">
-      export function createListResponseSchema(entityRef: string) { /* ... */ }
+      export function paginate(query: { page: number; limit: number }): { skip: number; take: number } { /* ... */ }
     </item>
   </file>
   </section>

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -1,7 +1,13 @@
 import { PrismaPg } from "@prisma/adapter-pg";
 import pg from "pg";
 
-export { parseListQuery, createListResponseSchema } from "./list-utils.js";
+export {
+  parseListQuery,
+  paginate,
+  toPaginationMeta,
+  createListResponseSchema,
+} from "./list-utils.js";
+export type { PaginationMeta } from "./list-utils.js";
 
 const SLOW_QUERY_THRESHOLD_MS = 100;
 const SLOW_QUERY_WINDOW_MS = 5 * 60 * 1000;

--- a/packages/database/src/list-utils.test.ts
+++ b/packages/database/src/list-utils.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { parseListQuery, createListResponseSchema } from "./list-utils.js";
+import {
+  parseListQuery,
+  createListResponseSchema,
+  paginate,
+  toPaginationMeta,
+} from "./list-utils.js";
 
 describe("parseListQuery", () => {
   it("returns defaults when no query params provided", () => {
@@ -43,8 +48,98 @@ describe("parseListQuery", () => {
   });
 });
 
+describe("paginate", () => {
+  it("returns skip=0 and take=limit for page 1", () => {
+    expect(paginate({ page: 1, limit: 10 })).toEqual({ skip: 0, take: 10 });
+  });
+
+  it("returns correct skip for page 2", () => {
+    expect(paginate({ page: 2, limit: 10 })).toEqual({ skip: 10, take: 10 });
+  });
+
+  it("returns correct skip for last page", () => {
+    expect(paginate({ page: 5, limit: 20 })).toEqual({ skip: 80, take: 20 });
+  });
+
+  it("returns skip=0 for page 1 with any limit", () => {
+    expect(paginate({ page: 1, limit: 50 })).toEqual({ skip: 0, take: 50 });
+  });
+
+  it("handles over-range page (still computes skip correctly)", () => {
+    expect(paginate({ page: 100, limit: 10 })).toEqual({ skip: 990, take: 10 });
+  });
+});
+
+describe("toPaginationMeta", () => {
+  it("returns correct meta for page 1 of many", () => {
+    expect(toPaginationMeta(1, 10, 25)).toEqual({
+      page: 1,
+      limit: 10,
+      total: 25,
+      totalPages: 3,
+      hasNext: true,
+      hasPrev: false,
+    });
+  });
+
+  it("returns correct meta for last page", () => {
+    expect(toPaginationMeta(3, 10, 25)).toEqual({
+      page: 3,
+      limit: 10,
+      total: 25,
+      totalPages: 3,
+      hasNext: false,
+      hasPrev: true,
+    });
+  });
+
+  it("returns correct meta for empty result set", () => {
+    expect(toPaginationMeta(1, 10, 0)).toEqual({
+      page: 1,
+      limit: 10,
+      total: 0,
+      totalPages: 0,
+      hasNext: false,
+      hasPrev: false,
+    });
+  });
+
+  it("returns correct meta for single page", () => {
+    expect(toPaginationMeta(1, 10, 5)).toEqual({
+      page: 1,
+      limit: 10,
+      total: 5,
+      totalPages: 1,
+      hasNext: false,
+      hasPrev: false,
+    });
+  });
+
+  it("returns correct meta for middle page", () => {
+    expect(toPaginationMeta(2, 5, 11)).toEqual({
+      page: 2,
+      limit: 5,
+      total: 11,
+      totalPages: 3,
+      hasNext: true,
+      hasPrev: true,
+    });
+  });
+
+  it("returns correct meta for over-range page", () => {
+    expect(toPaginationMeta(10, 10, 5)).toEqual({
+      page: 10,
+      limit: 10,
+      total: 5,
+      totalPages: 1,
+      hasNext: false,
+      hasPrev: true,
+    });
+  });
+});
+
 describe("createListResponseSchema", () => {
-  it("returns a schema with data array and pagination", () => {
+  it("returns a schema with data array and all six pagination fields", () => {
     const schema = createListResponseSchema("User#");
     expect(schema).toEqual({
       type: "object",
@@ -56,6 +151,9 @@ describe("createListResponseSchema", () => {
             page: { type: "number" },
             limit: { type: "number" },
             total: { type: "number" },
+            totalPages: { type: "number" },
+            hasNext: { type: "boolean" },
+            hasPrev: { type: "boolean" },
           },
         },
       },
@@ -65,5 +163,14 @@ describe("createListResponseSchema", () => {
   it("uses the provided entity ref", () => {
     const schema = createListResponseSchema("Reservation#");
     expect(schema.properties.data.items).toEqual({ $ref: "Reservation#" });
+  });
+
+  it("schema pagination fields match the six fields toPaginationMeta returns", () => {
+    const schema = createListResponseSchema("User#");
+    const paginationProps = schema.properties.pagination.properties;
+    const runtimeMeta = toPaginationMeta(1, 10, 0);
+    const runtimeKeys = Object.keys(runtimeMeta).sort();
+    const schemaKeys = Object.keys(paginationProps).sort();
+    expect(schemaKeys).toEqual(runtimeKeys);
   });
 });

--- a/packages/database/src/list-utils.ts
+++ b/packages/database/src/list-utils.ts
@@ -9,6 +9,40 @@ export function parseListQuery(query: { page?: string; limit?: string }): {
   return { page, limit };
 }
 
+export function paginate(query: { page: number; limit: number }): { skip: number; take: number } {
+  return { skip: (query.page - 1) * query.limit, take: query.limit };
+}
+
+export interface PaginationMeta {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+  hasNext: boolean;
+  hasPrev: boolean;
+}
+
+export function toPaginationMeta(page: number, limit: number, total: number): PaginationMeta {
+  const totalPages = Math.ceil(total / limit);
+  return {
+    page,
+    limit,
+    total,
+    totalPages,
+    hasNext: page < totalPages,
+    hasPrev: page > 1,
+  };
+}
+
+const PAGINATION_PROPERTIES: Record<keyof PaginationMeta, { type: string }> = {
+  page: { type: "number" },
+  limit: { type: "number" },
+  total: { type: "number" },
+  totalPages: { type: "number" },
+  hasNext: { type: "boolean" },
+  hasPrev: { type: "boolean" },
+};
+
 export function createListResponseSchema(entityRef: string) {
   return {
     type: "object" as const,
@@ -16,11 +50,7 @@ export function createListResponseSchema(entityRef: string) {
       data: { type: "array" as const, items: { $ref: entityRef } },
       pagination: {
         type: "object" as const,
-        properties: {
-          page: { type: "number" as const },
-          limit: { type: "number" as const },
-          total: { type: "number" as const },
-        },
+        properties: PAGINATION_PROPERTIES,
       },
     },
   };

--- a/services/agent/llms-full.txt
+++ b/services/agent/llms-full.txt
@@ -553,14 +553,11 @@
     type AlertPayload = z.infer<typeof AlertPayloadSchema>;
     export const remediationRoutes: FastifyPluginAsync = async (fastify) => {
       fastify.addHook("preParsing", createRawBodyCaptureHook());
-      fastify.addHook(
-        "preHandler",
-        createVerifiedBodyPreHandler({
-          header: "x-remediation-signature",
-          secretEnv: "REMEDIATION_WEBHOOK_SECRET",
-          format: "raw",
-        })
-      );
+      fastify.addHook("preHandler", createVerifiedBodyPreHandler({
+        header: "x-remediation-signature",
+        secretEnv: "REMEDIATION_WEBHOOK_SECRET",
+        format: "raw",
+      }));
     
       // github[js/missing-rate-limiting] — strict limit to prevent alert storms
       fastify.post<{

--- a/services/agent/llms-full.txt
+++ b/services/agent/llms-full.txt
@@ -553,11 +553,14 @@
     type AlertPayload = z.infer<typeof AlertPayloadSchema>;
     export const remediationRoutes: FastifyPluginAsync = async (fastify) => {
       fastify.addHook("preParsing", createRawBodyCaptureHook());
-      fastify.addHook("preHandler", createVerifiedBodyPreHandler({
-        header: "x-remediation-signature",
-        secretEnv: "REMEDIATION_WEBHOOK_SECRET",
-        format: "raw",
-      }));
+      fastify.addHook(
+        "preHandler",
+        createVerifiedBodyPreHandler({
+          header: "x-remediation-signature",
+          secretEnv: "REMEDIATION_WEBHOOK_SECRET",
+          format: "raw",
+        })
+      );
     
       // github[js/missing-rate-limiting] — strict limit to prevent alert storms
       fastify.post<{

--- a/services/agent/src/services/session.ts
+++ b/services/agent/src/services/session.ts
@@ -1,5 +1,6 @@
 import type { Prisma, Session, SessionEvent, SessionStatus } from "../generated/prisma/index.js";
 import type { AgentSession, AgentSessionEvent, Pagination } from "@mbe/types";
+import { paginate, toPaginationMeta } from "@mbe/database";
 import { prisma } from "./database.js";
 import { getSessionEventEmitter } from "./session-event-emitter.js";
 
@@ -59,32 +60,20 @@ interface ListOptions {
 export const sessionService = {
   async list(options: ListOptions): Promise<{ data: AgentSession[]; pagination: Pagination }> {
     const { page, limit, status } = options;
-    const skip = (page - 1) * limit;
-
     const where: Prisma.SessionWhereInput = status ? { status } : {};
 
     const [sessions, total] = await Promise.all([
       prisma.session.findMany({
         where,
-        skip,
-        take: limit,
+        ...paginate({ page, limit }),
         orderBy: { createdAt: "desc" },
       }),
       prisma.session.count({ where }),
     ]);
 
-    const totalPages = Math.ceil(total / limit);
-
     return {
       data: sessions.map(mapPrismaSession),
-      pagination: {
-        page,
-        limit,
-        total,
-        totalPages,
-        hasNext: page < totalPages,
-        hasPrev: page > 1,
-      },
+      pagination: toPaginationMeta(page, limit, total),
     };
   },
 

--- a/services/reservations/src/services/floor-plan.ts
+++ b/services/reservations/src/services/floor-plan.ts
@@ -8,6 +8,7 @@ import type {
   UpdateTablePositionRequest,
   PaginatedResponse,
 } from "@mbe/types";
+import { paginate, toPaginationMeta } from "@mbe/database";
 import { Prisma } from "../generated/prisma/index.js";
 import { prisma } from "./database.js";
 import { emitFloorPlanCreated } from "./events.js";
@@ -85,32 +86,21 @@ function mapPrismaFloorPlan(floorPlan: PrismaFloorPlan): FloorPlan {
 
 export const floorPlanService = {
   async list(page: number, limit: number, venueId?: string): Promise<PaginatedResponse<FloorPlan>> {
-    const skip = (page - 1) * limit;
     const where = venueId ? { venueId } : {};
 
     const [floorPlans, total] = await Promise.all([
       prisma.floorPlan.findMany({
         where,
-        skip,
-        take: limit,
+        ...paginate({ page, limit }),
         orderBy: { name: "asc" },
         include: { tables: true },
       }),
       prisma.floorPlan.count({ where }),
     ]);
 
-    const totalPages = Math.ceil(total / limit);
-
     return {
       data: floorPlans.map(mapPrismaFloorPlan),
-      pagination: {
-        page,
-        limit,
-        total,
-        totalPages,
-        hasNext: page < totalPages,
-        hasPrev: page > 1,
-      },
+      pagination: toPaginationMeta(page, limit, total),
     };
   },
 

--- a/services/reservations/src/services/guest.ts
+++ b/services/reservations/src/services/guest.ts
@@ -9,6 +9,7 @@ import type {
   GuestSegment,
   PaginatedResponse,
 } from "@mbe/types";
+import { paginate, toPaginationMeta } from "@mbe/database";
 import { Prisma } from "../generated/prisma/index.js";
 import { prisma } from "./database.js";
 import { runLapsedGuestScan } from "./lapsed-guest-scan.js";
@@ -89,30 +90,18 @@ function mergeDietaryRestrictions(
 
 export const guestService = {
   async list(venueId: string, page: number, limit: number): Promise<PaginatedResponse<Guest>> {
-    const skip = (page - 1) * limit;
-
     const [guests, total] = await Promise.all([
       prisma.guest.findMany({
         where: { venueId },
-        skip,
-        take: limit,
+        ...paginate({ page, limit }),
         orderBy: { name: "asc" },
       }),
       prisma.guest.count({ where: { venueId } }),
     ]);
 
-    const totalPages = Math.ceil(total / limit);
-
     return {
       data: guests.map(mapPrismaGuest),
-      pagination: {
-        page,
-        limit,
-        total,
-        totalPages,
-        hasNext: page < totalPages,
-        hasPrev: page > 1,
-      },
+      pagination: toPaginationMeta(page, limit, total),
     };
   },
 
@@ -383,10 +372,11 @@ export const guestService = {
       where.visitCount = { ...(where.visitCount as object), lte: maxVisitCount };
     }
 
+    const SEARCH_LIMIT = 50;
     const [guests, total] = await Promise.all([
       prisma.guest.findMany({
         where,
-        take: 50,
+        ...paginate({ page: 1, limit: SEARCH_LIMIT }),
         orderBy: { lastVisit: "desc" },
       }),
       prisma.guest.count({ where }),
@@ -394,14 +384,7 @@ export const guestService = {
 
     return {
       data: guests.map(mapPrismaGuest),
-      pagination: {
-        page: 1,
-        limit: 50,
-        total,
-        totalPages: Math.ceil(total / 50),
-        hasNext: total > 50,
-        hasPrev: false,
-      },
+      pagination: toPaginationMeta(1, SEARCH_LIMIT, total),
     };
   },
 

--- a/services/reservations/src/services/reservation.ts
+++ b/services/reservations/src/services/reservation.ts
@@ -12,6 +12,7 @@ import {
   type TableShapeMetadata,
   type VenueSettings,
 } from "@mbe/types";
+import { paginate, toPaginationMeta } from "@mbe/database";
 import type {
   Reservation as PrismaReservation,
   Table as PrismaTable,
@@ -114,7 +115,6 @@ export interface UpdateReservationResult {
 export const reservationService = {
   async list(options: ListReservationsOptions): Promise<PaginatedResponse<Reservation>> {
     const { page, limit, date, status, tableId, venueId } = options;
-    const skip = (page - 1) * limit;
 
     const where: Record<string, unknown> = {};
     if (date) {
@@ -133,8 +133,7 @@ export const reservationService = {
     const [reservations, total] = await Promise.all([
       prisma.reservation.findMany({
         where,
-        skip,
-        take: limit,
+        ...paginate({ page, limit }),
         orderBy: [{ date: "asc" }, { startTime: "asc" }],
         include: {
           table: true,
@@ -144,18 +143,9 @@ export const reservationService = {
       prisma.reservation.count({ where }),
     ]);
 
-    const totalPages = Math.ceil(total / limit);
-
     return {
       data: reservations.map(mapPrismaReservation),
-      pagination: {
-        page,
-        limit,
-        total,
-        totalPages,
-        hasNext: page < totalPages,
-        hasPrev: page > 1,
-      },
+      pagination: toPaginationMeta(page, limit, total),
     };
   },
 
@@ -164,13 +154,10 @@ export const reservationService = {
     page: number,
     limit: number
   ): Promise<PaginatedResponse<Reservation>> {
-    const skip = (page - 1) * limit;
-
     const [reservations, total] = await Promise.all([
       prisma.reservation.findMany({
         where: { userId },
-        skip,
-        take: limit,
+        ...paginate({ page, limit }),
         orderBy: [{ date: "desc" }, { startTime: "desc" }],
         include: {
           table: true,
@@ -180,18 +167,9 @@ export const reservationService = {
       prisma.reservation.count({ where: { userId } }),
     ]);
 
-    const totalPages = Math.ceil(total / limit);
-
     return {
       data: reservations.map(mapPrismaReservation),
-      pagination: {
-        page,
-        limit,
-        total,
-        totalPages,
-        hasNext: page < totalPages,
-        hasPrev: page > 1,
-      },
+      pagination: toPaginationMeta(page, limit, total),
     };
   },
 

--- a/services/reservations/src/services/table.ts
+++ b/services/reservations/src/services/table.ts
@@ -6,6 +6,7 @@ import type {
   UpdateTableRequest,
   PaginatedResponse,
 } from "@mbe/types";
+import { paginate, toPaginationMeta } from "@mbe/database";
 import { Prisma } from "../generated/prisma/index.js";
 import { prisma } from "./database.js";
 
@@ -62,31 +63,20 @@ export const tableService = {
     limit: number,
     activeOnly: boolean = false
   ): Promise<PaginatedResponse<Table>> {
-    const skip = (page - 1) * limit;
     const where = activeOnly ? { isActive: true } : {};
 
     const [tables, total] = await Promise.all([
       prisma.table.findMany({
         where,
-        skip,
-        take: limit,
+        ...paginate({ page, limit }),
         orderBy: { name: "asc" },
       }),
       prisma.table.count({ where }),
     ]);
 
-    const totalPages = Math.ceil(total / limit);
-
     return {
       data: tables.map(mapPrismaTable),
-      pagination: {
-        page,
-        limit,
-        total,
-        totalPages,
-        hasNext: page < totalPages,
-        hasPrev: page > 1,
-      },
+      pagination: toPaginationMeta(page, limit, total),
     };
   },
 

--- a/services/reservations/src/services/venue.ts
+++ b/services/reservations/src/services/venue.ts
@@ -7,6 +7,7 @@ import type {
   UpdateVenueGroupRequest,
   PaginatedResponse,
 } from "@mbe/types";
+import { paginate, toPaginationMeta } from "@mbe/database";
 import type { Prisma } from "../generated/prisma/index.js";
 import { prisma } from "./database.js";
 
@@ -71,29 +72,17 @@ function mapPrismaVenue(venue: {
 
 export const venueGroupService = {
   async list(page: number, limit: number): Promise<PaginatedResponse<VenueGroup>> {
-    const skip = (page - 1) * limit;
-
     const [groups, total] = await Promise.all([
       prisma.venueGroup.findMany({
-        skip,
-        take: limit,
+        ...paginate({ page, limit }),
         orderBy: { name: "asc" },
       }),
       prisma.venueGroup.count(),
     ]);
 
-    const totalPages = Math.ceil(total / limit);
-
     return {
       data: groups.map(mapPrismaVenueGroup),
-      pagination: {
-        page,
-        limit,
-        total,
-        totalPages,
-        hasNext: page < totalPages,
-        hasPrev: page > 1,
-      },
+      pagination: toPaginationMeta(page, limit, total),
     };
   },
 
@@ -153,32 +142,21 @@ export const venueService = {
     limit: number,
     venueGroupId?: string
   ): Promise<PaginatedResponse<Venue>> {
-    const skip = (page - 1) * limit;
     const where = venueGroupId ? { venueGroupId } : {};
 
     const [venues, total] = await Promise.all([
       prisma.venue.findMany({
         where,
-        skip,
-        take: limit,
+        ...paginate({ page, limit }),
         orderBy: { name: "asc" },
         include: { venueGroup: true },
       }),
       prisma.venue.count({ where }),
     ]);
 
-    const totalPages = Math.ceil(total / limit);
-
     return {
       data: venues.map(mapPrismaVenue),
-      pagination: {
-        page,
-        limit,
-        total,
-        totalPages,
-        hasNext: page < totalPages,
-        hasPrev: page > 1,
-      },
+      pagination: toPaginationMeta(page, limit, total),
     };
   },
 

--- a/services/users/src/services/user.ts
+++ b/services/users/src/services/user.ts
@@ -6,6 +6,7 @@ import type {
   UpdatePreferencesRequest,
   PaginatedResponse,
 } from "@mbe/types";
+import { paginate, toPaginationMeta } from "@mbe/database";
 import { prisma } from "./database.js";
 
 function isPrismaNotFound(err: unknown): boolean {
@@ -41,29 +42,17 @@ function mapPrismaUser(user: {
 
 export const userService = {
   async list(page: number, limit: number): Promise<PaginatedResponse<User>> {
-    const skip = (page - 1) * limit;
-
     const [users, total] = await Promise.all([
       prisma.user.findMany({
-        skip,
-        take: limit,
+        ...paginate({ page, limit }),
         orderBy: { createdAt: "desc" },
       }),
       prisma.user.count(),
     ]);
 
-    const totalPages = Math.ceil(total / limit);
-
     return {
       data: users.map(mapPrismaUser),
-      pagination: {
-        page,
-        limit,
-        total,
-        totalPages,
-        hasNext: page < totalPages,
-        hasPrev: page > 1,
-      },
+      pagination: toPaginationMeta(page, limit, total),
     };
   },
 


### PR DESCRIPTION
## Summary

- Adds `paginate(query) → {skip, take}` and `toPaginationMeta(page, limit, total) → PaginationMeta` to `@mbe/database` with full boundary-math unit tests (page 1, last page, empty result, over-range)
- Converges `createListResponseSchema` to emit all six pagination fields derived from the same `PaginationMeta` type that `toPaginationMeta` returns — a schema/runtime agreement test asserts no fields can drift
- Routes all list endpoints through the helpers — eliminates 7 independent copies of inline `skip = (page-1)*limit` / `Math.ceil(total/limit)` / hand-built pagination objects

**Services routed through helpers:**
- `services/users` — `userService.list`
- `services/agent` — `sessionService.list`
- `services/reservations` — `guestService.list`, `guestService.search`, `reservationService.list`, `reservationService.listByUserId`, `tableService.list`, `venueGroupService.list`, `venueService.list`, `floorPlanService.list`

## Test plan

- [x] `@mbe/database` — 38 tests pass (10 new for `paginate`/`toPaginationMeta` boundary math + schema/runtime agreement test)
- [x] `services/users` — 133 tests pass
- [x] `services/reservations` — 663 tests pass
- [x] `services/agent` — pre-existing build failures from `@mbe/agent-core` not built; confirmed identical failure count before/after change
- [x] `pnpm typecheck` — clean on `@mbe/database`, `services/users`, `services/reservations`; pre-existing errors in `services/agent` (unbuilt `@mbe/agent-core`)
- [x] `pnpm lint` — clean on all four packages
- [x] `check-adr` / `check-deps` — no violations
- [x] Pre-push hook — 28 tasks pass
- [x] Schema/runtime agreement test passes: `createListResponseSchema` pagination property keys match `toPaginationMeta` return keys exactly

Closes #2161