### PR TITLE
feat(agent-core): generated-artifact-determinism-reviewer + wire into diff-matched gate

### DIFF
--- a/.claude/agents/generated-artifact-determinism-reviewer.md
+++ b/.claude/agents/generated-artifact-determinism-reviewer.md
@@ -1,0 +1,81 @@
+---
+name: generated-artifact-determinism-reviewer
+description: Use this agent when a PR touches generated artifacts (`**/llms.txt`, `**/llms-full.txt`, `**/generated-schemas.ts`, `infrastructure/worker/dep-graph.json`, `docs/architecture/dependency-graph.md`) or the pack generator (`tools/cli/src/commands/pack.ts`). Catches the class of Integrity failure CI only surfaces after push: generated files that drift non-deterministically across platforms (locale-sensitive sorts produce different ordering on macOS vs Linux CI) or that have gone stale relative to the source they embed. This is the failure that wedged the #2195 → #2217 merge train — committed `llms-full.txt` embedded an older expanded form of `generated-schemas.ts` and an agent route, while CI regenerated a collapsed form, failing `git diff --exit-code` in the Integrity job.
+tools: Read, Grep, Glob, Bash
+---
+
+You are a determinism reviewer for this monorepo's generated artifacts. Your job is to catch drift and non-determinism in generated files BEFORE they reach the CI `Integrity` job, which regenerates every artifact and fails on any `git diff`.
+
+## Why you exist
+
+The `Integrity` job runs `node tools/cli/dist/index.js pack <pkg>` for every package plus the root, regenerates the dependency graph, and does `git diff --exit-code`. Two failure modes repeatedly broke `main`:
+
+1. **Cross-platform non-determinism.** `localeCompare()` with no explicit locale and bare `.sort()` on string arrays use the runtime ICU locale, which differs between macOS (en-US) and Linux CI (C/POSIX). The same source produced differently-ordered `llms.txt`/`llms-full.txt` on the two platforms, so a file regenerated and committed on macOS failed the Linux drift-check. Fixed once by replacing both sorts in `packDirectory` with the byte-order comparator `(a, b) => (a < b ? -1 : a > b ? 1 : 0)` — guard against regressions.
+2. **Stale embedded source.** `llms.txt`/`llms-full.txt` embed the contents of source files (including generated ones like `generated-schemas.ts`). When the source changes but the bundle is not regenerated, the committed bundle drifts from what `pack` produces. This is invisible locally unless you re-run the generator.
+
+Each occurrence cost 30+ minutes of merge-train triage. You make it a single verdict at review time.
+
+## Input
+
+You are spawned with a list of changed files (typically `git diff --name-only origin/main...HEAD`). If none is provided, diff against `origin/main` yourself.
+
+## What you catch
+
+### 1. Locale-sensitive sorting in the generator
+
+If `tools/cli/src/commands/pack.ts` (or anything it imports) is in the diff, grep the generator for non-deterministic ordering:
+
+```bash
+grep -nE "localeCompare|\.sort\(\s*\)" tools/cli/src/commands/pack.ts
+```
+
+- `localeCompare(` **without** an explicit locale + `{ sensitivity }` → BLOCK. It is locale-dependent.
+- bare `.sort()` on a string array (no comparator) → BLOCK. V8's default sort is fine for ASCII but the repo standard is the explicit byte-order comparator; flag it.
+- The approved comparator is `(a, b) => (a < b ? -1 : a > b ? 1 : 0)`. Anything else that orders strings for embedded output is suspect.
+
+### 2. Stale / uncommitted regeneration (the high-value check)
+
+If any generated artifact is in the diff, or any source that an artifact embeds changed, verify the committed artifacts actually match a fresh regeneration. Run the same thing CI runs:
+
+```bash
+pnpm install --frozen-lockfile        # worktrees have no node_modules
+pnpm build --filter @mbe/cli...       # the Integrity job runs dist, not src — rebuild it
+for pkg in packages/* apps/* services/*; do
+  [ -f "$pkg/llms.txt" ] && node tools/cli/dist/index.js pack "$pkg" >/dev/null 2>&1
+done
+node tools/cli/dist/index.js pack . >/dev/null 2>&1   # root bundle
+git diff --stat -- '*llms.txt' '*llms-full.txt'
+```
+
+Any non-empty diff → BLOCK, and name the drifted files. The fix is to regenerate from current source and commit (do NOT hand-edit the bundle).
+
+### 3. Dependency-graph drift
+
+If `package.json`, `pnpm-workspace.yaml`, or `pnpm-lock.yaml` changed but neither `infrastructure/worker/dep-graph.json` nor `docs/architecture/dependency-graph.md` is in the diff, the graph is likely stale → BLOCK with: run `pnpm graph && pnpm generate:dep-graph` and commit both. (The `regen-dep-graph.sh` PostToolUse hook regenerates these for in-Claude edits, but not for edits made elsewhere.)
+
+### 4. Manifest divergence
+
+If a package was added or deleted, check it is consistently represented in the regen manifest (`scripts/regen-manifest.mjs` or equivalent). A deleted package still listed there is a known source of root-`llms.txt` non-determinism.
+
+## What you do NOT check
+
+- Content/prose quality of CLAUDE.md or docs — `detect-instruction-rot` and humans own that.
+- Whether the embedded source itself is correct — you only check that the bundle MATCHES the source, not that the source is good.
+- Formatting handled by prettier (the PostToolUse hook covers it). You care about generator output determinism, not style.
+
+## Output format
+
+For each finding:
+
+```
+<file> — <BLOCK|WARN>: <one-sentence problem> → <exact command or fix>
+```
+
+End with a single-line verdict the merge gate can branch on:
+
+- `BLOCK — <N> determinism/drift issue(s); regenerate and recommit before merge` (any BLOCK finding), or
+- `PASS — generated artifacts are deterministic and in sync` (no BLOCK findings).
+
+## Tone
+
+Terse and command-oriented. Every BLOCK must come with the exact command that fixes it — the caller should be able to copy-paste your fix without thinking. When in doubt about non-determinism, run the regeneration and let `git diff` decide; empirical drift beats speculation.

--- a/packages/agent-core/src/__tests__/reviewers-for-diff.test.ts
+++ b/packages/agent-core/src/__tests__/reviewers-for-diff.test.ts
@@ -55,6 +55,47 @@ describe("reviewersForDiff — dependency-update-reviewer", () => {
   });
 });
 
+describe("reviewersForDiff — generated-artifact-determinism-reviewer", () => {
+  it("fires for a change to the pack generator", () => {
+    expect(reviewersForDiff(["tools/cli/src/commands/pack.ts"])).toContain(
+      "generated-artifact-determinism-reviewer"
+    );
+  });
+
+  it("fires for a per-package llms.txt change", () => {
+    expect(reviewersForDiff(["packages/agent-core/llms.txt"])).toContain(
+      "generated-artifact-determinism-reviewer"
+    );
+  });
+
+  it("fires for the root llms-full.txt", () => {
+    expect(reviewersForDiff(["llms-full.txt"])).toContain(
+      "generated-artifact-determinism-reviewer"
+    );
+  });
+
+  it("fires for a generated zod schema bundle", () => {
+    expect(reviewersForDiff(["packages/rialto-catalog/src/generated-schemas.ts"])).toContain(
+      "generated-artifact-determinism-reviewer"
+    );
+  });
+
+  it("fires for the dependency-graph artifacts", () => {
+    expect(reviewersForDiff(["infrastructure/worker/dep-graph.json"])).toContain(
+      "generated-artifact-determinism-reviewer"
+    );
+    expect(reviewersForDiff(["docs/architecture/dependency-graph.md"])).toContain(
+      "generated-artifact-determinism-reviewer"
+    );
+  });
+
+  it("does NOT fire for a hand-written markdown doc", () => {
+    expect(reviewersForDiff(["docs/adr/0001-rfc7807-errors.md"])).not.toContain(
+      "generated-artifact-determinism-reviewer"
+    );
+  });
+});
+
 describe("reviewersForDiff — no match / dedupe / order", () => {
   it("returns no reviewers for a plain library source file", () => {
     expect(reviewersForDiff(["packages/observability/src/error-rates.ts"])).toEqual([]);

--- a/packages/agent-core/src/pr-risk-classifier.ts
+++ b/packages/agent-core/src/pr-risk-classifier.ts
@@ -89,6 +89,23 @@ const DIFF_REVIEWERS: ReadonlyArray<{ name: string; matches: (file: string) => b
       f === "pnpm-lock.yaml" ||
       f === "pnpm-workspace.yaml",
   },
+  {
+    // Generated artifacts (llms.txt context bundles, generated zod schemas,
+    // dependency graph) and the pack generator that emits them. These drift
+    // non-deterministically across platforms (locale-sensitive sorts) or go
+    // stale relative to their source — a class of Integrity failure CI only
+    // catches after push. See the byte-order-comparator fix for the root cause.
+    name: "generated-artifact-determinism-reviewer",
+    matches: (f) =>
+      f === "tools/cli/src/commands/pack.ts" ||
+      f === "llms.txt" ||
+      f === "llms-full.txt" ||
+      f.endsWith("/llms.txt") ||
+      f.endsWith("/llms-full.txt") ||
+      f.endsWith("/generated-schemas.ts") ||
+      f === "infrastructure/worker/dep-graph.json" ||
+      f === "docs/architecture/dependency-graph.md",
+  },
 ];
 
 /**


### PR DESCRIPTION
## Summary

Adds a diff-matched review agent that catches the class of `Integrity` CI failure that only surfaces **after** push — the failure that wedged the #2195 → #2217 merge train and recurs whenever a PR touches generated artifacts.

The `Integrity` job regenerates every `llms.txt`/`llms-full.txt`, the dependency graph, and generated schemas, then does `git diff --exit-code`. Two failure modes keep breaking it:

1. **Cross-platform non-determinism** — `localeCompare()` / bare `.sort()` use the runtime ICU locale, which differs macOS vs Linux CI, so the same source produces different ordering. (Fixed once via the byte-order comparator; this guards against regressions.)
2. **Stale embedded source** — `llms*.txt` embed source files (incl. generated ones like `generated-schemas.ts`); when the source changes but the bundle isn't regenerated, the committed bundle drifts from what `pack` produces.

This agent makes both a single `BLOCK`/`PASS` verdict at review time instead of a 30-min merge-train triage after the fact.

## Changes

- **New agent** `.claude/agents/generated-artifact-determinism-reviewer.md` — encodes the locale-sort + stale-embed + dep-graph-drift + manifest-divergence checks, each with a copy-pasteable fix command, ending in a parseable `BLOCK`/`PASS` verdict the merge gate keys on.
- **Wired into `reviewersForDiff()`** (`packages/agent-core/src/pr-risk-classifier.ts`) — fires on `tools/cli/src/commands/pack.ts`, any `**/llms.txt` / `**/llms-full.txt`, `**/generated-schemas.ts`, `infrastructure/worker/dep-graph.json`, and `docs/architecture/dependency-graph.md`. Added last in the reviewer order so existing order is preserved.
- **6 new tests** in `reviewers-for-diff.test.ts` (one per trigger + a negative asserting a hand-written `.md` doc does not fire).

## Test plan

- [x] `pnpm --dir packages/agent-core vitest run reviewers-for-diff` — 18 pass (6 new)
- [x] `pnpm --dir packages/agent-core test` — 1070 pass
- [x] `pnpm --dir packages/agent-core typecheck` — 0 errors
- [x] `pnpm --dir packages/agent-core lint` — clean
- [x] `check-adr` (pre-commit) — no violations
- [ ] Reviewer becomes dispatchable only in a **new session** (subagent registry is snapshotted at session start) — verify it fires in the implement-queue gate next session

## Notes

- No linked issue — this came out of an in-session automation-gap analysis. Happy to file a tracking issue if preferred.
- Surfaced during this work: `@mbe/agent-service#test` flaked once in the full pre-push run (passed 255/255 in isolation; passed on retry). Pre-existing, unrelated — worth a `ci-fix` issue if it recurs.