### PR TITLE
fix(hospitality): BookingWidget hold-expiry timer stale closure

### DIFF
--- a/apps/hospitality/src/components/booking-widget/BookingWidget.tsx
+++ b/apps/hospitality/src/components/booking-widget/BookingWidget.tsx
@@ -157,8 +157,7 @@ export function BookingWidget({
     }, 1000);
 
     return () => clearInterval(interval);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data.hold]);
+  }, [data.hold, fetchSlots]);
 
   // Navigation handlers
   const handleFindTimes = useCallback(() => {


### PR DESCRIPTION
## Summary

- Remove the `// eslint-disable-next-line react-hooks/exhaustive-deps` comment suppressing the exhaustive-deps warning in the hold-expiry `useEffect`
- Add `fetchSlots` to the dependency array: `[data.hold, fetchSlots]`
- `fetchSlots`'s own `useCallback` dep array already correctly includes `[api, venueId, data.selectedDate, data.partySize]`

Without `fetchSlots` in the deps, if `data.partySize` or `data.selectedDate` changed after a hold was set, the timer would fire with a stale `fetchSlots` that queries the old date/party size — reloading availability for the wrong parameters after hold expiry.

## Test plan

- [x] `pnpm --dir apps/hospitality lint` — 0 errors (199 pre-existing warnings)
- [x] `pnpm --dir apps/hospitality typecheck` — clean
- [x] `pnpm --dir apps/hospitality test` — 76 test files, 944 tests passed
- [x] `pnpm --filter @mbe/cli start check-adr` — no violations
- [x] `pnpm --filter @mbe/cli start check-deps` — consistent
- [x] `pnpm regen` — all artifacts up to date
- [x] `node scripts/detect-instruction-rot.mjs` — no instruction rot

Closes #2393