### PR TITLE
fix(agent-service): stabilize flaky tests under parallel turbo load

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4428,11 +4428,14 @@
     type AlertPayload = z.infer<typeof AlertPayloadSchema>;
     export const remediationRoutes: FastifyPluginAsync = async (fastify) => {
       fastify.addHook("preParsing", createRawBodyCaptureHook());
-      fastify.addHook("preHandler", createVerifiedBodyPreHandler({
-        header: "x-remediation-signature",
-        secretEnv: "REMEDIATION_WEBHOOK_SECRET",
-        format: "raw",
-      }));
+      fastify.addHook(
+        "preHandler",
+        createVerifiedBodyPreHandler({
+          header: "x-remediation-signature",
+          secretEnv: "REMEDIATION_WEBHOOK_SECRET",
+          format: "raw",
+        })
+      );
     
       // github[js/missing-rate-limiting] — strict limit to prevent alert storms
       fastify.post<{

--- a/services/agent/llms-full.txt
+++ b/services/agent/llms-full.txt
@@ -553,11 +553,14 @@
     type AlertPayload = z.infer<typeof AlertPayloadSchema>;
     export const remediationRoutes: FastifyPluginAsync = async (fastify) => {
       fastify.addHook("preParsing", createRawBodyCaptureHook());
-      fastify.addHook("preHandler", createVerifiedBodyPreHandler({
-        header: "x-remediation-signature",
-        secretEnv: "REMEDIATION_WEBHOOK_SECRET",
-        format: "raw",
-      }));
+      fastify.addHook(
+        "preHandler",
+        createVerifiedBodyPreHandler({
+          header: "x-remediation-signature",
+          secretEnv: "REMEDIATION_WEBHOOK_SECRET",
+          format: "raw",
+        })
+      );
     
       // github[js/missing-rate-limiting] — strict limit to prevent alert storms
       fastify.post<{

--- a/services/agent/src/routes/session-events.integration.test.ts
+++ b/services/agent/src/routes/session-events.integration.test.ts
@@ -76,9 +76,14 @@ function makeLiveEvent(
   return { id, sessionId, type, data, createdAt: new Date().toISOString() };
 }
 
-/** Wait one macrotask so SSE writes flush before assertions. */
+/**
+ * Drain the macrotask queue so SSE writes flush before assertions.
+ * Uses setImmediate rather than setTimeout(resolve, 0) to avoid triggering
+ * the setTimeout spy in the "no poll timer" test and to be immune to
+ * timer-starvation under full parallel turbo load.
+ */
 function tick(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 0));
+  return new Promise((resolve) => setImmediate(resolve));
 }
 
 describe("Session Events SSE Integration", () => {

--- a/services/agent/src/services/session-executor.test.ts
+++ b/services/agent/src/services/session-executor.test.ts
@@ -179,9 +179,11 @@ describe("session-executor", () => {
       const sessions = Array.from({ length: 5 }, (_, i) => makeSession({ id: `concurrent-${i}` }));
       const promises = sessions.map((s) => executeSession(s));
 
-      // Wait for all 5 to enter runSession (controllers registered)
+      // Wait for all 5 to enter runSession (controllers registered).
+      // Use microtask-yield loop instead of setTimeout to avoid timer-starvation
+      // flakiness under full parallel turbo load (CI environment).
       while (resolvers.length < 5) {
-        await new Promise((resolve) => setTimeout(resolve, 5));
+        await Promise.resolve();
       }
 
       expect(getActiveSessionCount()).toBe(5);
@@ -319,8 +321,9 @@ describe("session-executor", () => {
       const session = makeSession({ id: "cancel-target" });
       const execPromise = executeSession(session);
 
+      // Microtask-yield loop — immune to timer starvation under full parallel load.
       while (resolvers.length < 1) {
-        await new Promise((resolve) => setTimeout(resolve, 5));
+        await Promise.resolve();
       }
 
       const cancelled = await cancelSession("cancel-target");


### PR DESCRIPTION
## Summary

- **Flaky test root cause**: Two timing-sensitive tests in `session-executor.test.ts` used `while (...) { await new Promise((resolve) => setTimeout(resolve, 5)); }` polling loops. Under full `turbo test:coverage` parallel load, the system is CPU-saturated and a 5ms timer can stall for 50-100ms+, causing the polling loop to exceed vitest's 5-second default test timeout — surfacing as a non-deterministic failure.
- **Secondary issue**: `tick()` in `session-events.integration.test.ts` used `setTimeout(resolve, 0)` which (a) is also timer-starvation sensitive under load, and (b) triggered the `setTimeout` spy in the adjacent "no poll timer" test, creating a latent count-mismatch risk.

## Fix

- **`session-executor.test.ts`** (lines 183-185, 322-324): Replace `setTimeout(resolve, 5)` polling with `await Promise.resolve()` microtask-yield loops. Microtask resolution is immune to timer starvation — it drains the Node.js microtask queue immediately after each yield, regardless of system load.
- **`session-events.integration.test.ts`** (line 81): Replace `setTimeout(resolve, 0)` in `tick()` with `setImmediate(resolve)`. `setImmediate` fires after I/O callbacks (the correct semantics for "wait for SSE writes to flush") and is not intercepted by the `setTimeout` spy in the adjacent test.

No source files changed — test isolation fixes only.

## Test plan

- [x] `pnpm --dir services/agent lint` — clean
- [x] `pnpm --dir services/agent typecheck` — clean
- [x] `pnpm --dir services/agent test` — 255/255 passed, confirmed stable over 10 consecutive local runs
- [x] Pre-push hook: regen --check clean, turbo typecheck clean, turbo test 255/255
- [x] `pnpm --filter @mbe/cli start check-adr` — no violations
- [x] `pnpm --filter @mbe/cli start check-deps` — no violations

Closes #2226