### PR TITLE
feat: accessibility CI failure gate + PR comments for AI-generated code (#2183)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,13 +284,48 @@ jobs:
 
       - name: Run a11y tests (accessibility vitest)
         run: pnpm --dir packages/rialto vitest run --reporter=json --outputFile=../../a11y-results.json src/test/accessibility src/test/token-contrast.test.ts # accessibility
-        continue-on-error: true
 
-      - name: Process results for attribution
-        run: node scripts/process-a11y-results.js || true
+      - name: Process results and fail on agent violations
+        if: always()
+        run: node scripts/process-a11y-results.mjs
         env:
           GITHUB_HEAD_REF: ${{ github.head_ref }}
           GITHUB_ACTOR: ${{ github.actor }}
+
+      - name: Comment a11y violations on PR
+        if: failure()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const violationsFile = 'a11y-violations.json';
+            if (!fs.existsSync(violationsFile)) return;
+            const entry = JSON.parse(fs.readFileSync(violationsFile, 'utf8'));
+            if (!entry.violations || entry.violations.length === 0) return;
+
+            const rows = entry.violations
+              .map(v => `| ${v.name.replace(/\|/g, '\\|')} | ${v.error.split('\n')[0].replace(/\|/g, '\\|')} |`)
+              .join('\n');
+
+            const body = [
+              '## Accessibility violations detected in AI-generated code',
+              '',
+              `**Branch:** \`${entry.branch}\`  `,
+              `**Failures:** ${entry.numFailures} of ${entry.numTests} tests`,
+              '',
+              '| Test | Error |',
+              '|------|-------|',
+              rows,
+              '',
+              'Fix these violations before merging. Run `pnpm --dir packages/rialto vitest run src/test/accessibility` locally to reproduce.',
+            ].join('\n');
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body,
+            });
 
   test:
     name: Test (Node ${{ matrix.node-version }})

--- a/scripts/__tests__/process-a11y-results.test.mjs
+++ b/scripts/__tests__/process-a11y-results.test.mjs
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { buildEntry, extractViolations, shouldFailBuild } from "../process-a11y-results.mjs";
+
+const AGENT_BRANCH = "worktree-agent-abc123";
+const HUMAN_BRANCH = "feat/new-component";
+
+const PASSING_RESULTS = {
+  numTotalTests: 28,
+  numPassedTests: 28,
+  numFailedTests: 0,
+  testResults: [],
+};
+
+const FAILING_RESULTS = {
+  numTotalTests: 28,
+  numPassedTests: 27,
+  numFailedTests: 1,
+  testResults: [
+    {
+      assertionResults: [
+        {
+          status: "failed",
+          fullName: "Accessibility — General Components Button",
+          failureMessages: ["Expected no violations but found 1: aria-label"],
+        },
+        {
+          status: "passed",
+          fullName: "Accessibility — General Components Alert",
+          failureMessages: [],
+        },
+      ],
+    },
+  ],
+};
+
+describe("extractViolations", () => {
+  it("returns empty array when all tests pass", () => {
+    const violations = extractViolations(PASSING_RESULTS);
+    expect(violations).toHaveLength(0);
+  });
+
+  it("extracts failed tests as violations", () => {
+    const violations = extractViolations(FAILING_RESULTS);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].name).toBe("Accessibility — General Components Button");
+    expect(violations[0].error).toContain("aria-label");
+  });
+});
+
+describe("buildEntry", () => {
+  it("marks agent branches as isAgent=true", () => {
+    const entry = buildEntry(PASSING_RESULTS, AGENT_BRANCH, "github-actions[bot]");
+    expect(entry.isAgent).toBe(true);
+    expect(entry.branch).toBe(AGENT_BRANCH);
+  });
+
+  it("marks human branches as isAgent=false", () => {
+    const entry = buildEntry(PASSING_RESULTS, HUMAN_BRANCH, "matt");
+    expect(entry.isAgent).toBe(false);
+  });
+
+  it("marks actor with 'bot' suffix as agent", () => {
+    const entry = buildEntry(PASSING_RESULTS, HUMAN_BRANCH, "dependabot[bot]");
+    expect(entry.isAgent).toBe(true);
+  });
+
+  it("includes violation count in the entry", () => {
+    const entry = buildEntry(FAILING_RESULTS, AGENT_BRANCH, "github-actions[bot]");
+    expect(entry.numFailures).toBe(1);
+    expect(entry.violations).toHaveLength(1);
+  });
+
+  it("includes a timestamp", () => {
+    const entry = buildEntry(PASSING_RESULTS, AGENT_BRANCH, "github-actions[bot]");
+    expect(entry.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});
+
+describe("shouldFailBuild", () => {
+  it("returns false when all tests pass on an agent branch", () => {
+    const entry = buildEntry(PASSING_RESULTS, AGENT_BRANCH, "github-actions[bot]");
+    expect(shouldFailBuild(entry)).toBe(false);
+  });
+
+  it("returns true when there are failures on an agent branch", () => {
+    const entry = buildEntry(FAILING_RESULTS, AGENT_BRANCH, "github-actions[bot]");
+    expect(shouldFailBuild(entry)).toBe(true);
+  });
+
+  it("returns false when there are failures on a human branch", () => {
+    const entry = buildEntry(FAILING_RESULTS, HUMAN_BRANCH, "matt");
+    expect(shouldFailBuild(entry)).toBe(false);
+  });
+});

--- a/scripts/process-a11y-results.mjs
+++ b/scripts/process-a11y-results.mjs
@@ -1,0 +1,107 @@
+/**
+ * scripts/process-a11y-results.mjs
+ * Parses Vitest JSON output, segments violations by author type, and exits
+ * non-zero when AI-generated code introduces a11y regressions.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+const RESULTS_FILE = "a11y-results.json";
+const HISTORY_FILE = "metrics/a11y-history.jsonl";
+const VIOLATIONS_FILE = "a11y-violations.json";
+
+/**
+ * Extract failed assertions from Vitest JSON output.
+ * @param {{ testResults?: Array<{ assertionResults: Array<{ status: string, fullName: string, failureMessages: string[] }> }> }} results
+ * @returns {Array<{ name: string, error: string }>}
+ */
+export function extractViolations(results) {
+  if (!results.testResults) return [];
+  const violations = [];
+  for (const suite of results.testResults) {
+    for (const assertion of suite.assertionResults) {
+      if (assertion.status === "failed") {
+        violations.push({
+          name: assertion.fullName,
+          error: assertion.failureMessages[0] ?? "unknown error",
+        });
+      }
+    }
+  }
+  return violations;
+}
+
+/**
+ * Build a structured history entry from test results.
+ * @param {object} results - Vitest JSON output
+ * @param {string} branch - Git branch name
+ * @param {string} actor - GitHub actor
+ * @returns {object}
+ */
+export function buildEntry(results, branch, actor) {
+  const isAgent =
+    branch.startsWith("agent-") || branch.startsWith("worktree-agent-") || actor.includes("bot");
+
+  return {
+    timestamp: new Date().toISOString(),
+    branch,
+    actor,
+    isAgent,
+    numTests: results.numTotalTests,
+    numPasses: results.numPassedTests,
+    numFailures: results.numFailedTests,
+    violations: extractViolations(results),
+  };
+}
+
+/**
+ * Decide whether to fail the build based on the entry.
+ * Only agent branches fail on a11y violations; human branches are advisory.
+ * @param {{ isAgent: boolean, numFailures: number }} entry
+ * @returns {boolean}
+ */
+export function shouldFailBuild(entry) {
+  return entry.isAgent && entry.numFailures > 0;
+}
+
+function main() {
+  if (!fs.existsSync(RESULTS_FILE)) {
+    console.error(`Results file not found: ${RESULTS_FILE}`);
+    process.exit(1);
+  }
+
+  const results = JSON.parse(fs.readFileSync(RESULTS_FILE, "utf-8"));
+  const branch = process.env.GITHUB_HEAD_REF || "local";
+  const actor = process.env.GITHUB_ACTOR || "human";
+
+  const entry = buildEntry(results, branch, actor);
+
+  // Ensure metrics directory exists
+  const metricsDir = path.dirname(HISTORY_FILE);
+  if (!fs.existsSync(metricsDir)) {
+    fs.mkdirSync(metricsDir, { recursive: true });
+  }
+
+  fs.appendFileSync(HISTORY_FILE, JSON.stringify(entry) + "\n");
+
+  // Write structured violations file for the PR comment step
+  fs.writeFileSync(VIOLATIONS_FILE, JSON.stringify(entry, null, 2));
+
+  const type = entry.isAgent ? "agent" : "human";
+  console.log(`Processed a11y results for ${branch} (${type}): ${entry.numFailures} failures`);
+
+  if (shouldFailBuild(entry)) {
+    console.error(
+      `FAIL: ${entry.numFailures} accessibility violation(s) detected in AI-generated code.`
+    );
+    for (const v of entry.violations) {
+      console.error(`  - ${v.name}`);
+    }
+    process.exit(1);
+  }
+}
+
+// Only run when executed directly, not when imported by tests
+if (import.meta.url === new URL(process.argv[1], "file://").href) {
+  main();
+}


### PR DESCRIPTION
## Summary

- Refactors `scripts/process-a11y-results.js` → `process-a11y-results.mjs` with exported pure functions (`extractViolations`, `buildEntry`, `shouldFailBuild`) to enable unit testing
- Removes `continue-on-error: true` from the a11y vitest step in the `a11y-attribution` CI job so failures now block the job
- Adds a `github-script` step that posts a violation table as a PR comment when the job fails (agent branches only)
- Adds 10 unit tests covering agent/human branch detection, violation extraction, and the fail-build logic
- The ACMM criterion `acmm:accessibility-ai-check` grep detection pattern (`pnpm --dir packages/rialto vitest .* accessibility`) was already satisfied by the existing ci.yml line; this PR makes the implementation substantive (real failure + comment surfacing)

## Test plan

- [ ] `pnpm vitest run scripts/__tests__/process-a11y-results.test.mjs` — 10 tests pass
- [ ] `pnpm lint` — clean (no new errors)
- [ ] `pnpm typecheck` — clean
- [ ] `pnpm --filter @mbe/cli start check-adr && pnpm --filter @mbe/cli start check-deps` — no violations
- [ ] `node scripts/detect-instruction-rot.mjs` — no rot detected
- [ ] CI `a11y-attribution` job now fails (exit 1) when axe violations are found on agent branches
- [ ] CI posts a PR comment with a Markdown table of violations on failure

Closes #2183