### PR TITLE
fix(docs): renumber colliding ADRs — resolve 5 ambiguous IDs

### DIFF
--- a/docs/adr/ADR-007-api-versioning-strategy.md
+++ b/docs/adr/ADR-007-api-versioning-strategy.md
@@ -1,11 +1,11 @@
 ---
-id: ADR-002
+id: ADR-007
 title: API Versioning Strategy
 status: active
 date: 2026-04-06
 ---
 
-# ADR-002: API Versioning Strategy
+# ADR-007: API Versioning Strategy
 
 ## Context
 

--- a/docs/adr/ADR-008-error-handling-standard.md
+++ b/docs/adr/ADR-008-error-handling-standard.md
@@ -1,11 +1,11 @@
 ---
-id: ADR-003
+id: ADR-008
 title: Error Handling Standard
 status: active
 date: 2026-04-06
 ---
 
-# ADR-003: Error Handling Standard
+# ADR-008: Error Handling Standard
 
 ## Context
 

--- a/docs/adr/ADR-009-health-check-patterns.md
+++ b/docs/adr/ADR-009-health-check-patterns.md
@@ -1,11 +1,11 @@
 ---
-id: ADR-004
+id: ADR-009
 title: Health Check Patterns
 status: active
 date: 2026-04-06
 ---
 
-# ADR-004: Health Check Patterns
+# ADR-009: Health Check Patterns
 
 ## Context
 

--- a/docs/adr/ADR-010-service-authentication.md
+++ b/docs/adr/ADR-010-service-authentication.md
@@ -1,11 +1,11 @@
 ---
-id: ADR-005
+id: ADR-010
 title: Service Authentication
 status: active
 date: 2026-04-06
 ---
 
-# ADR-005: Service Authentication
+# ADR-010: Service Authentication
 
 ## Context
 

--- a/docs/adr/ADR-011-edge-routing-architecture.md
+++ b/docs/adr/ADR-011-edge-routing-architecture.md
@@ -1,11 +1,11 @@
 ---
-id: ADR-006
+id: ADR-011
 title: Edge Routing Architecture
 status: active
 date: 2026-04-06
 ---
 
-# ADR-006: Edge Routing Architecture
+# ADR-011: Edge Routing Architecture
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -7,11 +7,16 @@ This directory contains Architecture Decision Records (ADRs) documenting signifi
 | ADR                                             | Title                                            | Status | Date       |
 | ----------------------------------------------- | ------------------------------------------------ | ------ | ---------- |
 | [ADR-001](ADR-001-rialto-over-tailwind.md)      | Design System Unification (Rialto over Tailwind) | active | 2026-03-28 |
-| [ADR-002](ADR-002-api-versioning-strategy.md)   | API Versioning Strategy                          | active | 2026-04-06 |
-| [ADR-003](ADR-003-error-handling-standard.md)   | Error Handling Standard                          | active | 2026-04-06 |
-| [ADR-004](ADR-004-health-check-patterns.md)     | Health Check Patterns                            | active | 2026-04-06 |
-| [ADR-005](ADR-005-service-authentication.md)    | Service Authentication                           | active | 2026-04-06 |
-| [ADR-006](ADR-006-edge-routing-architecture.md) | Edge Routing Architecture                        | active | 2026-04-06 |
+| [ADR-002](ADR-002-api-error-format.md)          | API Error Format                                 | active | 2026-04-06 |
+| [ADR-003](ADR-003-auth-architecture.md)         | Auth Architecture                                | active | 2026-04-06 |
+| [ADR-004](ADR-004-edge-routing.md)              | Edge Routing                                     | active | 2026-04-06 |
+| [ADR-005](ADR-005-agent-worktree-isolation.md)  | Agent Worktree Isolation                         | active | 2026-04-06 |
+| [ADR-006](ADR-006-health-check-architecture.md) | Health Check Architecture                        | active | 2026-04-06 |
+| [ADR-007](ADR-007-api-versioning-strategy.md)   | API Versioning Strategy                          | active | 2026-05-16 |
+| [ADR-008](ADR-008-error-handling-standard.md)   | Error Handling Standard                          | active | 2026-05-16 |
+| [ADR-009](ADR-009-health-check-patterns.md)     | Health Check Patterns                            | active | 2026-05-16 |
+| [ADR-010](ADR-010-service-authentication.md)    | Service Authentication                           | active | 2026-05-16 |
+| [ADR-011](ADR-011-edge-routing-architecture.md) | Edge Routing Architecture                        | active | 2026-06-14 |
 
 ## Format
 


### PR DESCRIPTION
## Summary

Resolves ADR number collisions (issue #2397):
- ADR-002 split: api-error-format (stays 002), api-versioning-strategy (→ 007)
- ADR-003 split: auth-architecture (stays 003), error-handling-standard (→ 008)
- ADR-004 split: edge-routing (stays 004), health-check-patterns (→ 009)
- ADR-005 split: agent-worktree-isolation (stays 005), service-authentication (→ 010)
- ADR-006 split: health-check-architecture (stays 006), edge-routing-architecture (→ 011)

Newer ADRs (by git history) renumbered to ADR-007 through ADR-011.

## Changes

- Renamed 5 ADR files via `git mv` preserving history
- Updated frontmatter `id:` field in each renamed file
- Updated `docs/adr/README.md` index with all 11 ADRs (ADR-001 through ADR-011)
- Verified check-adr CLI uses dynamic ADR discovery (no hardcoded number updates needed)
- Verified compound command uses dynamic ADR discovery

## Test Results

- `pnpm --dir tools/cli test -- check-adr` ✅ 6/6 passed
- `pnpm --dir tools/cli lint` ✅ No errors
- No hardcoded ADR numbers found in CLI tools

## Gate Results

- `pnpm lint` ✅ (ADR doc changes only, no code changes)
- `pnpm typecheck` ⚠️ Pre-existing @mbe/agent-core dependency issue (not caused by this PR)
- `pnpm test` ✅ ADR-specific tests pass

Closes #2397