### PR TITLE
fix(security): add rate limiting to confirm-attendance and manage-reservation routes

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14916,18 +14916,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5448,6 +5448,11 @@
     export const confirmAttendanceRoutes: FastifyPluginAsync = async (fastify) => {
       fastify.patch<{ Querystring: { token?: string } }>(
         "/public/v1/reservations/confirm",
+        {
+          config: {
+            rateLimit: { max: 10, timeWindow: "1 minute" },
+          },
+        },
         async (request, reply) => {
           const { token } = request.query;
     
@@ -7031,6 +7036,11 @@
     export const manageReservationRoutes: FastifyPluginAsync = async (fastify) => {
       fastify.get<{ Querystring: { token?: string } }>(
         "/public/v1/reservations/manage",
+        {
+          config: {
+            rateLimit: { max: 10, timeWindow: "1 minute" },
+          },
+        },
         async (request, reply) => {
           const { token } = request.query;
     
@@ -14916,7 +14926,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14926,18 +14926,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14916,7 +14916,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,18 +337,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,7 +337,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/services/reservations/llms-full.txt
+++ b/services/reservations/llms-full.txt
@@ -411,6 +411,11 @@
     export const confirmAttendanceRoutes: FastifyPluginAsync = async (fastify) => {
       fastify.patch<{ Querystring: { token?: string } }>(
         "/public/v1/reservations/confirm",
+        {
+          config: {
+            rateLimit: { max: 10, timeWindow: "1 minute" },
+          },
+        },
         async (request, reply) => {
           const { token } = request.query;
     
@@ -1994,6 +1999,11 @@
     export const manageReservationRoutes: FastifyPluginAsync = async (fastify) => {
       fastify.get<{ Querystring: { token?: string } }>(
         "/public/v1/reservations/manage",
+        {
+          config: {
+            rateLimit: { max: 10, timeWindow: "1 minute" },
+          },
+        },
         async (request, reply) => {
           const { token } = request.query;
     

--- a/services/reservations/src/routes/confirm-attendance.test.ts
+++ b/services/reservations/src/routes/confirm-attendance.test.ts
@@ -159,3 +159,29 @@ describe("PATCH /public/v1/reservations/confirm", () => {
     expect(response.headers["content-type"]).toContain("text/html");
   });
 });
+
+describe("PATCH /public/v1/reservations/confirm — rate limiting", () => {
+  it("has rate limiting configured at 10 req/min", async () => {
+    process.env.AUTH_BYPASS_IN_TESTS = "true";
+    const freshApp = await buildApp({ logger: false });
+    await freshApp.ready();
+
+    // Send 11 requests — the 11th should be rate-limited
+    const responses = [];
+    for (let i = 0; i < 11; i++) {
+      const response = await freshApp.inject({
+        method: "PATCH",
+        url: "/public/v1/reservations/confirm?token=garbage",
+      });
+      responses.push(response);
+    }
+
+    await freshApp.close();
+
+    // First 10 return 401 (invalid token), 11th should be rate limited
+    for (let i = 0; i < 10; i++) {
+      expect(responses[i].statusCode).toBe(401);
+    }
+    expect(responses[10].statusCode).toBe(429);
+  });
+});

--- a/services/reservations/src/routes/confirm-attendance.ts
+++ b/services/reservations/src/routes/confirm-attendance.ts
@@ -35,6 +35,11 @@ h1{color:#d97706;margin:0 0 .5rem}p{color:#4b5563;margin:0}</style></head>
 export const confirmAttendanceRoutes: FastifyPluginAsync = async (fastify) => {
   fastify.patch<{ Querystring: { token?: string } }>(
     "/public/v1/reservations/confirm",
+    {
+      config: {
+        rateLimit: { max: 10, timeWindow: "1 minute" },
+      },
+    },
     async (request, reply) => {
       const { token } = request.query;
 

--- a/services/reservations/src/routes/manage-reservation.test.ts
+++ b/services/reservations/src/routes/manage-reservation.test.ts
@@ -153,3 +153,29 @@ describe("GET /public/v1/reservations/manage", () => {
     expect(response.statusCode).toBe(400);
   });
 });
+
+describe("GET /public/v1/reservations/manage — rate limiting", () => {
+  it("has rate limiting configured at 10 req/min", async () => {
+    process.env.AUTH_BYPASS_IN_TESTS = "true";
+    const freshApp = await buildApp({ logger: false });
+    await freshApp.ready();
+
+    // Send 11 requests — the 11th should be rate-limited
+    const responses = [];
+    for (let i = 0; i < 11; i++) {
+      const response = await freshApp.inject({
+        method: "GET",
+        url: "/public/v1/reservations/manage?token=garbage-token",
+      });
+      responses.push(response);
+    }
+
+    await freshApp.close();
+
+    // First 10 return 401 (invalid token), 11th should be rate limited
+    for (let i = 0; i < 10; i++) {
+      expect(responses[i].statusCode).toBe(401);
+    }
+    expect(responses[10].statusCode).toBe(429);
+  });
+});

--- a/services/reservations/src/routes/manage-reservation.ts
+++ b/services/reservations/src/routes/manage-reservation.ts
@@ -6,6 +6,11 @@ import { venueService } from "../services/venue.js";
 export const manageReservationRoutes: FastifyPluginAsync = async (fastify) => {
   fastify.get<{ Querystring: { token?: string } }>(
     "/public/v1/reservations/manage",
+    {
+      config: {
+        rateLimit: { max: 10, timeWindow: "1 minute" },
+      },
+    },
     async (request, reply) => {
       const { token } = request.query;
 


### PR DESCRIPTION
## Summary

- Applies `config: { rateLimit: { max: 10, timeWindow: "1 minute" } }` to `PATCH /public/v1/reservations/confirm` (confirm-attendance route)
- Applies the same config to `GET /public/v1/reservations/manage` (manage-reservation route)
- Adds failing-first tests to both files verifying the 11th request within a window returns 429

Both routes were flagged by CodeQL alerts #106 and #107 (`js/missing-rate-limiting`, high severity). The fix adopts the identical pattern already used by `cancel-reservation.ts` and `modify-reservation.ts`.

## Test plan

- [x] New test: `PATCH /public/v1/reservations/confirm — rate limiting > has rate limiting configured at 10 req/min`
- [x] New test: `GET /public/v1/reservations/manage — rate limiting > has rate limiting configured at 10 req/min`
- [x] All 709 reservations service tests pass (50 test files)
- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `check-adr` and `check-deps` pass
- [x] `pnpm regen` run; updated `llms-full.txt` files staged

Closes #2350