### PR TITLE
feat(agent-core): add Reviewer Runner for implement-queue quality gate

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14941,18 +14941,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -12928,6 +12928,21 @@
       readonly suggestion?: string;
     }
   </file>
+  <file path="packages/agent-core/src/reviewer-runner.ts">
+    export interface ReviewerConfig {
+      /** Model to use for the reviewer. Default: haiku (fast + cheap). */
+      readonly model: string;
+      /** Maximum spend per review in USD. Default: 0.05. */
+      readonly maxBudgetUsd: number;
+      /** Wall-clock timeout in ms. Reviewer fails-open on timeout. Default: 30_000. */
+      readonly timeoutMs: number;
+    }
+    export const DEFAULT_REVIEWER_CONFIG: ReviewerConfig = {
+      model: resolveModelId("haiku"),
+      maxBudgetUsd: 0.05,
+      timeoutMs: 30_000,
+    };
+  </file>
   <file path="packages/agent-core/src/run-hardened-query.ts">
     export const apiCircuitBreaker = new CircuitBreaker({
       failureThreshold: CIRCUIT_BREAKER_FAILURE_THRESHOLD,
@@ -14926,7 +14941,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms.txt
+++ b/llms.txt
@@ -2873,6 +2873,18 @@
       }
     </item>
   </file>
+  <file path="packages/agent-core/src/reviewer-runner.ts">
+    <item priority="low">
+      interface ReviewerConfig {
+        model: string;
+        maxBudgetUsd: number;
+        timeoutMs: number;
+      }
+    </item>
+    <item priority="high">
+      export const DEFAULT_REVIEWER_CONFIG: ReviewerConfig;
+    </item>
+  </file>
   <file path="packages/agent-core/src/run-hardened-query.ts">
     <item priority="high">
       export const apiCircuitBreaker: unknown;

--- a/packages/agent-core/llms-full.txt
+++ b/packages/agent-core/llms-full.txt
@@ -1716,6 +1716,21 @@
       readonly suggestion?: string;
     }
   </file>
+  <file path="src/reviewer-runner.ts">
+    export interface ReviewerConfig {
+      /** Model to use for the reviewer. Default: haiku (fast + cheap). */
+      readonly model: string;
+      /** Maximum spend per review in USD. Default: 0.05. */
+      readonly maxBudgetUsd: number;
+      /** Wall-clock timeout in ms. Reviewer fails-open on timeout. Default: 30_000. */
+      readonly timeoutMs: number;
+    }
+    export const DEFAULT_REVIEWER_CONFIG: ReviewerConfig = {
+      model: resolveModelId("haiku"),
+      maxBudgetUsd: 0.05,
+      timeoutMs: 30_000,
+    };
+  </file>
   <file path="src/run-hardened-query.ts">
     export const apiCircuitBreaker = new CircuitBreaker({
       failureThreshold: CIRCUIT_BREAKER_FAILURE_THRESHOLD,

--- a/packages/agent-core/llms.txt
+++ b/packages/agent-core/llms.txt
@@ -636,6 +636,18 @@
       }
     </item>
   </file>
+  <file path="src/reviewer-runner.ts">
+    <item priority="low">
+      interface ReviewerConfig {
+        model: string;
+        maxBudgetUsd: number;
+        timeoutMs: number;
+      }
+    </item>
+    <item priority="high">
+      export const DEFAULT_REVIEWER_CONFIG: ReviewerConfig;
+    </item>
+  </file>
   <file path="src/run-hardened-query.ts">
     <item priority="high">
       export const apiCircuitBreaker: unknown;

--- a/packages/agent-core/src/__tests__/reviewer-runner.test.ts
+++ b/packages/agent-core/src/__tests__/reviewer-runner.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: vi.fn(),
+}));
+
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import {
+  runReviewer,
+  parseReviewerVerdict,
+  selectRetryAction,
+  DEFAULT_REVIEWER_CONFIG,
+} from "../reviewer-runner.js";
+import type { ReviewerConfig } from "../reviewer-runner.js";
+import type { ReviewInput, ReviewVerdict } from "../reviewer-contract.js";
+import { PASS_THRESHOLD } from "../reviewer-contract.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+async function* mockQueryGenerator(messages: unknown[]) {
+  for (const msg of messages) {
+    yield msg;
+  }
+}
+
+function makeSdkResult(
+  structured_output: unknown,
+  subtype: "success" | "error_max_turns" = "success"
+) {
+  return {
+    type: "result" as const,
+    subtype,
+    structured_output,
+    session_id: "reviewer-session",
+    uuid: "reviewer-uuid",
+    duration_ms: 800,
+    duration_api_ms: 700,
+    is_error: subtype !== "success",
+    num_turns: 1,
+    result: "",
+    total_cost_usd: 0.02,
+    usage: {
+      input_tokens: 1200,
+      output_tokens: 200,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+    },
+    modelUsage: {},
+    permission_denials: [],
+  };
+}
+
+function makeReviewInput(overrides: Partial<ReviewInput> = {}): ReviewInput {
+  return {
+    diff: "diff --git a/src/foo.ts b/src/foo.ts\n+const x = 1;",
+    verificationOutput: "lint: passed\ntypecheck: passed\ntest: 10 passed",
+    taskDescription: "Add a constant x to foo.ts",
+    acceptanceCriteria: ["x is defined in foo.ts", "tests pass"],
+    changedFiles: ["src/foo.ts"],
+    commitMessage: "feat: add constant x",
+    ...overrides,
+  };
+}
+
+function makeVerdict(overrides: Partial<ReviewVerdict> = {}): ReviewVerdict {
+  return {
+    verdict: "pass",
+    score: 8,
+    issues: [],
+    assessment: "Clean implementation",
+    reviewedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+// ── parseReviewerVerdict ─────────────────────────────────────────────────────
+
+describe("parseReviewerVerdict", () => {
+  it("parses a valid pass verdict from structured output", () => {
+    const raw = makeVerdict();
+    const result = parseReviewerVerdict(raw);
+    expect(result.verdict).toBe("pass");
+    expect(result.score).toBe(8);
+    expect(result.issues).toHaveLength(0);
+    expect(result.assessment).toBe("Clean implementation");
+  });
+
+  it("parses a flag verdict with issues", () => {
+    const raw = makeVerdict({
+      verdict: "flag",
+      score: 4,
+      issues: [
+        {
+          category: "hallucination",
+          description: "Added unrequested feature",
+          filePath: "src/foo.ts",
+        },
+      ],
+      assessment: "Worker hallucinated extra logic",
+    });
+    const result = parseReviewerVerdict(raw);
+    expect(result.verdict).toBe("flag");
+    expect(result.score).toBe(4);
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0].category).toBe("hallucination");
+  });
+
+  it("coerces verdict to flag when score is below PASS_THRESHOLD", () => {
+    const raw = makeVerdict({ verdict: "pass", score: 5 });
+    const result = parseReviewerVerdict(raw);
+    expect(result.verdict).toBe("flag");
+  });
+
+  it("coerces verdict to pass when score is at or above PASS_THRESHOLD", () => {
+    const raw = makeVerdict({ verdict: "flag", score: PASS_THRESHOLD });
+    const result = parseReviewerVerdict(raw);
+    expect(result.verdict).toBe("pass");
+  });
+
+  it("normalises issues to empty array when omitted", () => {
+    const raw = { ...makeVerdict(), issues: undefined } as unknown as ReviewVerdict;
+    const result = parseReviewerVerdict(raw);
+    expect(Array.isArray(result.issues)).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it("always adds reviewedAt timestamp", () => {
+    const raw = { ...makeVerdict(), reviewedAt: undefined } as unknown as ReviewVerdict;
+    const result = parseReviewerVerdict(raw);
+    expect(typeof result.reviewedAt).toBe("string");
+    expect(result.reviewedAt.length).toBeGreaterThan(0);
+  });
+});
+
+// ── selectRetryAction ────────────────────────────────────────────────────────
+
+describe("selectRetryAction", () => {
+  it("returns the action at the current retryCount index", () => {
+    const policy = { maxRetries: 2, actions: ["retry", "file_issue"] as const };
+    expect(selectRetryAction(policy, 0)).toBe("retry");
+    expect(selectRetryAction(policy, 1)).toBe("file_issue");
+  });
+
+  it("repeats the last action when retryCount exceeds actions length", () => {
+    const policy = { maxRetries: 5, actions: ["retry", "file_issue"] as const };
+    expect(selectRetryAction(policy, 2)).toBe("file_issue");
+    expect(selectRetryAction(policy, 10)).toBe("file_issue");
+  });
+
+  it("returns skip when actions is empty", () => {
+    const policy = { maxRetries: 0, actions: [] as const };
+    expect(selectRetryAction(policy, 0)).toBe("skip");
+  });
+});
+
+// ── runReviewer ──────────────────────────────────────────────────────────────
+
+describe("runReviewer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns pass outcome when LLM returns a passing verdict", async () => {
+    const raw = makeVerdict({ verdict: "pass", score: 9 });
+    vi.mocked(query).mockReturnValue(
+      mockQueryGenerator([makeSdkResult(raw)]) as ReturnType<typeof query>
+    );
+
+    const outcome = await runReviewer(makeReviewInput());
+    expect(outcome.verdict.verdict).toBe("pass");
+    expect(outcome.verdict.score).toBe(9);
+    expect(outcome.retryCount).toBe(0);
+  });
+
+  it("returns flag outcome when LLM returns a failing verdict", async () => {
+    const raw = makeVerdict({
+      verdict: "flag",
+      score: 3,
+      issues: [{ category: "regression", description: "broke existing test" }],
+      assessment: "Regression found",
+    });
+    vi.mocked(query).mockReturnValue(
+      mockQueryGenerator([makeSdkResult(raw)]) as ReturnType<typeof query>
+    );
+
+    const outcome = await runReviewer(makeReviewInput());
+    expect(outcome.verdict.verdict).toBe("flag");
+    expect(outcome.verdict.issues).toHaveLength(1);
+  });
+
+  it("records cost from the SDK result", async () => {
+    const raw = makeVerdict();
+    vi.mocked(query).mockReturnValue(
+      mockQueryGenerator([makeSdkResult(raw)]) as ReturnType<typeof query>
+    );
+
+    const outcome = await runReviewer(makeReviewInput());
+    expect(outcome.costUsd).toBe(0.02);
+  });
+
+  it("records positive durationMs", async () => {
+    const raw = makeVerdict();
+    vi.mocked(query).mockReturnValue(
+      mockQueryGenerator([makeSdkResult(raw)]) as ReturnType<typeof query>
+    );
+
+    const outcome = await runReviewer(makeReviewInput());
+    expect(outcome.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("passes retryCount into the outcome", async () => {
+    const raw = makeVerdict();
+    vi.mocked(query).mockReturnValue(
+      mockQueryGenerator([makeSdkResult(raw)]) as ReturnType<typeof query>
+    );
+
+    const outcome = await runReviewer(makeReviewInput(), { retryCount: 2 });
+    expect(outcome.retryCount).toBe(2);
+  });
+
+  it("fails-open (pass) when the LLM returns a non-success subtype", async () => {
+    vi.mocked(query).mockReturnValue(
+      mockQueryGenerator([makeSdkResult(null, "error_max_turns")]) as ReturnType<typeof query>
+    );
+
+    const outcome = await runReviewer(makeReviewInput());
+    expect(outcome.verdict.verdict).toBe("pass");
+  });
+
+  it("fails-open (pass) on LLM call error", async () => {
+    vi.mocked(query).mockImplementation(() => {
+      throw new Error("Network error");
+    });
+
+    const outcome = await runReviewer(makeReviewInput());
+    expect(outcome.verdict.verdict).toBe("pass");
+    expect(outcome.costUsd).toBe(0);
+  });
+
+  it("fails-open (pass) on timeout", async () => {
+    vi.useFakeTimers();
+
+    // Simulate a hanging query by returning a promise that never resolves.
+    // Cast through unknown to satisfy the async-iterable return type.
+    vi.mocked(query).mockReturnValue(
+      new Promise<never>(() => {}) as unknown as ReturnType<typeof query>
+    );
+
+    const outcomePromise = runReviewer(makeReviewInput(), {
+      config: { ...DEFAULT_REVIEWER_CONFIG, timeoutMs: 100 },
+    });
+
+    vi.advanceTimersByTime(200);
+    const outcome = await outcomePromise;
+    expect(outcome.verdict.verdict).toBe("pass");
+
+    vi.useRealTimers();
+  });
+
+  it("uses the haiku model by default", async () => {
+    const raw = makeVerdict();
+    vi.mocked(query).mockReturnValue(
+      mockQueryGenerator([makeSdkResult(raw)]) as ReturnType<typeof query>
+    );
+
+    await runReviewer(makeReviewInput());
+
+    const callArgs = vi.mocked(query).mock.calls[0];
+    expect(callArgs[0].options?.model).toMatch(/haiku/i);
+  });
+
+  it("honours model override in config", async () => {
+    const raw = makeVerdict();
+    vi.mocked(query).mockReturnValue(
+      mockQueryGenerator([makeSdkResult(raw)]) as ReturnType<typeof query>
+    );
+
+    const config: Partial<ReviewerConfig> = {
+      ...DEFAULT_REVIEWER_CONFIG,
+      model: "claude-sonnet-4-6",
+    };
+
+    await runReviewer(makeReviewInput(), { config });
+
+    const callArgs = vi.mocked(query).mock.calls[0];
+    expect(callArgs[0].options?.model).toBe("claude-sonnet-4-6");
+  });
+});

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -349,3 +349,12 @@ export type {
 } from "./reviewer-contract.js";
 
 export { PASS_THRESHOLD, DEFAULT_REVIEW_RETRY_POLICY } from "./reviewer-contract.js";
+
+// Reviewer runner (dispatches the Reviewer sub-agent in the merge train)
+export {
+  runReviewer,
+  parseReviewerVerdict,
+  selectRetryAction,
+  DEFAULT_REVIEWER_CONFIG,
+} from "./reviewer-runner.js";
+export type { ReviewerConfig, RunReviewerOptions } from "./reviewer-runner.js";

--- a/packages/agent-core/src/reviewer-runner.ts
+++ b/packages/agent-core/src/reviewer-runner.ts
@@ -1,0 +1,314 @@
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import type { SDKResultMessage } from "@anthropic-ai/claude-agent-sdk";
+import { resolveModelId } from "./model-registry.js";
+import type {
+  ReviewInput,
+  ReviewIssue,
+  ReviewOutcome,
+  ReviewRetryAction,
+  ReviewRetryPolicy,
+  ReviewVerdict,
+} from "./reviewer-contract.js";
+import { PASS_THRESHOLD } from "./reviewer-contract.js";
+
+// ── Configuration ────────────────────────────────────────────────────────────
+
+export interface ReviewerConfig {
+  /** Model to use for the reviewer. Default: haiku (fast + cheap). */
+  readonly model: string;
+  /** Maximum spend per review in USD. Default: 0.05. */
+  readonly maxBudgetUsd: number;
+  /** Wall-clock timeout in ms. Reviewer fails-open on timeout. Default: 30_000. */
+  readonly timeoutMs: number;
+}
+
+export const DEFAULT_REVIEWER_CONFIG: ReviewerConfig = {
+  model: resolveModelId("haiku"),
+  maxBudgetUsd: 0.05,
+  timeoutMs: 30_000,
+};
+
+// ── Options accepted by runReviewer ─────────────────────────────────────────
+
+export interface RunReviewerOptions {
+  /** How many times this piece of work has already been retried. Default: 0. */
+  readonly retryCount?: number;
+  /** Config overrides (model, budget, timeout). */
+  readonly config?: Partial<ReviewerConfig>;
+}
+
+// ── JSON Schema for structured output ───────────────────────────────────────
+
+const REVIEW_ISSUE_SCHEMA = {
+  type: "object" as const,
+  properties: {
+    category: {
+      type: "string" as const,
+      enum: [
+        "hallucination",
+        "regression",
+        "test_failure",
+        "lint_violation",
+        "type_error",
+        "security",
+        "incomplete",
+        "quality",
+      ],
+    },
+    description: { type: "string" as const },
+    filePath: { type: "string" as const },
+    lineNumber: { type: "number" as const },
+    suggestion: { type: "string" as const },
+  },
+  required: ["category", "description"] as const,
+  additionalProperties: false as const,
+};
+
+const VERDICT_SCHEMA = {
+  type: "object" as const,
+  properties: {
+    verdict: { type: "string" as const, enum: ["pass", "flag"] },
+    score: { type: "number" as const, minimum: 0, maximum: 10 },
+    issues: { type: "array" as const, items: REVIEW_ISSUE_SCHEMA },
+    strengths: { type: "string" as const },
+    assessment: { type: "string" as const },
+    reviewedAt: { type: "string" as const },
+  },
+  required: ["verdict", "score", "issues", "assessment"] as const,
+  additionalProperties: false as const,
+};
+
+// ── Prompt building ──────────────────────────────────────────────────────────
+
+const MAX_DIFF_LENGTH = 40_000;
+const MAX_VERIFICATION_LENGTH = 10_000;
+
+function buildReviewerPrompt(input: ReviewInput): string {
+  const diff =
+    input.diff.length > MAX_DIFF_LENGTH
+      ? input.diff.slice(0, MAX_DIFF_LENGTH) + "\n\n... (diff truncated)"
+      : input.diff;
+
+  const verification =
+    input.verificationOutput.length > MAX_VERIFICATION_LENGTH
+      ? input.verificationOutput.slice(0, MAX_VERIFICATION_LENGTH) + "\n... (truncated)"
+      : input.verificationOutput;
+
+  const criteria =
+    input.acceptanceCriteria.length > 0
+      ? input.acceptanceCriteria.map((c, i) => `${i + 1}. ${c}`).join("\n")
+      : "(none provided)";
+
+  return [
+    "You are an independent code reviewer evaluating a worker agent's output before it is merged.",
+    "Your job is to catch hallucinations, regressions, gate bypasses, and criteria gaps.",
+    "Be pragmatic: only flag real problems, not style preferences.",
+    "",
+    "## Task Description",
+    input.taskDescription,
+    "",
+    "## Acceptance Criteria",
+    criteria,
+    "",
+    "## Commit Message",
+    input.commitMessage,
+    "",
+    "## Changed Files",
+    input.changedFiles.join(", ") || "(none)",
+    "",
+    "## Verification Output (lint / typecheck / test)",
+    "```",
+    verification,
+    "```",
+    "",
+    "## Git Diff",
+    "```diff",
+    diff,
+    "```",
+    "",
+    "## Scoring Rubric (start at 10, deduct)",
+    "| Score | Label      | Criteria                                                              |",
+    "| ----- | ---------- | --------------------------------------------------------------------- |",
+    "| 9–10  | Excellent  | All AC met, no defects, clean code, tests pass, no regressions        |",
+    "| 7–8   | Good       | All AC met, minor nits (style, naming), no blocking issues            |",
+    "| 5–6   | Acceptable | All AC met but has non-trivial issues (messy code, missing edge case) |",
+    "| 3–4   | Poor       | Some AC missed or broken; requires rework before merging              |",
+    "| 0–2   | Failing    | Major problems: hallucinations, regressions, security, or no tests    |",
+    "",
+    "Scores >= 7 → verdict: pass. Scores <= 6 → verdict: flag.",
+    "One major defect (hallucination, regression, security) → max 4.",
+    "One minor defect (lint violation, missing edge case) → max 8.",
+    "All tests passing + no lint/type errors → floor of 5 even with quality nits.",
+    "",
+    "## Issue Categories",
+    "- hallucination: code or logic not justified by the task",
+    "- regression: existing behaviour broken without justification",
+    "- test_failure: worker's tests do not all pass",
+    "- lint_violation: ESLint/Prettier/style violations",
+    "- type_error: TypeScript compilation errors",
+    "- security: hardcoded secret, SQLi, XSS, or other OWASP finding",
+    "- incomplete: acceptance criteria addressed poorly or skipped",
+    "- quality: code quality concern (readability, performance, idiom)",
+    "",
+    "Return your review as JSON matching the output schema.",
+  ].join("\n");
+}
+
+// ── Fail-open sentinel ───────────────────────────────────────────────────────
+
+function makePassVerdict(assessment: string): ReviewVerdict {
+  return {
+    verdict: "pass",
+    score: 10,
+    issues: [],
+    assessment,
+    reviewedAt: new Date().toISOString(),
+  };
+}
+
+// ── parseReviewerVerdict ─────────────────────────────────────────────────────
+
+/**
+ * Normalises raw structured output from the SDK into a well-formed ReviewVerdict.
+ *
+ * Coerces score vs verdict consistency: the score is authoritative — if the
+ * worker labelled verdict="pass" but score < PASS_THRESHOLD, we override to
+ * "flag" (and vice-versa). This prevents the LLM from self-contradicting.
+ */
+export function parseReviewerVerdict(raw: ReviewVerdict): ReviewVerdict {
+  const score = typeof raw.score === "number" ? Math.max(0, Math.min(10, raw.score)) : 0;
+  const verdict: "pass" | "flag" = score >= PASS_THRESHOLD ? "pass" : "flag";
+  const issues: readonly ReviewIssue[] = Array.isArray(raw.issues) ? raw.issues : [];
+  const reviewedAt = raw.reviewedAt ?? new Date().toISOString();
+
+  return {
+    verdict,
+    score,
+    issues,
+    strengths: raw.strengths,
+    assessment: raw.assessment ?? "",
+    reviewedAt,
+  };
+}
+
+// ── selectRetryAction ────────────────────────────────────────────────────────
+
+/**
+ * Picks the appropriate retry action for the current attempt.
+ *
+ * The `actions` array is indexed by `retryCount`. If retryCount exceeds the
+ * array, the last action repeats. An empty actions array returns "skip".
+ */
+export function selectRetryAction(
+  policy: ReviewRetryPolicy,
+  retryCount: number
+): ReviewRetryAction {
+  if (policy.actions.length === 0) {
+    return "skip";
+  }
+
+  const idx = Math.min(retryCount, policy.actions.length - 1);
+  return policy.actions[idx];
+}
+
+// ── runReviewer ──────────────────────────────────────────────────────────────
+
+/**
+ * Dispatches the Reviewer sub-agent for a piece of completed worker output.
+ *
+ * Fail-open contract: if the LLM call errors, times out, or returns a
+ * non-success subtype, this function resolves with a pass verdict and logs
+ * a warning. False negatives (missed issues) are preferable to false
+ * positives (stuck merge train).
+ */
+export async function runReviewer(
+  input: ReviewInput,
+  opts: RunReviewerOptions = {}
+): Promise<ReviewOutcome> {
+  const retryCount = opts.retryCount ?? 0;
+  const config: ReviewerConfig = { ...DEFAULT_REVIEWER_CONFIG, ...opts.config };
+  const startMs = Date.now();
+
+  try {
+    const prompt = buildReviewerPrompt(input);
+
+    let result: SDKResultMessage | null = null;
+
+    const queryIterable = query({
+      prompt,
+      options: {
+        model: config.model,
+        maxTurns: 1,
+        maxBudgetUsd: config.maxBudgetUsd,
+        permissionMode: "plan",
+        systemPrompt: "You are a code reviewer. Respond only with the requested JSON verdict.",
+        outputFormat: {
+          type: "json_schema",
+          schema: VERDICT_SCHEMA,
+        },
+      },
+    });
+
+    const timeoutPromise = new Promise<null>((resolve) =>
+      setTimeout(() => resolve(null), config.timeoutMs)
+    );
+
+    // Race the iterable against the timeout.
+    const collected = await Promise.race([
+      (async () => {
+        for await (const message of queryIterable) {
+          if (message.type === "result") {
+            result = message as SDKResultMessage;
+          }
+        }
+        return result;
+      })(),
+      timeoutPromise,
+    ]);
+
+    if (collected === null) {
+      // Timeout — fail-open
+      return {
+        verdict: makePassVerdict("Reviewer timed out — proceeding fail-open"),
+        costUsd: 0,
+        durationMs: Date.now() - startMs,
+        retryCount,
+      };
+    }
+
+    if (!collected || collected.subtype !== "success") {
+      return {
+        verdict: makePassVerdict(
+          `Reviewer returned non-success subtype (${collected?.subtype ?? "no result"}) — proceeding fail-open`
+        ),
+        costUsd: (collected as SDKResultMessage | null)?.total_cost_usd ?? 0,
+        durationMs: Date.now() - startMs,
+        retryCount,
+      };
+    }
+
+    const raw = collected.structured_output as ReviewVerdict | undefined;
+    if (!raw || typeof raw.score !== "number") {
+      return {
+        verdict: makePassVerdict("Reviewer returned unreadable output — proceeding fail-open"),
+        costUsd: collected.total_cost_usd ?? 0,
+        durationMs: Date.now() - startMs,
+        retryCount,
+      };
+    }
+
+    return {
+      verdict: parseReviewerVerdict(raw),
+      costUsd: collected.total_cost_usd ?? 0,
+      durationMs: Date.now() - startMs,
+      retryCount,
+    };
+  } catch {
+    return {
+      verdict: makePassVerdict("Reviewer threw an error — proceeding fail-open"),
+      costUsd: 0,
+      durationMs: Date.now() - startMs,
+      retryCount,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `reviewer-runner.ts` in `packages/agent-core/src/` with three exported functions:
  - `runReviewer(input, opts)` — dispatches a Reviewer sub-agent via the Claude SDK, races against a configurable timeout, and fails-open (returns pass) on timeout, LLM error, or non-success SDK result
  - `parseReviewerVerdict(raw)` — normalises structured SDK output into a well-formed `ReviewVerdict`, enforcing score-vs-verdict consistency (score is authoritative over the `verdict` field)
  - `selectRetryAction(policy, retryCount)` — picks the appropriate `ReviewRetryAction` from a `ReviewRetryPolicy` based on current retry count, repeating the last action when retries exceed the policy array
- Exports all new symbols from `packages/agent-core/src/index.ts`
- 19 new TDD tests covering pass/flag parsing, score coercion, retry policy selection, cost/duration recording, fail-open behaviour (error, timeout, non-success subtype), and model override

## Test plan

- [x] `pnpm exec vitest run src/__tests__/reviewer-runner.test.ts` — 19/19 pass
- [x] `pnpm exec vitest run` (full suite) — 1128/1128 pass
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm --filter @mbe/cli start check-adr` — no violations
- [x] `pnpm --filter @mbe/cli start check-deps` — no mismatches
- [x] `pnpm regen` + `git status` — only llms artifacts updated (staged and committed)
- [x] `node scripts/detect-instruction-rot.mjs` — no rot
- [x] Pre-push hook passed (turbo test + typecheck across 6 packages)

Closes #2210