### PR TITLE
chore(acmm): daily audit 2026-06-16

### DIFF
--- a/.claude/acmm/state.json
+++ b/.claude/acmm/state.json
@@ -1,6 +1,6 @@
 {
-  "lastRun": "2026-06-13T17:05:05.986Z",
-  "currentLevel": 6,
+  "lastRun": "2026-06-16T17:07:04.904Z",
+  "currentLevel": 5,
   "checks": {
     "acmm:prereq-test-suite": {
       "passed": true,
@@ -346,11 +346,11 @@
       "substanceEvidence": null
     },
     "acmm:feedback-loops": {
-      "passed": true,
+      "passed": false,
       "evidence": "detected at: CLAUDE.md",
-      "verdict": "pass",
-      "substantive": true,
-      "substanceEvidence": null
+      "verdict": "hollow",
+      "substantive": false,
+      "substanceEvidence": "no entries from last 30 days"
     },
     "acmm:claude-md-auto-sync": {
       "passed": true,
@@ -598,9 +598,9 @@
       "substanceEvidence": null
     },
     "acmm:accessibility-ai-check": {
-      "passed": true,
-      "evidence": ".github/workflows/ci.yml contains: pnpm --dir packages/rialto vitest .* accessibility",
-      "verdict": "pass",
+      "passed": false,
+      "evidence": ".github/workflows/ci.yml does not contain: pnpm --dir packages/rialto vitest .* accessibility",
+      "verdict": "not-found",
       "substantive": null,
       "substanceEvidence": null
     },
@@ -792,6 +792,13 @@
       "verdict": "not-found",
       "substantive": null,
       "substanceEvidence": null
+    },
+    "meta:audit-freshness": {
+      "passed": true,
+      "evidence": "gh CLI unavailable or error",
+      "verdict": "unverifiable",
+      "substantive": null,
+      "substanceEvidence": null
     }
   },
   "history": [
@@ -884,6 +891,12 @@
       "level": 6,
       "detected": 111,
       "total": 113
+    },
+    {
+      "date": "2026-06-16",
+      "level": 5,
+      "detected": 110,
+      "total": 114
     }
   ],
   "issuesCreated": {
@@ -893,8 +906,8 @@
     "acmm:instruction-rot-detection": 1265,
     "acmm:repo-bench": 1266
   },
-  "levelName": "Fully Autonomous",
-  "role": "Strategist",
+  "levelName": "Semi-Automated",
+  "role": "Operator",
   "detectedIds": [
     "acmm:prereq-test-suite",
     "acmm:prereq-cicd",
@@ -944,7 +957,6 @@
     "acmm:instruction-sync-gate",
     "acmm:component-registry-integrity",
     "acmm:instruction-rot-detection",
-    "acmm:feedback-loops",
     "acmm:claude-md-auto-sync",
     "acmm:preference-index",
     "acmm:task-ledger",
@@ -980,7 +992,6 @@
     "acmm:feedback-loop-inventory",
     "acmm:budget-policy",
     "acmm:token-tracking",
-    "acmm:accessibility-ai-check",
     "acmm:auto-rollback",
     "acmm:multi-repo-orchestration",
     "fullsend:test-coverage",
@@ -1006,19 +1017,20 @@
     "meta:threshold-tuning",
     "meta:instruction-evolution",
     "meta:process-metrics",
-    "meta:fp-rate-healthy"
+    "meta:fp-rate-healthy",
+    "meta:audit-freshness"
   ],
   "computation": {
-    "level": 6,
+    "level": 5,
     "strict": true,
-    "levelName": "Fully Autonomous",
-    "role": "Strategist",
-    "characteristic": "The system acts on what it finds — generates issues, merges PRs, rolls back failures. Humans set policy and audit after the fact.",
+    "levelName": "Semi-Automated",
+    "role": "Operator",
+    "characteristic": "The system detects problems and proposes fixes without human initiation. Humans still approve; the system proposes.",
     "detectedByLevel": {
       "2": 3,
       "3": 6,
       "4": 16,
-      "5": 16,
+      "5": 15,
       "6": 8
     },
     "requiredByLevel": {
@@ -1029,8 +1041,8 @@
       "6": 8
     },
     "missingForNextLevel": [],
-    "nextTransitionTrigger": null,
-    "antiPattern": "Mistaking autonomy for abandonment: an autonomous codebase still needs a strategist to set direction, or it drifts toward local optima.",
+    "nextTransitionTrigger": "None — L6 is the terminal state. The human role becomes direction-setting, not code writing.",
+    "antiPattern": "Alert fatigue: generating proposals no one reviews. An unread suggestion is noise, not maturity.",
     "prerequisites": {
       "met": 7,
       "total": 8
@@ -1055,7 +1067,8 @@
         "threshold": 0.2,
         "direction": "below",
         "strict": true,
-        "dataAvailable": true
+        "dataAvailable": true,
+        "unverifiable": false
       },
       {
         "level": 4,
@@ -1066,7 +1079,8 @@
         "threshold": 0.5,
         "direction": "above",
         "strict": true,
-        "dataAvailable": true
+        "dataAvailable": true,
+        "unverifiable": false
       },
       {
         "level": 5,
@@ -1077,7 +1091,8 @@
         "threshold": 1,
         "direction": "above",
         "strict": true,
-        "dataAvailable": true
+        "dataAvailable": true,
+        "unverifiable": false
       },
       {
         "level": 6,
@@ -1088,7 +1103,20 @@
         "threshold": 0.1,
         "direction": "below",
         "strict": true,
-        "dataAvailable": true
+        "dataAvailable": true,
+        "unverifiable": false
+      },
+      {
+        "level": 6,
+        "name": "human-touch-ratio",
+        "description": "Human-touch ratio must be below 50% (merged agent PRs requiring non-author commits, 30-day window)",
+        "passed": false,
+        "value": 1,
+        "threshold": 0.5,
+        "direction": "below",
+        "strict": true,
+        "dataAvailable": true,
+        "unverifiable": false
       }
     ],
     "capped": false
@@ -1132,7 +1160,7 @@
     },
     "auto_qa_tuning": {
       "history_count": 2,
-      "measured_at": "2026-06-13T17:05:05.984Z"
+      "measured_at": "2026-06-16T17:07:04.902Z"
     }
   },
   "honestAuditNote": "Verified 2026-05-23: Level cap removed. All 3 original concerns addressed: (1) Strategic Dashboard updated with real autonomous activity audit log (PR #1688). (2) Auto-rollback drill mechanism implemented (PR #1678) — trigger with `gh workflow run auto-rollback.yml -f drill=true`. (3) llms.txt integrity fixed — root cause was Node version mismatch + stale api-versioning refs. Substance checks 5/5, behavioral gates all pass (91% acceptance, 0% reverts). Computed level 6."

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/mattbutlerengineering/mattbutlerengineering/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/mattbutlerengineering/mattbutlerengineering/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=flat-square)](./LICENSE)
 [![codecov](https://codecov.io/gh/mattbutlerengineering/mattbutlerengineering/graph/badge.svg?token=ANNEPED1FV)](https://codecov.io/gh/mattbutlerengineering/mattbutlerengineering)
-[![ACMM Level 6](https://img.shields.io/badge/ACMM-Level%206-d4a030?style=flat-square)](docs/acmm.md)
+[![ACMM Level 5 (stale unknown)](https://img.shields.io/badge/ACMM-Level%205%20%28stale%20unknown%29-9e9e9e?style=flat-square)](docs/acmm.md)
 
 > **Build status:** GitHub Actions runs CI checks on every PR. Verify changes locally with `pnpm lint`/`typecheck`/`test`. See [CONTRIBUTING.md](./CONTRIBUTING.md) for details.
 

--- a/plugins/acmm/scripts/inheritance.js
+++ b/plugins/acmm/scripts/inheritance.js
@@ -1,0 +1,123 @@
+/**
+ * Inheritance-aware criterion evaluation for monorepo/sub-project ACMM scoring.
+ *
+ * When a project has `acmm.inherit: true` in package.json, criteria checks first
+ * look locally, then (if not found and path is in globalPaths) at the repo root.
+ *
+ * Exports:
+ *   evaluateWithInheritance(allCriteria, projectPath, repoRoot, acmmConfig)
+ *     → { detectedIds: Set, criterionVerdicts: Map, origins: Map }
+ */
+
+import { evaluate } from "./evaluate.js";
+
+/**
+ * Determine whether a criterion's path should be inherited from the repo root.
+ *
+ * @param {{ detection: { pattern: any } }} criterion
+ * @param {{ inherit: boolean, globalPaths: string[], localOnly: string[] }} config
+ * @returns {boolean}
+ */
+function isInheritablePath(criterion, config) {
+  if (!config.inherit) return false;
+  if (!config.globalPaths || config.globalPaths.length === 0) return false;
+
+  const patterns = Array.isArray(criterion.detection.pattern)
+    ? criterion.detection.pattern
+    : [criterion.detection.pattern];
+
+  for (const pattern of patterns) {
+    const path = typeof pattern === "string" ? pattern : (pattern.file ?? "");
+    if (!path) continue;
+
+    // Check if this path (or a parent dir) is in globalPaths
+    for (const gp of config.globalPaths) {
+      // Normalize trailing slashes
+      const gpNorm = gp.endsWith("/") ? gp : gp + "/";
+      const pathNorm = path.endsWith("/") ? path : path + "/";
+
+      // Exact match or path starts with global path prefix
+      if (path === gp || pathNorm.startsWith(gpNorm)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Check if a criterion is in the localOnly list and must be detected locally.
+ *
+ * @param {{ detection: { pattern: any } }} criterion
+ * @param {{ localOnly: string[] }} config
+ * @returns {boolean}
+ */
+function isLocalOnly(criterion, config) {
+  if (!config.localOnly || config.localOnly.length === 0) return false;
+
+  const patterns = Array.isArray(criterion.detection.pattern)
+    ? criterion.detection.pattern
+    : [criterion.detection.pattern];
+
+  for (const pattern of patterns) {
+    const path = typeof pattern === "string" ? pattern : (pattern.file ?? "");
+    if (!path) continue;
+
+    for (const local of config.localOnly) {
+      if (path === local || path.startsWith(local.replace(/\/$/, "") + "/")) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Evaluate all criteria with inheritance support.
+ *
+ * @param {Array} allCriteria - All 85+ ACMM criteria
+ * @param {string} projectPath - Path to project being audited
+ * @param {string} repoRoot - Path to repo root
+ * @param {{ inherit: boolean, globalPaths: string[], localOnly: string[] }} acmmConfig
+ * @returns {{ detectedIds: Set<string>, criterionVerdicts: Map<string, Object>, origins: Map<string, string> }}
+ */
+export function evaluateWithInheritance(allCriteria, projectPath, repoRoot, acmmConfig) {
+  const detectedIds = new Set();
+  const criterionVerdicts = new Map();
+  const origins = new Map();
+
+  for (const criterion of allCriteria) {
+    // Check locally first
+    const localVerdict = evaluate(criterion, projectPath);
+    const localPassed = localVerdict.verdict === "pass" || localVerdict.verdict === "unverifiable";
+
+    if (localPassed) {
+      // Found locally — use that
+      detectedIds.add(criterion.id);
+      criterionVerdicts.set(criterion.id, localVerdict);
+      origins.set(criterion.id, "local");
+    } else if (!isLocalOnly(criterion, acmmConfig) && isInheritablePath(criterion, acmmConfig)) {
+      // Not found locally, but inheritable and path is global — check root
+      const rootVerdict = evaluate(criterion, repoRoot);
+      const rootPassed = rootVerdict.verdict === "pass" || rootVerdict.verdict === "unverifiable";
+
+      if (rootPassed) {
+        detectedIds.add(criterion.id);
+        criterionVerdicts.set(criterion.id, rootVerdict);
+        origins.set(criterion.id, "inherited");
+      } else {
+        // Not found anywhere
+        criterionVerdicts.set(criterion.id, rootVerdict);
+        origins.set(criterion.id, "not-found");
+      }
+    } else {
+      // Not found and either not inheritable or is localOnly
+      criterionVerdicts.set(criterion.id, localVerdict);
+      origins.set(criterion.id, "not-found");
+    }
+  }
+
+  return { detectedIds, criterionVerdicts, origins };
+}


### PR DESCRIPTION
## ACMM Maturity Regression Detected

**Level: L6 → L5** (110/114 criteria detected)

### Summary

The daily ACMM audit detected a regression from Level 6 (Fully Autonomous) to Level 5 (Semi-Automated). Two criteria regressed:
- `acmm:accessibility-ai-check`: CI workflow no longer contains the expected accessibility test pattern
- `acmm:feedback-loops`: Substance check failed — no entries from the last 30 days

One new criterion detected:
- `meta:audit-freshness`: Audit freshness validation

### Behavioral Gates (Strict Mode)

L6 is blocked by:
- **Human-touch ratio:** 100% (needs <50%)
  - All 22 merged agent PRs in the last 30 days had non-author commits
  - This indicates the system is fully autonomous but the feedback loop shows all PRs still requiring human review/changes

### What Changed

1. **inheritance.js** — New module implementing `evaluateWithInheritance()` for monorepo ACMM scoring. Enables:
   - Local-first criterion detection
   - Inheritance from repo root for global paths (CI, docs, contributing guides)
   - localOnly enforcement for project-specific criteria (CLAUDE.md, AGENTS.md)
   - Origin tracking (local vs inherited detection)

2. **README.md badge** — Updated from Level 6 to Level 5 with "(stale unknown)" indicator

3. **state.json** (gitignored) — Updated with current criterion verdicts and history entry

### Next Steps

To return to L6, address either:

**Option A: Restore missing criteria**
- Re-add accessibility test pattern to CI workflow (`.github/workflows/ci.yml`)
- Add recent feedback-loop entries (detected via `.claude/acmm/review-burden-metrics.js` scoring)

**Option B: Adjust human-touch gate**
- The metric reflects reality — all agent PRs required edits. This may be intentional; verify the gate threshold makes sense for this codebase.

### Test Results

- Audit: ✅ Completed successfully
- Rubric tests: 251/252 pass (1 unrelated failure in evals-score.test.js)
- Prerequisites: 7/8 ✅ (E2E tests not configured)

See `.claude/acmm/report.md` (gitignored, local only) for the full scorecard.

https://claude.ai/code/session_01M1HNeCTTWQRS2J4BSakfGh

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1HNeCTTWQRS2J4BSakfGh)_