### PR TITLE
fix(ci): swap llms integrity to manifest-driven pnpm regen --check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,31 +218,16 @@ jobs:
 
       - uses: ./.github/actions/setup-workspace
 
-      - name: Build CLI
-        run: pnpm build --filter @mbe/cli --force
-
-      - name: Check instruction sync (llms.txt)
-        run: |
-          for pkg in packages/* apps/* services/*; do
-            if [ -f "$pkg/llms.txt" ]; then
-              echo "Regenerating $pkg..."
-              node tools/cli/dist/index.js pack "$pkg"
-            fi
-          done
-          git diff --exit-code -- '*/llms.txt' '*/llms-full.txt' || \
-            (echo "ERROR: llms.txt files are out of sync. Run 'pnpm pack-changed' locally and commit." && exit 1)
+      # Generated-artifact staleness (llms.txt, registry.json, dep-graph.json,
+      # generated-schemas.ts, dependency-graph.md) is now verified in one
+      # manifest-driven step in the `build` job ("Verify generated artifacts are
+      # in sync"). This job keeps the non-regenerated doc validators below.
 
       - name: Check for instruction rot
         run: node scripts/detect-instruction-rot.mjs
 
       - name: Check doc freshness
         run: node scripts/check-doc-freshness.mjs
-
-      - name: Check component registry integrity
-        run: |
-          pnpm --filter @mattbutlerengineering/rialto build:registry
-          git diff --exit-code packages/rialto/registry.json || \
-            (echo "ERROR: registry.json is stale. Run 'pnpm --filter @mattbutlerengineering/rialto build:registry' locally and commit the result." && exit 1)
 
   build:
     name: Build
@@ -272,23 +257,17 @@ jobs:
       - name: Run Full Repository Audit
         run: pnpm repo-audit
 
-      - name: Regenerate dependency graph
+      - name: Verify generated artifacts are in sync
+        # Single manifest-driven staleness check (scripts/regen-manifest.mjs is
+        # the source of truth), replacing five separate regenerate+git-diff
+        # stanzas: llms.txt, registry.json, dep-graph.json, generated-schemas.ts,
+        # and dependency-graph.md. `pnpm regen` regenerates every committed
+        # artifact; `pnpm regen --check` then fails if any drifted, naming the
+        # stale artifact and the exact fix command. Add new artifacts to the
+        # manifest, not here.
         run: |
-          node scripts/generate-dep-graph.mjs
-          git diff --exit-code infrastructure/worker/dep-graph.json || \
-            (echo "ERROR: dep-graph.json is stale. Run 'pnpm generate:dep-graph' locally and commit the result." && exit 1)
-
-      - name: Check catalog drift
-        run: |
-          pnpm --filter @mbe/rialto-catalog generate
-          git diff --exit-code packages/rialto-catalog/src/generated-schemas.ts || \
-            (echo "ERROR: generated-schemas.ts is stale. Run 'pnpm --filter @mbe/rialto-catalog generate' locally and commit the result." && exit 1)
-
-      - name: Check dependency graph drift
-        run: |
-          pnpm graph
-          git diff --exit-code docs/architecture/dependency-graph.md || \
-            (echo "ERROR: dependency-graph.md is stale. Run 'pnpm graph' locally and commit the result." && exit 1)
+          pnpm regen
+          pnpm regen --check
 
       - name: Check bundle size budgets
         run: pnpm size:check

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -12,6 +12,21 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
+# Verify committed generated artifacts aren't stale before they reach CI.
+# Manifest-driven (scripts/regen-manifest.mjs) and fast: --check only runs
+# `git diff` on the tracked outputs, it does NOT regenerate. This catches the
+# common case where a generator ran (pre-commit pack-changed, a PostToolUse
+# hook, etc.) but the regenerated output was never staged/committed.
+# CI runs the full regenerate-then-verify; this is the cheap local backstop.
+if ! pnpm regen --check; then
+  echo ""
+  echo "ERROR: generated artifacts are out of sync (stale artifact + fix command shown above)."
+  echo "Run the printed 'fix:' command (or 'pnpm regen' to regenerate everything), then commit."
+  echo "Emergency bypass: git push --no-verify"
+  echo ""
+  exit 1
+fi
+
 # Run tests for packages affected by the current changes.
 # Uses turbo's --filter='...[ref]' to test only changed packages + dependents.
 # Turbo caching means repeated pushes of unchanged code are near-instant.


### PR DESCRIPTION
Completes the regen keystone: swaps CI's llms-integrity mechanism from the legacy per-package `pack` loop to the unified manifest-driven `pnpm regen --check`. This is the mechanism-swap portion of #2173 re-created cleanly off current main (the `pack.ts` determinism fix already landed via #2217).

## What changed (exactly 2 files)

**`.github/workflows/ci.yml`**
- `integrity` job: removed the `Build CLI` step, the `for pkg in packages/* apps/* services/*; do … node tools/cli/dist/index.js pack "$pkg" … git diff --exit-code` llms.txt sync loop, and the `Check component registry integrity` step. Replaced with a comment pointing to the single manifest-driven step in the `build` job. Kept the non-regen validators: `Check for instruction rot` and `Check doc freshness`.
- `build` job: collapsed the three separate regenerate+`git diff --exit-code` stanzas (`Regenerate dependency graph`, `Check catalog drift`, `Check dependency graph drift`) into one `Verify generated artifacts are in sync` step that runs `pnpm regen` then `pnpm regen --check` (scripts/regen-manifest.mjs is the single source of truth).

**`.husky/pre-push`**
- Added the cheap local backstop: `pnpm regen --check` (git-diff only, no regeneration) after the lockfile-sync check, with a `git push --no-verify` emergency-bypass note.

Untouched: `pack.ts`, `post-merge.yml`, and all generated llms/registry/dep-graph/schema files (main's are already correct from #2217).

## Local verification (mirrors the CI gating step)
- `pnpm build --filter @mbe/cli...` → built CLI + deps
- `pnpm regen` → regenerated every artifact family from source (llms-txt, rialto-registry, rialto-catalog-schemas, dep-graph-md, dep-graph-json)
- `pnpm regen --check` → **"All generated artifacts are up to date." (exit 0)**
- `git status` after regen → only the 2 intended files modified, zero artifact drift

Proves the new gating step passes green against main's committed artifacts.

Closes #2173
Closes #2027
Closes #2028

🤖 Generated with [Claude Code](https://claude.com/claude-code)