### PR TITLE
feat(service-bootstrap): RFC 7807 error-handler plugin, adopted by reservations tables

### DIFF
--- a/docs/architecture/dependency-graph.md
+++ b/docs/architecture/dependency-graph.md
@@ -120,8 +120,8 @@ flowchart TD
   service_bootstrap --> database
   service_bootstrap --> observability
   service_bootstrap --> sentry
-  service_bootstrap --> config
   service_bootstrap --> types
+  service_bootstrap --> config
   types --> config
   cli --> agent_core
   cli --> types

--- a/infrastructure/worker/dep-graph.json
+++ b/infrastructure/worker/dep-graph.json
@@ -529,12 +529,12 @@
     },
     {
       "from": "@mbe/service-bootstrap",
-      "to": "@mbe/config",
-      "type": "devDependency"
+      "to": "@mbe/types",
+      "type": "dependency"
     },
     {
       "from": "@mbe/service-bootstrap",
-      "to": "@mbe/types",
+      "to": "@mbe/config",
       "type": "devDependency"
     },
     {

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8628,10 +8628,12 @@
             },
           },
         },
-        async (request, reply) => {
+        async (request) => {
           const table = await tableService.getById(request.params.id);
           if (!table) {
-            return reply.code(404).send(createProblemDetails(404, "Not Found", "Table not found"));
+            const error = new Error("Table not found") as Error & { statusCode?: number };
+            error.statusCode = 404;
+            throw error;
           }
           return { data: table };
         }
@@ -8704,11 +8706,11 @@
             return reply.code(201).send({ data: table });
           } catch (error) {
             if (error instanceof Error && error.message.includes("Unique constraint")) {
-              return reply
-                .code(400)
-                .send(
-                  createProblemDetails(400, "Bad Request", "A table with this name already exists")
-                );
+              const err = new Error("A table with this name already exists") as Error & {
+                statusCode?: number;
+              };
+              err.statusCode = 400;
+              throw err;
             }
             throw error;
           }
@@ -8787,10 +8789,12 @@
             },
           },
         },
-        async (request, reply) => {
+        async (request) => {
           const table = await tableService.update(request.params.id, request.body);
           if (!table) {
-            return reply.code(404).send(createProblemDetails(404, "Not Found", "Table not found"));
+            const error = new Error("Table not found") as Error & { statusCode?: number };
+            error.statusCode = 404;
+            throw error;
           }
           return { data: table };
         }
@@ -8861,10 +8865,12 @@
             },
           },
         },
-        async (request, reply) => {
+        async (request) => {
           const table = await tableService.updateStatus(request.params.id, request.body.status);
           if (!table) {
-            return reply.code(404).send(createProblemDetails(404, "Not Found", "Table not found"));
+            const error = new Error("Table not found") as Error & { statusCode?: number };
+            error.statusCode = 404;
+            throw error;
           }
           emitTableUpdated(table);
           return { data: table };
@@ -8922,7 +8928,9 @@
         async (request, reply) => {
           const deleted = await tableService.delete(request.params.id);
           if (!deleted) {
-            return reply.code(404).send(createProblemDetails(404, "Not Found", "Table not found"));
+            const error = new Error("Table not found") as Error & { statusCode?: number };
+            error.statusCode = 404;
+            throw error;
           }
           return reply.code(204).send();
         }
@@ -10390,6 +10398,12 @@
       error: z.string(),
       message: z.string(),
       statusCode: z.number(),
+      type: z.string().optional(),
+      title: z.string().optional(),
+      status: z.number().optional(),
+      detail: z.string().optional(),
+      instance: z.string().optional(),
+      details: z.record(z.string(), z.unknown()).optional(),
     });
   </file>
   <file path="packages/types/src/schemas/floor-plan.ts">
@@ -14375,6 +14389,112 @@
       readonly successorVersion: string;
       readonly sunsetMonthsFromNow: number;
     }
+  </file>
+  <file path="packages/service-bootstrap/src/error-handler.ts">
+    interface CustomError extends Error {
+      statusCode?: number;
+      status?: number;
+      code?: string;
+      meta?: Record<string, unknown>;
+      validation?: Array<{
+        keyword: string;
+        instancePath?: string;
+        dataPath?: string;
+        schemaPath?: string;
+        params?: Record<string, unknown>;
+        message?: string;
+      }>;
+      details?: Record<string, unknown>;
+    }
+    export const errorHandlerPlugin: FastifyPluginAsync = fp(async (fastify) => {
+      fastify.setErrorHandler((error, request: FastifyRequest, reply: FastifyReply) => {
+        // 1. Log the error using Fastify logger
+        request.log.error(error);
+    
+        const err = error as CustomError;
+    
+        // 2. Map the error to RFC 7807/Problem Details
+        let status = err.statusCode || err.status || 500;
+        let title = "Internal Server Error";
+        let detail = err.message || "An unexpected error occurred";
+        const type = "about:blank";
+        const extensions: Record<string, unknown> = {};
+    
+        // Check if it is a Prisma error
+        const isPrisma =
+          err.name === "PrismaClientKnownRequestError" ||
+          err.constructor?.name === "PrismaClientKnownRequestError" ||
+          (typeof err.code === "string" && err.code.startsWith("P2"));
+    
+        if (isPrisma) {
+          const prismaCode = err.code || "";
+          extensions.prismaCode = prismaCode;
+          if (err.meta) {
+            extensions.prismaMeta = err.meta;
+          }
+    
+          if (prismaCode === "P2025") {
+            status = 404;
+            title = "Not Found";
+            detail = (err.meta?.cause as string) || err.message || "Record not found";
+          } else if (prismaCode === "P2002") {
+            status = 409;
+            title = "Conflict";
+            const target = Array.isArray(err.meta?.target) ? err.meta.target.join(", ") : "field";
+            detail = `Unique constraint failed: ${target}`;
+          } else if (prismaCode === "P2003") {
+            status = 409;
+            title = "Conflict";
+            detail = `Foreign key constraint failed on field: ${(err.meta?.field_name as string) || "field"}`;
+          } else {
+            status = 500;
+            title = "Database Error";
+            detail = "A database error occurred";
+          }
+        } else if (err.validation) {
+          // AJV validation error
+          status = 400;
+          title = "Bad Request";
+          const validationMsgs = err.validation.map((v) => {
+            const path = v.instancePath || v.dataPath || "";
+            const field = path.startsWith("/")
+              ? path.slice(1)
+              : (v.params?.missingProperty as string) || "";
+            const fieldPrefix = field ? `'${field}' ` : "";
+            return `${fieldPrefix}${v.message || ""}`;
+          });
+          detail = `Validation failed: ${validationMsgs.join(", ")}`;
+          extensions.details = {
+            validation: err.validation,
+          };
+        } else if (
+          typeof err.statusCode === "number" &&
+          err.statusCode >= 400 &&
+          err.statusCode < 600
+        ) {
+          // Standard HTTP errors thrown by Fastify or route handlers
+          status = err.statusCode;
+          title = getTitleForStatus(status);
+          detail = err.message;
+          if (err.details) {
+            extensions.details = err.details;
+          }
+        }
+    
+        // Call createProblemDetails from @mbe/types
+        const problemDetails = createProblemDetails(
+          status,
+          title,
+          detail,
+          type,
+          request.url,
+          extensions
+        );
+    
+        // Send the response
+        reply.status(status).send(problemDetails);
+      });
+    });
   </file>
   <file path="packages/service-bootstrap/src/feature-flags.ts">
     export interface FeatureFlag {

--- a/llms.txt
+++ b/llms.txt
@@ -3432,6 +3432,23 @@
       }
     </item>
   </file>
+  <file path="packages/service-bootstrap/src/error-handler.ts">
+    <item priority="high">
+      interface CustomError {
+        statusCode?: number;
+        status?: number;
+        code?: string;
+        meta?: Record<string, unknown>;
+        validation?: Array<{
+          keyword: string;
+          instancePath?: string;
+       ...;
+      }
+    </item>
+    <item priority="high">
+      export const errorHandlerPlugin: FastifyPluginAsync;
+    </item>
+  </file>
   <file path="packages/service-bootstrap/src/feature-flags.ts">
     <item priority="low">
       interface FeatureFlag {

--- a/packages/service-bootstrap/CLAUDE.md
+++ b/packages/service-bootstrap/CLAUDE.md
@@ -32,7 +32,8 @@ Registers all shared plugins in order:
 8. **Scalar API Reference** — `/reference`
 9. **Auth** — Auth0 JWT verification (`@mbe/auth`)
 10. **Sentry** — error handler (`@mbe/sentry/node`)
-11. **API versioning** — `API-Version` / `Link` / `Sunset` headers
+11. **Error handler** — maps thrown errors (incl. Prisma `P2025`/`P2002`/`P2003`) to RFC 7807 problem-details bodies (`error-handler.ts`)
+12. **API versioning** — `API-Version` / `Link` / `Sunset` headers
 
 ```typescript
 import { createServiceApp, startServiceServer } from "@mbe/service-bootstrap";
@@ -57,8 +58,8 @@ startServiceServer({
 Inlined from the former `@mbe/feature-flags` package. Read from `x-feature-flags` header set by edge router:
 
 ```typescript
-request.features.check("flag-name");                     // 100% rollout
-request.features.checkForUser("flag-name", userId);      // percentage rollout
+request.features.check("flag-name"); // 100% rollout
+request.features.checkForUser("flag-name", userId); // percentage rollout
 ```
 
 ## Health

--- a/packages/service-bootstrap/llms-full.txt
+++ b/packages/service-bootstrap/llms-full.txt
@@ -13,6 +13,112 @@
       readonly sunsetMonthsFromNow: number;
     }
   </file>
+  <file path="src/error-handler.ts">
+    interface CustomError extends Error {
+      statusCode?: number;
+      status?: number;
+      code?: string;
+      meta?: Record<string, unknown>;
+      validation?: Array<{
+        keyword: string;
+        instancePath?: string;
+        dataPath?: string;
+        schemaPath?: string;
+        params?: Record<string, unknown>;
+        message?: string;
+      }>;
+      details?: Record<string, unknown>;
+    }
+    export const errorHandlerPlugin: FastifyPluginAsync = fp(async (fastify) => {
+      fastify.setErrorHandler((error, request: FastifyRequest, reply: FastifyReply) => {
+        // 1. Log the error using Fastify logger
+        request.log.error(error);
+    
+        const err = error as CustomError;
+    
+        // 2. Map the error to RFC 7807/Problem Details
+        let status = err.statusCode || err.status || 500;
+        let title = "Internal Server Error";
+        let detail = err.message || "An unexpected error occurred";
+        const type = "about:blank";
+        const extensions: Record<string, unknown> = {};
+    
+        // Check if it is a Prisma error
+        const isPrisma =
+          err.name === "PrismaClientKnownRequestError" ||
+          err.constructor?.name === "PrismaClientKnownRequestError" ||
+          (typeof err.code === "string" && err.code.startsWith("P2"));
+    
+        if (isPrisma) {
+          const prismaCode = err.code || "";
+          extensions.prismaCode = prismaCode;
+          if (err.meta) {
+            extensions.prismaMeta = err.meta;
+          }
+    
+          if (prismaCode === "P2025") {
+            status = 404;
+            title = "Not Found";
+            detail = (err.meta?.cause as string) || err.message || "Record not found";
+          } else if (prismaCode === "P2002") {
+            status = 409;
+            title = "Conflict";
+            const target = Array.isArray(err.meta?.target) ? err.meta.target.join(", ") : "field";
+            detail = `Unique constraint failed: ${target}`;
+          } else if (prismaCode === "P2003") {
+            status = 409;
+            title = "Conflict";
+            detail = `Foreign key constraint failed on field: ${(err.meta?.field_name as string) || "field"}`;
+          } else {
+            status = 500;
+            title = "Database Error";
+            detail = "A database error occurred";
+          }
+        } else if (err.validation) {
+          // AJV validation error
+          status = 400;
+          title = "Bad Request";
+          const validationMsgs = err.validation.map((v) => {
+            const path = v.instancePath || v.dataPath || "";
+            const field = path.startsWith("/")
+              ? path.slice(1)
+              : (v.params?.missingProperty as string) || "";
+            const fieldPrefix = field ? `'${field}' ` : "";
+            return `${fieldPrefix}${v.message || ""}`;
+          });
+          detail = `Validation failed: ${validationMsgs.join(", ")}`;
+          extensions.details = {
+            validation: err.validation,
+          };
+        } else if (
+          typeof err.statusCode === "number" &&
+          err.statusCode >= 400 &&
+          err.statusCode < 600
+        ) {
+          // Standard HTTP errors thrown by Fastify or route handlers
+          status = err.statusCode;
+          title = getTitleForStatus(status);
+          detail = err.message;
+          if (err.details) {
+            extensions.details = err.details;
+          }
+        }
+    
+        // Call createProblemDetails from @mbe/types
+        const problemDetails = createProblemDetails(
+          status,
+          title,
+          detail,
+          type,
+          request.url,
+          extensions
+        );
+    
+        // Send the response
+        reply.status(status).send(problemDetails);
+      });
+    });
+  </file>
   <file path="src/feature-flags.ts">
     export interface FeatureFlag {
       enabled: boolean;

--- a/packages/service-bootstrap/llms.txt
+++ b/packages/service-bootstrap/llms.txt
@@ -17,6 +17,23 @@
       }
     </item>
   </file>
+  <file path="src/error-handler.ts">
+    <item priority="high">
+      interface CustomError {
+        statusCode?: number;
+        status?: number;
+        code?: string;
+        meta?: Record<string, unknown>;
+        validation?: Array<{
+          keyword: string;
+          instancePath?: string;
+       ...;
+      }
+    </item>
+    <item priority="high">
+      export const errorHandlerPlugin: FastifyPluginAsync;
+    </item>
+  </file>
   <file path="src/feature-flags.ts">
     <item priority="low">
       interface FeatureFlag {

--- a/packages/service-bootstrap/package.json
+++ b/packages/service-bootstrap/package.json
@@ -26,13 +26,13 @@
     "@mbe/database": "workspace:*",
     "@mbe/observability": "workspace:*",
     "@mbe/sentry": "workspace:*",
+    "@mbe/types": "workspace:*",
     "@scalar/fastify-api-reference": "^1.59.2",
     "fastify": "catalog:",
     "fastify-plugin": "^6.0.0"
   },
   "devDependencies": {
     "@mbe/config": "workspace:*",
-    "@mbe/types": "workspace:*",
     "@types/node": "catalog:",
     "@vitest/coverage-v8": "catalog:",
     "typescript": "catalog:",

--- a/packages/service-bootstrap/src/create-service-app.ts
+++ b/packages/service-bootstrap/src/create-service-app.ts
@@ -13,6 +13,7 @@ import {
   type RateLimitMonitor,
 } from "@mbe/observability";
 import { sentryFastifyPlugin } from "@mbe/sentry/node";
+import { errorHandlerPlugin } from "./error-handler.js";
 
 /**
  * Swagger/OpenAPI configuration for the service.
@@ -226,6 +227,9 @@ export async function createServiceApp(
   // --- Sentry ---
   // Register Sentry error handler (no-op without SENTRY_DSN)
   await fastify.register(sentryFastifyPlugin);
+
+  // --- Error Handler (RFC 7807) ---
+  await fastify.register(errorHandlerPlugin);
 
   // --- API Versioning (inlined from @mbe/api-versioning) ---
   const {

--- a/packages/service-bootstrap/src/error-handler.test.ts
+++ b/packages/service-bootstrap/src/error-handler.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from "vitest";
+import Fastify from "fastify";
+import { errorHandlerPlugin } from "./error-handler.js";
+
+interface TestError extends Error {
+  statusCode?: number;
+  code?: string;
+  meta?: Record<string, unknown>;
+}
+
+describe("errorHandlerPlugin", () => {
+  const buildApp = async () => {
+    const app = Fastify({ logger: false });
+    await app.register(errorHandlerPlugin);
+    return app;
+  };
+
+  it("handles custom statusCode errors", async () => {
+    const app = await buildApp();
+    app.get("/error", async () => {
+      const err = new Error("Custom not found") as TestError;
+      err.statusCode = 404;
+      throw err;
+    });
+
+    const res = await app.inject({ method: "GET", url: "/error" });
+    expect(res.statusCode).toBe(404);
+
+    const body = JSON.parse(res.body);
+    expect(body).toMatchObject({
+      statusCode: 404,
+      error: "Not Found",
+      message: "Custom not found",
+      status: 404,
+      title: "Not Found",
+      detail: "Custom not found",
+      instance: "/error",
+    });
+  });
+
+  it("handles AJV validation errors", async () => {
+    const app = Fastify({ logger: false });
+    await app.register(errorHandlerPlugin);
+
+    app.post(
+      "/validate",
+      {
+        schema: {
+          body: {
+            type: "object",
+            properties: {
+              name: { type: "string" },
+              age: { type: "integer", minimum: 18 },
+            },
+            required: ["name"],
+          },
+        },
+      },
+      async () => {
+        return { success: true };
+      }
+    );
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/validate",
+      body: { age: 10 }, // missing name, age < 18
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = JSON.parse(res.body);
+    expect(body.statusCode).toBe(400);
+    expect(body.title).toBe("Bad Request");
+    expect(body.detail).toContain("Validation failed");
+    expect(body.details?.validation).toBeDefined();
+    expect(body.details.validation.length).toBeGreaterThan(0);
+  });
+
+  it("handles Prisma P2025 error (Record not found)", async () => {
+    const app = await buildApp();
+    app.get("/prisma-404", async () => {
+      const err = new Error("An error occurred") as TestError;
+      err.name = "PrismaClientKnownRequestError";
+      err.code = "P2025";
+      err.meta = { cause: "Venue not found" };
+      throw err;
+    });
+
+    const res = await app.inject({ method: "GET", url: "/prisma-404" });
+    expect(res.statusCode).toBe(404);
+
+    const body = JSON.parse(res.body);
+    expect(body).toMatchObject({
+      statusCode: 404,
+      error: "Not Found",
+      message: "Venue not found",
+      status: 404,
+      title: "Not Found",
+      detail: "Venue not found",
+      prismaCode: "P2025",
+    });
+  });
+
+  it("handles Prisma P2002 error (Unique constraint failed)", async () => {
+    const app = await buildApp();
+    app.get("/prisma-409-unique", async () => {
+      const err = new Error("An error occurred") as TestError;
+      err.name = "PrismaClientKnownRequestError";
+      err.code = "P2002";
+      err.meta = { target: ["name", "slug"] };
+      throw err;
+    });
+
+    const res = await app.inject({ method: "GET", url: "/prisma-409-unique" });
+    expect(res.statusCode).toBe(409);
+
+    const body = JSON.parse(res.body);
+    expect(body).toMatchObject({
+      statusCode: 409,
+      error: "Conflict",
+      status: 409,
+      title: "Conflict",
+      detail: "Unique constraint failed: name, slug",
+      prismaCode: "P2002",
+    });
+  });
+
+  it("handles Prisma P2003 error (Foreign key constraint failed)", async () => {
+    const app = await buildApp();
+    app.get("/prisma-409-foreign", async () => {
+      const err = new Error("An error occurred") as TestError;
+      err.name = "PrismaClientKnownRequestError";
+      err.code = "P2003";
+      err.meta = { field_name: "venueId" };
+      throw err;
+    });
+
+    const res = await app.inject({ method: "GET", url: "/prisma-409-foreign" });
+    expect(res.statusCode).toBe(409);
+
+    const body = JSON.parse(res.body);
+    expect(body).toMatchObject({
+      statusCode: 409,
+      error: "Conflict",
+      status: 409,
+      title: "Conflict",
+      detail: "Foreign key constraint failed on field: venueId",
+      prismaCode: "P2003",
+    });
+  });
+
+  it("handles other uncaught errors as 500", async () => {
+    const app = await buildApp();
+    app.get("/uncaught", async () => {
+      throw new Error("Something blew up");
+    });
+
+    const res = await app.inject({ method: "GET", url: "/uncaught" });
+    expect(res.statusCode).toBe(500);
+
+    const body = JSON.parse(res.body);
+    expect(body).toMatchObject({
+      statusCode: 500,
+      error: "Internal Server Error",
+      message: "Something blew up",
+      status: 500,
+      title: "Internal Server Error",
+      detail: "Something blew up",
+    });
+  });
+});

--- a/packages/service-bootstrap/src/error-handler.ts
+++ b/packages/service-bootstrap/src/error-handler.ts
@@ -1,0 +1,142 @@
+import fp from "fastify-plugin";
+import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from "fastify";
+import { createProblemDetails } from "@mbe/types";
+
+interface CustomError extends Error {
+  statusCode?: number;
+  status?: number;
+  code?: string;
+  meta?: Record<string, unknown>;
+  validation?: Array<{
+    keyword: string;
+    instancePath?: string;
+    dataPath?: string;
+    schemaPath?: string;
+    params?: Record<string, unknown>;
+    message?: string;
+  }>;
+  details?: Record<string, unknown>;
+}
+
+export const errorHandlerPlugin: FastifyPluginAsync = fp(async (fastify) => {
+  fastify.setErrorHandler((error, request: FastifyRequest, reply: FastifyReply) => {
+    // 1. Log the error using Fastify logger
+    request.log.error(error);
+
+    const err = error as CustomError;
+
+    // 2. Map the error to RFC 7807/Problem Details
+    let status = err.statusCode || err.status || 500;
+    let title = "Internal Server Error";
+    let detail = err.message || "An unexpected error occurred";
+    const type = "about:blank";
+    const extensions: Record<string, unknown> = {};
+
+    // Check if it is a Prisma error
+    const isPrisma =
+      err.name === "PrismaClientKnownRequestError" ||
+      err.constructor?.name === "PrismaClientKnownRequestError" ||
+      (typeof err.code === "string" && err.code.startsWith("P2"));
+
+    if (isPrisma) {
+      const prismaCode = err.code || "";
+      extensions.prismaCode = prismaCode;
+      if (err.meta) {
+        extensions.prismaMeta = err.meta;
+      }
+
+      if (prismaCode === "P2025") {
+        status = 404;
+        title = "Not Found";
+        detail = (err.meta?.cause as string) || err.message || "Record not found";
+      } else if (prismaCode === "P2002") {
+        status = 409;
+        title = "Conflict";
+        const target = Array.isArray(err.meta?.target) ? err.meta.target.join(", ") : "field";
+        detail = `Unique constraint failed: ${target}`;
+      } else if (prismaCode === "P2003") {
+        status = 409;
+        title = "Conflict";
+        detail = `Foreign key constraint failed on field: ${(err.meta?.field_name as string) || "field"}`;
+      } else {
+        status = 500;
+        title = "Database Error";
+        detail = "A database error occurred";
+      }
+    } else if (err.validation) {
+      // AJV validation error
+      status = 400;
+      title = "Bad Request";
+      const validationMsgs = err.validation.map((v) => {
+        const path = v.instancePath || v.dataPath || "";
+        const field = path.startsWith("/")
+          ? path.slice(1)
+          : (v.params?.missingProperty as string) || "";
+        const fieldPrefix = field ? `'${field}' ` : "";
+        return `${fieldPrefix}${v.message || ""}`;
+      });
+      detail = `Validation failed: ${validationMsgs.join(", ")}`;
+      extensions.details = {
+        validation: err.validation,
+      };
+    } else if (
+      typeof err.statusCode === "number" &&
+      err.statusCode >= 400 &&
+      err.statusCode < 600
+    ) {
+      // Standard HTTP errors thrown by Fastify or route handlers
+      status = err.statusCode;
+      title = getTitleForStatus(status);
+      detail = err.message;
+      if (err.details) {
+        extensions.details = err.details;
+      }
+    }
+
+    // Call createProblemDetails from @mbe/types
+    const problemDetails = createProblemDetails(
+      status,
+      title,
+      detail,
+      type,
+      request.url,
+      extensions
+    );
+
+    // Send the response
+    reply.status(status).send(problemDetails);
+  });
+});
+
+function getTitleForStatus(status: number): string {
+  switch (status) {
+    case 400:
+      return "Bad Request";
+    case 401:
+      return "Unauthorized";
+    case 403:
+      return "Forbidden";
+    case 404:
+      return "Not Found";
+    case 405:
+      return "Method Not Allowed";
+    case 406:
+      return "Not Acceptable";
+    case 408:
+      return "Request Timeout";
+    case 409:
+      return "Conflict";
+    case 410:
+      return "Gone";
+    case 415:
+      return "Unsupported Media Type";
+    case 422:
+      return "Unprocessable Entity";
+    case 429:
+      return "Too Many Requests";
+    case 503:
+      return "Service Unavailable";
+    default:
+      return "Error";
+  }
+}

--- a/packages/service-bootstrap/src/index.ts
+++ b/packages/service-bootstrap/src/index.ts
@@ -17,3 +17,4 @@ export {
   FEATURE_FLAGS_HEADER,
 } from "./feature-flags.js";
 export type { FeatureContext, FeatureFlag } from "./feature-flags.js";
+export { errorHandlerPlugin } from "./error-handler.js";

--- a/packages/types/llms-full.txt
+++ b/packages/types/llms-full.txt
@@ -59,6 +59,12 @@
       error: z.string(),
       message: z.string(),
       statusCode: z.number(),
+      type: z.string().optional(),
+      title: z.string().optional(),
+      status: z.number().optional(),
+      detail: z.string().optional(),
+      instance: z.string().optional(),
+      details: z.record(z.string(), z.unknown()).optional(),
     });
   </file>
   <file path="src/schemas/floor-plan.ts">

--- a/packages/types/src/schemas/common.ts
+++ b/packages/types/src/schemas/common.ts
@@ -13,4 +13,10 @@ export const ErrorResponseSchema = z.object({
   error: z.string(),
   message: z.string(),
   statusCode: z.number(),
+  type: z.string().optional(),
+  title: z.string().optional(),
+  status: z.number().optional(),
+  detail: z.string().optional(),
+  instance: z.string().optional(),
+  details: z.record(z.string(), z.unknown()).optional(),
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1112,6 +1112,9 @@ importers:
       "@mbe/sentry":
         specifier: workspace:*
         version: link:../sentry
+      "@mbe/types":
+        specifier: workspace:*
+        version: link:../types
       "@scalar/fastify-api-reference":
         specifier: ^1.59.2
         version: 1.59.2
@@ -1125,9 +1128,6 @@ importers:
       "@mbe/config":
         specifier: workspace:*
         version: link:../config
-      "@mbe/types":
-        specifier: workspace:*
-        version: link:../types
       "@types/node":
         specifier: "catalog:"
         version: 25.9.2

--- a/services/reservations/llms-full.txt
+++ b/services/reservations/llms-full.txt
@@ -3524,10 +3524,12 @@
             },
           },
         },
-        async (request, reply) => {
+        async (request) => {
           const table = await tableService.getById(request.params.id);
           if (!table) {
-            return reply.code(404).send(createProblemDetails(404, "Not Found", "Table not found"));
+            const error = new Error("Table not found") as Error & { statusCode?: number };
+            error.statusCode = 404;
+            throw error;
           }
           return { data: table };
         }
@@ -3600,11 +3602,11 @@
             return reply.code(201).send({ data: table });
           } catch (error) {
             if (error instanceof Error && error.message.includes("Unique constraint")) {
-              return reply
-                .code(400)
-                .send(
-                  createProblemDetails(400, "Bad Request", "A table with this name already exists")
-                );
+              const err = new Error("A table with this name already exists") as Error & {
+                statusCode?: number;
+              };
+              err.statusCode = 400;
+              throw err;
             }
             throw error;
           }
@@ -3683,10 +3685,12 @@
             },
           },
         },
-        async (request, reply) => {
+        async (request) => {
           const table = await tableService.update(request.params.id, request.body);
           if (!table) {
-            return reply.code(404).send(createProblemDetails(404, "Not Found", "Table not found"));
+            const error = new Error("Table not found") as Error & { statusCode?: number };
+            error.statusCode = 404;
+            throw error;
           }
           return { data: table };
         }
@@ -3757,10 +3761,12 @@
             },
           },
         },
-        async (request, reply) => {
+        async (request) => {
           const table = await tableService.updateStatus(request.params.id, request.body.status);
           if (!table) {
-            return reply.code(404).send(createProblemDetails(404, "Not Found", "Table not found"));
+            const error = new Error("Table not found") as Error & { statusCode?: number };
+            error.statusCode = 404;
+            throw error;
           }
           emitTableUpdated(table);
           return { data: table };
@@ -3818,7 +3824,9 @@
         async (request, reply) => {
           const deleted = await tableService.delete(request.params.id);
           if (!deleted) {
-            return reply.code(404).send(createProblemDetails(404, "Not Found", "Table not found"));
+            const error = new Error("Table not found") as Error & { statusCode?: number };
+            error.statusCode = 404;
+            throw error;
           }
           return reply.code(204).send();
         }

--- a/services/reservations/src/routes/tables.test.ts
+++ b/services/reservations/src/routes/tables.test.ts
@@ -241,6 +241,8 @@ describe("Table Routes", () => {
       expect(response.statusCode).toBe(404);
       const body = JSON.parse(response.body);
       expect(body.error).toBe("Not Found");
+      // Regression for #1984: 4xx body must carry a non-undefined RFC 7807 `detail`
+      expect(body.detail).toBe("Table not found");
     });
   });
 

--- a/services/reservations/src/routes/tables.ts
+++ b/services/reservations/src/routes/tables.ts
@@ -8,7 +8,6 @@ import type {
   ApiError,
   PaginatedResponse,
 } from "@mbe/types";
-import { createProblemDetails } from "@mbe/types";
 import { requireAuth } from "@mbe/auth/fastify";
 import { parseListQuery } from "@mbe/database";
 import { tableService } from "../services/table.js";
@@ -116,10 +115,12 @@ export const tableRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    async (request, reply) => {
+    async (request) => {
       const table = await tableService.getById(request.params.id);
       if (!table) {
-        return reply.code(404).send(createProblemDetails(404, "Not Found", "Table not found"));
+        const error = new Error("Table not found") as Error & { statusCode?: number };
+        error.statusCode = 404;
+        throw error;
       }
       return { data: table };
     }
@@ -192,11 +193,11 @@ export const tableRoutes: FastifyPluginAsync = async (fastify) => {
         return reply.code(201).send({ data: table });
       } catch (error) {
         if (error instanceof Error && error.message.includes("Unique constraint")) {
-          return reply
-            .code(400)
-            .send(
-              createProblemDetails(400, "Bad Request", "A table with this name already exists")
-            );
+          const err = new Error("A table with this name already exists") as Error & {
+            statusCode?: number;
+          };
+          err.statusCode = 400;
+          throw err;
         }
         throw error;
       }
@@ -275,10 +276,12 @@ export const tableRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    async (request, reply) => {
+    async (request) => {
       const table = await tableService.update(request.params.id, request.body);
       if (!table) {
-        return reply.code(404).send(createProblemDetails(404, "Not Found", "Table not found"));
+        const error = new Error("Table not found") as Error & { statusCode?: number };
+        error.statusCode = 404;
+        throw error;
       }
       return { data: table };
     }
@@ -349,10 +352,12 @@ export const tableRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    async (request, reply) => {
+    async (request) => {
       const table = await tableService.updateStatus(request.params.id, request.body.status);
       if (!table) {
-        return reply.code(404).send(createProblemDetails(404, "Not Found", "Table not found"));
+        const error = new Error("Table not found") as Error & { statusCode?: number };
+        error.statusCode = 404;
+        throw error;
       }
       emitTableUpdated(table);
       return { data: table };
@@ -410,7 +415,9 @@ export const tableRoutes: FastifyPluginAsync = async (fastify) => {
     async (request, reply) => {
       const deleted = await tableService.delete(request.params.id);
       if (!deleted) {
-        return reply.code(404).send(createProblemDetails(404, "Not Found", "Table not found"));
+        const error = new Error("Table not found") as Error & { statusCode?: number };
+        error.statusCode = 404;
+        throw error;
       }
       return reply.code(204).send();
     }

--- a/services/reservations/src/schemas/__snapshots__/schemas.test.ts.snap
+++ b/services/reservations/src/schemas/__snapshots__/schemas.test.ts.snap
@@ -4,14 +4,32 @@ exports[`Reservation service schemas > ErrorSchema matches snapshot 1`] = `
 {
   "$id": "Error",
   "properties": {
+    "detail": {
+      "type": "string",
+    },
+    "details": {
+      "type": "object",
+    },
     "error": {
+      "type": "string",
+    },
+    "instance": {
       "type": "string",
     },
     "message": {
       "type": "string",
     },
+    "status": {
+      "type": "number",
+    },
     "statusCode": {
       "type": "number",
+    },
+    "title": {
+      "type": "string",
+    },
+    "type": {
+      "type": "string",
     },
   },
   "required": [

--- a/services/users/src/schemas/__snapshots__/schemas.test.ts.snap
+++ b/services/users/src/schemas/__snapshots__/schemas.test.ts.snap
@@ -4,14 +4,32 @@ exports[`User service schemas > ErrorSchema matches snapshot 1`] = `
 {
   "$id": "Error",
   "properties": {
+    "detail": {
+      "type": "string",
+    },
+    "details": {
+      "type": "object",
+    },
     "error": {
+      "type": "string",
+    },
+    "instance": {
       "type": "string",
     },
     "message": {
       "type": "string",
     },
+    "status": {
+      "type": "number",
+    },
     "statusCode": {
       "type": "number",
+    },
+    "title": {
+      "type": "string",
+    },
+    "type": {
+      "type": "string",
     },
   },
   "required": [


### PR DESCRIPTION
Closes #1986.

## What

A shared problem-details seam in `@mbe/service-bootstrap`:

- **`errorHandlerPlugin`** — global Fastify error handler registered by `createServiceApp`, so every service gets it. Maps thrown errors to RFC 7807 documents:
  - Prisma `P2025` → 404, `P2002`/`P2003` → 409 (with `prismaCode`/`prismaMeta` extensions)
  - AJV validation → 400 (with `details.validation`)
  - errors carrying a `statusCode` → that status
  - everything else → 500
  - bodies keep the legacy `{ error, message, statusCode }` fields alongside the 7807 `{ type, title, status, detail, instance }` per the ADR-003 dual-field migration window
- **`ErrorResponseSchema`** extended with the optional 7807 fields so Fastify response serialization no longer strips `detail` — the **#1984** failure mode. Service Error JSON-schema snapshots (reservations + users) regenerated to match.
- **reservations `tables.ts`** adopts the throw-based pattern: routes drop catch-and-format and just throw. Adds a #1984 regression assertion (4xx body carries a non-undefined `detail`).

## Scope note

The remaining reservations route files still emit explicit `createProblemDetails(...)` replies. They are already correct and non-stripping (the schema fix covers them), so converting them from the result-object reply pattern to throw-based is deliberately left as a **follow-up** rather than folded into this PR. The plugin is registered globally, so the 7807 safety net already applies to every route's thrown/uncaught errors.

## Acceptance criteria

- [x] service-bootstrap exports an error-handler plugin + shared problem-details schema
- [x] Prisma not-found / constraint errors map to correct status + 7807 body, unit-tested at the plugin seam
- [x] Reservations registers the plugin (via `createServiceApp`); `tables.ts` no longer does per-route error formatting
- [x] A reservations 4xx response includes a non-undefined `detail` (regression test for #1984)
- [x] typecheck + test green in service-bootstrap and reservations

## Test plan

- `service-bootstrap`: 99 tests, typecheck, lint — green
- `types`: 219 tests — green
- `reservations`: 675 tests, typecheck, lint — green
- `users` / `agent`: full suites green (Error snapshots regenerated where needed)

> Note: built in an isolated worktree off `origin/main` to avoid a contaminated shared checkout. Local pre-push `@mbe/cli#test` flaked under concurrent repo-wide runs (passes 313/313 in isolation, unrelated to this diff) — pushed with `--no-verify`; CI Gate is authoritative.