### PR TITLE
fix(e2e): replace tautological walk-in assertion with count delta + guest name check

### DIFF
--- a/apps/hospitality/e2e/walkin.spec.ts
+++ b/apps/hospitality/e2e/walkin.spec.ts
@@ -23,6 +23,10 @@ test.describe("CF-3: Walk-in creation", () => {
   test("creates walk-in and verifies timeline update", async ({ mockedPage }) => {
     await mockedPage.goto("timeline");
 
+    // Capture reservation count before walk-in creation
+    const reservationBlocks = mockedPage.getByTestId(/^reservation-block-/);
+    const initialCount = await reservationBlocks.count();
+
     // Click "Walk-In" button
     await mockedPage.getByRole("button", { name: /Walk.?In/i }).click();
 
@@ -34,7 +38,8 @@ test.describe("CF-3: Walk-in creation", () => {
 
     // Optionally enter guest name
     const guestNameInput = dialog.getByLabel(/guest name/i);
-    if (await guestNameInput.isVisible()) {
+    const hasGuestNameInput = await guestNameInput.isVisible();
+    if (hasGuestNameInput) {
       await guestNameInput.fill("Test Guest");
     }
 
@@ -44,9 +49,15 @@ test.describe("CF-3: Walk-in creation", () => {
     // Dialog closes
     await expect(dialog).not.toBeVisible();
 
-    // New reservation appears on timeline
-    const reservationBlocks = mockedPage.getByTestId(/^reservation-block-/);
-    await expect(reservationBlocks).toHaveCount(await reservationBlocks.count());
+    // New reservation block appears on timeline (count increased by 1)
+    await expect(reservationBlocks).toHaveCount(initialCount + 1);
+
+    // When guest name was entered, verify the walk-in block shows the guest name
+    if (hasGuestNameInput) {
+      await expect(
+        mockedPage.getByTestId(/^reservation-block-/).filter({ hasText: "Test Guest" })
+      ).toBeVisible();
+    }
   });
 
   test("cancels walk-in dialog", async ({ mockedPage }) => {


### PR DESCRIPTION
## Summary

- Removes the self-referential assertion `toHaveCount(await reservationBlocks.count())` in `apps/hospitality/e2e/walkin.spec.ts` — it compared a locator's count to its own count and could never fail regardless of whether walk-in creation worked.
- Captures `initialCount` before the walk-in dialog opens, then asserts `toHaveCount(initialCount + 1)` after "Seat Now" is clicked and the dialog closes.
- When the guest name input is visible (and "Test Guest" was entered), also asserts a reservation block with that text is visible — verifying the correct record appeared, not just any record.

## Test plan

- [ ] Spec passes `pnpm --dir apps/hospitality lint` (0 errors, only pre-existing warnings)
- [ ] Architecture audit: `check-adr` and `check-deps` both pass
- [ ] Instruction rot check passes
- [ ] Pre-push hook ran full turbo test + typecheck suite: 869 tests passed across 26 packages
- [ ] Playwright API usage (`filter({ hasText })`, `toHaveCount`, `count()`) matches patterns used in sibling E2E specs
- [ ] Reasoning: if walk-in creation were broken and no new block appeared, `toHaveCount(initialCount + 1)` would fail — the tautology cannot

Closes #2110