### PR TITLE
refactor(agent-core): wire post-commit quality gates through GateRunner

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2737,6 +2737,9 @@
     export class LlmEvaluationGate implements QualityGate {
       readonly name = "evaluation";
     
+      /** Set after evaluate() completes. Undefined before the gate runs. */
+      lastResult: EvaluationResult | undefined;
+    
       shouldSkip(context: GateContext): boolean {
         return context.evaluateSuccess === false;
       }
@@ -2747,6 +2750,8 @@
           const evalResult = await evaluateSuccess(context.taskDescription, context.diff, {
             commitTitle: context.commitMsg,
           });
+    
+          this.lastResult = evalResult;
     
           span.setAttribute("evaluation.passed", evalResult.passed);
           span.setAttribute("evaluation.confidence", evalResult.confidence);
@@ -14926,7 +14931,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14931,18 +14931,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms.txt
+++ b/llms.txt
@@ -777,6 +777,7 @@
     <item priority="high">
       class LlmEvaluationGate {
         name: unknown;
+        lastResult: EvaluationResult | undefined;
         async shouldSkip(): Promise<unknown>;
         async evaluate(): Promise<unknown>;
       }

--- a/packages/agent-core/llms-full.txt
+++ b/packages/agent-core/llms-full.txt
@@ -405,6 +405,9 @@
     export class LlmEvaluationGate implements QualityGate {
       readonly name = "evaluation";
     
+      /** Set after evaluate() completes. Undefined before the gate runs. */
+      lastResult: EvaluationResult | undefined;
+    
       shouldSkip(context: GateContext): boolean {
         return context.evaluateSuccess === false;
       }
@@ -415,6 +418,8 @@
           const evalResult = await evaluateSuccess(context.taskDescription, context.diff, {
             commitTitle: context.commitMsg,
           });
+    
+          this.lastResult = evalResult;
     
           span.setAttribute("evaluation.passed", evalResult.passed);
           span.setAttribute("evaluation.confidence", evalResult.confidence);

--- a/packages/agent-core/llms.txt
+++ b/packages/agent-core/llms.txt
@@ -86,6 +86,7 @@
     <item priority="high">
       class LlmEvaluationGate {
         name: unknown;
+        lastResult: EvaluationResult | undefined;
         async shouldSkip(): Promise<unknown>;
         async evaluate(): Promise<unknown>;
       }

--- a/packages/agent-core/src/__tests__/gate-runner.test.ts
+++ b/packages/agent-core/src/__tests__/gate-runner.test.ts
@@ -1,6 +1,30 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { GateContext, GateResult, QualityGate } from "../gate-runner.js";
 import { GateRunner } from "../gate-runner.js";
+
+// ── Mocks for real gate integration tests ────────────────────────────
+vi.mock("../diff-static-analyzer.js", () => ({
+  analyzeDiff: vi.fn(),
+}));
+
+vi.mock("../success-evaluator.js", () => ({
+  evaluateSuccess: vi.fn(),
+}));
+
+vi.mock("../diff-reviewer.js", () => ({
+  reviewDiff: vi.fn(),
+}));
+
+vi.mock("@opentelemetry/api", () => ({
+  trace: {
+    getTracer: () => ({
+      startSpan: () => ({
+        setAttribute: vi.fn(),
+        end: vi.fn(),
+      }),
+    }),
+  },
+}));
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -222,5 +246,207 @@ describe("GateRunner", () => {
       const result = await runner.run(makeContext());
       expect(result.passed).toBe(true);
     });
+  });
+});
+
+// ── Integration: GateRunner composed with real gate implementations ──
+
+describe("GateRunner integration with real gates", () => {
+  let analyzeDiff: ReturnType<typeof vi.fn>;
+  let evaluateSuccess: ReturnType<typeof vi.fn>;
+  let reviewDiff: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const staticMod = await import("../diff-static-analyzer.js");
+    const evalMod = await import("../success-evaluator.js");
+    const reviewMod = await import("../diff-reviewer.js");
+    analyzeDiff = vi.mocked(staticMod.analyzeDiff);
+    evaluateSuccess = vi.mocked(evalMod.evaluateSuccess);
+    reviewDiff = vi.mocked(reviewMod.reviewDiff);
+
+    analyzeDiff.mockReturnValue({ clean: true, violations: [] });
+    evaluateSuccess.mockResolvedValue({
+      passed: true,
+      confidence: 0.9,
+      reasoning: "Good",
+      issues: [],
+    });
+    reviewDiff.mockResolvedValue({ approved: true, issues: [] });
+  });
+
+  function makeRealContext(overrides: Partial<GateContext> = {}): GateContext {
+    return {
+      diff: "diff --git a/src/foo.ts b/src/foo.ts\n+const x = 1;",
+      taskDescription: "Fix the bug",
+      commitMsg: "fix: the bug",
+      evaluateSuccess: true,
+      runStaticAnalysis: true,
+      runSecurityReview: true,
+      ...overrides,
+    };
+  }
+
+  it("passes when all real gates pass", async () => {
+    const { StaticAnalysisGate } = await import("../gates/static-analysis-gate.js");
+    const { LlmEvaluationGate } = await import("../gates/llm-evaluation-gate.js");
+    const { SecurityReviewGate } = await import("../gates/security-review-gate.js");
+
+    const runner = new GateRunner([
+      new StaticAnalysisGate(),
+      new LlmEvaluationGate(),
+      new SecurityReviewGate(),
+    ]);
+
+    const result = await runner.run(makeRealContext());
+
+    expect(result.passed).toBe(true);
+    expect(result.results).toHaveLength(3);
+  });
+
+  it("fails when static analysis gate finds error violations", async () => {
+    analyzeDiff.mockReturnValue({
+      clean: false,
+      violations: [
+        {
+          file: "src/foo.ts",
+          line: 5,
+          rule: "no-secret",
+          message: "hardcoded secret",
+          severity: "error",
+        },
+      ],
+    });
+
+    const { StaticAnalysisGate } = await import("../gates/static-analysis-gate.js");
+    const { LlmEvaluationGate } = await import("../gates/llm-evaluation-gate.js");
+    const { SecurityReviewGate } = await import("../gates/security-review-gate.js");
+
+    const runner = new GateRunner([
+      new StaticAnalysisGate(),
+      new LlmEvaluationGate(),
+      new SecurityReviewGate(),
+    ]);
+
+    const result = await runner.run(makeRealContext());
+
+    expect(result.passed).toBe(false);
+    const staticResult = result.results.find((r) => r.gateName === "static-analysis");
+    expect(staticResult?.passed).toBe(false);
+    expect(staticResult?.details).toContain("hardcoded secret");
+  });
+
+  it("fails when LLM evaluation gate returns failed result", async () => {
+    evaluateSuccess.mockResolvedValue({
+      passed: false,
+      confidence: 0.2,
+      reasoning: "Task not addressed",
+      issues: [],
+    });
+
+    const { StaticAnalysisGate } = await import("../gates/static-analysis-gate.js");
+    const { LlmEvaluationGate } = await import("../gates/llm-evaluation-gate.js");
+    const { SecurityReviewGate } = await import("../gates/security-review-gate.js");
+
+    const runner = new GateRunner([
+      new StaticAnalysisGate(),
+      new LlmEvaluationGate(),
+      new SecurityReviewGate(),
+    ]);
+
+    const result = await runner.run(makeRealContext());
+
+    expect(result.passed).toBe(false);
+    const evalResult = result.results.find((r) => r.gateName === "evaluation");
+    expect(evalResult?.passed).toBe(false);
+    expect(evalResult?.details).toContain("Task not addressed");
+  });
+
+  it("fails when security review gate rejects", async () => {
+    reviewDiff.mockResolvedValue({ approved: false, issues: ["SQL injection detected"] });
+
+    const { StaticAnalysisGate } = await import("../gates/static-analysis-gate.js");
+    const { LlmEvaluationGate } = await import("../gates/llm-evaluation-gate.js");
+    const { SecurityReviewGate } = await import("../gates/security-review-gate.js");
+
+    const runner = new GateRunner([
+      new StaticAnalysisGate(),
+      new LlmEvaluationGate(),
+      new SecurityReviewGate(),
+    ]);
+
+    const result = await runner.run(makeRealContext());
+
+    expect(result.passed).toBe(false);
+    const secResult = result.results.find((r) => r.gateName === "security-review");
+    expect(secResult?.passed).toBe(false);
+    expect(secResult?.details).toContain("SQL injection detected");
+  });
+
+  it("skips LLM evaluation gate when evaluateSuccess=false in context", async () => {
+    const { StaticAnalysisGate } = await import("../gates/static-analysis-gate.js");
+    const { LlmEvaluationGate } = await import("../gates/llm-evaluation-gate.js");
+    const { SecurityReviewGate } = await import("../gates/security-review-gate.js");
+
+    const runner = new GateRunner([
+      new StaticAnalysisGate(),
+      new LlmEvaluationGate(),
+      new SecurityReviewGate(),
+    ]);
+
+    await runner.run(makeRealContext({ evaluateSuccess: false }));
+
+    expect(evaluateSuccess).not.toHaveBeenCalled();
+  });
+
+  it("skips security review gate when runSecurityReview=false in context", async () => {
+    const { StaticAnalysisGate } = await import("../gates/static-analysis-gate.js");
+    const { LlmEvaluationGate } = await import("../gates/llm-evaluation-gate.js");
+    const { SecurityReviewGate } = await import("../gates/security-review-gate.js");
+
+    const runner = new GateRunner([
+      new StaticAnalysisGate(),
+      new LlmEvaluationGate(),
+      new SecurityReviewGate(),
+    ]);
+
+    await runner.run(makeRealContext({ runSecurityReview: false }));
+
+    expect(reviewDiff).not.toHaveBeenCalled();
+  });
+
+  it("SecurityReviewGate skips when skipWhen callback returns true", async () => {
+    const { StaticAnalysisGate } = await import("../gates/static-analysis-gate.js");
+    const { LlmEvaluationGate } = await import("../gates/llm-evaluation-gate.js");
+    const { SecurityReviewGate } = await import("../gates/security-review-gate.js");
+
+    // Static analysis fails — security review should be skipped via skipWhen
+    analyzeDiff.mockReturnValue({
+      clean: false,
+      violations: [
+        { file: "src/a.ts", line: 1, rule: "no-secret", message: "secret", severity: "error" },
+      ],
+    });
+    let staticPassed = true;
+    const staticGate = new StaticAnalysisGate();
+    const secGate = new SecurityReviewGate({ skipWhen: () => !staticPassed });
+
+    // First gate will fail and we track that
+    const patchedStatic: QualityGate = {
+      name: staticGate.name,
+      shouldSkip: staticGate.shouldSkip?.bind(staticGate),
+      evaluate: async (ctx) => {
+        const r = await staticGate.evaluate(ctx);
+        staticPassed = r.passed;
+        return r;
+      },
+    };
+
+    const runner = new GateRunner([new LlmEvaluationGate(), patchedStatic, secGate]);
+
+    const result = await runner.run(makeRealContext());
+
+    expect(reviewDiff).not.toHaveBeenCalled();
+    expect(result.passed).toBe(false);
   });
 });

--- a/packages/agent-core/src/gates/llm-evaluation-gate.ts
+++ b/packages/agent-core/src/gates/llm-evaluation-gate.ts
@@ -1,5 +1,6 @@
 import { trace } from "@opentelemetry/api";
 import { evaluateSuccess } from "../success-evaluator.js";
+import type { EvaluationResult } from "../success-evaluator.js";
 import type { GateContext, GateResult, QualityGate } from "../gate-runner.js";
 
 const tracer = trace.getTracer("@mbe/agent-core");
@@ -10,9 +11,15 @@ const tracer = trace.getTracer("@mbe/agent-core");
  * The skip policy is absorbed inside `evaluateSuccess`: when the policy
  * fires, `evaluateSuccess` returns the inconclusive `skipped` result and
  * the gate passes.
+ *
+ * After `evaluate()` runs, `lastResult` holds the full EvaluationResult
+ * so callers can read it without triggering a second LLM call.
  */
 export class LlmEvaluationGate implements QualityGate {
   readonly name = "evaluation";
+
+  /** Set after evaluate() completes. Undefined before the gate runs. */
+  lastResult: EvaluationResult | undefined;
 
   shouldSkip(context: GateContext): boolean {
     return context.evaluateSuccess === false;
@@ -24,6 +31,8 @@ export class LlmEvaluationGate implements QualityGate {
       const evalResult = await evaluateSuccess(context.taskDescription, context.diff, {
         commitTitle: context.commitMsg,
       });
+
+      this.lastResult = evalResult;
 
       span.setAttribute("evaluation.passed", evalResult.passed);
       span.setAttribute("evaluation.confidence", evalResult.confidence);

--- a/packages/agent-core/src/post-commit-gateway.ts
+++ b/packages/agent-core/src/post-commit-gateway.ts
@@ -1,11 +1,13 @@
 import { trace } from "@opentelemetry/api";
 import { runVerification } from "./worktree-manager.js";
 import { storeVerificationLog, emitEvent } from "./utils.js";
-import { analyzeDiff } from "./diff-static-analyzer.js";
-import { evaluateSuccess } from "./success-evaluator.js";
-import type { EvaluationResult } from "./success-evaluator.js";
-import { reviewDiff } from "./diff-reviewer.js";
 import { isTrivialDepBump } from "./dep-bump-merger.js";
+import { GateRunner } from "./gate-runner.js";
+import type { GateContext, QualityGate } from "./gate-runner.js";
+import { StaticAnalysisGate } from "./gates/static-analysis-gate.js";
+import { LlmEvaluationGate } from "./gates/llm-evaluation-gate.js";
+import { SecurityReviewGate } from "./gates/security-review-gate.js";
+import type { EvaluationResult } from "./success-evaluator.js";
 import type { SessionEventCallback } from "./types.js";
 
 const tracer = trace.getTracer("@mbe/agent-core");
@@ -48,11 +50,12 @@ export interface PostCommitGatewayInput {
 /**
  * Run all post-commit validation gates and determine the PR outcome.
  *
- * Inline steps:
+ * Steps:
  *   1. Verification (lint + typecheck + tests)
- *   2. Static analysis (regex-based, no AI)
- *   3. LLM evaluation (skip-policy absorbed inside evaluateSuccess)
- *   4. Security review (skipped when static analysis failed)
+ *   2. Quality gates via GateRunner:
+ *      a. Static analysis (regex-based, no AI)
+ *      b. LLM evaluation (skip-policy absorbed inside evaluateSuccess)
+ *      c. Security review (skipped when static analysis failed)
  *
  * Returns a GatewayVerdict with:
  *   - `outcome`: "merge-direct" | "create-pr" | "create-draft-pr"
@@ -115,87 +118,64 @@ export async function runPostCommitGateway(
     return { outcome: "create-draft-pr", passed: false, gateFailures, errors };
   }
 
-  let evaluation: EvaluationResult | undefined;
-
-  // ── Step 2: Static analysis ───────────────────────────────────────────────
+  // ── Step 2: Quality gates via GateRunner ─────────────────────────────────
+  // SecurityReviewGate skips when static analysis failed — tracked via closure.
   let staticAnalysisPassed = true;
-  if (config.runStaticAnalysis !== false) {
-    const staticSpan = tracer.startSpan("agent_core.static_analysis_gate");
-    try {
-      const analysisResult = analyzeDiff(diff);
-      const errorViolations = analysisResult.violations.filter((v) => v.severity === "error");
-      staticAnalysisPassed = errorViolations.length === 0;
+  const evalGate = new LlmEvaluationGate();
+  const secGate = new SecurityReviewGate({ skipWhen: () => !staticAnalysisPassed });
+  const staticGate = new StaticAnalysisGate();
 
-      staticSpan.setAttribute("static_analysis.clean", analysisResult.clean);
-      staticSpan.setAttribute("static_analysis.violation_count", analysisResult.violations.length);
-      staticSpan.setAttribute("static_analysis.error_count", errorViolations.length);
+  // Wrap static gate to capture its pass result for the security gate dependency.
+  const trackingStaticGate: QualityGate = {
+    name: staticGate.name,
+    shouldSkip: (ctx) => staticGate.shouldSkip?.(ctx) ?? false,
+    evaluate: async (ctx) => {
+      const result = await staticGate.evaluate(ctx);
+      staticAnalysisPassed = result.passed;
+      return result;
+    },
+  };
 
-      if (!staticAnalysisPassed) {
-        const formatted = errorViolations
-          .map((v) => `${v.file}:${v.line} [${v.rule}] ${v.message}`)
-          .join("; ");
-        const details = `Static analysis errors: ${formatted}`;
-        gateFailures.push("static-analysis");
-        errors.push(details);
-        emitEvent(onEvent, "session:verification", { message: details });
-      } else if (!analysisResult.clean) {
-        const warnCount = analysisResult.violations.filter((v) => v.severity === "warning").length;
-        emitEvent(onEvent, "session:verification", {
-          message: `${warnCount} warning(s) (non-blocking)`,
-        });
+  const gateContext: GateContext = {
+    diff,
+    taskDescription,
+    commitMsg,
+    evaluateSuccess: config.evaluateSuccess !== false,
+    runStaticAnalysis: config.runStaticAnalysis !== false,
+    runSecurityReview: config.runSecurityReview !== false,
+  };
+
+  const runner = new GateRunner([trackingStaticGate, evalGate, secGate]);
+  const gateRunResult = await runner.run(gateContext);
+
+  // Collect failures and errors from gate results; emit events per gate
+  for (const gateResult of gateRunResult.results) {
+    if (gateResult.details === "skipped") continue;
+
+    if (!gateResult.passed) {
+      gateFailures.push(gateResult.gateName);
+      if (gateResult.details) {
+        errors.push(gateResult.details);
+        const eventType =
+          gateResult.gateName === "evaluation"
+            ? "session:evaluation"
+            : gateResult.gateName === "security-review"
+              ? "session:review"
+              : "session:verification";
+        emitEvent(onEvent, eventType, { message: gateResult.details });
       }
-    } finally {
-      staticSpan.end();
+    } else {
+      // Emit pass events for certain gates
+      if (gateResult.gateName === "evaluation" && gateResult.details) {
+        emitEvent(onEvent, "session:evaluation", { message: gateResult.details });
+      } else if (gateResult.gateName === "static-analysis" && gateResult.details) {
+        emitEvent(onEvent, "session:verification", { message: gateResult.details });
+      }
     }
   }
 
-  // ── Step 3: LLM evaluation ────────────────────────────────────────────────
-  if (config.evaluateSuccess !== false) {
-    const evalSpan = tracer.startSpan("agent_core.llm_evaluation_gate");
-    try {
-      const evalResult = await evaluateSuccess(taskDescription, diff, { commitTitle: commitMsg });
-      evaluation = evalResult;
-
-      evalSpan.setAttribute("evaluation.passed", evalResult.passed);
-      evalSpan.setAttribute("evaluation.confidence", evalResult.confidence);
-      if (evalResult.skipped) {
-        evalSpan.setAttribute("evaluation.skipped", true);
-      }
-
-      if (!evalResult.passed) {
-        const details = `Evaluation failed: ${evalResult.reasoning}`;
-        gateFailures.push("evaluation");
-        errors.push(details);
-        emitEvent(onEvent, "session:evaluation", { message: details });
-      } else {
-        emitEvent(onEvent, "session:evaluation", {
-          message: `confidence: ${evalResult.confidence.toFixed(2)}`,
-        });
-      }
-    } finally {
-      evalSpan.end();
-    }
-  }
-
-  // ── Step 4: Security review (skipped when static analysis failed) ─────────
-  if (config.runSecurityReview !== false && staticAnalysisPassed) {
-    const secSpan = tracer.startSpan("agent_core.security_review_gate");
-    try {
-      const reviewResult = await reviewDiff(diff);
-
-      secSpan.setAttribute("security_review.approved", reviewResult.approved);
-      secSpan.setAttribute("security_review.issues_count", reviewResult.issues.length);
-
-      if (!reviewResult.approved) {
-        const details = `Security review failed: ${reviewResult.issues.join("; ")}`;
-        gateFailures.push("security-review");
-        errors.push(details);
-        emitEvent(onEvent, "session:review", { message: details });
-      }
-    } finally {
-      secSpan.end();
-    }
-  }
+  // Read the EvaluationResult captured by the gate (no second LLM call)
+  const evaluation = evalGate.lastResult;
 
   const allGatesPass = gateFailures.length === 0;
 
@@ -203,7 +183,7 @@ export async function runPostCommitGateway(
     return { outcome: "create-draft-pr", passed: false, gateFailures, errors, evaluation };
   }
 
-  // ── Step 5: Determine merge strategy ─────────────────────────────────────
+  // ── Step 3: Determine merge strategy ─────────────────────────────────────
   const depBumpCheck = isTrivialDepBump(diff);
   if (depBumpCheck.isTrivial) {
     return { outcome: "merge-direct", passed: true, gateFailures: [], errors: [], evaluation };


### PR DESCRIPTION
## Summary

- Replaces the inline gate logic in `runPostCommitGateway` with `GateRunner` composition using the real `StaticAnalysisGate`, `LlmEvaluationGate`, and `SecurityReviewGate` implementations
- Adds `lastResult: EvaluationResult | undefined` to `LlmEvaluationGate` so callers can read the full evaluation result after the gate runs without triggering a second LLM call
- Cross-gate dependency (security review skips when static analysis fails) is preserved via a `skipWhen` closure passed to `SecurityReviewGate`
- Adds 7 integration tests in `gate-runner.test.ts` that compose real gate instances with `GateRunner` and verify the full pipeline behavior

## Test plan

- [x] `pnpm --dir packages/agent-core test` — 1116 tests pass (1109 original + 7 new integration tests)
- [x] `pnpm --dir packages/agent-core lint` — clean
- [x] `pnpm --dir packages/agent-core typecheck` — clean
- [x] `pnpm --filter @mbe/cli start check-adr` — no violations
- [x] `pnpm --filter @mbe/cli start check-deps` — no violations
- [x] `pnpm regen` — run; llms artifacts regenerated and committed
- [x] Pre-push hook ran full turbo test + typecheck across 6 affected packages — all passed

Closes #2368