### PR TITLE
refactor(api-client): deepen ApiClient.get() with params object

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -12845,15 +12845,14 @@
     }
   </file>
   <file path="packages/api-client/src/client.ts">
-    export interface ClientConfig {
-      baseUrl: string;
-      getAccessToken?: () => string | null | Promise<string | null>;
-      timeout?: number;
-      maxRetries?: number;
-      onError?: (error: ApiClientError) => void;
-    }
-    export interface RequestOptions extends RequestInit {
-      signal?: AbortSignal;
+    export type QueryParams = Record<string, string | number | boolean | undefined | null>;
+    export function buildQueryString(params: QueryParams): string {
+      const sp = new URLSearchParams();
+      for (const [key, value] of Object.entries(params)) {
+        if (value !== undefined && value !== null) sp.set(key, String(value));
+      }
+      const s = sp.toString();
+      return s ? `?${s}` : "";
     }
   </file>
   <file path="packages/api-client/src/floor-plans.ts">
@@ -12867,14 +12866,9 @@
           limit?: number;
         } = {}
       ): Promise<PaginatedResponse<FloorPlan>> {
-        const searchParams = new URLSearchParams();
-        if (params.venueId) searchParams.set("venueId", params.venueId);
-        if (params.page) searchParams.set("page", String(params.page));
-        if (params.limit) searchParams.set("limit", String(params.limit));
-    
-        const query = searchParams.toString();
         return this.client.get<PaginatedResponse<FloorPlan>>(
-          `/api/v1/floor-plans${query ? `?${query}` : ""}`
+          "/api/v1/floor-plans",
+          params as QueryParams
         );
       }
     
@@ -12999,18 +12993,9 @@
        * List reservations with optional filters
        */
       async list(params: ListReservationsParams = {}): Promise<PaginatedResponse<Reservation>> {
-        const searchParams = new URLSearchParams();
-        if (params.page) searchParams.set("page", String(params.page));
-        if (params.limit) searchParams.set("limit", String(params.limit));
-        if (params.date) searchParams.set("date", params.date);
-        if (params.status) searchParams.set("status", params.status);
-        if (params.tableId) searchParams.set("tableId", params.tableId);
-        if (params.venueId) searchParams.set("venueId", params.venueId);
-        if (params.guestId) searchParams.set("guestId", params.guestId);
-    
-        const query = searchParams.toString();
         return this.client.get<PaginatedResponse<Reservation>>(
-          `/api/v1/reservations${query ? `?${query}` : ""}`
+          "/api/v1/reservations",
+          params as QueryParams
         );
       }
     
@@ -13182,14 +13167,7 @@
        * List tables with optional filters
        */
       async list(params: ListTablesParams = {}): Promise<PaginatedResponse<Table>> {
-        const searchParams = new URLSearchParams();
-        if (params.page) searchParams.set("page", String(params.page));
-        if (params.limit) searchParams.set("limit", String(params.limit));
-        if (params.venueId) searchParams.set("venueId", params.venueId);
-        if (params.activeOnly !== undefined) searchParams.set("activeOnly", String(params.activeOnly));
-    
-        const query = searchParams.toString();
-        return this.client.get<PaginatedResponse<Table>>(`/api/v1/tables${query ? `?${query}` : ""}`);
+        return this.client.get<PaginatedResponse<Table>>("/api/v1/tables", params as QueryParams);
       }
     
       /**
@@ -13294,13 +13272,7 @@
       async list(
         params: { page?: number; limit?: number; venueGroupId?: string } = {}
       ): Promise<PaginatedResponse<Venue>> {
-        const searchParams = new URLSearchParams();
-        if (params.page) searchParams.set("page", String(params.page));
-        if (params.limit) searchParams.set("limit", String(params.limit));
-        if (params.venueGroupId) searchParams.set("venueGroupId", params.venueGroupId);
-    
-        const query = searchParams.toString();
-        return this.client.get<PaginatedResponse<Venue>>(`/api/v1/venues${query ? `?${query}` : ""}`);
+        return this.client.get<PaginatedResponse<Venue>>("/api/v1/venues", params as QueryParams);
       }
     
       /**

--- a/llms.txt
+++ b/llms.txt
@@ -2950,18 +2950,10 @@
   </file>
   <file path="packages/api-client/src/client.ts">
     <item priority="low">
-      interface ClientConfig {
-        baseUrl: string;
-        getAccessToken?: () => string | null | Promise<string | null>;
-        timeout?: number;
-        maxRetries?: number;
-        onError?: (error: ApiClientError) => void;
-      }
+      type QueryParams = Record<string, string | number | boolean | undefined | null>;
     </item>
-    <item priority="low">
-      interface RequestOptions {
-        signal?: AbortSignal;
-      }
+    <item priority="high">
+      export function buildQueryString(params: QueryParams): string { /* ... */ }
     </item>
   </file>
   <file path="packages/api-client/src/floor-plans.ts">

--- a/packages/api-client/llms-full.txt
+++ b/packages/api-client/llms-full.txt
@@ -34,15 +34,14 @@
     }
   </file>
   <file path="src/client.ts">
-    export interface ClientConfig {
-      baseUrl: string;
-      getAccessToken?: () => string | null | Promise<string | null>;
-      timeout?: number;
-      maxRetries?: number;
-      onError?: (error: ApiClientError) => void;
-    }
-    export interface RequestOptions extends RequestInit {
-      signal?: AbortSignal;
+    export type QueryParams = Record<string, string | number | boolean | undefined | null>;
+    export function buildQueryString(params: QueryParams): string {
+      const sp = new URLSearchParams();
+      for (const [key, value] of Object.entries(params)) {
+        if (value !== undefined && value !== null) sp.set(key, String(value));
+      }
+      const s = sp.toString();
+      return s ? `?${s}` : "";
     }
   </file>
   <file path="src/floor-plans.ts">
@@ -56,14 +55,9 @@
           limit?: number;
         } = {}
       ): Promise<PaginatedResponse<FloorPlan>> {
-        const searchParams = new URLSearchParams();
-        if (params.venueId) searchParams.set("venueId", params.venueId);
-        if (params.page) searchParams.set("page", String(params.page));
-        if (params.limit) searchParams.set("limit", String(params.limit));
-    
-        const query = searchParams.toString();
         return this.client.get<PaginatedResponse<FloorPlan>>(
-          `/api/v1/floor-plans${query ? `?${query}` : ""}`
+          "/api/v1/floor-plans",
+          params as QueryParams
         );
       }
     
@@ -188,18 +182,9 @@
        * List reservations with optional filters
        */
       async list(params: ListReservationsParams = {}): Promise<PaginatedResponse<Reservation>> {
-        const searchParams = new URLSearchParams();
-        if (params.page) searchParams.set("page", String(params.page));
-        if (params.limit) searchParams.set("limit", String(params.limit));
-        if (params.date) searchParams.set("date", params.date);
-        if (params.status) searchParams.set("status", params.status);
-        if (params.tableId) searchParams.set("tableId", params.tableId);
-        if (params.venueId) searchParams.set("venueId", params.venueId);
-        if (params.guestId) searchParams.set("guestId", params.guestId);
-    
-        const query = searchParams.toString();
         return this.client.get<PaginatedResponse<Reservation>>(
-          `/api/v1/reservations${query ? `?${query}` : ""}`
+          "/api/v1/reservations",
+          params as QueryParams
         );
       }
     
@@ -371,14 +356,7 @@
        * List tables with optional filters
        */
       async list(params: ListTablesParams = {}): Promise<PaginatedResponse<Table>> {
-        const searchParams = new URLSearchParams();
-        if (params.page) searchParams.set("page", String(params.page));
-        if (params.limit) searchParams.set("limit", String(params.limit));
-        if (params.venueId) searchParams.set("venueId", params.venueId);
-        if (params.activeOnly !== undefined) searchParams.set("activeOnly", String(params.activeOnly));
-    
-        const query = searchParams.toString();
-        return this.client.get<PaginatedResponse<Table>>(`/api/v1/tables${query ? `?${query}` : ""}`);
+        return this.client.get<PaginatedResponse<Table>>("/api/v1/tables", params as QueryParams);
       }
     
       /**
@@ -483,13 +461,7 @@
       async list(
         params: { page?: number; limit?: number; venueGroupId?: string } = {}
       ): Promise<PaginatedResponse<Venue>> {
-        const searchParams = new URLSearchParams();
-        if (params.page) searchParams.set("page", String(params.page));
-        if (params.limit) searchParams.set("limit", String(params.limit));
-        if (params.venueGroupId) searchParams.set("venueGroupId", params.venueGroupId);
-    
-        const query = searchParams.toString();
-        return this.client.get<PaginatedResponse<Venue>>(`/api/v1/venues${query ? `?${query}` : ""}`);
+        return this.client.get<PaginatedResponse<Venue>>("/api/v1/venues", params as QueryParams);
       }
     
       /**

--- a/packages/api-client/llms.txt
+++ b/packages/api-client/llms.txt
@@ -40,18 +40,10 @@
   </file>
   <file path="src/client.ts">
     <item priority="low">
-      interface ClientConfig {
-        baseUrl: string;
-        getAccessToken?: () => string | null | Promise<string | null>;
-        timeout?: number;
-        maxRetries?: number;
-        onError?: (error: ApiClientError) => void;
-      }
+      type QueryParams = Record<string, string | number | boolean | undefined | null>;
     </item>
-    <item priority="low">
-      interface RequestOptions {
-        signal?: AbortSignal;
-      }
+    <item priority="high">
+      export function buildQueryString(params: QueryParams): string { /* ... */ }
     </item>
   </file>
   <file path="src/floor-plans.ts">

--- a/packages/api-client/src/agent-sessions.ts
+++ b/packages/api-client/src/agent-sessions.ts
@@ -1,5 +1,5 @@
 import { ApiClient } from "./client.js";
-import type { ClientConfig } from "./client.js";
+import type { ClientConfig, QueryParams } from "./client.js";
 
 export interface SessionSummary {
   readonly id: string;
@@ -49,12 +49,7 @@ export class AgentSessionClient extends ApiClient {
   }
 
   async listSessions(params: ListSessionsParams = {}): Promise<PaginatedSessions> {
-    const qs = new URLSearchParams();
-    if (params.status) qs.set("status", params.status);
-    if (params.page !== undefined) qs.set("page", String(params.page));
-    if (params.limit !== undefined) qs.set("limit", String(params.limit));
-    const query = qs.toString();
-    return this.get<PaginatedSessions>(`/v1/sessions${query ? `?${query}` : ""}`);
+    return this.get<PaginatedSessions>("/v1/sessions", params as QueryParams);
   }
 
   async cancelSession(id: string): Promise<SessionSummary> {

--- a/packages/api-client/src/availability.ts
+++ b/packages/api-client/src/availability.ts
@@ -6,7 +6,7 @@ import type {
   ConfirmHoldRequest,
   Reservation,
 } from "@mbe/types";
-import type { ApiClient } from "./client.js";
+import type { ApiClient, QueryParams } from "./client.js";
 
 export interface GetTimeSlotsParams {
   venueId: string;
@@ -29,27 +29,18 @@ export class AvailabilityClient {
    * Get available time slots for a venue on a specific date
    */
   async getTimeSlots(params: GetTimeSlotsParams): Promise<TimeSlot[]> {
-    const searchParams = new URLSearchParams();
-    searchParams.set("date", params.date);
-    searchParams.set("partySize", String(params.partySize));
-    if (params.duration) searchParams.set("duration", String(params.duration));
-
-    return this.client.getOne<TimeSlot[]>(
-      `/api/v1/availability/${params.venueId}?${searchParams.toString()}`
-    );
+    const { venueId, ...query } = params;
+    return this.client.getOne<TimeSlot[]>(`/api/v1/availability/${venueId}`, query as QueryParams);
   }
 
   /**
    * Get dates with availability in a range
    */
   async getDates(params: GetDatesParams): Promise<DateAvailability[]> {
-    const searchParams = new URLSearchParams();
-    searchParams.set("startDate", params.startDate);
-    searchParams.set("endDate", params.endDate);
-    searchParams.set("partySize", String(params.partySize));
-
+    const { venueId, ...query } = params;
     return this.client.getOne<DateAvailability[]>(
-      `/api/v1/availability/${params.venueId}/dates?${searchParams.toString()}`
+      `/api/v1/availability/${venueId}/dates`,
+      query as QueryParams
     );
   }
 }

--- a/packages/api-client/src/client.test.ts
+++ b/packages/api-client/src/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { ApiClient, ApiClientError } from "./client.js";
+import { ApiClient, ApiClientError, buildQueryString } from "./client.js";
 
 // Mock global fetch
 const mockFetch = vi.fn<typeof fetch>();
@@ -483,6 +483,146 @@ describe("ApiClient", () => {
       const client = new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 0 });
 
       await expect(client.getOne("/api/v1/users/999")).rejects.toThrow(ApiClientError);
+    });
+  });
+
+  describe("get() with params", () => {
+    it("should append query string when params are provided", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ items: [] }));
+
+      const client = new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 0 });
+      await client.get("/api/v1/reservations", { venueId: "v1", date: "2026-06-01" });
+
+      const [url] = mockFetch.mock.calls[0]!;
+      const parsed = new URL(url as string);
+      expect(parsed.searchParams.get("venueId")).toBe("v1");
+      expect(parsed.searchParams.get("date")).toBe("2026-06-01");
+    });
+
+    it("should omit undefined values from query string", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ items: [] }));
+
+      const client = new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 0 });
+      await client.get("/api/v1/reservations", { venueId: "v1", date: undefined });
+
+      const [url] = mockFetch.mock.calls[0]!;
+      const parsed = new URL(url as string);
+      expect(parsed.searchParams.get("venueId")).toBe("v1");
+      expect(parsed.searchParams.has("date")).toBe(false);
+    });
+
+    it("should omit null values from query string", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ items: [] }));
+
+      const client = new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 0 });
+      await client.get("/api/v1/reservations", { venueId: "v1", status: null });
+
+      const [url] = mockFetch.mock.calls[0]!;
+      const parsed = new URL(url as string);
+      expect(parsed.searchParams.get("venueId")).toBe("v1");
+      expect(parsed.searchParams.has("status")).toBe(false);
+    });
+
+    it("should stringify number values", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ items: [] }));
+
+      const client = new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 0 });
+      await client.get("/api/v1/tables", { page: 2, limit: 10 });
+
+      const [url] = mockFetch.mock.calls[0]!;
+      const parsed = new URL(url as string);
+      expect(parsed.searchParams.get("page")).toBe("2");
+      expect(parsed.searchParams.get("limit")).toBe("10");
+    });
+
+    it("should stringify boolean values", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ items: [] }));
+
+      const client = new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 0 });
+      await client.get("/api/v1/tables", { activeOnly: true });
+
+      const [url] = mockFetch.mock.calls[0]!;
+      const parsed = new URL(url as string);
+      expect(parsed.searchParams.get("activeOnly")).toBe("true");
+    });
+
+    it("should produce no query string when params is empty object", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ items: [] }));
+
+      const client = new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 0 });
+      await client.get("/api/v1/venues", {});
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/venues");
+    });
+
+    it("should produce no query string when params is omitted", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ items: [] }));
+
+      const client = new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 0 });
+      await client.get("/api/v1/venues");
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.test.com/api/v1/venues");
+    });
+
+    it("should join multiple params correctly", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ items: [] }));
+
+      const client = new ApiClient({ baseUrl: "https://api.test.com", maxRetries: 0 });
+      await client.get("/api/v1/reservations", {
+        venueId: "v1",
+        date: "2026-06-01",
+        status: "CONFIRMED",
+        page: 1,
+        limit: 20,
+      });
+
+      const [url] = mockFetch.mock.calls[0]!;
+      const parsed = new URL(url as string);
+      expect(parsed.searchParams.get("venueId")).toBe("v1");
+      expect(parsed.searchParams.get("date")).toBe("2026-06-01");
+      expect(parsed.searchParams.get("status")).toBe("CONFIRMED");
+      expect(parsed.searchParams.get("page")).toBe("1");
+      expect(parsed.searchParams.get("limit")).toBe("20");
+    });
+  });
+
+  describe("buildQueryString", () => {
+    it("should return empty string for empty params", () => {
+      expect(buildQueryString({})).toBe("");
+    });
+
+    it("should omit undefined values", () => {
+      const result = buildQueryString({ a: "hello", b: undefined });
+      const parsed = new URLSearchParams(result.slice(1));
+      expect(parsed.has("b")).toBe(false);
+      expect(parsed.get("a")).toBe("hello");
+    });
+
+    it("should omit null values", () => {
+      const result = buildQueryString({ a: "hello", b: null });
+      const parsed = new URLSearchParams(result.slice(1));
+      expect(parsed.has("b")).toBe(false);
+    });
+
+    it("should stringify numbers", () => {
+      const result = buildQueryString({ page: 3 });
+      expect(result).toBe("?page=3");
+    });
+
+    it("should stringify booleans", () => {
+      const result = buildQueryString({ activeOnly: false });
+      expect(result).toBe("?activeOnly=false");
+    });
+
+    it("should return empty string when all values are undefined or null", () => {
+      expect(buildQueryString({ a: undefined, b: null })).toBe("");
+    });
+
+    it("should start with ? when any value is present", () => {
+      const result = buildQueryString({ key: "val" });
+      expect(result.startsWith("?")).toBe(true);
     });
   });
 

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -1,6 +1,21 @@
 import type { ApiError } from "@mbe/types";
 import type { z } from "zod";
 
+/**
+ * Describes the value types accepted in a query-params object.
+ * undefined and null values are omitted; all others are stringified.
+ */
+export type QueryParams = Record<string, string | number | boolean | undefined | null>;
+
+export function buildQueryString(params: QueryParams): string {
+  const sp = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null) sp.set(key, String(value));
+  }
+  const s = sp.toString();
+  return s ? `?${s}` : "";
+}
+
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_RETRIES = 3;
 const BASE_BACKOFF_MS = 1_000;
@@ -92,8 +107,9 @@ export class ApiClient {
     return data as T;
   }
 
-  get<T>(path: string, schema?: z.ZodSchema<T>): Promise<T> {
-    return this.request<T>(path, { method: "GET" }, schema);
+  get<T>(path: string, params?: QueryParams, schema?: z.ZodSchema<T>): Promise<T> {
+    const query = params ? buildQueryString(params) : "";
+    return this.request<T>(`${path}${query}`, { method: "GET" }, schema);
   }
 
   post<T>(path: string, body: unknown, schema?: z.ZodSchema<T>): Promise<T> {
@@ -126,8 +142,8 @@ export class ApiClient {
    * GET + unwrap `.data` from ApiResponse envelope.
    * Use for single-resource endpoints that return `{ data: T }`.
    */
-  async getOne<T>(path: string): Promise<T> {
-    const response = await this.get<{ data: T }>(path);
+  async getOne<T>(path: string, params?: QueryParams): Promise<T> {
+    const response = await this.get<{ data: T }>(path, params);
     return response.data;
   }
 

--- a/packages/api-client/src/floor-plans.ts
+++ b/packages/api-client/src/floor-plans.ts
@@ -6,7 +6,7 @@ import type {
   Table,
   PaginatedResponse,
 } from "@mbe/types";
-import type { ApiClient } from "./client.js";
+import type { ApiClient, QueryParams } from "./client.js";
 
 export class FloorPlansClient {
   constructor(private client: ApiClient) {}
@@ -18,14 +18,9 @@ export class FloorPlansClient {
       limit?: number;
     } = {}
   ): Promise<PaginatedResponse<FloorPlan>> {
-    const searchParams = new URLSearchParams();
-    if (params.venueId) searchParams.set("venueId", params.venueId);
-    if (params.page) searchParams.set("page", String(params.page));
-    if (params.limit) searchParams.set("limit", String(params.limit));
-
-    const query = searchParams.toString();
     return this.client.get<PaginatedResponse<FloorPlan>>(
-      `/api/v1/floor-plans${query ? `?${query}` : ""}`
+      "/api/v1/floor-plans",
+      params as QueryParams
     );
   }
 

--- a/packages/api-client/src/guests.ts
+++ b/packages/api-client/src/guests.ts
@@ -14,7 +14,7 @@ export interface FindOrCreateGuestRequest {
   name: string;
   dietaryRestrictions?: string[];
 }
-import type { ApiClient } from "./client.js";
+import type { ApiClient, QueryParams } from "./client.js";
 
 export interface ListGuestsParams {
   page?: number;
@@ -35,27 +35,19 @@ export class GuestsClient {
    * List guests for a venue
    */
   async list(params: ListGuestsParams): Promise<PaginatedResponse<Guest>> {
-    const searchParams = new URLSearchParams();
-    searchParams.set("venueId", params.venueId);
-    if (params.page) searchParams.set("page", String(params.page));
-    if (params.limit) searchParams.set("limit", String(params.limit));
-
-    return this.client.get<PaginatedResponse<Guest>>(`/api/v1/guests?${searchParams.toString()}`);
+    return this.client.get<PaginatedResponse<Guest>>(
+      "/api/v1/guests",
+      params as unknown as QueryParams
+    );
   }
 
   /**
    * Search guests
    */
   async search(params: SearchGuestsParams): Promise<PaginatedResponse<Guest>> {
-    const searchParams = new URLSearchParams();
-    searchParams.set("venueId", params.venueId);
-    if (params.query) searchParams.set("query", params.query);
-    if (params.hasNotVisitedInDays) {
-      searchParams.set("hasNotVisitedInDays", String(params.hasNotVisitedInDays));
-    }
-
     return this.client.get<PaginatedResponse<Guest>>(
-      `/api/v1/guests/search?${searchParams.toString()}`
+      "/api/v1/guests/search",
+      params as unknown as QueryParams
     );
   }
 

--- a/packages/api-client/src/reservations.ts
+++ b/packages/api-client/src/reservations.ts
@@ -5,7 +5,7 @@ import type {
   CreateReservationRequest,
   UpdateReservationRequest,
 } from "@mbe/types";
-import type { ApiClient } from "./client.js";
+import type { ApiClient, QueryParams } from "./client.js";
 
 export interface ListReservationsParams {
   page?: number;
@@ -24,18 +24,9 @@ export class ReservationsClient {
    * List reservations with optional filters
    */
   async list(params: ListReservationsParams = {}): Promise<PaginatedResponse<Reservation>> {
-    const searchParams = new URLSearchParams();
-    if (params.page) searchParams.set("page", String(params.page));
-    if (params.limit) searchParams.set("limit", String(params.limit));
-    if (params.date) searchParams.set("date", params.date);
-    if (params.status) searchParams.set("status", params.status);
-    if (params.tableId) searchParams.set("tableId", params.tableId);
-    if (params.venueId) searchParams.set("venueId", params.venueId);
-    if (params.guestId) searchParams.set("guestId", params.guestId);
-
-    const query = searchParams.toString();
     return this.client.get<PaginatedResponse<Reservation>>(
-      `/api/v1/reservations${query ? `?${query}` : ""}`
+      "/api/v1/reservations",
+      params as QueryParams
     );
   }
 

--- a/packages/api-client/src/tables.ts
+++ b/packages/api-client/src/tables.ts
@@ -1,5 +1,5 @@
 import type { PaginatedResponse, Table, CreateTableRequest, UpdateTableRequest } from "@mbe/types";
-import type { ApiClient } from "./client.js";
+import type { ApiClient, QueryParams } from "./client.js";
 
 export interface ListTablesParams {
   page?: number;
@@ -15,14 +15,7 @@ export class TablesClient {
    * List tables with optional filters
    */
   async list(params: ListTablesParams = {}): Promise<PaginatedResponse<Table>> {
-    const searchParams = new URLSearchParams();
-    if (params.page) searchParams.set("page", String(params.page));
-    if (params.limit) searchParams.set("limit", String(params.limit));
-    if (params.venueId) searchParams.set("venueId", params.venueId);
-    if (params.activeOnly !== undefined) searchParams.set("activeOnly", String(params.activeOnly));
-
-    const query = searchParams.toString();
-    return this.client.get<PaginatedResponse<Table>>(`/api/v1/tables${query ? `?${query}` : ""}`);
+    return this.client.get<PaginatedResponse<Table>>("/api/v1/tables", params as QueryParams);
   }
 
   /**

--- a/packages/api-client/src/venues.ts
+++ b/packages/api-client/src/venues.ts
@@ -7,7 +7,7 @@ import type {
   CreateVenueGroupRequest,
   UpdateVenueGroupRequest,
 } from "@mbe/types";
-import type { ApiClient } from "./client.js";
+import type { ApiClient, QueryParams } from "./client.js";
 
 export class VenuesClient {
   constructor(private client: ApiClient) {}
@@ -18,13 +18,7 @@ export class VenuesClient {
   async list(
     params: { page?: number; limit?: number; venueGroupId?: string } = {}
   ): Promise<PaginatedResponse<Venue>> {
-    const searchParams = new URLSearchParams();
-    if (params.page) searchParams.set("page", String(params.page));
-    if (params.limit) searchParams.set("limit", String(params.limit));
-    if (params.venueGroupId) searchParams.set("venueGroupId", params.venueGroupId);
-
-    const query = searchParams.toString();
-    return this.client.get<PaginatedResponse<Venue>>(`/api/v1/venues${query ? `?${query}` : ""}`);
+    return this.client.get<PaginatedResponse<Venue>>("/api/v1/venues", params as QueryParams);
   }
 
   /**


### PR DESCRIPTION
## Summary

- Adds `buildQueryString(params: QueryParams): string` to `client.ts` — filters undefined/null, stringifies numbers and booleans, returns `""` for empty params or `"?key=val&..."` otherwise
- Changes `ApiClient.get()` signature from `(path, schema?)` to `(path, params?, schema?)` so query-string construction is an HTTP concern of the base class, not each resource client
- Updates `getOne()` to also accept `params?` and pass it through to `get()`
- Removes ~50 lines of repeated `URLSearchParams` boilerplate from `reservations.ts`, `guests.ts`, `venues.ts`, `tables.ts`, `availability.ts`, `floor-plans.ts`, and `agent-sessions.ts`
- Exports `QueryParams` type from `client.ts` for call-site casts

## Test plan

- [x] TDD: wrote failing tests for `buildQueryString` and `get()` params first (RED), verified errors, then implemented (GREEN)
- [x] Tests: 177 passed (13 test files) — no regressions
- [x] `pnpm --dir packages/api-client lint` — clean
- [x] `pnpm --dir packages/api-client typecheck` — clean
- [x] `pnpm --filter @mbe/cli start check-adr` — no violations
- [x] `pnpm --filter @mbe/cli start check-deps` — no mismatches
- [x] `pnpm regen --check` — all artifacts up to date

Closes #2146