### PR TITLE
refactor(agent): push CI retry count into sessionService

### DIFF
--- a/services/agent/src/routes/webhooks.test.ts
+++ b/services/agent/src/routes/webhooks.test.ts
@@ -9,6 +9,7 @@ vi.mock("../services/session.js", () => ({
     getById: vi.fn(),
     create: vi.fn(),
     triggerSession: vi.fn(),
+    countCiRetries: vi.fn(),
     updateStatus: vi.fn(),
     delete: vi.fn(),
     addEvent: vi.fn(),
@@ -86,7 +87,10 @@ describe("Webhook Routes", () => {
     process.env.GITHUB_TOKEN = "test-github-token";
     app = await buildApp({ logger: false });
     await app.ready();
-    vi.mocked(sessionService.triggerSession).mockResolvedValue({ session: mockSession, accepted: true });
+    vi.mocked(sessionService.triggerSession).mockResolvedValue({
+      session: mockSession,
+      accepted: true,
+    });
   });
 
   afterEach(async () => {
@@ -477,18 +481,8 @@ describe("Webhook Routes", () => {
         },
       };
 
-      it("creates a retry session for failed CI on agent branch", async () => {
-        vi.mocked(sessionService.list).mockResolvedValueOnce({
-          data: [],
-          pagination: {
-            page: 1,
-            limit: 100,
-            total: 0,
-            totalPages: 0,
-            hasNext: false,
-            hasPrev: false,
-          },
-        });
+      it("creates a retry session for failed CI on agent branch (below limit)", async () => {
+        vi.mocked(sessionService.countCiRetries).mockResolvedValueOnce(0);
 
         const payloadStr = JSON.stringify(checkRunPayload);
         const signature = signPayload(payloadStr, WEBHOOK_SECRET);
@@ -504,6 +498,9 @@ describe("Webhook Routes", () => {
         });
 
         expect(response.statusCode).toBe(200);
+        expect(vi.mocked(sessionService.countCiRetries)).toHaveBeenCalledWith(
+          "agent/fix-login-bug"
+        );
         expect(vi.mocked(sessionService.triggerSession)).toHaveBeenCalledWith(
           expect.objectContaining({
             taskDescription: expect.stringContaining("[CI Retry 1/3]"),
@@ -511,25 +508,27 @@ describe("Webhook Routes", () => {
         );
       });
 
-      it("skips retry when max retries reached", async () => {
-        const retries = Array.from({ length: 3 }, (_, i) => ({
-          ...mockSession,
-          id: `retry-${i}`,
-          branchName: "agent/fix-login-bug",
-          taskDescription: `[CI Retry ${i + 1}/3] Fix CI failure`,
-        }));
+      it("skips retry when at max retries limit", async () => {
+        vi.mocked(sessionService.countCiRetries).mockResolvedValueOnce(3);
 
-        vi.mocked(sessionService.list).mockResolvedValueOnce({
-          data: retries,
-          pagination: {
-            page: 1,
-            limit: 100,
-            total: 3,
-            totalPages: 1,
-            hasNext: false,
-            hasPrev: false,
+        const payloadStr = JSON.stringify(checkRunPayload);
+        const signature = signPayload(payloadStr, WEBHOOK_SECRET);
+
+        await app.inject({
+          method: "POST",
+          url: "/v1/webhooks/github",
+          payload: checkRunPayload,
+          headers: {
+            "x-github-event": "check_run",
+            "x-hub-signature-256": signature,
           },
         });
+
+        expect(vi.mocked(sessionService.triggerSession)).not.toHaveBeenCalled();
+      });
+
+      it("skips retry when above max retries limit", async () => {
+        vi.mocked(sessionService.countCiRetries).mockResolvedValueOnce(5);
 
         const payloadStr = JSON.stringify(checkRunPayload);
         const signature = signPayload(payloadStr, WEBHOOK_SECRET);

--- a/services/agent/src/routes/webhooks.ts
+++ b/services/agent/src/routes/webhooks.ts
@@ -2,10 +2,7 @@ import type { FastifyPluginAsync } from "fastify";
 import { type ApiError, createProblemDetails } from "@mbe/types";
 import { extractIssueIntent } from "@mbe/agent-core";
 import { sessionService } from "../services/session.js";
-import {
-  createRawBodyCaptureHook,
-  createVerifiedBodyPreHandler,
-} from "../lib/verified-webhook.js";
+import { createRawBodyCaptureHook, createVerifiedBodyPreHandler } from "../lib/verified-webhook.js";
 
 const GITHUB_API_BASE = "https://api.github.com";
 const REQUIRED_PERMISSION = "write";
@@ -129,11 +126,14 @@ async function checkCollaboratorPermission(
 
 export const webhookRoutes: FastifyPluginAsync = async (fastify) => {
   fastify.addHook("preParsing", createRawBodyCaptureHook());
-  fastify.addHook("preHandler", createVerifiedBodyPreHandler({
-    header: "x-hub-signature-256",
-    secretEnv: "GITHUB_WEBHOOK_SECRET",
-    format: "sha256=",
-  }));
+  fastify.addHook(
+    "preHandler",
+    createVerifiedBodyPreHandler({
+      header: "x-hub-signature-256",
+      secretEnv: "GITHUB_WEBHOOK_SECRET",
+      format: "sha256=",
+    })
+  );
 
   // POST /v1/webhooks/github — Handle GitHub webhook events
   // github[js/missing-rate-limiting] — restrictive limit for high-impact webhook
@@ -326,7 +326,13 @@ async function handleIssueCommentEvent(
 }
 
 async function handleCheckRunEvent(
-  fastify: { log: { info: (...args: unknown[]) => void; warn: (...args: unknown[]) => void; error: (...args: unknown[]) => void } },
+  fastify: {
+    log: {
+      info: (...args: unknown[]) => void;
+      warn: (...args: unknown[]) => void;
+      error: (...args: unknown[]) => void;
+    };
+  },
   event: GitHubCheckRunEvent
 ): Promise<void> {
   if (event.action !== "completed") return;
@@ -336,24 +342,20 @@ async function handleCheckRunEvent(
   const branch = event.check_run.check_suite.head_branch;
   if (!branch || !branch.startsWith(AGENT_BRANCH_PREFIX)) return;
 
-  // Check how many retry sessions already exist for this branch
-  const existing = await sessionService.list({ page: 1, limit: 100 });
-  const retries = existing.data.filter(
-    (s) => s.branchName === branch && s.taskDescription.includes("[CI Retry")
-  );
+  const retryCount = await sessionService.countCiRetries(branch);
 
-  if (retries.length >= MAX_CI_RETRIES) {
-    fastify.log.info({ branch, retries: retries.length }, "Max CI retries reached — skipping");
+  if (retryCount >= MAX_CI_RETRIES) {
+    fastify.log.info({ branch, retries: retryCount }, "Max CI retries reached — skipping");
     return;
   }
 
   const taskDescription =
-    `[CI Retry ${retries.length + 1}/${MAX_CI_RETRIES}] ` +
+    `[CI Retry ${retryCount + 1}/${MAX_CI_RETRIES}] ` +
     `Fix CI failure on branch ${branch}.\n\n` +
     `Check run "${event.check_run.name}" failed at commit ${event.check_run.head_sha}.\n` +
     `Review the CI output and fix the failing tests or build errors.`;
 
-  fastify.log.info({ branch, attempt: retries.length + 1 }, "Creating CI retry session");
+  fastify.log.info({ branch, attempt: retryCount + 1 }, "Creating CI retry session");
 
   const result = await sessionService.triggerSession({
     taskDescription,
@@ -361,9 +363,6 @@ async function handleCheckRunEvent(
   });
 
   if (!result.accepted) {
-    fastify.log.warn(
-      { branch },
-      "Concurrency cap reached — CI retry session not created"
-    );
+    fastify.log.warn({ branch }, "Concurrency cap reached — CI retry session not created");
   }
 }

--- a/services/agent/src/services/session.test.ts
+++ b/services/agent/src/services/session.test.ts
@@ -268,9 +268,7 @@ describe("sessionService", () => {
       expect(result.session).not.toBeNull();
       expect(result.session!.id).toBe("sess-1");
       expect(prisma.session.create).toHaveBeenCalled();
-      expect(executeSession).toHaveBeenCalledWith(
-        expect.objectContaining({ id: "sess-1" })
-      );
+      expect(executeSession).toHaveBeenCalledWith(expect.objectContaining({ id: "sess-1" }));
     });
 
     it("wraps task description in <task> tags", async () => {
@@ -648,6 +646,60 @@ describe("sessionService", () => {
 
       const result = await sessionService.listEvents("sess-1");
       expect(result[0].createdAt).toBe("2026-03-01T12:00:00.000Z");
+    });
+  });
+
+  describe("countCiRetries", () => {
+    it("counts sessions matching branch and CI Retry prefix", async () => {
+      vi.mocked(prisma.session.count).mockResolvedValueOnce(2);
+
+      const result = await sessionService.countCiRetries("agent/fix-login-bug");
+
+      expect(prisma.session.count).toHaveBeenCalledWith({
+        where: {
+          branchName: "agent/fix-login-bug",
+          taskDescription: { contains: "[CI Retry" },
+        },
+      });
+      expect(result).toBe(2);
+    });
+
+    it("returns 0 when no retries exist for the branch", async () => {
+      vi.mocked(prisma.session.count).mockResolvedValueOnce(0);
+
+      const result = await sessionService.countCiRetries("agent/other-branch");
+
+      expect(result).toBe(0);
+    });
+
+    it("excludes sessions from other branches", async () => {
+      vi.mocked(prisma.session.count).mockResolvedValueOnce(0);
+
+      await sessionService.countCiRetries("agent/branch-a");
+
+      expect(prisma.session.count).toHaveBeenCalledWith({
+        where: {
+          branchName: "agent/branch-a",
+          taskDescription: { contains: "[CI Retry" },
+        },
+      });
+    });
+
+    it("excludes sessions without the CI Retry prefix", async () => {
+      // The Prisma query filters by taskDescription contains — only retry sessions match
+      vi.mocked(prisma.session.count).mockResolvedValueOnce(1);
+
+      const result = await sessionService.countCiRetries("agent/fix-login-bug");
+
+      // Count query is scoped to branchName + CI Retry prefix — non-retry sessions excluded
+      expect(prisma.session.count).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            taskDescription: { contains: "[CI Retry" },
+          }),
+        })
+      );
+      expect(result).toBe(1);
     });
   });
 

--- a/services/agent/src/services/session.ts
+++ b/services/agent/src/services/session.ts
@@ -126,12 +126,8 @@ export const sessionService = {
     return mapPrismaSession(session);
   },
 
-  async triggerSession(
-    opts: TriggerSessionOptions
-  ): Promise<TriggerSessionResult> {
-    const { executeSession, getActiveSessionCount } = await import(
-      "./session-executor.js"
-    );
+  async triggerSession(opts: TriggerSessionOptions): Promise<TriggerSessionResult> {
+    const { executeSession, getActiveSessionCount } = await import("./session-executor.js");
 
     if (getActiveSessionCount() >= MAX_CONCURRENT) {
       return { session: null, accepted: false };
@@ -230,6 +226,12 @@ export const sessionService = {
        ORDER BY s.updated_at ASC
     `;
     return rows.map((r) => r.id);
+  },
+
+  async countCiRetries(branchName: string): Promise<number> {
+    return prisma.session.count({
+      where: { branchName, taskDescription: { contains: "[CI Retry" } },
+    });
   },
 
   async findByStatus(status: SessionStatus): Promise<AgentSession[]> {


### PR DESCRIPTION
## Summary

- Adds `sessionService.countCiRetries(branchName): Promise<number>` that uses a single `prisma.session.count()` call with branch and `[CI Retry` prefix filter
- Replaces the O(N) `sessionService.list({ page: 1, limit: 100 })` + in-memory `.filter()` in `handleCheckRunEvent` with the new single DB round-trip
- Eliminates silent pagination truncation (limit:100 could undercount) and the scattered substring-match knowledge that lived in the route

## Test plan

- [x] 4 new `countCiRetries` unit tests in session.test.ts (RED→GREEN via TDD): matching branch counted; other branches excluded; sessions without prefix excluded; returns 0 for no retries
- [x] Updated webhooks.test.ts CI retry section: 3 guard paths (below/at/above limit) now mock `countCiRetries` instead of `list`; `sessionService.list` no longer called in the retry path
- [x] `pnpm --dir services/agent test` — 268/268 pass (24 test files)
- [x] `pnpm --dir services/agent lint` — clean
- [x] `pnpm --dir services/agent typecheck` — clean
- [x] `pnpm --filter @mbe/cli start check-adr` — no violations
- [x] `pnpm --filter @mbe/cli start check-deps` — all consistent
- [x] `pnpm regen:check` — all artifacts up to date
- [x] `node scripts/detect-instruction-rot.mjs` — no rot detected

Closes #2147