### PR TITLE
feat(ci): continuous ACMM regression detection

### DIFF
--- a/.github/workflows/acmm-regression.yml
+++ b/.github/workflows/acmm-regression.yml
@@ -1,0 +1,68 @@
+name: ACMM Regression Detection
+
+# Continuous ACMM maturity regression detection.
+#
+# Weekly, this refreshes the ACMM report and compares the repo's maturity
+# level against the last recorded level in `.claude/acmm/state.json`. If the
+# level dropped, it auto-opens an issue (labels `acmm` + `ready`) naming the
+# regressed criteria — deduplicated so only one regression issue is open at a
+# time. If the level is stable or improved, it bumps the state timestamp.
+#
+# The comparison/dedup logic lives in `scripts/acmm-regression-check.mjs`
+# (unit-tested); this workflow just wires inputs and runs it.
+
+on:
+  schedule:
+    # Saturday 15:00 UTC = 08:00 PT — fits the documented weekend schedule.
+    - cron: "0 15 * * 6"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+
+concurrency:
+  group: acmm-regression
+  cancel-in-progress: true
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4/v5
+        with:
+          fetch-depth: 1
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: ".nvmrc"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Refresh ACMM report
+        run: node scripts/generate-acmm-report.mjs
+
+      - name: Detect regression / update state
+        run: node scripts/acmm-regression-check.mjs
+
+      - name: Commit updated state timestamp
+        run: |
+          if git diff --quiet .claude/acmm/state.json; then
+            echo "No state change to commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .claude/acmm/state.json
+          git commit -m "chore(acmm): refresh regression-check state timestamp"
+          git push

--- a/scripts/__tests__/acmm-regression-check.test.mjs
+++ b/scripts/__tests__/acmm-regression-check.test.mjs
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import {
+  detectRegression,
+  regressedCriteria,
+  buildIssuePayload,
+  hasOpenRegressionIssue,
+  withUpdatedTimestamp,
+  REGRESSION_MARKER,
+} from "../acmm-regression-check.mjs";
+
+const STATE = {
+  currentLevel: 4,
+  levelName: "Integrated",
+  lastRun: "2026-06-01T00:00:00.000Z",
+  checks: {
+    "acmm:prereq-test-suite": { passed: true, evidence: "vitest.config.ts" },
+    "acmm:claude-md": { passed: true, evidence: "CLAUDE.md" },
+    "acmm:editor-config": { passed: false, evidence: "none" },
+    "acmm:repo-bench": { passed: false, evidence: "missing" },
+  },
+};
+
+describe("detectRegression", () => {
+  it("flags a regression when current level is below previous", () => {
+    const result = detectRegression(6, 4);
+    expect(result.regressed).toBe(true);
+    expect(result.previousLevel).toBe(6);
+    expect(result.currentLevel).toBe(4);
+  });
+
+  it("does not flag when level is stable", () => {
+    expect(detectRegression(4, 4).regressed).toBe(false);
+  });
+
+  it("does not flag when level improved", () => {
+    expect(detectRegression(3, 5).regressed).toBe(false);
+  });
+
+  it("treats a missing previous level as no regression (first run)", () => {
+    expect(detectRegression(null, 4).regressed).toBe(false);
+    expect(detectRegression(undefined, 4).regressed).toBe(false);
+  });
+});
+
+describe("regressedCriteria", () => {
+  it("returns the ids of failing checks", () => {
+    const ids = regressedCriteria(STATE.checks);
+    expect(ids).toEqual(["acmm:editor-config", "acmm:repo-bench"]);
+  });
+
+  it("returns an empty array when all checks pass", () => {
+    expect(regressedCriteria({ "a:foo": { passed: true } })).toEqual([]);
+  });
+
+  it("handles missing checks object", () => {
+    expect(regressedCriteria(undefined)).toEqual([]);
+  });
+});
+
+describe("buildIssuePayload", () => {
+  it("produces title, body, and acmm+ready labels", () => {
+    const payload = buildIssuePayload({
+      previousLevel: 6,
+      currentLevel: 4,
+      levelName: "Integrated",
+      failingIds: ["acmm:editor-config", "acmm:repo-bench"],
+    });
+    expect(payload.labels).toEqual(["acmm", "ready"]);
+    expect(payload.title).toContain("6");
+    expect(payload.title).toContain("4");
+    expect(payload.body).toContain(REGRESSION_MARKER);
+    expect(payload.body).toContain("acmm:editor-config");
+    expect(payload.body).toContain("acmm:repo-bench");
+    expect(payload.body).toContain("6");
+    expect(payload.body).toContain("4");
+  });
+
+  it("includes the level name when provided", () => {
+    const payload = buildIssuePayload({
+      previousLevel: 5,
+      currentLevel: 3,
+      levelName: "Senior Engineer",
+      failingIds: [],
+    });
+    expect(payload.body).toContain("Senior Engineer");
+  });
+});
+
+describe("hasOpenRegressionIssue", () => {
+  it("returns true when an open issue carries the regression marker", () => {
+    const issues = [{ number: 10, body: `something ${REGRESSION_MARKER} else`, state: "open" }];
+    expect(hasOpenRegressionIssue(issues)).toBe(true);
+  });
+
+  it("returns false when no issue carries the marker", () => {
+    const issues = [{ number: 10, body: "unrelated", state: "open" }];
+    expect(hasOpenRegressionIssue(issues)).toBe(false);
+  });
+
+  it("ignores closed issues that carry the marker", () => {
+    const issues = [{ number: 10, body: REGRESSION_MARKER, state: "closed" }];
+    expect(hasOpenRegressionIssue(issues)).toBe(false);
+  });
+
+  it("returns false for an empty list", () => {
+    expect(hasOpenRegressionIssue([])).toBe(false);
+  });
+});
+
+describe("withUpdatedTimestamp", () => {
+  it("returns a new state object with an updated lastRun, without mutating", () => {
+    const next = withUpdatedTimestamp(STATE, "2026-06-14T12:00:00.000Z");
+    expect(next.lastRun).toBe("2026-06-14T12:00:00.000Z");
+    expect(STATE.lastRun).toBe("2026-06-01T00:00:00.000Z");
+    expect(next).not.toBe(STATE);
+    expect(next.currentLevel).toBe(STATE.currentLevel);
+  });
+});

--- a/scripts/acmm-regression-check.mjs
+++ b/scripts/acmm-regression-check.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+
+/**
+ * Continuous ACMM regression detection.
+ *
+ * Reads the repo-level ACMM state (`.claude/acmm/state.json`, refreshed by
+ * `generate-acmm-report.mjs` / the audit) and compares the current maturity
+ * level against the last recorded level. If the level dropped, it emits an
+ * issue payload (labels `acmm` + `ready`) naming the regressed criteria;
+ * otherwise it bumps the state timestamp.
+ *
+ * The pure decision functions are exported and unit-tested. The CLI section at
+ * the bottom wires them to the filesystem + GitHub. The workflow at
+ * `.github/workflows/acmm-regression.yml` invokes the CLI.
+ *
+ * Usage: node scripts/acmm-regression-check.mjs
+ *   Env: GH_TOKEN (for `gh`), GITHUB_REPOSITORY (owner/repo).
+ */
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+const STATE_PATH = resolve(ROOT, ".claude", "acmm", "state.json");
+
+/**
+ * Marker embedded in regression issue bodies so we can deduplicate against
+ * already-open regression issues without relying on title text.
+ */
+export const REGRESSION_MARKER = "<!-- acmm-regression -->";
+
+/**
+ * Decide whether the level regressed. A missing previous level (first run)
+ * is never a regression.
+ * @returns {{ regressed: boolean, previousLevel: number|null, currentLevel: number }}
+ */
+export function detectRegression(previousLevel, currentLevel) {
+  const hasPrevious = typeof previousLevel === "number";
+  return {
+    regressed: hasPrevious && currentLevel < previousLevel,
+    previousLevel: hasPrevious ? previousLevel : null,
+    currentLevel,
+  };
+}
+
+/** Ids of checks that are currently failing — the regressed criteria. */
+export function regressedCriteria(checks) {
+  if (!checks) return [];
+  return Object.entries(checks)
+    .filter(([, check]) => check?.passed === false)
+    .map(([id]) => id);
+}
+
+/** Build the GitHub issue payload for a detected regression. Pure. */
+export function buildIssuePayload({ previousLevel, currentLevel, levelName, failingIds }) {
+  const title = `ACMM regression: maturity level dropped from ${previousLevel} to ${currentLevel}`;
+  const criteriaList =
+    failingIds.length > 0
+      ? failingIds.map((id) => `- \`${id}\``).join("\n")
+      : "_No specific failing criteria were recorded in state.json._";
+  const body = `${REGRESSION_MARKER}
+## ACMM maturity regression detected
+
+The scheduled ACMM audit found that the repository's maturity level dropped.
+
+| | Level |
+| --- | --- |
+| Previous | ${previousLevel} |
+| Current | ${currentLevel}${levelName ? ` (${levelName})` : ""} |
+
+### Criteria that regressed (currently failing)
+
+${criteriaList}
+
+### Next steps
+
+Restore the failing criteria above to recover the previous maturity level, or
+update \`.claude/acmm/state.json\` if the drop is intentional. This issue was
+opened automatically by \`.github/workflows/acmm-regression.yml\`.`;
+
+  return { title, body, labels: ["acmm", "ready"] };
+}
+
+/**
+ * True when any OPEN issue body carries the regression marker — used to avoid
+ * opening duplicate regression issues.
+ */
+export function hasOpenRegressionIssue(issues) {
+  return issues.some(
+    (issue) =>
+      issue.state === "open" &&
+      typeof issue.body === "string" &&
+      issue.body.includes(REGRESSION_MARKER)
+  );
+}
+
+/** Return a new state object with an updated lastRun timestamp. Immutable. */
+export function withUpdatedTimestamp(state, timestamp) {
+  return { ...state, lastRun: timestamp };
+}
+
+// ---------------------------------------------------------------------------
+// CLI: filesystem + GitHub wiring (not unit-tested; the logic above is).
+// ---------------------------------------------------------------------------
+
+function readState() {
+  if (!existsSync(STATE_PATH)) {
+    throw new Error(`ACMM state not found at ${STATE_PATH}`);
+  }
+  return JSON.parse(readFileSync(STATE_PATH, "utf8"));
+}
+
+/** Last recorded level from the history array (the level before this run). */
+function previousLevelFromHistory(state) {
+  const history = Array.isArray(state.history) ? state.history : [];
+  const last = history[history.length - 1];
+  return typeof last?.level === "number" ? last.level : null;
+}
+
+async function fetchOpenRegressionIssues() {
+  const { execFileSync } = await import("node:child_process");
+  const raw = execFileSync(
+    "gh",
+    [
+      "issue",
+      "list",
+      "--label",
+      "acmm",
+      "--state",
+      "open",
+      "--limit",
+      "100",
+      "--json",
+      "number,body,state",
+    ],
+    { encoding: "utf8" }
+  );
+  const parsed = JSON.parse(raw);
+  return Array.isArray(parsed) ? parsed : [];
+}
+
+async function createIssue(payload) {
+  const { execFileSync } = await import("node:child_process");
+  execFileSync(
+    "gh",
+    [
+      "issue",
+      "create",
+      "--title",
+      payload.title,
+      "--body",
+      payload.body,
+      "--label",
+      payload.labels.join(","),
+    ],
+    { stdio: "inherit" }
+  );
+}
+
+async function main() {
+  const state = readState();
+  const currentLevel = typeof state.currentLevel === "number" ? state.currentLevel : 1;
+  const previousLevel = previousLevelFromHistory(state);
+  const { regressed } = detectRegression(previousLevel, currentLevel);
+
+  if (!regressed) {
+    const next = withUpdatedTimestamp(state, new Date().toISOString());
+    writeFileSync(STATE_PATH, JSON.stringify(next, null, 2) + "\n");
+    console.log(`No ACMM regression (level ${currentLevel}). Updated lastRun timestamp.`);
+    return;
+  }
+
+  const failingIds = regressedCriteria(state.checks);
+  const payload = buildIssuePayload({
+    previousLevel,
+    currentLevel,
+    levelName: state.levelName,
+    failingIds,
+  });
+
+  const openIssues = await fetchOpenRegressionIssues();
+  if (hasOpenRegressionIssue(openIssues)) {
+    console.log("ACMM regression detected, but an open regression issue already exists. Skipping.");
+    return;
+  }
+
+  await createIssue(payload);
+  console.log(`Opened ACMM regression issue (level ${previousLevel} -> ${currentLevel}).`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
Closes #2260

## What

Adds continuous, automated ACMM maturity regression detection so drift is caught without a manual `/acmm-audit` run.

- **`.github/workflows/acmm-regression.yml`** — runs weekly (Saturday 15:00 UTC = 08:00 PT, fitting the documented weekend schedule) plus `workflow_dispatch`. Installs deps, refreshes the ACMM report via `scripts/generate-acmm-report.mjs`, then runs the check script. Uses `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` via env; no untrusted input is interpolated into run blocks.
- **`scripts/acmm-regression-check.mjs`** — reads `.claude/acmm/state.json`, compares `currentLevel` against the last recorded `history[].level`, and:
  - on regression: opens an issue labeled `acmm` + `ready` whose body names the regressed (failing) criteria and shows previous vs current level, deduplicated via an HTML-comment marker so only one regression issue stays open at a time;
  - otherwise: bumps `lastRun` and the workflow commits the timestamp.
  - GitHub calls go through `execFileSync` (no shell) — no command injection.
- **`scripts/__tests__/acmm-regression-check.test.mjs`** — unit tests for the pure decision functions (regression detected/stable/improved/first-run, regressed-criteria extraction, issue-payload shape + labels, open-issue dedup including closed-issue handling, immutable timestamp update).

## Acceptance criteria
- [x] Workflow runs weekly on schedule
- [x] Runs `generate-acmm-report.mjs` and compares level against `state.json`
- [x] Auto-creates issue with `acmm` + `ready` labels on regression
- [x] Issue body lists regressed criteria + previous vs current level
- [x] Deduplicates against an already-open regression issue
- [x] Updates `state.json` timestamp on a no-regression run

## Gates
- `vitest` (scripts config): 14/14 new tests pass, 22/22 acmm tests pass
- `check-adr`: no violations · `check-deps`: consistent
- `pnpm regen` in a clean worktree: zero drift (scripts/ is not a workspace; no generated artifacts affected)
- `detect-instruction-rot`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)