### PR TITLE
fix(gen): fix deleteSpec optimistic-revert race in useSpecsApi

### DIFF
--- a/apps/gen/src/hooks/useSpecsApi.test.ts
+++ b/apps/gen/src/hooks/useSpecsApi.test.ts
@@ -187,4 +187,38 @@ describe("useSpecsApi — deleteSpec", () => {
     expect(result.current.specs).toHaveLength(1);
     expect(result.current.specs[0]!.id).toBe("spec-1");
   });
+
+  it("concurrent deletes: A fails, B succeeds — B stays deleted, A is restored", async () => {
+    const specA = makeSpec({ id: "spec-a", prompt: "Spec A" });
+    const specB = makeSpec({ id: "spec-b", prompt: "Spec B" });
+    mockGet.mockResolvedValueOnce({ data: [specA, specB] });
+
+    const { result } = renderHook(() => useSpecsApi());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // Delete B resolves immediately (success), A rejects after a delay (failure)
+    let rejectDeleteA!: (e: unknown) => void;
+    const deleteAPromise = new Promise((_resolve, reject) => {
+      rejectDeleteA = reject;
+    });
+
+    mockDelete
+      .mockReturnValueOnce(deleteAPromise) // A — will fail
+      .mockResolvedValueOnce({}); // B — succeeds immediately
+
+    await act(async () => {
+      // Fire both deletes without awaiting them individually
+      const pendingA = result.current.deleteSpec("spec-a");
+      const pendingB = result.current.deleteSpec("spec-b");
+
+      // Let B succeed, then fail A
+      rejectDeleteA(new Error("Server Error"));
+      await Promise.allSettled([pendingA, pendingB]);
+    });
+
+    const ids = result.current.specs.map((s) => s.id);
+    // A must be restored (its delete failed), B must stay gone (its delete succeeded)
+    expect(ids).toContain("spec-a");
+    expect(ids).not.toContain("spec-b");
+  });
 });

--- a/apps/gen/src/hooks/useSpecsApi.ts
+++ b/apps/gen/src/hooks/useSpecsApi.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useMemo } from "react";
+import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import { useAuth } from "@mbe/auth/react";
 import { ApiClient } from "@mbe/api-client";
 import type { StoredSpec } from "../types.js";
@@ -37,6 +37,12 @@ export function useSpecsApi(): UseSpecsApiReturn {
 
   const [specs, setSpecs] = useState<StoredSpec[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  // Mirror of specs in a ref so deleteSpec can read the current list without
+  // taking specs as a useCallback dependency (which would recreate on every render).
+  const specsRef = useRef<StoredSpec[]>(specs);
+  useEffect(() => {
+    specsRef.current = specs;
+  }, [specs]);
 
   const fetchSpecs = useCallback(async (): Promise<void> => {
     // NOTE: We deliberately do NOT call setIsLoading(true) synchronously here.
@@ -86,18 +92,23 @@ export function useSpecsApi(): UseSpecsApiReturn {
 
   const deleteSpec = useCallback(
     async (id: string): Promise<void> => {
+      // Read current specs via ref — avoids adding specs to the dep array,
+      // keeping deleteSpec identity stable across renders.
+      const itemToDelete = specsRef.current.find((s) => s.id === id);
       // Optimistic removal from local state
-      const previous = specs;
       setSpecs((prev) => prev.filter((s) => s.id !== id));
       try {
         await client.delete(`/api/gen/specs/${id}`);
       } catch (err) {
-        // Revert on error
-        setSpecs(previous);
+        // Revert only the failed item via functional update — concurrent
+        // successful deletes are not affected (no stale snapshot overwrite).
+        if (itemToDelete !== undefined) {
+          setSpecs((prev) => (prev.some((s) => s.id === id) ? prev : [...prev, itemToDelete]));
+        }
         console.error("[useSpecsApi] deleteSpec error:", err);
       }
     },
-    [client, specs]
+    [client]
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Replaced stale-snapshot revert (`setSpecs(previous)`) with a functional `setSpecs` that re-inserts only the failed item, leaving concurrently-succeeded deletes untouched.
- Added a `specsRef` (kept current in a `useEffect`) so `deleteSpec` can look up the item to capture without taking `specs` as a `useCallback` dependency — identity is now stable across renders.
- Added a TDD test simulating the race: delete A (fails) fires concurrently with delete B (succeeds); after settlement B is absent and A is restored.

## Test plan

- [x] New test: concurrent delete A-fails/B-succeeds — B stays deleted, A restored
- [x] Existing test: single failure revert still works
- [x] Existing test: optimistic removal on success still works
- [x] `pnpm --dir apps/gen lint` — 0 errors (100 pre-existing warnings)
- [x] `pnpm --dir apps/gen typecheck` — 0 errors from our files (2 pre-existing TS7006 errors in JsonInspector/PreviewPane unrelated to this change)
- [x] `pnpm --dir apps/gen test` — 200/200 passed (18/18 test files)
- [x] `check-adr` + `check-deps` — no violations
- [x] `regen --check` — all artifacts in sync
- [x] `detect-instruction-rot.mjs` — no rot detected
- [x] Pre-push turbo test gate — 26/26 tasks, 663 tests passed

Closes #2116