### PR TITLE
fix(gen): use @mbe/api-client in SharedSpecPage and surface clipboard failures

### DIFF
--- a/apps/gen/llms-full.txt
+++ b/apps/gen/llms-full.txt
@@ -45,14 +45,16 @@
       const [copied, setCopied] = useState(false);
       const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     
-      const copy = useCallback(async (text: string) => {
+      const copy = useCallback(async (text: string): Promise<boolean> => {
         if (timerRef.current) {
           clearTimeout(timerRef.current);
         }
     
+        let succeeded = false;
         try {
           if (navigator.clipboard?.writeText) {
             await navigator.clipboard.writeText(text);
+            succeeded = true;
           } else {
             window.prompt("Copy to clipboard:", text);
           }
@@ -65,6 +67,8 @@
           setCopied(false);
           timerRef.current = null;
         }, 2000);
+    
+        return succeeded;
       }, []);
     
       return { copied, copy };

--- a/apps/gen/src/hooks/useCopyToClipboard.test.ts
+++ b/apps/gen/src/hooks/useCopyToClipboard.test.ts
@@ -70,6 +70,42 @@ describe("useCopyToClipboard", () => {
     promptSpy.mockRestore();
   });
 
+  it("returns true when clipboard write succeeds", async () => {
+    const { result } = renderHook(() => useCopyToClipboard());
+    let returnValue: boolean | undefined;
+    await act(async () => {
+      returnValue = await result.current.copy("success text");
+    });
+    expect(returnValue).toBe(true);
+  });
+
+  it("returns false when clipboard write fails (fallback to prompt)", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("denied"));
+    Object.assign(navigator, { clipboard: { writeText } });
+    vi.spyOn(window, "prompt").mockReturnValue(null);
+
+    const { result } = renderHook(() => useCopyToClipboard());
+    let returnValue: boolean | undefined;
+    await act(async () => {
+      returnValue = await result.current.copy("fail text");
+    });
+    expect(returnValue).toBe(false);
+    vi.restoreAllMocks();
+  });
+
+  it("returns false when clipboard API is missing (fallback to prompt)", async () => {
+    Object.assign(navigator, { clipboard: {} });
+    vi.spyOn(window, "prompt").mockReturnValue(null);
+
+    const { result } = renderHook(() => useCopyToClipboard());
+    let returnValue: boolean | undefined;
+    await act(async () => {
+      returnValue = await result.current.copy("no api text");
+    });
+    expect(returnValue).toBe(false);
+    vi.restoreAllMocks();
+  });
+
   it("clears previous timeout when copy is called multiple times", async () => {
     const { result } = renderHook(() => useCopyToClipboard());
     await act(async () => {

--- a/apps/gen/src/hooks/useCopyToClipboard.ts
+++ b/apps/gen/src/hooks/useCopyToClipboard.ts
@@ -4,14 +4,16 @@ export function useCopyToClipboard() {
   const [copied, setCopied] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const copy = useCallback(async (text: string) => {
+  const copy = useCallback(async (text: string): Promise<boolean> => {
     if (timerRef.current) {
       clearTimeout(timerRef.current);
     }
 
+    let succeeded = false;
     try {
       if (navigator.clipboard?.writeText) {
         await navigator.clipboard.writeText(text);
+        succeeded = true;
       } else {
         window.prompt("Copy to clipboard:", text);
       }
@@ -24,6 +26,8 @@ export function useCopyToClipboard() {
       setCopied(false);
       timerRef.current = null;
     }, 2000);
+
+    return succeeded;
   }, []);
 
   return { copied, copy };

--- a/apps/gen/src/pages/SharedSpecPage.test.tsx
+++ b/apps/gen/src/pages/SharedSpecPage.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable mbe-local/prefer-rialto-components */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
@@ -68,8 +67,41 @@ vi.mock("../contexts/ThemeContext.js", () => ({
   useTheme: () => ({ theme: "light", toggleTheme: vi.fn() }),
 }));
 
-const mockFetch = vi.fn();
-vi.stubGlobal("fetch", mockFetch);
+// Mock @mbe/api-client — ApiClient must be a class (constructable) in the mock
+const mockRequest = vi.fn();
+
+vi.mock("@mbe/api-client", () => {
+  class MockApiClient {
+    request = mockRequest;
+    get = mockRequest;
+  }
+  class MockApiClientError extends Error {
+    statusCode: number;
+    category: string;
+    constructor(statusCode: number, message: string) {
+      super(message);
+      this.name = "ApiClientError";
+      this.statusCode = statusCode;
+      this.category = statusCode === 404 ? "notFound" : "serverError";
+    }
+  }
+  return {
+    ApiClient: MockApiClient,
+    ApiClientError: MockApiClientError,
+  };
+});
+
+// Import MockApiClientError for use in tests — must match the class used in the mock
+class MockApiClientError extends Error {
+  statusCode: number;
+  category: string;
+  constructor(statusCode: number, message: string) {
+    super(message);
+    this.name = "ApiClientError";
+    this.statusCode = statusCode;
+    this.category = statusCode === 404 ? "notFound" : "serverError";
+  }
+}
 
 import { SharedSpecPage } from "./SharedSpecPage.js";
 
@@ -98,20 +130,33 @@ const MOCK_SPEC = {
 describe("SharedSpecPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
   });
 
   it("shows loading skeletons initially", () => {
-    mockFetch.mockReturnValue(new Promise(() => {}));
+    mockRequest.mockReturnValue(new Promise(() => {}));
     renderWithRoute("abc-123");
     expect(screen.getByTestId("skeleton-group")).toBeDefined();
   });
 
-  it("shows spec after successful fetch", async () => {
-    mockFetch.mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: () => Promise.resolve({ data: MOCK_SPEC }),
+  it("uses @mbe/api-client (not raw fetch) to load the spec", async () => {
+    mockRequest.mockResolvedValue({ data: MOCK_SPEC });
+    renderWithRoute("abc-123");
+    await waitFor(() => {
+      expect(screen.getByText("Build a dashboard")).toBeDefined();
     });
+    expect(mockRequest).toHaveBeenCalledWith(
+      "/api/gen/specs/abc-123",
+      expect.objectContaining({ method: "GET", signal: expect.any(AbortSignal) })
+    );
+  });
+
+  it("shows spec after successful fetch via api-client", async () => {
+    mockRequest.mockResolvedValue({ data: MOCK_SPEC });
     renderWithRoute("abc-123");
     await waitFor(() => {
       expect(screen.getByText("Build a dashboard")).toBeDefined();
@@ -119,12 +164,8 @@ describe("SharedSpecPage", () => {
     expect(screen.getByTestId("renderer")).toBeDefined();
   });
 
-  it("shows error state when spec not found (404)", async () => {
-    mockFetch.mockResolvedValue({
-      ok: false,
-      status: 404,
-      statusText: "Not Found",
-    });
+  it("shows error state when spec not found (404) via api-client", async () => {
+    mockRequest.mockRejectedValue(new MockApiClientError(404, "Not Found"));
     renderWithRoute("nonexistent");
     await waitFor(() => {
       expect(screen.getByTestId("empty-state")).toBeDefined();
@@ -132,8 +173,8 @@ describe("SharedSpecPage", () => {
     expect(screen.getByText("Spec not found")).toBeDefined();
   });
 
-  it("shows error state when fetch fails", async () => {
-    mockFetch.mockRejectedValue(new Error("Network error"));
+  it("shows error state when fetch fails (network error)", async () => {
+    mockRequest.mockRejectedValue(new Error("Network error"));
     renderWithRoute("abc-123");
     await waitFor(() => {
       expect(screen.getByTestId("empty-state")).toBeDefined();
@@ -141,27 +182,19 @@ describe("SharedSpecPage", () => {
     expect(screen.getByText("Network error")).toBeDefined();
   });
 
-  it("shows error when non-ok response", async () => {
-    mockFetch.mockResolvedValue({
-      ok: false,
-      status: 500,
-      statusText: "Internal Server Error",
-    });
+  it("shows error when api-client throws non-404 error", async () => {
+    mockRequest.mockRejectedValue(new MockApiClientError(500, "Internal Server Error"));
     renderWithRoute("abc-123");
     await waitFor(() => {
       expect(screen.getByTestId("empty-state")).toBeDefined();
     });
   });
 
-  it("renders copy link button and copies to clipboard", async () => {
+  it("renders copy link button and copies to clipboard (success)", async () => {
     const mockWriteText = vi.fn().mockResolvedValue(undefined);
     Object.assign(navigator, { clipboard: { writeText: mockWriteText } });
 
-    mockFetch.mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: () => Promise.resolve({ data: MOCK_SPEC }),
-    });
+    mockRequest.mockResolvedValue({ data: MOCK_SPEC });
     renderWithRoute("abc-123");
 
     await waitFor(() => {
@@ -173,22 +206,32 @@ describe("SharedSpecPage", () => {
     });
   });
 
-  it("renders theme toggle", async () => {
-    mockFetch.mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: () => Promise.resolve({ data: MOCK_SPEC }),
+  it("shows clipboard failure feedback when copy returns false", async () => {
+    const mockWriteText = vi.fn().mockRejectedValue(new Error("denied"));
+    Object.assign(navigator, { clipboard: { writeText: mockWriteText } });
+    vi.spyOn(window, "prompt").mockReturnValue(null);
+
+    mockRequest.mockResolvedValue({ data: MOCK_SPEC });
+    renderWithRoute("abc-123");
+
+    await waitFor(() => {
+      expect(screen.getByText("Copy Link")).toBeDefined();
     });
+    fireEvent.click(screen.getByText("Copy Link"));
+    await waitFor(() => {
+      expect(screen.getByText("Copy failed")).toBeDefined();
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("renders theme toggle", async () => {
+    mockRequest.mockResolvedValue({ data: MOCK_SPEC });
     renderWithRoute("abc-123");
     expect(screen.getByTestId("theme-toggle")).toBeDefined();
   });
 
   it("renders Generated with AI badge on success", async () => {
-    mockFetch.mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: () => Promise.resolve({ data: MOCK_SPEC }),
-    });
+    mockRequest.mockResolvedValue({ data: MOCK_SPEC });
     renderWithRoute("abc-123");
     await waitFor(() => {
       expect(screen.getByTestId("badge")).toBeDefined();

--- a/apps/gen/src/pages/SharedSpecPage.tsx
+++ b/apps/gen/src/pages/SharedSpecPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { useParams, Link } from "react-router-dom";
 import { JSONUIProvider, Renderer } from "@json-render/react";
 import type { Spec } from "@json-render/react";
@@ -14,6 +14,7 @@ import {
   ThemeToggle,
   Divider,
 } from "@mattbutlerengineering/rialto";
+import { ApiClient, ApiClientError } from "@mbe/api-client";
 import { useTheme } from "../contexts/ThemeContext.js";
 import { useCopyToClipboard } from "../hooks/useCopyToClipboard.js";
 import styles from "./SharedSpecPage.module.css";
@@ -100,37 +101,35 @@ export function SharedSpecPage() {
   const [errorMessage, setErrorMessage] = useState<string | null>(
     id ? null : "No spec ID provided."
   );
+  const [copyFailed, setCopyFailed] = useState(false);
   const { copied, copy } = useCopyToClipboard();
+
+  // Public endpoint — no auth token needed
+  const client = useMemo(() => new ApiClient({ baseUrl: "" }), []);
 
   useEffect(() => {
     if (!id) return;
 
-    let cancelled = false;
+    const controller = new AbortController();
 
     async function fetchSpec() {
       try {
-        const response = await fetch(`/api/gen/specs/${id}`);
-        if (cancelled) return;
+        const json = await client.request<{ data: StoredSpec }>(`/api/gen/specs/${id}`, {
+          method: "GET",
+          signal: controller.signal,
+        });
 
-        if (response.status === 404) {
+        setStoredSpec(json.data);
+        setLoadState("success");
+      } catch (err) {
+        if (controller.signal.aborted) return;
+
+        if (err instanceof ApiClientError && err.category === "notFound") {
           setLoadState("error");
           setErrorMessage("Spec not found.");
           return;
         }
 
-        if (!response.ok) {
-          setLoadState("error");
-          setErrorMessage(`Failed to load spec: ${response.statusText}`);
-          return;
-        }
-
-        const json = (await response.json()) as { data: StoredSpec };
-        if (cancelled) return;
-
-        setStoredSpec(json.data);
-        setLoadState("success");
-      } catch (err) {
-        if (cancelled) return;
         const message = err instanceof Error ? err.message : "Unexpected error loading spec.";
         setLoadState("error");
         setErrorMessage(message);
@@ -140,13 +139,23 @@ export function SharedSpecPage() {
     void fetchSpec();
 
     return () => {
-      cancelled = true;
+      controller.abort();
     };
-  }, [id]);
+  }, [id, client]);
 
-  const handleCopyLink = useCallback(() => {
-    void copy(window.location.href);
+  const handleCopyLink = useCallback(async () => {
+    const succeeded = await copy(window.location.href);
+    if (!succeeded) {
+      setCopyFailed(true);
+      setTimeout(() => setCopyFailed(false), 2000);
+    }
   }, [copy]);
+
+  function copyButtonLabel() {
+    if (copyFailed) return "Copy failed";
+    if (copied) return "Copied!";
+    return "Copy Link";
+  }
 
   return (
     <div className={styles.page}>
@@ -218,10 +227,10 @@ export function SharedSpecPage() {
                 </div>
 
                 <div className={styles.actions}>
-                  <Button variant="ghost" size="sm" onClick={handleCopyLink}>
+                  <Button variant="ghost" size="sm" onClick={() => void handleCopyLink()}>
                     <Text className={styles.buttonContent}>
                       <LinkIcon />
-                      {copied ? "Copied!" : "Copy Link"}
+                      {copyButtonLabel()}
                     </Text>
                   </Button>
                   <Link to="/gen/">

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4432,14 +4432,11 @@
     type AlertPayload = z.infer<typeof AlertPayloadSchema>;
     export const remediationRoutes: FastifyPluginAsync = async (fastify) => {
       fastify.addHook("preParsing", createRawBodyCaptureHook());
-      fastify.addHook(
-        "preHandler",
-        createVerifiedBodyPreHandler({
-          header: "x-remediation-signature",
-          secretEnv: "REMEDIATION_WEBHOOK_SECRET",
-          format: "raw",
-        })
-      );
+      fastify.addHook("preHandler", createVerifiedBodyPreHandler({
+        header: "x-remediation-signature",
+        secretEnv: "REMEDIATION_WEBHOOK_SECRET",
+        format: "raw",
+      }));
     
       // github[js/missing-rate-limiting] — strict limit to prevent alert storms
       fastify.post<{

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2535,14 +2535,16 @@
       const [copied, setCopied] = useState(false);
       const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     
-      const copy = useCallback(async (text: string) => {
+      const copy = useCallback(async (text: string): Promise<boolean> => {
         if (timerRef.current) {
           clearTimeout(timerRef.current);
         }
     
+        let succeeded = false;
         try {
           if (navigator.clipboard?.writeText) {
             await navigator.clipboard.writeText(text);
+            succeeded = true;
           } else {
             window.prompt("Copy to clipboard:", text);
           }
@@ -2555,6 +2557,8 @@
           setCopied(false);
           timerRef.current = null;
         }, 2000);
+    
+        return succeeded;
       }, []);
     
       return { copied, copy };
@@ -4428,11 +4432,14 @@
     type AlertPayload = z.infer<typeof AlertPayloadSchema>;
     export const remediationRoutes: FastifyPluginAsync = async (fastify) => {
       fastify.addHook("preParsing", createRawBodyCaptureHook());
-      fastify.addHook("preHandler", createVerifiedBodyPreHandler({
-        header: "x-remediation-signature",
-        secretEnv: "REMEDIATION_WEBHOOK_SECRET",
-        format: "raw",
-      }));
+      fastify.addHook(
+        "preHandler",
+        createVerifiedBodyPreHandler({
+          header: "x-remediation-signature",
+          secretEnv: "REMEDIATION_WEBHOOK_SECRET",
+          format: "raw",
+        })
+      );
     
       // github[js/missing-rate-limiting] — strict limit to prevent alert storms
       fastify.post<{

--- a/services/agent/llms-full.txt
+++ b/services/agent/llms-full.txt
@@ -553,14 +553,11 @@
     type AlertPayload = z.infer<typeof AlertPayloadSchema>;
     export const remediationRoutes: FastifyPluginAsync = async (fastify) => {
       fastify.addHook("preParsing", createRawBodyCaptureHook());
-      fastify.addHook(
-        "preHandler",
-        createVerifiedBodyPreHandler({
-          header: "x-remediation-signature",
-          secretEnv: "REMEDIATION_WEBHOOK_SECRET",
-          format: "raw",
-        })
-      );
+      fastify.addHook("preHandler", createVerifiedBodyPreHandler({
+        header: "x-remediation-signature",
+        secretEnv: "REMEDIATION_WEBHOOK_SECRET",
+        format: "raw",
+      }));
     
       // github[js/missing-rate-limiting] — strict limit to prevent alert storms
       fastify.post<{

--- a/services/agent/llms-full.txt
+++ b/services/agent/llms-full.txt
@@ -553,11 +553,14 @@
     type AlertPayload = z.infer<typeof AlertPayloadSchema>;
     export const remediationRoutes: FastifyPluginAsync = async (fastify) => {
       fastify.addHook("preParsing", createRawBodyCaptureHook());
-      fastify.addHook("preHandler", createVerifiedBodyPreHandler({
-        header: "x-remediation-signature",
-        secretEnv: "REMEDIATION_WEBHOOK_SECRET",
-        format: "raw",
-      }));
+      fastify.addHook(
+        "preHandler",
+        createVerifiedBodyPreHandler({
+          header: "x-remediation-signature",
+          secretEnv: "REMEDIATION_WEBHOOK_SECRET",
+          format: "raw",
+        })
+      );
     
       // github[js/missing-rate-limiting] — strict limit to prevent alert storms
       fastify.post<{


### PR DESCRIPTION
## Summary

- Replaces raw `fetch()` in `SharedSpecPage` spec load with `ApiClient.request()`, preserving equivalent 404/error handling via `ApiClientError.category` and `AbortController` cancellation
- Changes `useCopyToClipboard.copy()` to return `boolean` (`true` = clipboard write succeeded, `false` = fell back to prompt/failed)
- `handleCopyLink` now shows `"Copy failed"` user-visible feedback when `copy()` returns `false`; no dead cleanup return from the click handler
- Tests cover: api-client fetch success + 404 detection + network error; clipboard success + failure feedback

## Test plan

- [x] `pnpm --dir apps/gen test` — 204 tests pass (up from 199)
- [x] `pnpm --dir apps/gen typecheck` — clean
- [x] `pnpm --dir apps/gen lint` — 0 errors (warnings are pre-existing)
- [x] `pnpm --filter @mbe/cli start check-adr` — no violations
- [x] `pnpm --filter @mbe/cli start check-deps` — no mismatches
- [x] `node scripts/detect-instruction-rot.mjs` — no rot detected
- [x] `pnpm regen --check` — all artifacts up to date

Closes #2117