### PR TITLE
fix(reservations): pass real venue name to win-back emails

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14461,18 +14461,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6677,7 +6677,9 @@
           if (!guest) {
             return reply.code(404).send(createProblemDetails(404, "Not Found", "Guest not found"));
           }
-          const sent = await sendWinBack(guest, fastify.notificationPort);
+          const venue = await venueService.getById(guest.venueId);
+          const venueName = venue?.name ?? guest.venueId;
+          const sent = await sendWinBack(guest, fastify.notificationPort, venueName);
           return { data: { sent } };
         }
       );
@@ -11512,7 +11514,8 @@
   <file path="services/reservations/src/services/win-back.ts">
     export async function sendWinBack(
       guest: Guest,
-      notificationPort: NotificationDispatcher
+      notificationPort: NotificationDispatcher,
+      venueName: string
     ): Promise<boolean> {
       const preference = (guest.communicationPreference ?? "email_only") as CommunicationPreference;
     
@@ -11536,7 +11539,7 @@
         {
           guestName: guest.name,
           guestEmail: guest.email,
-          venueName: "your favourite restaurant",
+          venueName,
         },
         preference
       );
@@ -14458,7 +14461,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms.txt
+++ b/llms.txt
@@ -2368,7 +2368,8 @@
     <item priority="high">
       export async function sendWinBack(
         guest: Guest,
-        notificationPort: NotificationDispatcher
+        notificationPort: NotificationDispatcher,
+        venueName: string
       ): Promise<boolean> { /* ... */ }
     </item>
   </file>

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,18 +337,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,7 +337,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/services/reservations/llms-full.txt
+++ b/services/reservations/llms-full.txt
@@ -1607,7 +1607,9 @@
           if (!guest) {
             return reply.code(404).send(createProblemDetails(404, "Not Found", "Guest not found"));
           }
-          const sent = await sendWinBack(guest, fastify.notificationPort);
+          const venue = await venueService.getById(guest.venueId);
+          const venueName = venue?.name ?? guest.venueId;
+          const sent = await sendWinBack(guest, fastify.notificationPort, venueName);
           return { data: { sent } };
         }
       );
@@ -5635,7 +5637,8 @@
   <file path="src/services/win-back.ts">
     export async function sendWinBack(
       guest: Guest,
-      notificationPort: NotificationDispatcher
+      notificationPort: NotificationDispatcher,
+      venueName: string
     ): Promise<boolean> {
       const preference = (guest.communicationPreference ?? "email_only") as CommunicationPreference;
     
@@ -5659,7 +5662,7 @@
         {
           guestName: guest.name,
           guestEmail: guest.email,
-          venueName: "your favourite restaurant",
+          venueName,
         },
         preference
       );

--- a/services/reservations/llms.txt
+++ b/services/reservations/llms.txt
@@ -604,7 +604,8 @@
     <item priority="high">
       export async function sendWinBack(
         guest: Guest,
-        notificationPort: NotificationDispatcher
+        notificationPort: NotificationDispatcher,
+        venueName: string
       ): Promise<boolean> { /* ... */ }
     </item>
   </file>

--- a/services/reservations/src/routes/guests.ts
+++ b/services/reservations/src/routes/guests.ts
@@ -12,6 +12,7 @@ import type {
 import { createProblemDetails } from "@mbe/types";
 import { requireAuth } from "@mbe/auth/fastify";
 import { guestService } from "../services/guest.js";
+import { venueService } from "../services/venue.js";
 import { sendWinBack } from "../services/win-back.js";
 
 export const guestRoutes: FastifyPluginAsync = async (fastify) => {
@@ -582,7 +583,9 @@ export const guestRoutes: FastifyPluginAsync = async (fastify) => {
       if (!guest) {
         return reply.code(404).send(createProblemDetails(404, "Not Found", "Guest not found"));
       }
-      const sent = await sendWinBack(guest, fastify.notificationPort);
+      const venue = await venueService.getById(guest.venueId);
+      const venueName = venue?.name ?? guest.venueId;
+      const sent = await sendWinBack(guest, fastify.notificationPort, venueName);
       return { data: { sent } };
     }
   );

--- a/services/reservations/src/services/win-back.test.ts
+++ b/services/reservations/src/services/win-back.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Guest } from "@mbe/types";
+import type { NotificationDispatcher } from "@mbe/notifications";
+import { sendWinBack } from "./win-back.js";
+
+function makeGuest(overrides: Partial<Guest> = {}): Guest {
+  return {
+    id: "guest-1",
+    venueId: "venue-1",
+    name: "Alice Smith",
+    email: "alice@example.com",
+    phone: null,
+    notes: null,
+    visitCount: 3,
+    lifetimeSpend: null,
+    lastVisit: null,
+    tags: null,
+    dietaryRestrictions: null,
+    communicationPreference: "email_only",
+    staffNotes: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeNotificationPort(): NotificationDispatcher {
+  return {
+    sendBookingConfirmation: vi.fn().mockResolvedValue(undefined),
+    sendBookingReminder: vi.fn().mockResolvedValue(undefined),
+    sendBookingModified: vi.fn().mockResolvedValue(undefined),
+    sendBookingCancelled: vi.fn().mockResolvedValue(undefined),
+    sendWinBack: vi.fn().mockResolvedValue(undefined),
+  } as unknown as NotificationDispatcher;
+}
+
+describe("sendWinBack", () => {
+  it("passes the correct venueName to the notification dispatcher", async () => {
+    const guest = makeGuest();
+    const port = makeNotificationPort();
+
+    await sendWinBack(guest, port, "The Grand Bistro");
+
+    expect(port.sendWinBack).toHaveBeenCalledWith(
+      expect.objectContaining({ venueName: "The Grand Bistro" }),
+      expect.any(String)
+    );
+  });
+
+  it("does NOT use the hardcoded fallback string when a real venueName is provided", async () => {
+    const guest = makeGuest();
+    const port = makeNotificationPort();
+
+    await sendWinBack(guest, port, "Riverside Grill");
+
+    const [payload] = (port.sendWinBack as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(payload.venueName).not.toBe("your favourite restaurant");
+  });
+
+  it("returns false and skips dispatch for transactional_only guests", async () => {
+    const guest = makeGuest({ communicationPreference: "transactional_only" });
+    const port = makeNotificationPort();
+
+    const result = await sendWinBack(guest, port, "Any Venue");
+
+    expect(result).toBe(false);
+    expect(port.sendWinBack).not.toHaveBeenCalled();
+  });
+
+  it("returns false when guest has no email address", async () => {
+    const guest = makeGuest({ email: null });
+    const port = makeNotificationPort();
+
+    const result = await sendWinBack(guest, port, "Any Venue");
+
+    expect(result).toBe(false);
+    expect(port.sendWinBack).not.toHaveBeenCalled();
+  });
+
+  it("returns true when message is sent", async () => {
+    const guest = makeGuest();
+    const port = makeNotificationPort();
+
+    const result = await sendWinBack(guest, port, "The Grand Bistro");
+
+    expect(result).toBe(true);
+  });
+});

--- a/services/reservations/src/services/win-back.ts
+++ b/services/reservations/src/services/win-back.ts
@@ -10,7 +10,8 @@ import { resolveChannel } from "./booking-notifications.js";
  */
 export async function sendWinBack(
   guest: Guest,
-  notificationPort: NotificationDispatcher
+  notificationPort: NotificationDispatcher,
+  venueName: string
 ): Promise<boolean> {
   const preference = (guest.communicationPreference ?? "email_only") as CommunicationPreference;
 
@@ -34,7 +35,7 @@ export async function sendWinBack(
     {
       guestName: guest.name,
       guestEmail: guest.email,
-      venueName: "your favourite restaurant",
+      venueName,
     },
     preference
   );


### PR DESCRIPTION
## Summary

- Add `venueName: string` parameter to `sendWinBack` function signature in `services/reservations/src/services/win-back.ts`
- Remove the hardcoded `"your favourite restaurant"` string
- Update the win-back route handler in `guests.ts` to look up the venue by `guest.venueId` and pass the real venue name
- Create `win-back.test.ts` with 5 tests asserting the correct venue name propagates to the notification dispatcher

## Test plan

- [x] `win-back.test.ts` asserts `venueName` matches the passed-in string (not the hardcoded value)
- [x] Tests for skip cases (transactional_only preference, no email address) still pass
- [x] All 714 tests pass in `services/reservations`
- [x] `pnpm lint` green
- [x] `pnpm typecheck` green
- [x] `check-adr` and `check-deps` green
- [x] `pnpm regen` run; generated artifact changes staged alongside code changes

Closes #2388