### PR TITLE
feat(acmm): audit-freshness criterion + stale badge variant

### DIFF
--- a/plugins/acmm/scripts/__tests__/audit-freshness.test.js
+++ b/plugins/acmm/scripts/__tests__/audit-freshness.test.js
@@ -1,0 +1,115 @@
+/**
+ * Tests for the audit-freshness criterion.
+ *
+ * The criterion checks that the state file (.claude/acmm/state.json) is no
+ * older than 7 days. It uses an injectable `now` seam for deterministic tests.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { checkAuditFreshness, AUDIT_FRESHNESS_CRITERION } from "../audit-freshness.js";
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "acmm-freshness-"));
+  const stateDir = join(root, ".claude", "acmm");
+  mkdirSync(stateDir, { recursive: true });
+  return {
+    root,
+    writeState(lastRun) {
+      writeFileSync(
+        join(stateDir, "state.json"),
+        JSON.stringify({ lastRun, currentLevel: 6, checks: {}, history: [], issuesCreated: {} }),
+        "utf-8"
+      );
+    },
+    cleanup() {
+      rmSync(root, { recursive: true, force: true });
+    },
+  };
+}
+
+const NOW = new Date("2026-06-14T12:00:00.000Z");
+const FRESH = new Date("2026-06-10T12:00:00.000Z").toISOString(); // 4 days ago
+const EXACTLY_7_DAYS = new Date(NOW.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString();
+const STALE = new Date("2026-05-27T12:00:00.000Z").toISOString(); // 18 days ago
+
+// ── checkAuditFreshness ──────────────────────────────────────────────────────
+
+test("checkAuditFreshness: state file 4 days old → passes", () => {
+  const fx = fixture();
+  fx.writeState(FRESH);
+  const result = checkAuditFreshness(fx.root, { now: NOW });
+  assert.equal(result.passed, true);
+  assert.ok(result.evidence, "evidence should be non-empty");
+  fx.cleanup();
+});
+
+test("checkAuditFreshness: state file exactly 7 days old → passes (boundary inclusive)", () => {
+  const fx = fixture();
+  fx.writeState(EXACTLY_7_DAYS);
+  const result = checkAuditFreshness(fx.root, { now: NOW });
+  assert.equal(result.passed, true);
+  fx.cleanup();
+});
+
+test("checkAuditFreshness: state file 18 days old → fails", () => {
+  const fx = fixture();
+  fx.writeState(STALE);
+  const result = checkAuditFreshness(fx.root, { now: NOW });
+  assert.equal(result.passed, false);
+  assert.ok(
+    result.evidence.includes("18") || result.evidence.includes("day"),
+    "evidence should mention age"
+  );
+  fx.cleanup();
+});
+
+test("checkAuditFreshness: no state file → fails", () => {
+  const fx = fixture();
+  // Don't write state file
+  const result = checkAuditFreshness(fx.root, { now: NOW });
+  assert.equal(result.passed, false);
+  assert.ok(result.evidence, "evidence should explain why it failed");
+  fx.cleanup();
+});
+
+test("checkAuditFreshness: empty lastRun → fails", () => {
+  const fx = fixture();
+  fx.writeState("");
+  const result = checkAuditFreshness(fx.root, { now: NOW });
+  assert.equal(result.passed, false);
+  assert.ok(result.evidence, "evidence should explain why it failed");
+  fx.cleanup();
+});
+
+test("checkAuditFreshness: uses default now when not injected", () => {
+  const fx = fixture();
+  // Write a timestamp from 1 day ago (should be fresh)
+  const oneDayAgo = new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString();
+  fx.writeState(oneDayAgo);
+  const result = checkAuditFreshness(fx.root);
+  assert.equal(result.passed, true, "1-day-old state should pass freshness check");
+  fx.cleanup();
+});
+
+// ── AUDIT_FRESHNESS_CRITERION shape ─────────────────────────────────────────
+
+test("AUDIT_FRESHNESS_CRITERION: has required criterion fields", () => {
+  assert.ok(typeof AUDIT_FRESHNESS_CRITERION.id === "string", "should have id");
+  assert.ok(typeof AUDIT_FRESHNESS_CRITERION.name === "string", "should have name");
+  assert.ok(typeof AUDIT_FRESHNESS_CRITERION.description === "string", "should have description");
+  assert.ok(typeof AUDIT_FRESHNESS_CRITERION.check === "function", "should have check function");
+  assert.ok(AUDIT_FRESHNESS_CRITERION.detection, "should have detection");
+});
+
+test("AUDIT_FRESHNESS_CRITERION: check function is checkAuditFreshness", () => {
+  assert.equal(AUDIT_FRESHNESS_CRITERION.check, checkAuditFreshness);
+});
+
+test("AUDIT_FRESHNESS_CRITERION: detection type is active", () => {
+  assert.equal(AUDIT_FRESHNESS_CRITERION.detection.type, "active");
+});

--- a/plugins/acmm/scripts/__tests__/badge.test.js
+++ b/plugins/acmm/scripts/__tests__/badge.test.js
@@ -1,0 +1,161 @@
+/**
+ * Tests for badge.js — fresh/stale badge rendering and updateBadge behavior.
+ *
+ * Fresh state (lastRun <= 7 days ago): normal level-colored badge
+ * Stale state (lastRun > 7 days ago): grey badge with audit date
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { badgeMarkdown, staleBadgeMarkdown, updateBadge } from "../outputs/badge.js";
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "acmm-badge-"));
+  return {
+    root,
+    readme(content) {
+      writeFileSync(join(root, "README.md"), content, "utf-8");
+    },
+    readReadme() {
+      return readFileSync(join(root, "README.md"), "utf-8");
+    },
+    cleanup() {
+      rmSync(root, { recursive: true, force: true });
+    },
+  };
+}
+
+const FRESH_NOW = new Date("2026-06-14T12:00:00.000Z");
+const FRESH_LAST_RUN = new Date("2026-06-10T12:00:00.000Z").toISOString(); // 4 days ago
+const STALE_LAST_RUN = new Date("2026-05-27T12:00:00.000Z").toISOString(); // 18 days ago
+
+// ── badgeMarkdown ────────────────────────────────────────────────────────────
+
+test("badgeMarkdown: level 6 produces gold badge", () => {
+  const md = badgeMarkdown(6);
+  assert.ok(md.includes("ACMM-Level%206"), "should mention level 6");
+  assert.ok(md.includes("d4a030"), "level 6 should be gold");
+  assert.ok(md.startsWith("[!["), "should be markdown image link");
+});
+
+test("badgeMarkdown: level 0 produces not-scored badge", () => {
+  const md = badgeMarkdown(0);
+  assert.ok(md.includes("not%20scored"), "level 0 should say not scored");
+});
+
+// ── staleBadgeMarkdown ───────────────────────────────────────────────────────
+
+test("staleBadgeMarkdown: produces grey badge", () => {
+  const md = staleBadgeMarkdown(6, "2026-05-27");
+  assert.ok(md.includes("9e9e9e"), "stale badge should use grey color");
+});
+
+test("staleBadgeMarkdown: includes audit date in label", () => {
+  const md = staleBadgeMarkdown(6, "2026-05-27");
+  assert.ok(md.includes("2026"), "stale badge should include the year");
+  assert.ok(md.includes("05"), "stale badge should include the month");
+});
+
+test("staleBadgeMarkdown: links to docs/acmm.md", () => {
+  const md = staleBadgeMarkdown(6, "2026-05-27");
+  assert.ok(md.includes("docs/acmm.md"), "stale badge should link to docs/acmm.md");
+});
+
+test("staleBadgeMarkdown: is different from fresh badgeMarkdown for same level", () => {
+  const fresh = badgeMarkdown(6);
+  const stale = staleBadgeMarkdown(6, "2026-05-27");
+  assert.notEqual(fresh, stale, "stale badge must differ from fresh badge");
+});
+
+// ── updateBadge with freshness ───────────────────────────────────────────────
+
+test("updateBadge: fresh state emits normal badge (fenced)", () => {
+  const fx = fixture();
+  fx.readme("before\n<!-- acmm:begin -->old badge<!-- acmm:end -->\nafter");
+  const result = updateBadge(fx.root, 6, { lastRun: FRESH_LAST_RUN }, FRESH_NOW);
+  assert.equal(result, "updated");
+  const content = fx.readReadme();
+  assert.ok(content.includes("d4a030"), "fresh state should use level color (gold for L6)");
+  assert.ok(!content.includes("9e9e9e"), "fresh state should not use grey");
+  fx.cleanup();
+});
+
+test("updateBadge: stale state emits grey badge (fenced)", () => {
+  const fx = fixture();
+  fx.readme("before\n<!-- acmm:begin -->old badge<!-- acmm:end -->\nafter");
+  const result = updateBadge(fx.root, 6, { lastRun: STALE_LAST_RUN }, FRESH_NOW);
+  assert.equal(result, "updated");
+  const content = fx.readReadme();
+  assert.ok(content.includes("9e9e9e"), "stale state should use grey color");
+  assert.ok(!content.includes("d4a030"), "stale state should not use level color");
+  fx.cleanup();
+});
+
+test("updateBadge: stale badge contains audit date", () => {
+  const fx = fixture();
+  fx.readme("before\n<!-- acmm:begin -->old badge<!-- acmm:end -->\nafter");
+  updateBadge(fx.root, 6, { lastRun: STALE_LAST_RUN }, FRESH_NOW);
+  const content = fx.readReadme();
+  // Date from STALE_LAST_RUN is 2026-05-27
+  assert.ok(content.includes("2026"), "stale badge should include the year");
+  fx.cleanup();
+});
+
+test("updateBadge: fresh badge already matching returns no-change", () => {
+  const fx = fixture();
+  const freshBadge = badgeMarkdown(6);
+  fx.readme(`before\n<!-- acmm:begin -->${freshBadge}<!-- acmm:end -->\nafter`);
+  const result = updateBadge(fx.root, 6, { lastRun: FRESH_LAST_RUN }, FRESH_NOW);
+  assert.equal(result, "no-change");
+  fx.cleanup();
+});
+
+test("updateBadge: stale badge already matching returns no-change", () => {
+  const fx = fixture();
+  const staleBadge = staleBadgeMarkdown(6, "2026-05-27");
+  fx.readme(`before\n<!-- acmm:begin -->${staleBadge}<!-- acmm:end -->\nafter`);
+  const result = updateBadge(fx.root, 6, { lastRun: STALE_LAST_RUN }, FRESH_NOW);
+  assert.equal(result, "no-change");
+  fx.cleanup();
+});
+
+test("updateBadge: empty lastRun treats state as stale", () => {
+  const fx = fixture();
+  fx.readme("before\n<!-- acmm:begin -->old badge<!-- acmm:end -->\nafter");
+  const result = updateBadge(fx.root, 6, { lastRun: "" }, FRESH_NOW);
+  assert.equal(result, "updated");
+  const content = fx.readReadme();
+  assert.ok(content.includes("9e9e9e"), "missing lastRun should produce grey stale badge");
+  fx.cleanup();
+});
+
+test("updateBadge: no-readme returned when README.md missing", () => {
+  const fx = fixture();
+  const result = updateBadge(fx.root, 6, { lastRun: FRESH_LAST_RUN }, FRESH_NOW);
+  assert.equal(result, "no-readme");
+  fx.cleanup();
+});
+
+test("updateBadge: no-fence returned when README has no fences or badge", () => {
+  const fx = fixture();
+  fx.readme("# Some readme with no badge");
+  const result = updateBadge(fx.root, 6, { lastRun: FRESH_LAST_RUN }, FRESH_NOW);
+  assert.equal(result, "no-fence");
+  fx.cleanup();
+});
+
+test("updateBadge: backwards compat — called with no state treats as stale", () => {
+  const fx = fixture();
+  fx.readme("before\n<!-- acmm:begin -->old badge<!-- acmm:end -->\nafter");
+  // Call with old 2-arg signature (no state, no now)
+  const result = updateBadge(fx.root, 4);
+  assert.equal(result, "updated");
+  const content = fx.readReadme();
+  // Without state, no lastRun = stale
+  assert.ok(content.includes("9e9e9e"), "no state should produce grey stale badge");
+  fx.cleanup();
+});

--- a/plugins/acmm/scripts/__tests__/meta-criteria.test.js
+++ b/plugins/acmm/scripts/__tests__/meta-criteria.test.js
@@ -253,8 +253,8 @@ describe("checkProductImprovements", () => {
 });
 
 describe("META_CRITERIA", () => {
-  test("exports 5 criteria", () => {
-    assert.equal(META_CRITERIA.length, 5);
+  test("exports 6 criteria", () => {
+    assert.equal(META_CRITERIA.length, 6);
   });
 
   test("all criteria have required fields", () => {

--- a/plugins/acmm/scripts/audit-freshness.js
+++ b/plugins/acmm/scripts/audit-freshness.js
@@ -1,0 +1,75 @@
+/**
+ * Audit-freshness criterion: checks that the ACMM state file is no older than 7 days.
+ *
+ * Uses an injectable `now` clock seam for deterministic testing.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { STATE_PATH } from "./state.js";
+
+const FRESHNESS_WINDOW_DAYS = 7;
+const FRESHNESS_WINDOW_MS = FRESHNESS_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+
+/**
+ * Check whether the ACMM state file was last updated within the freshness window.
+ *
+ * @param {string} cwd - repo root
+ * @param {{ now?: Date }} [opts] - injectable clock seam for testing
+ * @returns {{ passed: boolean, evidence: string }}
+ */
+export function checkAuditFreshness(cwd, opts = {}) {
+  const now = opts.now ?? new Date();
+  const statePath = join(cwd, STATE_PATH);
+
+  if (!existsSync(statePath)) {
+    return { passed: false, evidence: "state file not found — run `acmm-audit` to create it" };
+  }
+
+  let lastRun;
+  try {
+    const parsed = JSON.parse(readFileSync(statePath, "utf-8"));
+    lastRun = parsed.lastRun;
+  } catch {
+    return { passed: false, evidence: "state file is unreadable or invalid JSON" };
+  }
+
+  if (!lastRun) {
+    return { passed: false, evidence: "state.lastRun is empty — audit has never completed" };
+  }
+
+  const lastRunDate = new Date(lastRun);
+  if (isNaN(lastRunDate.getTime())) {
+    return { passed: false, evidence: `state.lastRun is not a valid date: ${lastRun}` };
+  }
+
+  const ageMs = now.getTime() - lastRunDate.getTime();
+  const ageDays = Math.floor(ageMs / (1000 * 60 * 60 * 24));
+
+  if (ageMs > FRESHNESS_WINDOW_MS) {
+    return {
+      passed: false,
+      evidence: `last audit was ${ageDays} day(s) ago (limit: ${FRESHNESS_WINDOW_DAYS} days) — re-run \`acmm-audit\``,
+    };
+  }
+
+  return {
+    passed: true,
+    evidence: `last audit was ${ageDays} day(s) ago (within ${FRESHNESS_WINDOW_DAYS}-day window)`,
+  };
+}
+
+/** @type {import('./sources/types.js').Criterion} */
+export const AUDIT_FRESHNESS_CRITERION = {
+  id: "meta:audit-freshness",
+  source: "meta",
+  level: 6,
+  category: "self-improvement",
+  name: "Audit freshness",
+  description: `ACMM state file is no older than ${FRESHNESS_WINDOW_DAYS} days`,
+  rationale:
+    "A stale audit gives a false sense of maturity. Freshness gates ensure the score reflects the current state of the repo.",
+  scannable: false,
+  detection: { type: "active", pattern: STATE_PATH },
+  check: checkAuditFreshness,
+};

--- a/plugins/acmm/scripts/meta-criteria.js
+++ b/plugins/acmm/scripts/meta-criteria.js
@@ -1,6 +1,7 @@
 import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { execFileSync as _execFileSync } from "node:child_process";
+import { AUDIT_FRESHNESS_CRITERION } from "./audit-freshness.js";
 
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
@@ -208,4 +209,5 @@ export const META_CRITERIA = [
     detection: { type: "active", pattern: "github:improvement-label" },
     check: checkProductImprovements,
   },
+  AUDIT_FRESHNESS_CRITERION,
 ];

--- a/plugins/acmm/scripts/outputs/badge.js
+++ b/plugins/acmm/scripts/outputs/badge.js
@@ -4,6 +4,10 @@
  *
  * The badge is idempotent — running the injector on an already-up-to-date README
  * produces no diff.
+ *
+ * Freshness: when `state.lastRun` is older than STALE_THRESHOLD_DAYS (7 days), the
+ * badge is rendered in grey with the audit date instead of the level color, making
+ * stale audits visually distinct.
  */
 
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
@@ -12,7 +16,10 @@ import { join } from "node:path";
 const BEGIN = "<!-- acmm:begin -->";
 const END = "<!-- acmm:end -->";
 const BADGE_RE =
-  /\[!\[ACMM Level \d+\]\(https:\/\/img\.shields\.io\/badge\/ACMM-Level%20\d+-[0-9a-f]+\?style=flat-square\)\]\(docs\/acmm\.md\)/;
+  /\[!\[ACMM Level \d+\]\(https:\/\/img\.shields\.io\/badge\/[^)]+\)\]\(docs\/acmm\.md\)/;
+
+const STALE_THRESHOLD_DAYS = 7;
+const STALE_COLOR = "9e9e9e";
 
 /** L1 red → L6 gold, matches rialto --rialto-accent (#d4a030). */
 function colorFor(level) {
@@ -38,27 +45,66 @@ function colorFor(level) {
  * @param {number} level 0..6
  * @returns {string} The markdown badge snippet (image only, no fences).
  */
-function badgeMarkdown(level) {
+export function badgeMarkdown(level) {
   const label = level === 0 ? "ACMM-not%20scored" : `ACMM-Level%20${level}`;
   const color = colorFor(level);
   return `[![ACMM Level ${level}](https://img.shields.io/badge/${label}-${color}?style=flat-square)](docs/acmm.md)`;
 }
 
 /**
+ * Stale variant: grey badge showing the (outdated) audit date.
+ *
+ * @param {number} level 0..6
+ * @param {string} auditDate ISO date string (YYYY-MM-DD) of the last run
+ * @returns {string} The markdown badge snippet (image only, no fences).
+ */
+export function staleBadgeMarkdown(level, auditDate) {
+  const levelStr = level === 0 ? "0" : String(level);
+  const label = `ACMM-Level%20${levelStr}%20%28stale%20${auditDate}%29`;
+  return `[![ACMM Level ${levelStr} (stale ${auditDate})](https://img.shields.io/badge/${label}-${STALE_COLOR}?style=flat-square)](docs/acmm.md)`;
+}
+
+/**
+ * Determine which badge markdown to use based on state freshness.
+ *
+ * @param {number} level
+ * @param {{ lastRun?: string } | undefined} state
+ * @param {Date} now
+ * @returns {string}
+ */
+function chooseBadge(level, state, now) {
+  const lastRun = state?.lastRun;
+  if (!lastRun) {
+    return staleBadgeMarkdown(level, "unknown");
+  }
+  const lastRunDate = new Date(lastRun);
+  const ageMs = now.getTime() - lastRunDate.getTime();
+  const ageDays = ageMs / (1000 * 60 * 60 * 24);
+  if (ageDays > STALE_THRESHOLD_DAYS) {
+    const auditDate = lastRun.slice(0, 10);
+    return staleBadgeMarkdown(level, auditDate);
+  }
+  return badgeMarkdown(level);
+}
+
+/**
  * Rewrite the badge in README.md in-place. Returns one of:
- * - `"updated"`  — README was modified
+ * - `"updated"`   — README was modified
  * - `"no-change"` — badge already matched target
  * - `"no-fence"`  — README has no begin/end fence (user needs to insert placeholders)
  * - `"no-readme"` — README missing
  *
  * @param {string} cwd
  * @param {number} level
+ * @param {{ lastRun?: string } | undefined} [state] - ACMM state (for freshness check)
+ * @param {Date} [now] - injectable clock seam for testing
  */
-export function updateBadge(cwd, level) {
+export function updateBadge(cwd, level, state, now = new Date()) {
   const readmePath = join(cwd, "README.md");
   if (!existsSync(readmePath)) return "no-readme";
 
   const original = readFileSync(readmePath, "utf-8");
+  const target = chooseBadge(level, state, now);
 
   // Try fenced approach first (<!-- acmm:begin/end -->), fall back to regex
   const beginIdx = original.indexOf(BEGIN);
@@ -66,7 +112,7 @@ export function updateBadge(cwd, level) {
   if (beginIdx >= 0 && endIdx > beginIdx) {
     const before = original.slice(0, beginIdx + BEGIN.length);
     const after = original.slice(endIdx);
-    const updated = before + badgeMarkdown(level) + after;
+    const updated = before + target + after;
     if (updated === original) return "no-change";
     writeFileSync(readmePath, updated, "utf-8");
     return "updated";
@@ -74,7 +120,7 @@ export function updateBadge(cwd, level) {
 
   // Fence-free: find existing badge by regex and replace in-place
   if (!BADGE_RE.test(original)) return "no-fence";
-  const updated = original.replace(BADGE_RE, badgeMarkdown(level));
+  const updated = original.replace(BADGE_RE, target);
   if (updated === original) return "no-change";
   writeFileSync(readmePath, updated, "utf-8");
   return "updated";


### PR DESCRIPTION
## Summary

- Adds `meta:audit-freshness` criterion that checks `state.lastRun` is no older than 7 days, using an injectable `now` clock seam for deterministic tests. Registered in `META_CRITERIA` so the existing `evaluate()`/`computeLevel` path handles it without touching level math.
- Updates `outputs/badge.js` to export `badgeMarkdown` and new `staleBadgeMarkdown`. `updateBadge` now accepts optional `state` (for `lastRun`) and injectable `now`. Stale state (>7 days) writes a grey (`9e9e9e`) badge with the audit date; fresh state emits the existing level-colored badge unchanged. Old 2-arg callers get the stale path (no `lastRun` = stale).
- Existing `META_CRITERIA` test count updated from 5 → 6.

## Test plan

- [x] 15 badge tests (`badge.test.js`) — fresh/stale rendering, no-change idempotency, no-readme/no-fence fallbacks, backwards compat
- [x] 9 freshness criterion tests (`audit-freshness.test.js`) — fresh, exactly 7 days (inclusive boundary), stale, no file, empty lastRun, default clock, criterion shape
- [x] 20 meta-criteria tests — all pass including the updated count test
- [x] `pnpm lint` — 35 tasks, all successful
- [x] `check-adr` — no violations
- [x] `check-deps` — all consistent
- [x] `node scripts/detect-instruction-rot.mjs` — no rot detected
- [x] Pre-push hook: tests + typecheck — 29 tasks, all passing

Closes #2024