### PR TITLE
perf(reservations): scan venues concurrently via Promise.allSettled

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4570,11 +4570,14 @@
     type AlertPayload = z.infer<typeof AlertPayloadSchema>;
     export const remediationRoutes: FastifyPluginAsync = async (fastify) => {
       fastify.addHook("preParsing", createRawBodyCaptureHook());
-      fastify.addHook("preHandler", createVerifiedBodyPreHandler({
-        header: "x-remediation-signature",
-        secretEnv: "REMEDIATION_WEBHOOK_SECRET",
-        format: "raw",
-      }));
+      fastify.addHook(
+        "preHandler",
+        createVerifiedBodyPreHandler({
+          header: "x-remediation-signature",
+          secretEnv: "REMEDIATION_WEBHOOK_SECRET",
+          format: "raw",
+        })
+      );
     
       // github[js/missing-rate-limiting] — strict limit to prevent alert storms
       fastify.post<{

--- a/services/agent/llms-full.txt
+++ b/services/agent/llms-full.txt
@@ -553,11 +553,14 @@
     type AlertPayload = z.infer<typeof AlertPayloadSchema>;
     export const remediationRoutes: FastifyPluginAsync = async (fastify) => {
       fastify.addHook("preParsing", createRawBodyCaptureHook());
-      fastify.addHook("preHandler", createVerifiedBodyPreHandler({
-        header: "x-remediation-signature",
-        secretEnv: "REMEDIATION_WEBHOOK_SECRET",
-        format: "raw",
-      }));
+      fastify.addHook(
+        "preHandler",
+        createVerifiedBodyPreHandler({
+          header: "x-remediation-signature",
+          secretEnv: "REMEDIATION_WEBHOOK_SECRET",
+          format: "raw",
+        })
+      );
     
       // github[js/missing-rate-limiting] — strict limit to prevent alert storms
       fastify.post<{

--- a/services/reservations/src/services/lapsed-guest-cron.test.ts
+++ b/services/reservations/src/services/lapsed-guest-cron.test.ts
@@ -161,6 +161,91 @@ describe("createLapsedGuestMonitor (prisma interface)", () => {
   });
 });
 
+describe("createLapsedGuestMonitor — concurrent scanning", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("scans all venues concurrently (Promise.allSettled — one failure does not abort others)", async () => {
+    const order: string[] = [];
+
+    const getVenueIds = vi.fn<() => Promise<string[]>>().mockResolvedValue(["v1", "v2", "v3"]);
+    const runScan = vi
+      .fn<(venueId: string) => Promise<LapsingGuest[]>>()
+      .mockImplementation((venueId) => {
+        if (venueId === "v2") {
+          return Promise.reject(new Error("v2 db error"));
+        }
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            order.push(venueId);
+            resolve([]);
+          }, 10);
+        });
+      });
+
+    const log = makeLogger();
+    const monitor = createLapsedGuestMonitor({
+      getVenueIds,
+      runScan,
+      startupDelayMs: 0,
+      intervalMs: 10000,
+    });
+
+    monitor.start(log);
+    // Wait long enough for all concurrent scans to finish (all 10ms timers + buffer)
+    await new Promise((r) => setTimeout(r, 50));
+    monitor.stop();
+
+    // All three scans were launched (v2 rejects, v1 and v3 succeed)
+    expect(runScan).toHaveBeenCalledTimes(3);
+    // v1 and v3 both completed despite v2 failing
+    expect(order).toContain("v1");
+    expect(order).toContain("v3");
+    // v2's error was logged individually, not swallowed
+    expect(log.error).toHaveBeenCalledWith(
+      expect.objectContaining({ venueId: "v2", err: expect.any(Error) }),
+      "lapsed guest scan: venue error"
+    );
+    // The top-level scan did NOT error (allSettled absorbs individual failures)
+    expect(log.error).not.toHaveBeenCalledWith(
+      expect.objectContaining({}),
+      "lapsed guest scan: error"
+    );
+  });
+
+  it("logs per-venue error individually without aborting sibling scans", async () => {
+    const getVenueIds = vi.fn<() => Promise<string[]>>().mockResolvedValue(["va", "vb"]);
+    const runScan = vi
+      .fn<(venueId: string) => Promise<LapsingGuest[]>>()
+      .mockImplementation((venueId) => {
+        if (venueId === "va") return Promise.reject(new Error("va failure"));
+        return Promise.resolve([]);
+      });
+
+    const log = makeLogger();
+    const monitor = createLapsedGuestMonitor({
+      getVenueIds,
+      runScan,
+      startupDelayMs: 0,
+      intervalMs: 10000,
+    });
+
+    monitor.start(log);
+    await new Promise((r) => setTimeout(r, 20));
+    monitor.stop();
+
+    // vb was still scanned even though va failed
+    expect(runScan).toHaveBeenCalledWith("vb");
+    expect(log.error).toHaveBeenCalledWith(
+      expect.objectContaining({ venueId: "va" }),
+      "lapsed guest scan: venue error"
+    );
+    // No top-level crash
+    expect(log.error).not.toHaveBeenCalledWith(expect.anything(), "lapsed guest scan: error");
+  });
+});
+
 // Retain legacy callback-based tests for the function signature (backwards-compat reference)
 function makeDeps(overrides: Partial<Parameters<typeof createLapsedGuestMonitor>[0]> = {}) {
   return {

--- a/services/reservations/src/services/lapsed-guest-cron.ts
+++ b/services/reservations/src/services/lapsed-guest-cron.ts
@@ -88,15 +88,18 @@ export function createLapsedGuestMonitor(config: LapsedGuestMonitorConfig): Laps
       const scan = async () => {
         try {
           const venueIds = await getVenueIds();
-          for (const venueId of venueIds) {
-            const lapsing = await runScan(venueId);
-            if (lapsing.length > 0) {
+          const results = await Promise.allSettled(venueIds.map((venueId) => runScan(venueId)));
+          results.forEach((result, i) => {
+            const venueId = venueIds[i];
+            if (result.status === "rejected") {
+              log.error({ venueId, err: result.reason }, "lapsed guest scan: venue error");
+            } else if (result.value.length > 0) {
               log.info(
-                { venueId, count: lapsing.length },
+                { venueId, count: result.value.length },
                 "lapsed guest scan: found lapsing guests"
               );
             }
-          }
+          });
         } catch (err) {
           log.error({ err }, "lapsed guest scan: error");
         }


### PR DESCRIPTION
## Summary

- Replace sequential `for...of` loop in `createLapsedGuestMonitor` with `Promise.allSettled` so all venue scans run concurrently
- Per-venue errors are now logged individually with `venueId` context and do not abort sibling scans
- Top-level `catch` is preserved for `getVenueIds()` failures

## Test plan

- [ ] Two new tests prove concurrent behavior: all venues are scanned even when one fails mid-scan
- [ ] Existing 9 tests for both prisma and callback interfaces all still pass (707 total tests pass)
- [ ] `pnpm lint` — clean
- [ ] `pnpm typecheck` — clean
- [ ] `pnpm test` — 707/707 pass
- [ ] `check-adr` + `check-deps` — no violations
- [ ] `pnpm regen` — artifacts regenerated and committed

Closes #2313