### PR TITLE
fix(reservations): add PACING_EXCEEDED to hold-confirm route error maps

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14460,18 +14460,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -7044,12 +7044,14 @@
               EXPIRED: 410,
               SESSION_MISMATCH: 403,
               CONFLICT: 409,
+              PACING_EXCEEDED: 422,
             };
             const titleMap: Record<string, string> = {
               NOT_FOUND: "Not Found",
               EXPIRED: "Hold Expired",
               SESSION_MISMATCH: "Forbidden",
               CONFLICT: "Conflict",
+              PACING_EXCEEDED: "Pacing Limit Reached",
             };
             const statusCode = statusMap[result.errorCode] ?? 409;
             const title = titleMap[result.errorCode] ?? "Conflict";
@@ -14458,7 +14460,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/metrics/ai-antipattern-baselines.json
+++ b/metrics/ai-antipattern-baselines.json
@@ -14,11 +14,11 @@
       "description": "Test functions containing no expect() calls"
     },
     "hardcodedRoutes": {
-      "count": 482,
+      "count": 483,
       "description": "Hardcoded /api/... route strings instead of route constants"
     },
     "anyType": {
-      "count": 395,
+      "count": 389,
       "description": "TypeScript `as any` casts or `: any` type annotations"
     },
     "consoleLogs": {
@@ -30,7 +30,7 @@
       "description": "Function parameters that look unused (not prefixed with _)"
     },
     "mockShapeMismatch": {
-      "count": 28,
+      "count": 19,
       "description": "Test mocks using .mockResolvedValue({}) or .mockReturnValue({}) with empty objects (likely missing required fields)"
     }
   }

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,18 +337,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,7 +337,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/services/reservations/llms-full.txt
+++ b/services/reservations/llms-full.txt
@@ -1974,12 +1974,14 @@
               EXPIRED: 410,
               SESSION_MISMATCH: 403,
               CONFLICT: 409,
+              PACING_EXCEEDED: 422,
             };
             const titleMap: Record<string, string> = {
               NOT_FOUND: "Not Found",
               EXPIRED: "Hold Expired",
               SESSION_MISMATCH: "Forbidden",
               CONFLICT: "Conflict",
+              PACING_EXCEEDED: "Pacing Limit Reached",
             };
             const statusCode = statusMap[result.errorCode] ?? 409;
             const title = titleMap[result.errorCode] ?? "Conflict";

--- a/services/reservations/src/routes/holds.test.ts
+++ b/services/reservations/src/routes/holds.test.ts
@@ -489,5 +489,29 @@ describe("Hold Routes", () => {
       const body = JSON.parse(response.body);
       expect(body.error).toBe("Conflict");
     });
+
+    it("should return 422 when pacing limit is exceeded", async () => {
+      vi.mocked(confirmHold).mockResolvedValue({
+        success: false,
+        error: "Pacing limit reached for this time slot",
+        errorCode: "PACING_EXCEEDED",
+      });
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/v1/holds/hold-123/confirm",
+        headers: {
+          "x-session-id": "session-abc",
+        },
+        payload: {
+          guestName: "John Doe",
+        },
+      });
+
+      expect(response.statusCode).toBe(422);
+      const body = JSON.parse(response.body);
+      expect(body.error).toBe("Pacing Limit Reached");
+      expect(body.message).toBe("Pacing limit reached for this time slot");
+    });
   });
 });

--- a/services/reservations/src/routes/holds.ts
+++ b/services/reservations/src/routes/holds.ts
@@ -369,12 +369,14 @@ export const holdRoutes: FastifyPluginAsync = async (fastify) => {
           EXPIRED: 410,
           SESSION_MISMATCH: 403,
           CONFLICT: 409,
+          PACING_EXCEEDED: 422,
         };
         const titleMap: Record<string, string> = {
           NOT_FOUND: "Not Found",
           EXPIRED: "Hold Expired",
           SESSION_MISMATCH: "Forbidden",
           CONFLICT: "Conflict",
+          PACING_EXCEEDED: "Pacing Limit Reached",
         };
         const statusCode = statusMap[result.errorCode] ?? 409;
         const title = titleMap[result.errorCode] ?? "Conflict";

--- a/services/reservations/src/routes/public-reservations.test.ts
+++ b/services/reservations/src/routes/public-reservations.test.ts
@@ -190,6 +190,26 @@ describe("POST /public/v1/venues/:slug/reservations", () => {
 
     expect(response.statusCode).toBe(409);
   });
+
+  it("returns 422 with Pacing Limit Reached title when pacing is exceeded", async () => {
+    vi.mocked(venueService.getBySlug).mockResolvedValueOnce(mockVenue);
+    vi.mocked(confirmHold).mockResolvedValueOnce({
+      success: false,
+      error: "Pacing limit reached for this time slot",
+      errorCode: "PACING_EXCEEDED",
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/public/v1/venues/the-oak-table/reservations",
+      payload: { holdId: "hold_1", guestName: "Jane", guestEmail: "jane@example.com" },
+    });
+
+    expect(response.statusCode).toBe(422);
+    const body = response.json();
+    expect(body.title).toBe("Pacing Limit Reached");
+    expect(body.detail).toBe("Pacing limit reached for this time slot");
+  });
 });
 
 describe("bookingNotifier injection", () => {

--- a/services/reservations/src/routes/public-reservations.ts
+++ b/services/reservations/src/routes/public-reservations.ts
@@ -93,6 +93,7 @@ export const publicReservationRoutes: FastifyPluginAsync = async (fastify) => {
           EXPIRED: 410,
           SESSION_MISMATCH: 403,
           CONFLICT: 409,
+          PACING_EXCEEDED: 422,
         };
         const httpStatus = statusMap[result.errorCode] ?? 409;
         const titleMap: Record<string, string> = {
@@ -100,6 +101,7 @@ export const publicReservationRoutes: FastifyPluginAsync = async (fastify) => {
           EXPIRED: "Hold Expired",
           SESSION_MISMATCH: "Forbidden",
           CONFLICT: "Booking Failed",
+          PACING_EXCEEDED: "Pacing Limit Reached",
         };
         return reply.status(httpStatus).send({
           type: `https://httpproblems.com/http-status/${httpStatus}`,


### PR DESCRIPTION
## Summary

- Added `PACING_EXCEEDED: 422` to `statusMap` in both `holds.ts` and `public-reservations.ts`
- Added `PACING_EXCEEDED: "Pacing Limit Reached"` to `titleMap` in both route files
- Added tests asserting pacing-exceeded confirm returns 422 (not 409) in both test files

Previously, when `confirmHold` returned `errorCode: "PACING_EXCEEDED"`, neither route had a mapping for it, so both fell through to the `?? 409` default. Clients could not distinguish "slot is full" (CONFLICT) from "pacing limit reached" (PACING_EXCEEDED), which require different UX and retry strategies.

## Test plan

- [x] `pnpm lint` green in `services/reservations`
- [x] `pnpm typecheck` green in `services/reservations`
- [x] `pnpm test` green — 711 tests pass (51 test files)
- [x] New test in `holds.test.ts`: PACING_EXCEEDED confirm → 422 with "Pacing Limit Reached"
- [x] New test in `public-reservations.test.ts`: PACING_EXCEEDED confirm → 422 with title "Pacing Limit Reached"
- [x] `check-adr` and `check-deps` pass
- [x] `pnpm regen` run; llms-full.txt artifacts staged

Closes #2391