### PR TITLE
feat(agent-core): proactive context budget management

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3665,20 +3665,26 @@
           };
         }
     
-        const { resultMessage, stuckReason, rawTurnMetrics, rawToolCallMetrics, errorMessage } =
-          await runHardenedQuery(
-            {
-              prompt: config.taskDescription,
-              cwd: worktree.path,
-              model: config.model,
-              maxTurns: config.maxTurns,
-              maxBudgetUsd: config.maxBudgetUsd,
-              allowedTools: config.allowedTools,
-              systemPromptAppend: systemPrompt,
-              stuckDetectorConfig: config.stuckDetectorConfig,
-            },
-            onEvent
-          );
+        const {
+          resultMessage,
+          stuckReason,
+          rawTurnMetrics,
+          rawToolCallMetrics,
+          errorMessage,
+          contextMetrics,
+        } = await runHardenedQuery(
+          {
+            prompt: config.taskDescription,
+            cwd: worktree.path,
+            model: config.model,
+            maxTurns: config.maxTurns,
+            maxBudgetUsd: config.maxBudgetUsd,
+            allowedTools: config.allowedTools,
+            systemPromptAppend: systemPrompt,
+            stuckDetectorConfig: config.stuckDetectorConfig,
+          },
+          onEvent
+        );
     
         // Propagate errors from runHardenedQuery as phase failures
         if (errorMessage) {
@@ -3698,6 +3704,7 @@
             stuckReason: stuckReason ?? undefined,
             turnMetrics: buildTurnMetricsList(rawTurnMetrics),
             toolCallMetrics: buildToolCallMetricsList(rawToolCallMetrics),
+            contextMetrics: contextMetrics ?? undefined,
           },
         };
       }
@@ -12208,6 +12215,15 @@
       readonly durationMs: number;
     }
   </file>
+  <file path="packages/agent-core/src/context-budget.ts">
+    export type ContextStrategy = "targeted_reads" | "wrap_up" | "checkpoint" | "graceful_exit";
+    export interface ContextUsage {
+      readonly used: number;
+      readonly limit: number;
+      readonly remaining: number;
+      readonly percentUsed: number;
+    }
+  </file>
   <file path="packages/agent-core/src/cost-tracker.ts">
     export function extractTokenUsage(result: SDKResultMessage): TokenUsage {
       return {
@@ -13130,7 +13146,14 @@
       ctx: PipelineContext,
       rootSpan: ReturnType<ReturnType<typeof trace.getTracer>["startSpan"]>
     ): SessionResult {
-      const { resultMessage, stuckReason, gatewayEvaluation, turnMetrics, toolCallMetrics } = ctx;
+      const {
+        resultMessage,
+        stuckReason,
+        gatewayEvaluation,
+        turnMetrics,
+        toolCallMetrics,
+        contextMetrics,
+      } = ctx;
       const errors = [...ctx.errors];
     
       if (stuckReason) {
@@ -13199,6 +13222,11 @@
         if (failureCategory) rootSpan.setAttribute("session.failure_category", failureCategory);
         rootSpan.setAttribute("session.turn_count", collectedTurnMetrics.length);
         rootSpan.setAttribute("session.tool_call_count", collectedToolCallMetrics.length);
+        if (contextMetrics) {
+          rootSpan.setAttribute("session.context_percent_at_exit", contextMetrics.contextPercentAtExit);
+          rootSpan.setAttribute("session.peak_context_percent", contextMetrics.peakContextPercent);
+          rootSpan.setAttribute("session.context_compaction_count", contextMetrics.compactionCount);
+        }
     
         emitEvent(ctx.onEvent, "session:result", {
           message: `Session completed: ${finalResult.status}`,
@@ -13215,6 +13243,13 @@
               ? {
                   evaluation_confidence: String(evalSummary.confidence),
                   evaluation_reasoning: evalSummary.reasoning,
+                }
+              : {}),
+            ...(contextMetrics
+              ? {
+                  context_percent_at_exit: String(contextMetrics.contextPercentAtExit),
+                  peak_context_percent: String(contextMetrics.peakContextPercent),
+                  context_compaction_count: String(contextMetrics.compactionCount),
                 }
               : {}),
           },
@@ -14799,7 +14834,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms.txt
+++ b/llms.txt
@@ -2474,6 +2474,19 @@
       }
     </item>
   </file>
+  <file path="packages/agent-core/src/context-budget.ts">
+    <item priority="low">
+      type ContextStrategy = "targeted_reads" | "wrap_up" | "checkpoint" | "graceful_exit";
+    </item>
+    <item priority="low">
+      interface ContextUsage {
+        used: number;
+        limit: number;
+        remaining: number;
+        percentUsed: number;
+      }
+    </item>
+  </file>
   <file path="packages/agent-core/src/cost-tracker.ts">
     <item priority="high">
       export function extractTokenUsage(result: SDKResultMessage): TokenUsage { /* ... */ }

--- a/packages/agent-core/llms-full.txt
+++ b/packages/agent-core/llms-full.txt
@@ -718,20 +718,26 @@
           };
         }
     
-        const { resultMessage, stuckReason, rawTurnMetrics, rawToolCallMetrics, errorMessage } =
-          await runHardenedQuery(
-            {
-              prompt: config.taskDescription,
-              cwd: worktree.path,
-              model: config.model,
-              maxTurns: config.maxTurns,
-              maxBudgetUsd: config.maxBudgetUsd,
-              allowedTools: config.allowedTools,
-              systemPromptAppend: systemPrompt,
-              stuckDetectorConfig: config.stuckDetectorConfig,
-            },
-            onEvent
-          );
+        const {
+          resultMessage,
+          stuckReason,
+          rawTurnMetrics,
+          rawToolCallMetrics,
+          errorMessage,
+          contextMetrics,
+        } = await runHardenedQuery(
+          {
+            prompt: config.taskDescription,
+            cwd: worktree.path,
+            model: config.model,
+            maxTurns: config.maxTurns,
+            maxBudgetUsd: config.maxBudgetUsd,
+            allowedTools: config.allowedTools,
+            systemPromptAppend: systemPrompt,
+            stuckDetectorConfig: config.stuckDetectorConfig,
+          },
+          onEvent
+        );
     
         // Propagate errors from runHardenedQuery as phase failures
         if (errorMessage) {
@@ -751,6 +757,7 @@
             stuckReason: stuckReason ?? undefined,
             turnMetrics: buildTurnMetricsList(rawTurnMetrics),
             toolCallMetrics: buildToolCallMetricsList(rawToolCallMetrics),
+            contextMetrics: contextMetrics ?? undefined,
           },
         };
       }
@@ -1007,6 +1014,15 @@
       readonly error?: string;
       /** Wall-clock duration of the run in milliseconds. */
       readonly durationMs: number;
+    }
+  </file>
+  <file path="src/context-budget.ts">
+    export type ContextStrategy = "targeted_reads" | "wrap_up" | "checkpoint" | "graceful_exit";
+    export interface ContextUsage {
+      readonly used: number;
+      readonly limit: number;
+      readonly remaining: number;
+      readonly percentUsed: number;
     }
   </file>
   <file path="src/cost-tracker.ts">
@@ -1931,7 +1947,14 @@
       ctx: PipelineContext,
       rootSpan: ReturnType<ReturnType<typeof trace.getTracer>["startSpan"]>
     ): SessionResult {
-      const { resultMessage, stuckReason, gatewayEvaluation, turnMetrics, toolCallMetrics } = ctx;
+      const {
+        resultMessage,
+        stuckReason,
+        gatewayEvaluation,
+        turnMetrics,
+        toolCallMetrics,
+        contextMetrics,
+      } = ctx;
       const errors = [...ctx.errors];
     
       if (stuckReason) {
@@ -2000,6 +2023,11 @@
         if (failureCategory) rootSpan.setAttribute("session.failure_category", failureCategory);
         rootSpan.setAttribute("session.turn_count", collectedTurnMetrics.length);
         rootSpan.setAttribute("session.tool_call_count", collectedToolCallMetrics.length);
+        if (contextMetrics) {
+          rootSpan.setAttribute("session.context_percent_at_exit", contextMetrics.contextPercentAtExit);
+          rootSpan.setAttribute("session.peak_context_percent", contextMetrics.peakContextPercent);
+          rootSpan.setAttribute("session.context_compaction_count", contextMetrics.compactionCount);
+        }
     
         emitEvent(ctx.onEvent, "session:result", {
           message: `Session completed: ${finalResult.status}`,
@@ -2016,6 +2044,13 @@
               ? {
                   evaluation_confidence: String(evalSummary.confidence),
                   evaluation_reasoning: evalSummary.reasoning,
+                }
+              : {}),
+            ...(contextMetrics
+              ? {
+                  context_percent_at_exit: String(contextMetrics.contextPercentAtExit),
+                  peak_context_percent: String(contextMetrics.peakContextPercent),
+                  context_compaction_count: String(contextMetrics.compactionCount),
                 }
               : {}),
           },

--- a/packages/agent-core/llms.txt
+++ b/packages/agent-core/llms.txt
@@ -242,6 +242,19 @@
       }
     </item>
   </file>
+  <file path="src/context-budget.ts">
+    <item priority="low">
+      type ContextStrategy = "targeted_reads" | "wrap_up" | "checkpoint" | "graceful_exit";
+    </item>
+    <item priority="low">
+      interface ContextUsage {
+        used: number;
+        limit: number;
+        remaining: number;
+        percentUsed: number;
+      }
+    </item>
+  </file>
   <file path="src/cost-tracker.ts">
     <item priority="high">
       export function extractTokenUsage(result: SDKResultMessage): TokenUsage { /* ... */ }

--- a/packages/agent-core/src/__tests__/context-budget.test.ts
+++ b/packages/agent-core/src/__tests__/context-budget.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from "vitest";
+import { createContextBudget, MODEL_CONTEXT_LIMITS } from "../context-budget.js";
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function makeTurnData(inputTokens: number, outputTokens: number) {
+  return { inputTokens, outputTokens };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+describe("ContextBudget", () => {
+  describe("MODEL_CONTEXT_LIMITS", () => {
+    it("has entries for known model patterns", () => {
+      expect(MODEL_CONTEXT_LIMITS["claude-sonnet-4-6"]).toBe(200_000);
+      expect(MODEL_CONTEXT_LIMITS["claude-opus-4-8"]).toBe(1_000_000);
+      expect(MODEL_CONTEXT_LIMITS["claude-haiku-4-5-20251001"]).toBe(200_000);
+    });
+  });
+
+  describe("createContextBudget", () => {
+    it("returns a ContextBudget with initial zero usage", () => {
+      const budget = createContextBudget("claude-sonnet-4-6");
+      const usage = budget.usage();
+      expect(usage.used).toBe(0);
+      expect(usage.limit).toBe(200_000);
+      expect(usage.remaining).toBe(200_000);
+      expect(usage.percentUsed).toBe(0);
+    });
+
+    it("uses fallback limit for unknown models", () => {
+      const budget = createContextBudget("unknown-model-xyz");
+      expect(budget.usage().limit).toBe(200_000);
+    });
+  });
+
+  describe("track()", () => {
+    it("accumulates token usage across turns", () => {
+      const budget = createContextBudget("claude-sonnet-4-6");
+      budget.track(makeTurnData(10_000, 5_000));
+      budget.track(makeTurnData(20_000, 3_000));
+
+      const usage = budget.usage();
+      // Uses the latest inputTokens as the running context size
+      // (input tokens reflect the full conversation so far)
+      expect(usage.used).toBe(20_000);
+    });
+
+    it("calculates percentUsed correctly", () => {
+      const budget = createContextBudget("claude-sonnet-4-6"); // 200k limit
+      budget.track(makeTurnData(100_000, 5_000));
+
+      const usage = budget.usage();
+      expect(usage.percentUsed).toBe(50);
+      expect(usage.remaining).toBe(100_000);
+    });
+  });
+
+  describe("trackCompaction()", () => {
+    it("increments compaction count", () => {
+      const budget = createContextBudget("claude-sonnet-4-6");
+      budget.trackCompaction();
+      budget.trackCompaction();
+      expect(budget.compactionCount()).toBe(2);
+    });
+  });
+
+  describe("shouldCompact()", () => {
+    it("returns false below 85% usage", () => {
+      const budget = createContextBudget("claude-sonnet-4-6");
+      budget.track(makeTurnData(160_000, 5_000)); // 80%
+      expect(budget.shouldCompact()).toBe(false);
+    });
+
+    it("returns true at 85%+ usage", () => {
+      const budget = createContextBudget("claude-sonnet-4-6");
+      budget.track(makeTurnData(170_000, 5_000)); // 85%
+      expect(budget.shouldCompact()).toBe(true);
+    });
+  });
+
+  describe("strategyHint()", () => {
+    it("returns null below 50%", () => {
+      const budget = createContextBudget("claude-sonnet-4-6");
+      budget.track(makeTurnData(90_000, 5_000)); // 45%
+      expect(budget.strategyHint()).toBeNull();
+    });
+
+    it("returns 'targeted_reads' at 50%", () => {
+      const budget = createContextBudget("claude-sonnet-4-6");
+      budget.track(makeTurnData(100_000, 5_000)); // 50%
+      const hint = budget.strategyHint();
+      expect(hint).not.toBeNull();
+      expect(hint!.strategy).toBe("targeted_reads");
+      expect(hint!.percentUsed).toBe(50);
+    });
+
+    it("returns 'wrap_up' at 70%", () => {
+      const budget = createContextBudget("claude-sonnet-4-6");
+      budget.track(makeTurnData(140_000, 5_000)); // 70%
+      const hint = budget.strategyHint();
+      expect(hint!.strategy).toBe("wrap_up");
+    });
+
+    it("returns 'checkpoint' at 85%", () => {
+      const budget = createContextBudget("claude-sonnet-4-6");
+      budget.track(makeTurnData(170_000, 5_000)); // 85%
+      const hint = budget.strategyHint();
+      expect(hint!.strategy).toBe("checkpoint");
+    });
+
+    it("returns 'graceful_exit' at 95%", () => {
+      const budget = createContextBudget("claude-sonnet-4-6");
+      budget.track(makeTurnData(190_000, 5_000)); // 95%
+      const hint = budget.strategyHint();
+      expect(hint!.strategy).toBe("graceful_exit");
+    });
+
+    it("returns highest applicable strategy (not lower ones)", () => {
+      const budget = createContextBudget("claude-sonnet-4-6");
+      budget.track(makeTurnData(190_000, 5_000)); // 95%
+      const hint = budget.strategyHint();
+      // Should return graceful_exit, not targeted_reads or wrap_up
+      expect(hint!.strategy).toBe("graceful_exit");
+    });
+  });
+
+  describe("strategyMessage()", () => {
+    it("returns null below 50%", () => {
+      const budget = createContextBudget("claude-sonnet-4-6");
+      budget.track(makeTurnData(90_000, 5_000));
+      expect(budget.strategyMessage()).toBeNull();
+    });
+
+    it("returns a human-readable message at 70%", () => {
+      const budget = createContextBudget("claude-sonnet-4-6");
+      budget.track(makeTurnData(140_000, 5_000));
+      const msg = budget.strategyMessage();
+      expect(msg).toContain("70%");
+      expect(msg).toContain("wrap up");
+    });
+  });
+
+  describe("peakPercent()", () => {
+    it("tracks the highest percentage seen", () => {
+      const budget = createContextBudget("claude-sonnet-4-6");
+      budget.track(makeTurnData(150_000, 5_000)); // 75%
+      budget.track(makeTurnData(100_000, 5_000)); // 50% (after compaction, context shrinks)
+      expect(budget.peakPercent()).toBe(75);
+    });
+  });
+
+  describe("truncateToolOutput()", () => {
+    it("returns short output unchanged", () => {
+      const budget = createContextBudget("claude-sonnet-4-6");
+      const short = "hello world";
+      expect(budget.truncateToolOutput(short)).toBe(short);
+    });
+
+    it("truncates output exceeding default max", () => {
+      const budget = createContextBudget("claude-sonnet-4-6");
+      // Default max is ~5000 tokens. At ~4 chars/token, that's ~20k chars.
+      const long = "x".repeat(25_000);
+      const result = budget.truncateToolOutput(long);
+      expect(result.length).toBeLessThan(long.length);
+      expect(result).toContain("...truncated");
+    });
+
+    it("respects custom maxChars", () => {
+      const budget = createContextBudget("claude-sonnet-4-6", { maxToolOutputChars: 100 });
+      const long = "x".repeat(200);
+      const result = budget.truncateToolOutput(long);
+      expect(result.length).toBeLessThanOrEqual(200); // includes the truncation message
+      expect(result).toContain("...truncated");
+    });
+  });
+
+  describe("metrics()", () => {
+    it("returns context metrics for Langfuse", () => {
+      const budget = createContextBudget("claude-sonnet-4-6");
+      budget.track(makeTurnData(150_000, 5_000));
+      budget.trackCompaction();
+
+      const metrics = budget.metrics();
+      expect(metrics.contextPercentAtExit).toBe(75);
+      expect(metrics.peakContextPercent).toBe(75);
+      expect(metrics.contextLimit).toBe(200_000);
+      expect(metrics.compactionCount).toBe(1);
+    });
+  });
+
+  describe("opus model with 1M context", () => {
+    it("thresholds scale with larger context window", () => {
+      const budget = createContextBudget("claude-opus-4-8");
+      budget.track(makeTurnData(500_000, 5_000)); // 50% of 1M
+      const hint = budget.strategyHint();
+      expect(hint).not.toBeNull();
+      expect(hint!.strategy).toBe("targeted_reads");
+    });
+  });
+});

--- a/packages/agent-core/src/context-budget.ts
+++ b/packages/agent-core/src/context-budget.ts
@@ -1,0 +1,213 @@
+/**
+ * Proactive context management for agent sessions.
+ *
+ * Tracks estimated token usage per turn and exposes strategy hints
+ * at configurable thresholds so the session loop can take preemptive
+ * action before hitting context limits.
+ */
+
+// ── Types ──────────────────────────────────────────────────────────
+
+export type ContextStrategy = "targeted_reads" | "wrap_up" | "checkpoint" | "graceful_exit";
+
+export interface ContextUsage {
+  readonly used: number;
+  readonly limit: number;
+  readonly remaining: number;
+  readonly percentUsed: number;
+}
+
+export interface ContextStrategyHint {
+  readonly strategy: ContextStrategy;
+  readonly percentUsed: number;
+  readonly message: string;
+}
+
+export interface ContextMetrics {
+  readonly contextPercentAtExit: number;
+  readonly peakContextPercent: number;
+  readonly contextLimit: number;
+  readonly compactionCount: number;
+}
+
+export interface TurnTokenData {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+}
+
+export interface ContextBudgetConfig {
+  /** Max tool output in characters before truncation. Default: 20_000 (~5k tokens). */
+  readonly maxToolOutputChars: number;
+}
+
+export interface ContextBudget {
+  /** Record token usage from a turn. inputTokens = cumulative context size. */
+  track(turn: TurnTokenData): void;
+  /** Record a compaction event. */
+  trackCompaction(): void;
+  /** Current context usage snapshot. */
+  usage(): ContextUsage;
+  /** Number of compactions observed. */
+  compactionCount(): number;
+  /** Whether context is high enough to warrant compaction (85%+). */
+  shouldCompact(): boolean;
+  /** Strategy hint for the current usage level, or null if below 50%. */
+  strategyHint(): ContextStrategyHint | null;
+  /** Human-readable strategy message, or null if below 50%. */
+  strategyMessage(): string | null;
+  /** Peak context percentage seen during the session. */
+  peakPercent(): number;
+  /** Truncate tool output if it exceeds the configured max. */
+  truncateToolOutput(output: string): string;
+  /** Metrics for Langfuse/observability. */
+  metrics(): ContextMetrics;
+}
+
+// ── Model context limits ───────────────────────────────────────────
+
+const FALLBACK_CONTEXT_LIMIT = 200_000;
+
+export const MODEL_CONTEXT_LIMITS: Readonly<Record<string, number>> = {
+  "claude-haiku-4-5-20251001": 200_000,
+  "claude-sonnet-4-6": 200_000,
+  "claude-opus-4-8": 1_000_000,
+};
+
+function resolveContextLimit(modelId: string): number {
+  // Exact match first
+  if (MODEL_CONTEXT_LIMITS[modelId] !== undefined) {
+    return MODEL_CONTEXT_LIMITS[modelId];
+  }
+  // Pattern match for model families
+  if (modelId.includes("opus")) return 1_000_000;
+  if (modelId.includes("sonnet")) return 200_000;
+  if (modelId.includes("haiku")) return 200_000;
+  return FALLBACK_CONTEXT_LIMIT;
+}
+
+// ── Threshold definitions ──────────────────────────────────────────
+
+interface Threshold {
+  readonly percent: number;
+  readonly strategy: ContextStrategy;
+  readonly message: string;
+}
+
+// Ordered highest-first so we return the most urgent applicable strategy
+const THRESHOLDS: readonly Threshold[] = [
+  {
+    percent: 95,
+    strategy: "graceful_exit",
+    message: "Context at {pct}% — commit what is done, log remaining work as TODO",
+  },
+  {
+    percent: 85,
+    strategy: "checkpoint",
+    message: "Context at {pct}% — summarize progress, commit partial work if possible",
+  },
+  {
+    percent: 70,
+    strategy: "wrap_up",
+    message: "Context at {pct}% — wrap up current task, avoid exploratory reads",
+  },
+  {
+    percent: 50,
+    strategy: "targeted_reads",
+    message: "Context at {pct}% — prefer targeted reads over full-file reads",
+  },
+];
+
+// ── Factory ────────────────────────────────────────────────────────
+
+const DEFAULT_CONFIG: ContextBudgetConfig = {
+  maxToolOutputChars: 20_000,
+};
+
+export function createContextBudget(
+  modelId: string,
+  configOverrides?: Partial<ContextBudgetConfig>
+): ContextBudget {
+  const budgetConfig = { ...DEFAULT_CONFIG, ...configOverrides };
+  const limit = resolveContextLimit(modelId);
+
+  let currentUsed = 0;
+  let peak = 0;
+  let compactions = 0;
+
+  function percentUsed(): number {
+    return Math.round((currentUsed / limit) * 100);
+  }
+
+  return {
+    track(turn: TurnTokenData): void {
+      // inputTokens reflects cumulative conversation context
+      currentUsed = turn.inputTokens;
+      const pct = percentUsed();
+      if (pct > peak) {
+        peak = pct;
+      }
+    },
+
+    trackCompaction(): void {
+      compactions++;
+    },
+
+    usage(): ContextUsage {
+      const pct = percentUsed();
+      return {
+        used: currentUsed,
+        limit,
+        remaining: Math.max(0, limit - currentUsed),
+        percentUsed: pct,
+      };
+    },
+
+    compactionCount(): number {
+      return compactions;
+    },
+
+    shouldCompact(): boolean {
+      return percentUsed() >= 85;
+    },
+
+    strategyHint(): ContextStrategyHint | null {
+      const pct = percentUsed();
+      for (const threshold of THRESHOLDS) {
+        if (pct >= threshold.percent) {
+          return {
+            strategy: threshold.strategy,
+            percentUsed: pct,
+            message: threshold.message.replace("{pct}", String(pct)),
+          };
+        }
+      }
+      return null;
+    },
+
+    strategyMessage(): string | null {
+      const hint = this.strategyHint();
+      return hint?.message ?? null;
+    },
+
+    peakPercent(): number {
+      return peak;
+    },
+
+    truncateToolOutput(output: string): string {
+      if (output.length <= budgetConfig.maxToolOutputChars) {
+        return output;
+      }
+      const truncated = output.slice(0, budgetConfig.maxToolOutputChars);
+      return `${truncated}\n\n...truncated (${output.length} chars total). Use offset/limit to read specific sections.`;
+    },
+
+    metrics(): ContextMetrics {
+      return {
+        contextPercentAtExit: percentUsed(),
+        peakContextPercent: peak,
+        contextLimit: limit,
+        compactionCount: compactions,
+      };
+    },
+  };
+}

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -62,6 +62,17 @@ export { createToolPermissionHandler, normalizeBashCommand } from "./tool-permis
 // Cost tracking
 export { extractTokenUsage, extractCost, buildSessionResult } from "./cost-tracker.js";
 
+// Context budget (proactive context management)
+export { createContextBudget, MODEL_CONTEXT_LIMITS } from "./context-budget.js";
+export type {
+  ContextBudget,
+  ContextUsage,
+  ContextStrategy,
+  ContextStrategyHint,
+  ContextMetrics,
+  ContextBudgetConfig,
+} from "./context-budget.js";
+
 // Stuck detection
 export { createStuckDetector, DEFAULT_STUCK_CONFIG } from "./stuck-detector.js";
 export type {

--- a/packages/agent-core/src/phases/pipeline-types.ts
+++ b/packages/agent-core/src/phases/pipeline-types.ts
@@ -7,6 +7,7 @@ import type {
   ToolCallMetrics,
 } from "../types.js";
 import type { StuckPattern } from "../stuck-detector.js";
+import type { ContextMetrics } from "../context-budget.js";
 import type { EvaluationResult } from "../success-evaluator.js";
 import type { GatewayVerdict } from "../post-commit-gateway.js";
 import type { TaskSignals } from "../task-signal-registry.js";
@@ -47,6 +48,7 @@ export interface PipelineContext {
   readonly stuckReason?: StuckPattern;
   readonly turnMetrics?: readonly TurnMetrics[];
   readonly toolCallMetrics?: readonly ToolCallMetrics[];
+  readonly contextMetrics?: ContextMetrics;
 
   // VerificationPhase outputs
   readonly hasChanges?: boolean;

--- a/packages/agent-core/src/phases/query-phase.ts
+++ b/packages/agent-core/src/phases/query-phase.ts
@@ -28,20 +28,26 @@ export class QueryPhase implements PipelinePhase {
       };
     }
 
-    const { resultMessage, stuckReason, rawTurnMetrics, rawToolCallMetrics, errorMessage } =
-      await runHardenedQuery(
-        {
-          prompt: config.taskDescription,
-          cwd: worktree.path,
-          model: config.model,
-          maxTurns: config.maxTurns,
-          maxBudgetUsd: config.maxBudgetUsd,
-          allowedTools: config.allowedTools,
-          systemPromptAppend: systemPrompt,
-          stuckDetectorConfig: config.stuckDetectorConfig,
-        },
-        onEvent
-      );
+    const {
+      resultMessage,
+      stuckReason,
+      rawTurnMetrics,
+      rawToolCallMetrics,
+      errorMessage,
+      contextMetrics,
+    } = await runHardenedQuery(
+      {
+        prompt: config.taskDescription,
+        cwd: worktree.path,
+        model: config.model,
+        maxTurns: config.maxTurns,
+        maxBudgetUsd: config.maxBudgetUsd,
+        allowedTools: config.allowedTools,
+        systemPromptAppend: systemPrompt,
+        stuckDetectorConfig: config.stuckDetectorConfig,
+      },
+      onEvent
+    );
 
     // Propagate errors from runHardenedQuery as phase failures
     if (errorMessage) {
@@ -61,6 +67,7 @@ export class QueryPhase implements PipelinePhase {
         stuckReason: stuckReason ?? undefined,
         turnMetrics: buildTurnMetricsList(rawTurnMetrics),
         toolCallMetrics: buildToolCallMetricsList(rawToolCallMetrics),
+        contextMetrics: contextMetrics ?? undefined,
       },
     };
   }

--- a/packages/agent-core/src/run-hardened-query.ts
+++ b/packages/agent-core/src/run-hardened-query.ts
@@ -19,6 +19,8 @@ import { trace, SpanStatusCode } from "@opentelemetry/api";
 import { startObservation } from "@langfuse/tracing";
 import { createStuckDetector } from "./stuck-detector.js";
 import type { StuckPattern, StuckDetectorConfig } from "./stuck-detector.js";
+import { createContextBudget } from "./context-budget.js";
+import type { ContextMetrics } from "./context-budget.js";
 import { mapSdkMessage } from "./event-mapper.js";
 import type { TurnMetricsEvent } from "./event-mapper.js";
 import { sanitizeStreamChunk } from "./sanitize-output.js";
@@ -91,6 +93,8 @@ export interface HardenedQueryResult {
   readonly rawToolCallMetrics: readonly RawToolCallMetric[];
   /** Set when the query failed due to an unrecoverable error (SDK throw, etc.). */
   readonly errorMessage: string | null;
+  /** Context budget metrics for observability. */
+  readonly contextMetrics: ContextMetrics | null;
 }
 
 // ── Main function ─────────────────────────────────────────────────────
@@ -129,12 +133,14 @@ export async function runHardenedQuery(
       rawTurnMetrics: [],
       rawToolCallMetrics: [],
       errorMessage: msg,
+      contextMetrics: null,
     };
   }
 
   const abortController = new AbortController();
   const canUseTool = createToolPermissionHandler(config.cwd);
   const detector = createStuckDetector(config.stuckDetectorConfig);
+  const contextBudget = createContextBudget(config.model);
 
   let conversation: ReturnType<typeof query>;
   try {
@@ -175,6 +181,7 @@ export async function runHardenedQuery(
       rawTurnMetrics: [],
       rawToolCallMetrics: [],
       errorMessage: errMsg,
+      contextMetrics: null,
     };
   }
 
@@ -277,6 +284,18 @@ export async function runHardenedQuery(
                 costUsd: tm.costUsd,
                 modelId: tm.modelId,
               });
+
+              // Track context budget from cumulative input tokens
+              contextBudget.track({
+                inputTokens: tm.inputTokens,
+                outputTokens: tm.outputTokens,
+              });
+              const hint = contextBudget.strategyMessage();
+              if (hint) {
+                emitEvent(onEvent, "session:stuck", {
+                  message: `Context budget: ${hint}`,
+                });
+              }
             }
 
             if (mapped.type === "session:tool_use") {
@@ -316,6 +335,7 @@ export async function runHardenedQuery(
             message.subtype === "compact_boundary"
           ) {
             compactionCount++;
+            contextBudget.trackCompaction();
             if (compactionCount >= MAX_COMPACTIONS) {
               innerStuck = {
                 type: "context_window_loop",
@@ -399,6 +419,7 @@ export async function runHardenedQuery(
         rawTurnMetrics,
         rawToolCallMetrics,
         errorMessage: errMsg,
+        contextMetrics: contextBudget.metrics(),
       };
     }
   } finally {
@@ -420,6 +441,7 @@ export async function runHardenedQuery(
       rawTurnMetrics,
       rawToolCallMetrics,
       errorMessage: circuitMsg,
+      contextMetrics: contextBudget.metrics(),
     };
   }
 
@@ -429,5 +451,6 @@ export async function runHardenedQuery(
     rawTurnMetrics,
     rawToolCallMetrics,
     errorMessage: null,
+    contextMetrics: contextBudget.metrics(),
   };
 }

--- a/packages/agent-core/src/session-runner.ts
+++ b/packages/agent-core/src/session-runner.ts
@@ -192,7 +192,14 @@ function buildFinalResult(
   ctx: PipelineContext,
   rootSpan: ReturnType<ReturnType<typeof trace.getTracer>["startSpan"]>
 ): SessionResult {
-  const { resultMessage, stuckReason, gatewayEvaluation, turnMetrics, toolCallMetrics } = ctx;
+  const {
+    resultMessage,
+    stuckReason,
+    gatewayEvaluation,
+    turnMetrics,
+    toolCallMetrics,
+    contextMetrics,
+  } = ctx;
   const errors = [...ctx.errors];
 
   if (stuckReason) {
@@ -261,6 +268,11 @@ function buildFinalResult(
     if (failureCategory) rootSpan.setAttribute("session.failure_category", failureCategory);
     rootSpan.setAttribute("session.turn_count", collectedTurnMetrics.length);
     rootSpan.setAttribute("session.tool_call_count", collectedToolCallMetrics.length);
+    if (contextMetrics) {
+      rootSpan.setAttribute("session.context_percent_at_exit", contextMetrics.contextPercentAtExit);
+      rootSpan.setAttribute("session.peak_context_percent", contextMetrics.peakContextPercent);
+      rootSpan.setAttribute("session.context_compaction_count", contextMetrics.compactionCount);
+    }
 
     emitEvent(ctx.onEvent, "session:result", {
       message: `Session completed: ${finalResult.status}`,
@@ -277,6 +289,13 @@ function buildFinalResult(
           ? {
               evaluation_confidence: String(evalSummary.confidence),
               evaluation_reasoning: evalSummary.reasoning,
+            }
+          : {}),
+        ...(contextMetrics
+          ? {
+              context_percent_at_exit: String(contextMetrics.contextPercentAtExit),
+              peak_context_percent: String(contextMetrics.peakContextPercent),
+              context_compaction_count: String(contextMetrics.compactionCount),
             }
           : {}),
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,7 +144,7 @@ importers:
         version: 2.9.17
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   apps/gen:
     dependencies:
@@ -220,7 +220,7 @@ importers:
         version: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   apps/hospitality:
     dependencies:
@@ -317,7 +317,7 @@ importers:
         version: 1.3.0(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -393,7 +393,7 @@ importers:
         version: 1.3.0(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   apps/rialto-web:
     dependencies:
@@ -469,7 +469,7 @@ importers:
         version: 1.3.0(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   infrastructure/pulumi:
     dependencies:
@@ -506,7 +506,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/agent-core:
     dependencies:
@@ -543,7 +543,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/agent-test-utils:
     dependencies:
@@ -571,7 +571,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/api-client:
     dependencies:
@@ -590,7 +590,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/auth:
     dependencies:
@@ -645,7 +645,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/config:
     devDependencies:
@@ -724,7 +724,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/jobs:
     dependencies:
@@ -749,7 +749,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/mcp-server:
     dependencies:
@@ -786,7 +786,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/notifications:
     dependencies:
@@ -811,7 +811,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/observability:
     dependencies:
@@ -872,7 +872,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/rialto:
     devDependencies:
@@ -893,7 +893,7 @@ importers:
         version: 10.4.3(storybook@10.4.3(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       '@storybook/addon-docs':
         specifier: ^10.4.3
-        version: 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.3(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.3(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@storybook/addon-onboarding':
         specifier: ^10.4.3
         version: 10.4.3(storybook@10.4.3(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
@@ -905,7 +905,7 @@ importers:
         version: 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.3(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)
       '@storybook/react-vite':
         specifier: ^10.4.3
-        version: 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.61.1)(storybook@10.4.3(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.61.1)(storybook@10.4.3(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@storybook/test':
         specifier: ^8.6.15
         version: 8.6.15(storybook@10.4.3(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
@@ -919,8 +919,8 @@ importers:
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.0)
       '@types/node':
-        specifier: ^25.9.2
-        version: 25.9.2
+        specifier: ^25.9.3
+        version: 25.9.3
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17
@@ -929,10 +929,10 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.2(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/browser-playwright':
         specifier: ^4.1.8
-        version: 4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
+        version: 4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
       '@vitest/coverage-v8':
         specifier: ^4.1.8
         version: 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.9)
@@ -971,13 +971,13 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vite-plugin-dts:
         specifier: ^5.0.2
-        version: 5.0.2(@microsoft/api-extractor@7.57.6(@types/node@25.9.2))(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 5.0.2(@microsoft/api-extractor@7.57.6(@types/node@25.9.3))(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest-axe:
         specifier: ^0.1.0
         version: 0.1.0(vitest@4.1.9)
@@ -1029,7 +1029,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/rialto-plugin:
     dependencies:
@@ -1082,7 +1082,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/service-bootstrap:
     dependencies:
@@ -1137,7 +1137,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/types:
     dependencies:
@@ -1156,7 +1156,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   services/agent:
     dependencies:
@@ -1253,7 +1253,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   services/reservations:
     dependencies:
@@ -1350,7 +1350,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   services/users:
     dependencies:
@@ -1432,7 +1432,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   tools/cli:
     dependencies:
@@ -1481,7 +1481,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
 packages:
 
@@ -4739,9 +4739,6 @@ packages:
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
-
-  '@types/node@25.9.2':
-    resolution: {integrity: sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==}
 
   '@types/node@25.9.3':
     resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
@@ -11337,11 +11334,11 @@ snapshots:
 
   '@isaacs/string-locale-compare@1.1.0': {}
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
-      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     optionalDependencies:
       typescript: 6.0.3
 
@@ -11469,24 +11466,24 @@ snapshots:
       '@types/react': 19.2.17
       react: 19.2.7
 
-  '@microsoft/api-extractor-model@7.33.4(@types/node@25.9.2)':
+  '@microsoft/api-extractor-model@7.33.4(@types/node@25.9.3)':
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.20.3(@types/node@25.9.2)
+      '@rushstack/node-core-library': 5.20.3(@types/node@25.9.3)
     transitivePeerDependencies:
       - '@types/node'
     optional: true
 
-  '@microsoft/api-extractor@7.57.6(@types/node@25.9.2)':
+  '@microsoft/api-extractor@7.57.6(@types/node@25.9.3)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.33.4(@types/node@25.9.2)
+      '@microsoft/api-extractor-model': 7.33.4(@types/node@25.9.3)
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.20.3(@types/node@25.9.2)
+      '@rushstack/node-core-library': 5.20.3(@types/node@25.9.3)
       '@rushstack/rig-package': 0.7.2
-      '@rushstack/terminal': 0.22.3(@types/node@25.9.2)
-      '@rushstack/ts-command-line': 5.3.3(@types/node@25.9.2)
+      '@rushstack/terminal': 0.22.3(@types/node@25.9.3)
+      '@rushstack/ts-command-line': 5.3.3(@types/node@25.9.3)
       diff: 8.0.4
       lodash: 4.18.1
       minimatch: 10.2.3
@@ -12700,7 +12697,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.61.1':
     optional: true
 
-  '@rushstack/node-core-library@5.20.3(@types/node@25.9.2)':
+  '@rushstack/node-core-library@5.20.3(@types/node@25.9.3)':
     dependencies:
       ajv: 8.18.0
       ajv-draft-04: 1.0.0(ajv@8.18.0)
@@ -12711,12 +12708,12 @@ snapshots:
       resolve: 1.22.12
       semver: 7.5.4
     optionalDependencies:
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
     optional: true
 
-  '@rushstack/problem-matcher@0.2.1(@types/node@25.9.2)':
+  '@rushstack/problem-matcher@0.2.1(@types/node@25.9.3)':
     optionalDependencies:
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
     optional: true
 
   '@rushstack/rig-package@0.7.2':
@@ -12725,18 +12722,18 @@ snapshots:
       strip-json-comments: 3.1.1
     optional: true
 
-  '@rushstack/terminal@0.22.3(@types/node@25.9.2)':
+  '@rushstack/terminal@0.22.3(@types/node@25.9.3)':
     dependencies:
-      '@rushstack/node-core-library': 5.20.3(@types/node@25.9.2)
-      '@rushstack/problem-matcher': 0.2.1(@types/node@25.9.2)
+      '@rushstack/node-core-library': 5.20.3(@types/node@25.9.3)
+      '@rushstack/problem-matcher': 0.2.1(@types/node@25.9.3)
       supports-color: 8.1.1
     optionalDependencies:
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
     optional: true
 
-  '@rushstack/ts-command-line@5.3.3(@types/node@25.9.2)':
+  '@rushstack/ts-command-line@5.3.3(@types/node@25.9.3)':
     dependencies:
-      '@rushstack/terminal': 0.22.3(@types/node@25.9.2)
+      '@rushstack/terminal': 0.22.3(@types/node@25.9.3)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -13034,10 +13031,10 @@ snapshots:
       axe-core: 4.12.0
       storybook: 10.4.3(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
-  '@storybook/addon-docs@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.3(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@storybook/addon-docs@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.3(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.7)
-      '@storybook/csf-plugin': 10.4.3(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.3(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@storybook/csf-plugin': 10.4.3(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.3(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@storybook/icons': 2.0.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@storybook/react-dom-shim': 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.3(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       react: 19.2.7
@@ -13063,33 +13060,33 @@ snapshots:
       '@storybook/icons': 2.0.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       storybook: 10.4.3(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     optionalDependencies:
-      '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
-      '@vitest/browser-playwright': 4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/browser-playwright': 4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
       '@vitest/runner': 4.1.9
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.4.3(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.3(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@storybook/builder-vite@10.4.3(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.3(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.3(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.3(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@storybook/csf-plugin': 10.4.3(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.3(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       storybook: 10.4.3(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       ts-dedent: 2.2.0
-      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.4.3(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.3(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@storybook/csf-plugin@10.4.3(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.3(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       storybook: 10.4.3(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.28.1
       rollup: 4.61.1
-      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@storybook/global@5.0.0': {}
 
@@ -13113,11 +13110,11 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@storybook/react-vite@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.61.1)(storybook@10.4.3(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@storybook/react-vite@10.4.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.61.1)(storybook@10.4.3(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@rollup/pluginutils': 5.4.0(rollup@4.61.1)
-      '@storybook/builder-vite': 10.4.3(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.3(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@storybook/builder-vite': 10.4.3(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.4.3(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@storybook/react': 10.4.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.3(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)
       empathic: 2.0.1
       magic-string: 0.30.21
@@ -13127,7 +13124,7 @@ snapshots:
       resolve: 1.22.12
       storybook: 10.4.3(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       tsconfig-paths: 4.2.0
-      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -13238,7 +13235,7 @@ snapshots:
       '@stryker-mutator/util': 9.6.1
       semver: 7.7.4
       tslib: 2.8.1
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     dependencies:
@@ -13420,10 +13417,6 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@25.9.2':
-    dependencies:
-      undici-types: 7.24.6
-
   '@types/node@25.9.3':
     dependencies:
       undici-types: 7.24.6
@@ -13464,7 +13457,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
     optional: true
 
   '@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3))(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)':
@@ -13623,40 +13616,18 @@ snapshots:
 
   '@vercel/oidc@3.2.0': {}
 
-  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-
   '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  '@vitest/browser-playwright@4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)':
+  '@vitest/browser-playwright@4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)':
     dependencies:
-      '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
-      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       playwright: 1.60.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
-    transitivePeerDependencies:
-      - bufferutil
-      - msw
-      - utf-8-validate
-      - vite
-
-  '@vitest/browser@4.1.8(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)':
-    dependencies:
-      '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@vitest/utils': 4.1.8
-      magic-string: 0.30.21
-      pngjs: 7.0.0
-      sirv: 3.0.2
-      tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
-      ws: 8.21.0
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -13672,14 +13643,13 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
-    optional: true
 
   '@vitest/coverage-v8@4.1.8(@vitest/browser@4.1.8)(vitest@4.1.9)':
     dependencies:
@@ -13693,7 +13663,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
     optionalDependencies:
       '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
 
@@ -13721,14 +13691,6 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 4.1.8
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-
   '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.8
@@ -13736,15 +13698,6 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-    optional: true
-
-  '@vitest/mocker@4.1.9(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 4.1.9
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.9(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
@@ -14354,7 +14307,7 @@ snapshots:
 
   chrome-launcher@0.13.4:
     dependencies:
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
       escape-string-regexp: 1.0.5
       is-wsl: 2.2.0
       lighthouse-logger: 1.2.0
@@ -14365,7 +14318,7 @@ snapshots:
 
   chrome-launcher@1.2.1:
     dependencies:
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 2.0.2
@@ -17978,7 +17931,7 @@ snapshots:
 
   speedline-core@1.4.3:
     dependencies:
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
       image-ssim: 0.2.0
       jpeg-js: 0.4.4
 
@@ -18529,7 +18482,7 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-dts@1.0.2(@microsoft/api-extractor@7.57.6(@types/node@25.9.2))(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  unplugin-dts@1.0.2(@microsoft/api-extractor@7.57.6(@types/node@25.9.3))(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@rollup/pluginutils': 5.4.0(rollup@4.61.1)
       '@volar/typescript': 2.4.28
@@ -18541,11 +18494,11 @@ snapshots:
       typescript: 6.0.3
       unplugin: 2.3.11
     optionalDependencies:
-      '@microsoft/api-extractor': 7.57.6(@types/node@25.9.2)
+      '@microsoft/api-extractor': 7.57.6(@types/node@25.9.3)
       esbuild: 0.28.1
       rolldown: 1.0.3
       rollup: 4.61.1
-      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -18591,13 +18544,13 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-plugin-dts@5.0.2(@microsoft/api-extractor@7.57.6(@types/node@25.9.2))(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vite-plugin-dts@5.0.2(@microsoft/api-extractor@7.57.6(@types/node@25.9.3))(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
-      unplugin-dts: 1.0.2(@microsoft/api-extractor@7.57.6(@types/node@25.9.2))(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      unplugin-dts: 1.0.2(@microsoft/api-extractor@7.57.6(@types/node@25.9.3))(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.61.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
     optionalDependencies:
-      '@microsoft/api-extractor': 7.57.6(@types/node@25.9.2)
+      '@microsoft/api-extractor': 7.57.6(@types/node@25.9.3)
       rollup: 4.61.1
-      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vue/language-core'
@@ -18617,22 +18570,6 @@ snapshots:
       workbox-window: 7.4.0
     transitivePeerDependencies:
       - supports-color
-
-  vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rolldown: 1.0.3
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 25.9.2
-      esbuild: 0.28.1
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      terser: 5.48.0
-      tsx: 4.22.4
-      yaml: 2.9.0
 
   vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
@@ -18658,40 +18595,9 @@ snapshots:
       dom-accessibility-api: 0.5.16
       lodash-es: 4.18.1
       redent: 3.0.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
-  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.9
-      '@vitest/runner': 4.1.9
-      '@vitest/snapshot': 4.1.9
-      '@vitest/spy': 4.1.9
-      '@vitest/utils': 4.1.9
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.0.0
-      tinybench: 2.9.0
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 25.9.2
-      '@vitest/browser-playwright': 4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
-      '@vitest/coverage-v8': 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.9)
-      jsdom: 29.1.1
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.9
       '@vitest/mocker': 4.1.9(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -18716,36 +18622,8 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 25.9.3
+      '@vitest/browser-playwright': 4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
       '@vitest/coverage-v8': 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.9)
-      jsdom: 29.1.1
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.9
-      '@vitest/runner': 4.1.9
-      '@vitest/snapshot': 4.1.9
-      '@vitest/spy': 4.1.9
-      '@vitest/utils': 4.1.9
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.0.0
-      tinybench: 2.9.0
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 25.9.3
       jsdom: 29.1.1
     transitivePeerDependencies:
       - msw


### PR DESCRIPTION
Closes #2307

## Summary
- Add `ContextBudget` module that tracks estimated token usage per turn and provides threshold-based strategy hints before sessions hit context limits
- Model-specific context limits (200k for sonnet/haiku, 1M for opus) with pattern-based fallback
- Four threshold strategies: 50% targeted_reads, 70% wrap_up, 85% checkpoint, 95% graceful_exit
- Integrated into `runHardenedQuery` turn loop — tracks tokens each turn, emits strategy hints as session events, tracks compaction events
- Context metrics (`contextPercentAtExit`, `peakContextPercent`, `compactionCount`) emitted to both OTel spans and Langfuse trace metadata
- Pipeline context extended with `contextMetrics` field flowing from QueryPhase through session result

## Files Changed
- `packages/agent-core/src/context-budget.ts` — new module (ContextBudget factory, model limits, threshold definitions, tool output truncation)
- `packages/agent-core/src/run-hardened-query.ts` — create budget per query, track tokens/compactions, emit strategy hints
- `packages/agent-core/src/session-runner.ts` — propagate context metrics to OTel spans and Langfuse
- `packages/agent-core/src/phases/pipeline-types.ts` — add `contextMetrics` to PipelineContext
- `packages/agent-core/src/phases/query-phase.ts` — propagate contextMetrics from query result
- `packages/agent-core/src/index.ts` — export new types and factory

## Test plan
- [x] 22 unit tests for ContextBudget covering threshold transitions, truncation, metrics, model limits
- [x] All 1109 existing agent-core tests pass
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] Architecture audit (check-adr, check-deps) clean
- [x] `pnpm regen` — artifacts up to date