### PR TITLE
refactor(api-client): delete shallow HealthClient pass-through wrapper

### DIFF
--- a/apps/hospitality/src/components/SystemHealthBadge.test.tsx
+++ b/apps/hospitality/src/components/SystemHealthBadge.test.tsx
@@ -76,12 +76,11 @@ function makeAuthResult(overrides: Partial<AuthReturnType> = {}): AuthReturnType
 
 type ApiClientReturnType = ReturnType<typeof useApiClient>;
 
-function makeApiClient(overrides: Record<string, unknown> = {}): ApiClientReturnType {
+function makeApiClient(getOverride?: ReturnType<typeof vi.fn>): ApiClientReturnType {
   return {
-    health: {
-      getSystemHealth: vi.fn(),
+    client: {
+      get: getOverride ?? vi.fn(),
     },
-    ...overrides,
   } as unknown as ApiClientReturnType;
 }
 
@@ -123,20 +122,18 @@ describe("SystemHealthBadge", () => {
       makeAuthResult({ user: makeAuthUser({ raw: makeJWTPayload({ permissions: ["admin"] }) }) })
     );
 
-    const mockGetSystemHealth = vi.fn().mockResolvedValue({
+    const mockGet = vi.fn().mockResolvedValue({
       status: "healthy",
       timestamp: "2026-01-15T12:00:00Z",
     });
-    vi.mocked(useApiClient).mockReturnValue(
-      makeApiClient({ health: { getSystemHealth: mockGetSystemHealth } })
-    );
+    vi.mocked(useApiClient).mockReturnValue(makeApiClient(mockGet));
 
     await act(async () => {
       render(<SystemHealthBadge />);
     });
 
     await waitFor(() => {
-      expect(mockGetSystemHealth).toHaveBeenCalled();
+      expect(mockGet).toHaveBeenCalledWith("/api/health/system");
     });
 
     // Verify useApiClient hook was called (not raw fetch)
@@ -159,10 +156,8 @@ describe("SystemHealthBadge", () => {
       deploy: { status: "healthy" },
     };
 
-    const mockGetSystemHealth = vi.fn().mockResolvedValue(healthData);
-    vi.mocked(useApiClient).mockReturnValue(
-      makeApiClient({ health: { getSystemHealth: mockGetSystemHealth } })
-    );
+    const mockGet = vi.fn().mockResolvedValue(healthData);
+    vi.mocked(useApiClient).mockReturnValue(makeApiClient(mockGet));
 
     await act(async () => {
       render(<SystemHealthBadge />);
@@ -188,10 +183,8 @@ describe("SystemHealthBadge", () => {
       makeAuthResult({ user: makeAuthUser({ raw: makeJWTPayload({ permissions: ["admin"] }) }) })
     );
 
-    const mockGetSystemHealth = vi.fn().mockRejectedValue(new Error("Network error"));
-    vi.mocked(useApiClient).mockReturnValue(
-      makeApiClient({ health: { getSystemHealth: mockGetSystemHealth } })
-    );
+    const mockGet = vi.fn().mockRejectedValue(new Error("Network error"));
+    vi.mocked(useApiClient).mockReturnValue(makeApiClient(mockGet));
 
     await act(async () => {
       render(<SystemHealthBadge />);
@@ -206,12 +199,10 @@ describe("SystemHealthBadge", () => {
       makeAuthResult({ user: makeAuthUser({ raw: makeJWTPayload({ permissions: ["admin"] }) }) })
     );
 
-    const mockGetSystemHealth = vi
+    const mockGet = vi
       .fn()
       .mockRejectedValue(Object.assign(new Error("500 Service Unavailable"), { statusCode: 500 }));
-    vi.mocked(useApiClient).mockReturnValue(
-      makeApiClient({ health: { getSystemHealth: mockGetSystemHealth } })
-    );
+    vi.mocked(useApiClient).mockReturnValue(makeApiClient(mockGet));
 
     await act(async () => {
       render(<SystemHealthBadge />);
@@ -230,10 +221,8 @@ describe("SystemHealthBadge", () => {
       timestamp: "2026-01-15T12:00:00Z",
     };
 
-    const mockGetSystemHealth = vi.fn().mockResolvedValue(healthData);
-    vi.mocked(useApiClient).mockReturnValue(
-      makeApiClient({ health: { getSystemHealth: mockGetSystemHealth } })
-    );
+    const mockGet = vi.fn().mockResolvedValue(healthData);
+    vi.mocked(useApiClient).mockReturnValue(makeApiClient(mockGet));
 
     await act(async () => {
       render(<SystemHealthBadge />);
@@ -263,24 +252,22 @@ describe("SystemHealthBadge — polling", () => {
       makeAuthResult({ user: makeAuthUser({ raw: makeJWTPayload({ permissions: ["admin"] }) }) })
     );
 
-    const mockGetSystemHealth = vi.fn().mockResolvedValue({
+    const mockGet = vi.fn().mockResolvedValue({
       status: "healthy",
       timestamp: "2026-01-15T12:00:00Z",
     });
-    vi.mocked(useApiClient).mockReturnValue(
-      makeApiClient({ health: { getSystemHealth: mockGetSystemHealth } })
-    );
+    vi.mocked(useApiClient).mockReturnValue(makeApiClient(mockGet));
 
     await act(async () => {
       render(<SystemHealthBadge />);
     });
 
-    const initialCalls = mockGetSystemHealth.mock.calls.length;
+    const initialCalls = mockGet.mock.calls.length;
 
     await act(async () => {
       vi.advanceTimersByTime(60_000);
     });
 
-    expect(mockGetSystemHealth.mock.calls.length).toBeGreaterThan(initialCalls);
+    expect(mockGet.mock.calls.length).toBeGreaterThan(initialCalls);
   });
 });

--- a/apps/hospitality/src/components/SystemHealthBadge.tsx
+++ b/apps/hospitality/src/components/SystemHealthBadge.tsx
@@ -52,7 +52,7 @@ export function SystemHealthBadge() {
 
   const fetchHealth = useCallback(async () => {
     try {
-      const data = await api.health.getSystemHealth();
+      const data = await api.client.get<SystemHealth>("/api/health/system");
       setHealth(data);
     } catch {
       // Silent failure — badge just shows stale data

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4428,14 +4428,11 @@
     type AlertPayload = z.infer<typeof AlertPayloadSchema>;
     export const remediationRoutes: FastifyPluginAsync = async (fastify) => {
       fastify.addHook("preParsing", createRawBodyCaptureHook());
-      fastify.addHook(
-        "preHandler",
-        createVerifiedBodyPreHandler({
-          header: "x-remediation-signature",
-          secretEnv: "REMEDIATION_WEBHOOK_SECRET",
-          format: "raw",
-        })
-      );
+      fastify.addHook("preHandler", createVerifiedBodyPreHandler({
+        header: "x-remediation-signature",
+        secretEnv: "REMEDIATION_WEBHOOK_SECRET",
+        format: "raw",
+      }));
     
       // github[js/missing-rate-limiting] — strict limit to prevent alert storms
       fastify.post<{

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -12978,7 +12978,6 @@
         floorPlans: new FloorPlansClient(client),
         availability: new AvailabilityClient(client),
         holds: new HoldsClient(client),
-        health: new HealthClient(client),
       };
     }
   </file>

--- a/packages/api-client/llms-full.txt
+++ b/packages/api-client/llms-full.txt
@@ -168,7 +168,6 @@
         floorPlans: new FloorPlansClient(client),
         availability: new AvailabilityClient(client),
         holds: new HoldsClient(client),
-        health: new HealthClient(client),
       };
     }
   </file>

--- a/packages/api-client/src/health.test.ts
+++ b/packages/api-client/src/health.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ApiClient } from "./client.js";
-import { HealthClient } from "./health.js";
+import type { SystemHealth } from "./health.js";
 
 const mockFetch = vi.fn<typeof fetch>();
 vi.stubGlobal("fetch", mockFetch);
@@ -14,76 +14,73 @@ function jsonResponse(body: unknown, status = 200): Response {
 }
 
 function makeClient() {
-  const apiClient = new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 0 });
-  return new HealthClient(apiClient);
+  return new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 0 });
 }
 
-describe("HealthClient", () => {
+describe("system health via ApiClient.get", () => {
   beforeEach(() => {
     mockFetch.mockReset();
   });
 
-  describe("getSystemHealth", () => {
-    it("requests GET /api/health/system", async () => {
-      const healthData = {
-        status: "healthy",
-        timestamp: "2026-01-15T12:00:00Z",
-      };
-      mockFetch.mockResolvedValueOnce(jsonResponse(healthData));
+  it("requests GET /api/health/system", async () => {
+    const healthData = {
+      status: "healthy",
+      timestamp: "2026-01-15T12:00:00Z",
+    };
+    mockFetch.mockResolvedValueOnce(jsonResponse(healthData));
 
-      await makeClient().getSystemHealth();
+    await makeClient().get<SystemHealth>("/api/health/system");
 
-      const [url, options] = mockFetch.mock.calls[0]!;
-      expect(url).toBe("https://api.test.com/api/health/system");
-      expect(options?.method ?? "GET").toBe("GET");
-    });
+    const [url, options] = mockFetch.mock.calls[0]!;
+    expect(url).toBe("https://api.test.com/api/health/system");
+    expect(options?.method ?? "GET").toBe("GET");
+  });
 
-    it("returns system health data", async () => {
-      const healthData = {
-        status: "healthy",
-        timestamp: "2026-01-15T12:00:00Z",
-        services: {
-          "users-api": { status: "healthy", latency: 42 },
-          "reservations-api": { status: "degraded", latency: 150 },
-        },
-        ci: { status: "healthy" },
-        deploy: { status: "healthy" },
-      };
-      mockFetch.mockResolvedValueOnce(jsonResponse(healthData));
+  it("returns system health data", async () => {
+    const healthData = {
+      status: "healthy",
+      timestamp: "2026-01-15T12:00:00Z",
+      services: {
+        "users-api": { status: "healthy", latency: 42 },
+        "reservations-api": { status: "degraded", latency: 150 },
+      },
+      ci: { status: "healthy" },
+      deploy: { status: "healthy" },
+    };
+    mockFetch.mockResolvedValueOnce(jsonResponse(healthData));
 
-      const result = await makeClient().getSystemHealth();
-      expect(result).toEqual(healthData);
-    });
+    const result = await makeClient().get<SystemHealth>("/api/health/system");
+    expect(result).toEqual(healthData);
+  });
 
-    it("returns minimal health data without optional fields", async () => {
-      const healthData = {
-        status: "healthy",
-        timestamp: "2026-01-15T12:00:00Z",
-      };
-      mockFetch.mockResolvedValueOnce(jsonResponse(healthData));
+  it("returns minimal health data without optional fields", async () => {
+    const healthData = {
+      status: "healthy",
+      timestamp: "2026-01-15T12:00:00Z",
+    };
+    mockFetch.mockResolvedValueOnce(jsonResponse(healthData));
 
-      const result = await makeClient().getSystemHealth();
-      expect(result).toEqual(healthData);
-      expect(result.services).toBeUndefined();
-      expect(result.ci).toBeUndefined();
-      expect(result.deploy).toBeUndefined();
-    });
+    const result = await makeClient().get<SystemHealth>("/api/health/system");
+    expect(result).toEqual(healthData);
+    expect(result.services).toBeUndefined();
+    expect(result.ci).toBeUndefined();
+    expect(result.deploy).toBeUndefined();
+  });
 
-    it("propagates errors from the API client", async () => {
-      mockFetch.mockResolvedValueOnce(
-        jsonResponse(
-          { error: "Internal Server Error", message: "Service unavailable", statusCode: 500 },
-          500
-        )
-      );
+  it("propagates errors from the API client", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(
+        { error: "Internal Server Error", message: "Service unavailable", statusCode: 500 },
+        500
+      )
+    );
 
-      await expect(makeClient().getSystemHealth()).rejects.toThrow();
-    });
+    await expect(makeClient().get<SystemHealth>("/api/health/system")).rejects.toThrow();
+  });
 
-    it("propagates network errors", async () => {
-      mockFetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+  it("propagates network errors", async () => {
+    mockFetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
 
-      await expect(makeClient().getSystemHealth()).rejects.toThrow(TypeError);
-    });
+    await expect(makeClient().get<SystemHealth>("/api/health/system")).rejects.toThrow(TypeError);
   });
 });

--- a/packages/api-client/src/health.ts
+++ b/packages/api-client/src/health.ts
@@ -1,5 +1,3 @@
-import type { ApiClient } from "./client.js";
-
 export interface ServiceHealth {
   readonly status: string;
   readonly version?: string;
@@ -13,15 +11,4 @@ export interface SystemHealth {
   readonly staticSites?: Record<string, { status: string }>;
   readonly ci?: { status: string };
   readonly deploy?: { status: string };
-}
-
-export class HealthClient {
-  constructor(private client: ApiClient) {}
-
-  /**
-   * Get system-wide health status (admin only)
-   */
-  async getSystemHealth(): Promise<SystemHealth> {
-    return this.client.get<SystemHealth>("/api/health/system");
-  }
 }

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -26,7 +26,7 @@ export {
   type CreateSessionRequest,
   type ListSessionsParams,
 } from "./agent-sessions.js";
-export { HealthClient, type SystemHealth, type ServiceHealth } from "./health.js";
+export type { SystemHealth, ServiceHealth } from "./health.js";
 
 import { ApiClient } from "./client.js";
 import type { ApiClientError } from "./client.js";
@@ -37,8 +37,6 @@ import { TablesClient } from "./tables.js";
 import { GuestsClient } from "./guests.js";
 import { FloorPlansClient } from "./floor-plans.js";
 import { AvailabilityClient, HoldsClient } from "./availability.js";
-import { HealthClient } from "./health.js";
-
 /**
  * Create a configured API client for the MBE platform
  */
@@ -68,6 +66,5 @@ export function createApiClient(config: {
     floorPlans: new FloorPlansClient(client),
     availability: new AvailabilityClient(client),
     holds: new HoldsClient(client),
-    health: new HealthClient(client),
   };
 }

--- a/services/agent/llms-full.txt
+++ b/services/agent/llms-full.txt
@@ -553,14 +553,11 @@
     type AlertPayload = z.infer<typeof AlertPayloadSchema>;
     export const remediationRoutes: FastifyPluginAsync = async (fastify) => {
       fastify.addHook("preParsing", createRawBodyCaptureHook());
-      fastify.addHook(
-        "preHandler",
-        createVerifiedBodyPreHandler({
-          header: "x-remediation-signature",
-          secretEnv: "REMEDIATION_WEBHOOK_SECRET",
-          format: "raw",
-        })
-      );
+      fastify.addHook("preHandler", createVerifiedBodyPreHandler({
+        header: "x-remediation-signature",
+        secretEnv: "REMEDIATION_WEBHOOK_SECRET",
+        format: "raw",
+      }));
     
       // github[js/missing-rate-limiting] — strict limit to prevent alert storms
       fastify.post<{


### PR DESCRIPTION
## Summary

- Deleted the `HealthClient` class whose sole method was `this.client.get<SystemHealth>("/api/health/system")` — interface equaled implementation with zero added behaviour
- `SystemHealth` and `ServiceHealth` types are retained and re-exported from `packages/api-client/src/health.ts`
- Removed `HealthClient` export, import, and `health:` factory slot from `packages/api-client/src/index.ts`
- Updated `SystemHealthBadge.tsx` to call `api.client.get<SystemHealth>("/api/health/system")` directly
- Updated `SystemHealthBadge.test.tsx` mock from `health: { getSystemHealth }` to `client: { get }` shape

## Call sites updated

- `apps/hospitality/src/components/SystemHealthBadge.tsx` — the only external caller; now calls `api.client.get<SystemHealth>("/api/health/system")` directly

## Gate results

- `pnpm typecheck` — clean on `@mbe/api-client` and `@mbe/hospitality`
- `pnpm lint` — clean on both packages (warnings only, no errors)
- `pnpm test` — `@mbe/api-client`: 162/162 passed; `SystemHealthBadge`: 9/9 passed
- `check-adr` + `check-deps` — no violations
- `pnpm regen --check` — clean after regenerating `packages/api-client/llms-full.txt`, root `llms-full.txt`, and `services/agent/llms-full.txt`
- `node scripts/detect-instruction-rot.mjs` — no instruction rot detected

Closes #2154