### PR TITLE
refactor(reservations): extract createResendAdapter factory

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -15026,7 +15026,7 @@
     }
   </file>
   <file path="services/reservations/src/notifications.ts">
-    export function createNotificationPort(): NotificationDispatcher {
+    export function createResendAdapter(): ResendNotificationAdapter {
       const resendClient = process.env.RESEND_API_KEY
         ? (new Resend(process.env.RESEND_API_KEY) as unknown as {
             emails: {
@@ -15035,11 +15035,14 @@
           })
         : null;
     
-      const emailAdapter = new ResendNotificationAdapter({
+      return new ResendNotificationAdapter({
         resend: resendClient,
         fromAddress: process.env.EMAIL_FROM ?? "reservations@mattbutlerengineering.com",
         manageBaseUrl: process.env.MANAGE_BASE_URL ?? "https://mattbutlerengineering.com",
       });
+    }
+    export function createNotificationPort(): NotificationDispatcher {
+      const emailAdapter = createResendAdapter();
     
       const smsAdapter =
         process.env.TWILIO_ACCOUNT_SID &&

--- a/llms.txt
+++ b/llms.txt
@@ -4036,6 +4036,9 @@
   </file>
   <file path="services/reservations/src/notifications.ts">
     <item priority="high">
+      export function createResendAdapter(): ResendNotificationAdapter { /* ... */ }
+    </item>
+    <item priority="high">
       export function createNotificationPort(): NotificationDispatcher { /* ... */ }
     </item>
   </file>

--- a/services/reservations/llms-full.txt
+++ b/services/reservations/llms-full.txt
@@ -5772,7 +5772,7 @@
     }
   </file>
   <file path="src/notifications.ts">
-    export function createNotificationPort(): NotificationDispatcher {
+    export function createResendAdapter(): ResendNotificationAdapter {
       const resendClient = process.env.RESEND_API_KEY
         ? (new Resend(process.env.RESEND_API_KEY) as unknown as {
             emails: {
@@ -5781,11 +5781,14 @@
           })
         : null;
     
-      const emailAdapter = new ResendNotificationAdapter({
+      return new ResendNotificationAdapter({
         resend: resendClient,
         fromAddress: process.env.EMAIL_FROM ?? "reservations@mattbutlerengineering.com",
         manageBaseUrl: process.env.MANAGE_BASE_URL ?? "https://mattbutlerengineering.com",
       });
+    }
+    export function createNotificationPort(): NotificationDispatcher {
+      const emailAdapter = createResendAdapter();
     
       const smsAdapter =
         process.env.TWILIO_ACCOUNT_SID &&

--- a/services/reservations/llms.txt
+++ b/services/reservations/llms.txt
@@ -641,6 +641,9 @@
   </file>
   <file path="src/notifications.ts">
     <item priority="high">
+      export function createResendAdapter(): ResendNotificationAdapter { /* ... */ }
+    </item>
+    <item priority="high">
       export function createNotificationPort(): NotificationDispatcher { /* ... */ }
     </item>
   </file>

--- a/services/reservations/src/notifications.test.ts
+++ b/services/reservations/src/notifications.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Import lazily so we can control env vars before module evaluates
+async function importNotifications() {
+  return import("./notifications.js");
+}
+
+vi.mock("resend", () => {
+  const ResendMock = vi.fn().mockImplementation(function (
+    this: Record<string, unknown>,
+    apiKey: string
+  ) {
+    this._apiKey = apiKey;
+    this.emails = { send: vi.fn().mockResolvedValue({ id: "email-id-123" }) };
+  });
+  return { Resend: ResendMock };
+});
+
+vi.mock("@mbe/notifications", () => {
+  const ResendNotificationAdapterMock = vi.fn().mockImplementation(function (
+    this: Record<string, unknown>,
+    config: unknown
+  ) {
+    this._config = config;
+  });
+  const TwilioSmsAdapterMock = vi.fn();
+  const NotificationDispatcherMock = vi.fn().mockImplementation(function (
+    this: Record<string, unknown>,
+    deps: unknown
+  ) {
+    this._deps = deps;
+  });
+  return {
+    ResendNotificationAdapter: ResendNotificationAdapterMock,
+    TwilioSmsAdapter: TwilioSmsAdapterMock,
+    NotificationDispatcher: NotificationDispatcherMock,
+  };
+});
+
+describe("createResendAdapter", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    Object.keys(process.env).forEach((key) => {
+      if (!(key in originalEnv)) {
+        delete process.env[key];
+      }
+    });
+    Object.assign(process.env, originalEnv);
+  });
+
+  it("returns a ResendNotificationAdapter when RESEND_API_KEY is set", async () => {
+    process.env.RESEND_API_KEY = "re_test_key";
+    process.env.EMAIL_FROM = "test@example.com";
+    process.env.MANAGE_BASE_URL = "https://example.com";
+
+    const { createResendAdapter } = await importNotifications();
+    const adapter = createResendAdapter();
+
+    const { ResendNotificationAdapter } = await import("@mbe/notifications");
+    expect(ResendNotificationAdapter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fromAddress: "test@example.com",
+        manageBaseUrl: "https://example.com",
+      })
+    );
+    expect(adapter).toBeDefined();
+  });
+
+  it("returns a ResendNotificationAdapter with null resend client when RESEND_API_KEY is missing", async () => {
+    delete process.env.RESEND_API_KEY;
+    process.env.EMAIL_FROM = "noreply@example.com";
+    process.env.MANAGE_BASE_URL = "https://example.com";
+
+    const { createResendAdapter } = await importNotifications();
+    const adapter = createResendAdapter();
+
+    const { ResendNotificationAdapter } = await import("@mbe/notifications");
+    expect(ResendNotificationAdapter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resend: null,
+      })
+    );
+    expect(adapter).toBeDefined();
+  });
+
+  it("uses default values for EMAIL_FROM and MANAGE_BASE_URL when not set", async () => {
+    delete process.env.RESEND_API_KEY;
+    delete process.env.EMAIL_FROM;
+    delete process.env.MANAGE_BASE_URL;
+
+    const { createResendAdapter } = await importNotifications();
+    createResendAdapter();
+
+    const { ResendNotificationAdapter } = await import("@mbe/notifications");
+    expect(ResendNotificationAdapter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fromAddress: "reservations@mattbutlerengineering.com",
+        manageBaseUrl: "https://mattbutlerengineering.com",
+      })
+    );
+  });
+
+  it("builds the Resend client with the API key when provided", async () => {
+    process.env.RESEND_API_KEY = "re_live_secretkey";
+
+    const { createResendAdapter } = await importNotifications();
+    createResendAdapter();
+
+    const { Resend } = await import("resend");
+    expect(Resend).toHaveBeenCalledWith("re_live_secretkey");
+  });
+});
+
+describe("createNotificationPort", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns a NotificationDispatcher", async () => {
+    const { createNotificationPort } = await importNotifications();
+    const dispatcher = createNotificationPort();
+
+    const { NotificationDispatcher } = await import("@mbe/notifications");
+    expect(NotificationDispatcher).toHaveBeenCalled();
+    expect(dispatcher).toBeDefined();
+  });
+});

--- a/services/reservations/src/notifications.ts
+++ b/services/reservations/src/notifications.ts
@@ -6,10 +6,12 @@ import {
 } from "@mbe/notifications";
 
 /**
- * Creates the default NotificationDispatcher backed by Resend (email)
- * and optionally Twilio (SMS). Reads env vars once at creation time.
+ * Reads Resend env vars once and constructs a ResendNotificationAdapter.
+ * Single source of truth for RESEND_API_KEY / EMAIL_FROM / MANAGE_BASE_URL.
+ * Returns the adapter regardless of whether the API key is set — the adapter
+ * no-ops on sends when resend is null (key missing).
  */
-export function createNotificationPort(): NotificationDispatcher {
+export function createResendAdapter(): ResendNotificationAdapter {
   const resendClient = process.env.RESEND_API_KEY
     ? (new Resend(process.env.RESEND_API_KEY) as unknown as {
         emails: {
@@ -18,11 +20,19 @@ export function createNotificationPort(): NotificationDispatcher {
       })
     : null;
 
-  const emailAdapter = new ResendNotificationAdapter({
+  return new ResendNotificationAdapter({
     resend: resendClient,
     fromAddress: process.env.EMAIL_FROM ?? "reservations@mattbutlerengineering.com",
     manageBaseUrl: process.env.MANAGE_BASE_URL ?? "https://mattbutlerengineering.com",
   });
+}
+
+/**
+ * Creates the default NotificationDispatcher backed by Resend (email)
+ * and optionally Twilio (SMS). Reads env vars once at creation time.
+ */
+export function createNotificationPort(): NotificationDispatcher {
+  const emailAdapter = createResendAdapter();
 
   const smsAdapter =
     process.env.TWILIO_ACCOUNT_SID &&


### PR DESCRIPTION
## Summary

- Extracts `createResendAdapter()` factory in `services/reservations/src/notifications.ts` as the single owner of Resend client construction and env-var reads (`RESEND_API_KEY`, `EMAIL_FROM`, `MANAGE_BASE_URL`)
- `createNotificationPort()` now delegates to `createResendAdapter()` — no duplicated `new Resend(...)` / `ResendNotificationAdapter` construction
- Adds unit tests covering configured (API key present) and unconfigured (missing key → null client, default addresses) paths

## Test plan

- [ ] `pnpm --dir services/reservations lint` — passes
- [ ] `pnpm --dir services/reservations typecheck` — passes
- [ ] `pnpm --dir services/reservations test` — 55 files, 740 tests, all green
- [ ] `pnpm --filter @mbe/cli start check-adr` — no violations
- [ ] `pnpm --filter @mbe/cli start check-deps` — consistent
- [ ] `pnpm regen` — artifacts regenerated, root llms.txt committed

Closes #2043