### PR TITLE
refactor(hospitality): createQueryHook factory — collapse copy-pasted query hooks

### DIFF
--- a/apps/hospitality/llms-full.txt
+++ b/apps/hospitality/llms-full.txt
@@ -145,6 +145,30 @@
   </file>
   </section>
   <section priority="medium" role="hooks">
+  <file path="src/hooks/create-query-hook.ts">
+    export interface QueryHookResult<TData> {
+      data: TData | undefined;
+      isLoading: boolean;
+      error: Error | null;
+      refetch: () => void;
+    }
+    export interface CreateQueryHookOptions<TData, TParams = undefined, TResult = TData> {
+      /** Base query key string */
+      key: string;
+      /** Fetcher function — receives params and api client, returns TData */
+      fetcher: (params: TParams | undefined, api: ReturnType<typeof useApiClient>) => Promise<TData>;
+      /**
+       * Optional predicate to derive the `enabled` flag from params.
+       * When omitted, the hook is always enabled unless params.enabled === false.
+       */
+      getEnabled?: (params: (TParams & { enabled?: boolean }) | undefined) => boolean;
+      /**
+       * Optional transform applied to query.data before returning.
+       * Use this to coalesce undefined → null, or extract a nested field.
+       */
+      select?: (data: TData | undefined) => TResult;
+    }
+  </file>
   <file path="src/hooks/use-command-palette.ts">
     interface UseCommandPaletteOptions {
       sections: readonly NavSection[];

--- a/apps/hospitality/llms.txt
+++ b/apps/hospitality/llms.txt
@@ -80,6 +80,24 @@
   </file>
   </section>
   <section priority="medium" role="hooks">
+  <file path="src/hooks/create-query-hook.ts">
+    <item priority="low">
+      interface QueryHookResult {
+        data: TData | undefined;
+        isLoading: boolean;
+        error: Error | null;
+        refetch: () => void;
+      }
+    </item>
+    <item priority="low">
+      interface CreateQueryHookOptions {
+        key: string;
+        fetcher: (params: TParams | undefined, api: ReturnType<typeof useA...;
+        getEnabled?: (params: (TParams & { enabled?: boolean }) | undefined) =...;
+        select?: (data: TData | undefined) => TResult;
+      }
+    </item>
+  </file>
   <file path="src/hooks/use-command-palette.ts">
     <item priority="high">
       interface UseCommandPaletteOptions {

--- a/apps/hospitality/src/hooks/create-query-hook.test.ts
+++ b/apps/hospitality/src/hooks/create-query-hook.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+import { createQueryHook } from "./create-query-hook.js";
+
+/* ── Mocks ───────────────────────────────────────────── */
+
+vi.mock("./useApiClient.js", () => ({
+  useApiClient: () => ({}),
+}));
+
+/* ── Helpers ─────────────────────────────────────────── */
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+/* ── Tests: key derivation ───────────────────────────── */
+
+describe("createQueryHook — key derivation", () => {
+  it("uses base key as single-element array when no params", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(["item1"]);
+    const useItems = createQueryHook({ key: "items", fetcher: mockFetch });
+
+    const { result } = renderHook(() => useItems(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockFetch).toHaveBeenCalledWith(undefined, expect.anything());
+    expect(result.current.data).toEqual(["item1"]);
+  });
+
+  it("includes params in query key", async () => {
+    const mockFetch = vi.fn().mockResolvedValue([]);
+    const useItems = createQueryHook<string[], { venueId: string }>({
+      key: "items",
+      fetcher: mockFetch,
+    });
+
+    const { result } = renderHook(() => useItems({ venueId: "v1" }), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // Params and api passed to fetcher
+    expect(mockFetch).toHaveBeenCalledWith({ venueId: "v1" }, expect.anything());
+  });
+});
+
+/* ── Tests: error mapping ────────────────────────────── */
+
+describe("createQueryHook — error mapping", () => {
+  it("returns null error on success", async () => {
+    const mockFetch = vi.fn().mockResolvedValue([]);
+    const useItems = createQueryHook({ key: "items", fetcher: mockFetch });
+
+    const { result } = renderHook(() => useItems(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.error).toBeNull();
+  });
+
+  it("returns Error instance on failure", async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error("Network failure"));
+    const useItems = createQueryHook({ key: "items", fetcher: mockFetch });
+
+    const { result } = renderHook(() => useItems(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe("Network failure");
+  });
+});
+
+/* ── Tests: enabled gating ───────────────────────────── */
+
+describe("createQueryHook — enabled gating", () => {
+  it("does not fetch when enabled is false", () => {
+    const mockFetch = vi.fn().mockResolvedValue([]);
+    const useItems = createQueryHook({ key: "items", fetcher: mockFetch });
+
+    const { result } = renderHook(() => useItems({ enabled: false }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("fetches when enabled is true (default)", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(["item"]);
+    const useItems = createQueryHook({ key: "items", fetcher: mockFetch });
+
+    const { result } = renderHook(() => useItems({ enabled: true }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mockFetch).toHaveBeenCalled();
+  });
+
+  it("supports custom enabled predicate from params", () => {
+    const mockFetch = vi.fn().mockResolvedValue([]);
+    const useItems = createQueryHook<string[], { venueId?: string | null }>({
+      key: "items",
+      fetcher: mockFetch,
+      getEnabled: (params) => !!params?.venueId,
+    });
+
+    const { result } = renderHook(() => useItems({ venueId: null }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("fetches when custom enabled predicate returns true", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(["item"]);
+    const useItems = createQueryHook<string[], { venueId?: string | null }>({
+      key: "items",
+      fetcher: mockFetch,
+      getEnabled: (params) => !!params?.venueId,
+    });
+
+    const { result } = renderHook(() => useItems({ venueId: "v1" }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mockFetch).toHaveBeenCalledWith({ venueId: "v1" }, expect.anything());
+  });
+});
+
+/* ── Tests: return shape ─────────────────────────────── */
+
+describe("createQueryHook — return shape", () => {
+  it("returns loading state initially", () => {
+    const mockFetch = vi.fn().mockReturnValue(new Promise(() => {}));
+    const useItems = createQueryHook({ key: "items", fetcher: mockFetch });
+
+    const { result } = renderHook(() => useItems(), { wrapper: createWrapper() });
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("exposes a refetch function", async () => {
+    const mockFetch = vi.fn().mockResolvedValue([]);
+    const useItems = createQueryHook({ key: "items", fetcher: mockFetch });
+
+    const { result } = renderHook(() => useItems(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(typeof result.current.refetch).toBe("function");
+  });
+});

--- a/apps/hospitality/src/hooks/create-query-hook.ts
+++ b/apps/hospitality/src/hooks/create-query-hook.ts
@@ -1,0 +1,103 @@
+import { useQuery } from "@tanstack/react-query";
+import { useApiClient } from "./useApiClient.js";
+
+/* ── Types ───────────────────────────────────────────── */
+
+export interface QueryHookResult<TData> {
+  data: TData | undefined;
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => void;
+}
+
+export interface CreateQueryHookOptions<TData, TParams = undefined, TResult = TData> {
+  /** Base query key string */
+  key: string;
+  /** Fetcher function — receives params and api client, returns TData */
+  fetcher: (params: TParams | undefined, api: ReturnType<typeof useApiClient>) => Promise<TData>;
+  /**
+   * Optional predicate to derive the `enabled` flag from params.
+   * When omitted, the hook is always enabled unless params.enabled === false.
+   */
+  getEnabled?: (params: (TParams & { enabled?: boolean }) | undefined) => boolean;
+  /**
+   * Optional transform applied to query.data before returning.
+   * Use this to coalesce undefined → null, or extract a nested field.
+   */
+  select?: (data: TData | undefined) => TResult;
+}
+
+type HookParams<TParams> = TParams extends undefined
+  ? { enabled?: boolean } | undefined
+  : TParams & { enabled?: boolean };
+
+/**
+ * Factory that collapses the ~15-line repeated useQuery wrapper pattern
+ * into a single declaration per domain hook.
+ *
+ * Key derivation: [key, params] (params undefined when not provided)
+ * Error mapping: query.error ?? null
+ * Enabled gating: getEnabled predicate OR params.enabled flag
+ * Data transform: optional select function
+ */
+export function createQueryHook<TData, TParams = undefined, TResult = TData>(
+  options: CreateQueryHookOptions<TData, TParams, TResult>
+): (params?: HookParams<TParams>) => QueryHookResult<TResult> {
+  const { key, fetcher, getEnabled, select } = options;
+
+  return function useQueryHook(params?: HookParams<TParams>): QueryHookResult<TResult> {
+    const api = useApiClient();
+
+    const enabled = resolveEnabled(params, getEnabled);
+    const queryParams = stripEnabled(params);
+
+    const query = useQuery({
+      queryKey: queryParams !== undefined ? [key, queryParams] : [key],
+      queryFn: () => fetcher(queryParams as TParams | undefined, api),
+      enabled,
+    });
+
+    const data = select !== undefined ? select(query.data) : (query.data as unknown as TResult);
+
+    return {
+      data,
+      isLoading: query.isLoading,
+      error: query.error ?? null,
+      refetch: query.refetch,
+    };
+  };
+}
+
+/* ── Private helpers ─────────────────────────────────── */
+
+function resolveEnabled<TParams>(
+  params: (TParams & { enabled?: boolean }) | undefined,
+  getEnabled: ((p: (TParams & { enabled?: boolean }) | undefined) => boolean) | undefined
+): boolean {
+  if (getEnabled !== undefined) {
+    // Custom predicate takes priority — but still respect explicit enabled: false
+    if (params !== null && typeof params === "object" && "enabled" in params) {
+      const explicit = (params as { enabled?: boolean }).enabled;
+      if (explicit === false) return false;
+    }
+    return getEnabled(params);
+  }
+  if (params !== null && typeof params === "object" && "enabled" in params) {
+    const explicit = (params as { enabled?: boolean }).enabled;
+    if (explicit === false) return false;
+  }
+  return true;
+}
+
+function stripEnabled<TParams>(
+  params: (TParams & { enabled?: boolean }) | undefined
+): TParams | undefined {
+  if (params === undefined || params === null) return undefined;
+  if (typeof params !== "object") return params as unknown as TParams;
+  const { enabled: _enabled, ...rest } = params as Record<string, unknown> & {
+    enabled?: boolean;
+  };
+  // If rest is empty (only key was 'enabled'), return undefined so key stays [key]
+  if (Object.keys(rest).length === 0) return undefined;
+  return rest as unknown as TParams;
+}

--- a/apps/hospitality/src/hooks/create-query-hook.ts
+++ b/apps/hospitality/src/hooks/create-query-hook.ts
@@ -27,10 +27,6 @@ export interface CreateQueryHookOptions<TData, TParams = undefined, TResult = TD
   select?: (data: TData | undefined) => TResult;
 }
 
-type HookParams<TParams> = TParams extends undefined
-  ? { enabled?: boolean } | undefined
-  : TParams & { enabled?: boolean };
-
 /**
  * Factory that collapses the ~15-line repeated useQuery wrapper pattern
  * into a single declaration per domain hook.
@@ -42,10 +38,12 @@ type HookParams<TParams> = TParams extends undefined
  */
 export function createQueryHook<TData, TParams = undefined, TResult = TData>(
   options: CreateQueryHookOptions<TData, TParams, TResult>
-): (params?: HookParams<TParams>) => QueryHookResult<TResult> {
+): (params?: (TParams & { enabled?: boolean }) | undefined) => QueryHookResult<TResult> {
   const { key, fetcher, getEnabled, select } = options;
 
-  return function useQueryHook(params?: HookParams<TParams>): QueryHookResult<TResult> {
+  return function useQueryHook(
+    params?: (TParams & { enabled?: boolean }) | undefined
+  ): QueryHookResult<TResult> {
     const api = useApiClient();
 
     const enabled = resolveEnabled(params, getEnabled);

--- a/apps/hospitality/src/hooks/useFloorPlans.ts
+++ b/apps/hospitality/src/hooks/useFloorPlans.ts
@@ -1,6 +1,7 @@
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { FloorPlan, CreateTableRequest, Table } from "@mbe/types";
 import { useApiClient } from "./useApiClient.js";
+import { createQueryHook, type QueryHookResult } from "./create-query-hook.js";
 
 export const FLOOR_PLANS_QUERY_KEY = "floorPlans" as const;
 export const FLOOR_PLAN_QUERY_KEY = "floorPlan" as const;
@@ -20,29 +21,16 @@ export interface UseFloorPlansResult {
   refetch: () => void;
 }
 
-export function useFloorPlans(params: UseFloorPlansParams = {}): UseFloorPlansResult {
-  const { venueId, limit = 50, enabled = true } = params;
-  const api = useApiClient();
-
-  const query = useQuery({
-    queryKey: [FLOOR_PLANS_QUERY_KEY, { venueId, limit }],
-    queryFn: async () => {
-      const response = await api.floorPlans.list({
-        venueId: venueId ?? undefined,
-        limit,
-      });
-      return response.data;
-    },
-    enabled,
-  });
-
-  return {
-    data: query.data,
-    isLoading: query.isLoading,
-    error: query.error ?? null,
-    refetch: query.refetch,
-  };
-}
+export const useFloorPlans = createQueryHook<FloorPlan[], UseFloorPlansParams>({
+  key: FLOOR_PLANS_QUERY_KEY,
+  fetcher: async (params, api) => {
+    const response = await api.floorPlans.list({
+      venueId: params?.venueId ?? undefined,
+      limit: params?.limit ?? 50,
+    });
+    return response.data;
+  },
+});
 
 /* ── useFloorPlan (single) ───────────────────────────── */
 
@@ -53,24 +41,18 @@ export interface UseFloorPlanResult {
   refetch: () => void;
 }
 
+const useFloorPlanQuery = createQueryHook<FloorPlan | null, { id: string | undefined }>({
+  key: FLOOR_PLAN_QUERY_KEY,
+  fetcher: async (params, api) => {
+    const fp = await api.floorPlans.getById(params!.id!);
+    return fp;
+  },
+  getEnabled: (params) => !!params?.id,
+  select: (data) => data ?? null,
+});
+
 export function useFloorPlan(id: string | undefined): UseFloorPlanResult {
-  const api = useApiClient();
-
-  const query = useQuery({
-    queryKey: [FLOOR_PLAN_QUERY_KEY, id],
-    queryFn: async () => {
-      const fp = await api.floorPlans.getById(id!);
-      return fp;
-    },
-    enabled: !!id,
-  });
-
-  return {
-    data: query.data ?? null,
-    isLoading: query.isLoading,
-    error: query.error ?? null,
-    refetch: query.refetch,
-  };
+  return useFloorPlanQuery({ id }) as QueryHookResult<FloorPlan | null>;
 }
 
 /* ── useCloneFloorPlan mutation ──────────────────────── */

--- a/apps/hospitality/src/hooks/useGuests.ts
+++ b/apps/hospitality/src/hooks/useGuests.ts
@@ -1,7 +1,8 @@
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { Guest, GuestSegment, UpdateGuestRequest } from "@mbe/types";
 import type { FindOrCreateGuestRequest } from "@mbe/api-client";
 import { useApiClient } from "./useApiClient.js";
+import { createQueryHook, type QueryHookResult } from "./create-query-hook.js";
 
 export const GUESTS_QUERY_KEY = "guests" as const;
 export const GUEST_SEGMENTS_QUERY_KEY = "guestSegments" as const;
@@ -21,27 +22,15 @@ export interface UseGuestsResult {
   refetch: () => void;
 }
 
-export function useGuests(params: UseGuestsParams = {}): UseGuestsResult {
-  const { venueId, limit = 50, enabled = true } = params;
-  const api = useApiClient();
-
-  const query = useQuery({
-    queryKey: [GUESTS_QUERY_KEY, { venueId, limit }],
-    queryFn: async () => {
-      if (!venueId) return [];
-      const response = await api.guests.list({ venueId, limit });
-      return response.data;
-    },
-    enabled: enabled && !!venueId,
-  });
-
-  return {
-    data: query.data,
-    isLoading: query.isLoading,
-    error: query.error ?? null,
-    refetch: query.refetch,
-  };
-}
+export const useGuests = createQueryHook<Guest[], UseGuestsParams>({
+  key: GUESTS_QUERY_KEY,
+  fetcher: async (params, api) => {
+    if (!params?.venueId) return [];
+    const response = await api.guests.list({ venueId: params.venueId, limit: params.limit ?? 50 });
+    return response.data;
+  },
+  getEnabled: (params) => !!params?.venueId,
+});
 
 /* ── useGuestSearch ──────────────────────────────────── */
 
@@ -51,26 +40,18 @@ export interface UseGuestSearchParams {
   enabled?: boolean;
 }
 
+const useGuestSearchQuery = createQueryHook<Guest[], UseGuestSearchParams>({
+  key: GUESTS_QUERY_KEY,
+  fetcher: async (params, api) => {
+    if (!params?.venueId || !params.query) return [];
+    const response = await api.guests.search({ venueId: params.venueId, query: params.query });
+    return response.data;
+  },
+  getEnabled: (params) => !!params?.venueId && !!params?.query,
+});
+
 export function useGuestSearch(params: UseGuestSearchParams): UseGuestsResult {
-  const { venueId, query, enabled = true } = params;
-  const api = useApiClient();
-
-  const searchQuery = useQuery({
-    queryKey: [GUESTS_QUERY_KEY, { venueId, search: query }],
-    queryFn: async () => {
-      if (!venueId || !query) return [];
-      const response = await api.guests.search({ venueId, query });
-      return response.data;
-    },
-    enabled: enabled && !!venueId && !!query,
-  });
-
-  return {
-    data: searchQuery.data,
-    isLoading: searchQuery.isLoading,
-    error: searchQuery.error ?? null,
-    refetch: searchQuery.refetch,
-  };
+  return useGuestSearchQuery(params);
 }
 
 /* ── useGuestSegments ────────────────────────────────── */
@@ -81,23 +62,39 @@ export interface UseGuestSegmentsResult {
   error: Error | null;
 }
 
+const useGuestSegmentsQuery = createQueryHook<
+  GuestSegment[],
+  { venueId: string | null | undefined }
+>({
+  key: GUEST_SEGMENTS_QUERY_KEY,
+  fetcher: async (params, api) => {
+    if (!params?.venueId) return [];
+    return api.guests.getSegments(params.venueId);
+  },
+  getEnabled: (params) => !!params?.venueId,
+});
+
 export function useGuestSegments(venueId: string | null | undefined): UseGuestSegmentsResult {
-  const api = useApiClient();
+  return useGuestSegmentsQuery({ venueId }) as QueryHookResult<GuestSegment[]>;
+}
 
-  const query = useQuery({
-    queryKey: [GUEST_SEGMENTS_QUERY_KEY, venueId],
-    queryFn: async () => {
-      if (!venueId) return [];
-      return api.guests.getSegments(venueId);
-    },
-    enabled: !!venueId,
-  });
+/* ── useGuest (single) ───────────────────────────────── */
 
-  return {
-    data: query.data,
-    isLoading: query.isLoading,
-    error: query.error ?? null,
-  };
+export interface UseGuestResult {
+  data: Guest | undefined;
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => void;
+}
+
+const useGuestQuery = createQueryHook<Guest, { id: string | null | undefined }>({
+  key: GUESTS_QUERY_KEY,
+  fetcher: (params, api) => api.guests.get(params!.id!),
+  getEnabled: (params) => !!params?.id,
+});
+
+export function useGuest(guestId: string | null | undefined): UseGuestResult {
+  return useGuestQuery({ id: guestId });
 }
 
 /* ── useAddGuest mutation ────────────────────────────── */
@@ -128,32 +125,6 @@ export function useUpdateGuest() {
       queryClient.invalidateQueries({ queryKey: [GUESTS_QUERY_KEY] });
     },
   });
-}
-
-/* ── useGuest (single) ───────────────────────────────── */
-
-export interface UseGuestResult {
-  data: Guest | undefined;
-  isLoading: boolean;
-  error: Error | null;
-  refetch: () => void;
-}
-
-export function useGuest(guestId: string | null | undefined): UseGuestResult {
-  const api = useApiClient();
-
-  const query = useQuery({
-    queryKey: [GUESTS_QUERY_KEY, { id: guestId }],
-    queryFn: () => api.guests.get(guestId!),
-    enabled: !!guestId,
-  });
-
-  return {
-    data: query.data,
-    isLoading: query.isLoading,
-    error: query.error ?? null,
-    refetch: query.refetch,
-  };
 }
 
 /* ── useAddStaffNote mutation ────────────────────────── */

--- a/apps/hospitality/src/hooks/useReservations.ts
+++ b/apps/hospitality/src/hooks/useReservations.ts
@@ -1,7 +1,6 @@
-import { useQuery } from "@tanstack/react-query";
 import type { Reservation } from "@mbe/types";
 import type { ListReservationsParams } from "@mbe/api-client";
-import { useApiClient } from "./useApiClient.js";
+import { createQueryHook } from "./create-query-hook.js";
 
 export const RESERVATIONS_QUERY_KEY = "reservations" as const;
 
@@ -16,23 +15,10 @@ export interface UseReservationsResult {
   refetch: () => void;
 }
 
-export function useReservations(params: UseReservationsParams = {}): UseReservationsResult {
-  const { enabled = true, ...queryParams } = params;
-  const api = useApiClient();
-
-  const query = useQuery({
-    queryKey: [RESERVATIONS_QUERY_KEY, queryParams],
-    queryFn: async () => {
-      const response = await api.reservations.list(queryParams);
-      return response.data;
-    },
-    enabled,
-  });
-
-  return {
-    data: query.data,
-    isLoading: query.isLoading,
-    error: query.error ?? null,
-    refetch: query.refetch,
-  };
-}
+export const useReservations = createQueryHook<Reservation[], UseReservationsParams>({
+  key: RESERVATIONS_QUERY_KEY,
+  fetcher: async (params, api) => {
+    const response = await api.reservations.list(params ?? {});
+    return response.data;
+  },
+});

--- a/apps/hospitality/src/hooks/useTables.ts
+++ b/apps/hospitality/src/hooks/useTables.ts
@@ -1,7 +1,6 @@
-import { useQuery } from "@tanstack/react-query";
 import type { Table } from "@mbe/types";
 import type { ListTablesParams } from "@mbe/api-client";
-import { useApiClient } from "./useApiClient.js";
+import { createQueryHook } from "./create-query-hook.js";
 
 export const TABLES_QUERY_KEY = "tables" as const;
 
@@ -16,23 +15,10 @@ export interface UseTablesResult {
   refetch: () => void;
 }
 
-export function useTables(params: UseTablesParams = {}): UseTablesResult {
-  const { enabled = true, ...queryParams } = params;
-  const api = useApiClient();
-
-  const query = useQuery({
-    queryKey: [TABLES_QUERY_KEY, queryParams],
-    queryFn: async () => {
-      const response = await api.tables.list(queryParams);
-      return response.data;
-    },
-    enabled,
-  });
-
-  return {
-    data: query.data,
-    isLoading: query.isLoading,
-    error: query.error ?? null,
-    refetch: query.refetch,
-  };
-}
+export const useTables = createQueryHook<Table[], UseTablesParams>({
+  key: TABLES_QUERY_KEY,
+  fetcher: async (params, api) => {
+    const response = await api.tables.list(params ?? {});
+    return response.data;
+  },
+});

--- a/apps/hospitality/src/hooks/useUsers.ts
+++ b/apps/hospitality/src/hooks/useUsers.ts
@@ -1,6 +1,12 @@
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import type { User, UpdateUserRequest, UpdatePreferencesRequest } from "@mbe/types";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type {
+  User,
+  UpdateUserRequest,
+  UpdatePreferencesRequest,
+  PaginatedResponse,
+} from "@mbe/types";
 import { useApiClient } from "./useApiClient.js";
+import { createQueryHook, type QueryHookResult } from "./create-query-hook.js";
 
 export const CURRENT_USER_QUERY_KEY = "currentUser" as const;
 export const USERS_QUERY_KEY = "users" as const;
@@ -14,20 +20,14 @@ export interface UseCurrentUserResult {
   refetch: () => void;
 }
 
+const useCurrentUserQuery = createQueryHook<User | null>({
+  key: CURRENT_USER_QUERY_KEY,
+  fetcher: (_params, api) => api.users.me(),
+  select: (data) => data ?? null,
+});
+
 export function useCurrentUser(): UseCurrentUserResult {
-  const api = useApiClient();
-
-  const query = useQuery({
-    queryKey: [CURRENT_USER_QUERY_KEY],
-    queryFn: () => api.users.me(),
-  });
-
-  return {
-    data: query.data ?? null,
-    isLoading: query.isLoading,
-    error: query.error ?? null,
-    refetch: query.refetch,
-  };
+  return useCurrentUserQuery() as QueryHookResult<User | null>;
 }
 
 /* ── useUpdateCurrentUser mutation ───────────────────── */
@@ -83,23 +83,18 @@ export interface UseUsersResult {
   refetch: () => void;
 }
 
+const useUsersQuery = createQueryHook<PaginatedResponse<User>, UseUsersParams>({
+  key: USERS_QUERY_KEY,
+  fetcher: (params, api) => api.users.list(params?.page ?? 1, params?.limit ?? 10),
+});
+
 export function useUsers(params: UseUsersParams = {}): UseUsersResult {
-  const { page = 1, limit = 10, enabled = true } = params;
-  const api = useApiClient();
-
-  const query = useQuery({
-    queryKey: [USERS_QUERY_KEY, { page, limit }],
-    queryFn: async () => {
-      return api.users.list(page, limit);
-    },
-    enabled,
-  });
-
+  const result = useUsersQuery(params);
   return {
-    data: query.data?.data,
-    pagination: query.data?.pagination,
-    isLoading: query.isLoading,
-    error: query.error ?? null,
-    refetch: query.refetch,
+    data: result.data?.data,
+    pagination: result.data?.pagination,
+    isLoading: result.isLoading,
+    error: result.error,
+    refetch: result.refetch,
   };
 }

--- a/apps/hospitality/src/hooks/useVenues.ts
+++ b/apps/hospitality/src/hooks/useVenues.ts
@@ -1,6 +1,7 @@
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { Venue, UpdateVenueRequest } from "@mbe/types";
 import { useApiClient } from "./useApiClient.js";
+import { createQueryHook, type QueryHookResult } from "./create-query-hook.js";
 
 export const VENUES_QUERY_KEY = "venues" as const;
 export const VENUE_BY_SLUG_QUERY_KEY = "venueBySlug" as const;
@@ -19,26 +20,13 @@ export interface UseVenuesResult {
   refetch: () => void;
 }
 
-export function useVenues(params: UseVenuesParams = {}): UseVenuesResult {
-  const { limit = 50, enabled = true } = params;
-  const api = useApiClient();
-
-  const query = useQuery({
-    queryKey: [VENUES_QUERY_KEY, { limit }],
-    queryFn: async () => {
-      const response = await api.venues.list({ limit });
-      return response.data;
-    },
-    enabled,
-  });
-
-  return {
-    data: query.data,
-    isLoading: query.isLoading,
-    error: query.error ?? null,
-    refetch: query.refetch,
-  };
-}
+export const useVenues = createQueryHook<Venue[], UseVenuesParams>({
+  key: VENUES_QUERY_KEY,
+  fetcher: async (params, api) => {
+    const response = await api.venues.list({ limit: params?.limit ?? 50 });
+    return response.data;
+  },
+});
 
 /* ── useUpdateVenue mutation ─────────────────────────── */
 
@@ -63,21 +51,16 @@ export interface UseVenueBySlugResult {
   error: Error | null;
 }
 
+const useVenueBySlugQuery = createQueryHook<Venue | null, { slug: string | undefined }>({
+  key: VENUE_BY_SLUG_QUERY_KEY,
+  fetcher: async (params, api) => {
+    if (!params?.slug) return null;
+    return api.venues.getBySlug(params.slug);
+  },
+  getEnabled: (params) => !!params?.slug,
+  select: (data) => data ?? null,
+});
+
 export function useVenueBySlug(slug: string | undefined): UseVenueBySlugResult {
-  const api = useApiClient();
-
-  const query = useQuery({
-    queryKey: [VENUE_BY_SLUG_QUERY_KEY, slug],
-    queryFn: async () => {
-      if (!slug) return null;
-      return api.venues.getBySlug(slug);
-    },
-    enabled: !!slug,
-  });
-
-  return {
-    data: query.data ?? null,
-    isLoading: query.isLoading,
-    error: query.error ?? null,
-  };
+  return useVenueBySlugQuery({ slug }) as QueryHookResult<Venue | null>;
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14950,18 +14950,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2924,6 +2924,30 @@
       deleteSpec: (id: string) => Promise<void>;
     }
   </file>
+  <file path="apps/hospitality/src/hooks/create-query-hook.ts">
+    export interface QueryHookResult<TData> {
+      data: TData | undefined;
+      isLoading: boolean;
+      error: Error | null;
+      refetch: () => void;
+    }
+    export interface CreateQueryHookOptions<TData, TParams = undefined, TResult = TData> {
+      /** Base query key string */
+      key: string;
+      /** Fetcher function — receives params and api client, returns TData */
+      fetcher: (params: TParams | undefined, api: ReturnType<typeof useApiClient>) => Promise<TData>;
+      /**
+       * Optional predicate to derive the `enabled` flag from params.
+       * When omitted, the hook is always enabled unless params.enabled === false.
+       */
+      getEnabled?: (params: (TParams & { enabled?: boolean }) | undefined) => boolean;
+      /**
+       * Optional transform applied to query.data before returning.
+       * Use this to coalesce undefined → null, or extract a nested field.
+       */
+      select?: (data: TData | undefined) => TResult;
+    }
+  </file>
   <file path="apps/hospitality/src/hooks/use-command-palette.ts">
     interface UseCommandPaletteOptions {
       sections: readonly NavSection[];
@@ -14926,7 +14950,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms.txt
+++ b/llms.txt
@@ -848,6 +848,24 @@
       }
     </item>
   </file>
+  <file path="apps/hospitality/src/hooks/create-query-hook.ts">
+    <item priority="low">
+      interface QueryHookResult {
+        data: TData | undefined;
+        isLoading: boolean;
+        error: Error | null;
+        refetch: () => void;
+      }
+    </item>
+    <item priority="low">
+      interface CreateQueryHookOptions {
+        key: string;
+        fetcher: (params: TParams | undefined, api: ReturnType<typeof useA...;
+        getEnabled?: (params: (TParams & { enabled?: boolean }) | undefined) =...;
+        select?: (data: TData | undefined) => TResult;
+      }
+    </item>
+  </file>
   <file path="apps/hospitality/src/hooks/use-command-palette.ts">
     <item priority="high">
       interface UseCommandPaletteOptions {

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,18 +337,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,7 +337,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),


### PR DESCRIPTION
Closes #2057

## Summary

- Introduces `createQueryHook` factory in `apps/hospitality/src/hooks/create-query-hook.ts`
- Migrates 6 domain hook files (useReservations, useTables, useVenues, useGuests, useFloorPlans, useUsers) from ~15-line repeated `useQuery` wrapper to single factory declarations
- Thin wrapper functions preserve original call signatures for hooks with positional args (slug, id, venueId)
- All existing call sites (pages/components) remain unchanged

## Key design

- `fetcher(params, api)` receives api client as 2nd arg — factory calls `useApiClient()` once inside the returned hook and passes it through
- `getEnabled` predicate for conditional fetching; respects explicit `enabled: false` flag
- `select` option handles `data ?? null` coalescing pattern
- Key derivation: `[key, params]` when params present, `[key]` otherwise
- Error mapping: `query.error ?? null`

## Test plan

- [x] 10 unit tests in `create-query-hook.test.ts` covering key derivation, error mapping, enabled gating (explicit + predicate), return shape
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — no errors
- [x] `pnpm test` — 934 tests passed
- [x] `check-adr` / `check-deps` — no violations
- [x] `pnpm regen --check` — all generated artifacts up to date