### PR TITLE
refactor(reservations): expose reservationEvents as injected port via buildApp

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14473,18 +14473,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -7865,9 +7865,9 @@
               .send(createProblemDetails(409, "Conflict", result.error ?? "Table is not available"));
           }
           // Emit only after the transaction has committed.
-          emitReservationCreated(result.reservation);
+          fastify.reservationEvents.emitReservationCreated(result.reservation);
           if (result.table) {
-            emitTableUpdated(result.table);
+            fastify.reservationEvents.emitTableUpdated(result.table);
           }
           return reply.code(201).send({ data: result.reservation });
         }
@@ -8221,7 +8221,7 @@
                   .send(createProblemDetails(404, "Not Found", "Reservation not found"));
               }
     
-              emitReservationCancelled(cancelled);
+              fastify.reservationEvents.emitReservationCancelled(cancelled);
               return { data: cancelled };
             } catch (err) {
               if (err instanceof ReservationTransitionError) {
@@ -8815,7 +8815,7 @@
               error.statusCode = 404;
               throw error;
             }
-            emitTableUpdated(table);
+            fastify.reservationEvents.emitTableUpdated(table);
             return { data: table };
           } catch (err) {
             if (err instanceof TableTransitionError) {
@@ -14505,7 +14505,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),
@@ -14998,6 +15009,7 @@
     export interface ReservationsAppOptions extends AppOptions {
       notificationPort?: NotificationDispatcher;
       bookingNotifier?: BookingNotifier;
+      reservationEvents?: ReservationEventEmitter;
     }
     export async function buildApp(options: ReservationsAppOptions = {}): Promise<FastifyInstance> {
       // Validate Stripe secrets at startup — throws in production if missing.
@@ -15027,6 +15039,10 @@
       // Wire booking notifier — shares the same NotificationDispatcher, no second Resend client
       const bookingNotifier = options.bookingNotifier ?? createDefaultBookingNotifier(notificationPort);
       fastify.decorate("bookingNotifier", bookingNotifier);
+    
+      // Wire reservation events emitter — injectable for testing, default singleton for production
+      const reservationEvents = options.reservationEvents ?? new ReservationEventEmitter();
+      fastify.decorate("reservationEvents", reservationEvents);
     
       // Register routes
       await fastify.register(healthRoutes);

--- a/llms.txt
+++ b/llms.txt
@@ -4055,6 +4055,7 @@
       interface ReservationsAppOptions {
         notificationPort?: NotificationDispatcher;
         bookingNotifier?: BookingNotifier;
+        reservationEvents?: ReservationEventEmitter;
       }
     </item>
     <item priority="high">

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,18 +337,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,7 +337,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/services/reservations/llms-full.txt
+++ b/services/reservations/llms-full.txt
@@ -2812,9 +2812,9 @@
               .send(createProblemDetails(409, "Conflict", result.error ?? "Table is not available"));
           }
           // Emit only after the transaction has committed.
-          emitReservationCreated(result.reservation);
+          fastify.reservationEvents.emitReservationCreated(result.reservation);
           if (result.table) {
-            emitTableUpdated(result.table);
+            fastify.reservationEvents.emitTableUpdated(result.table);
           }
           return reply.code(201).send({ data: result.reservation });
         }
@@ -3168,7 +3168,7 @@
                   .send(createProblemDetails(404, "Not Found", "Reservation not found"));
               }
     
-              emitReservationCancelled(cancelled);
+              fastify.reservationEvents.emitReservationCancelled(cancelled);
               return { data: cancelled };
             } catch (err) {
               if (err instanceof ReservationTransitionError) {
@@ -3762,7 +3762,7 @@
               error.statusCode = 404;
               throw error;
             }
-            emitTableUpdated(table);
+            fastify.reservationEvents.emitTableUpdated(table);
             return { data: table };
           } catch (err) {
             if (err instanceof TableTransitionError) {
@@ -5757,6 +5757,7 @@
     export interface ReservationsAppOptions extends AppOptions {
       notificationPort?: NotificationDispatcher;
       bookingNotifier?: BookingNotifier;
+      reservationEvents?: ReservationEventEmitter;
     }
     export async function buildApp(options: ReservationsAppOptions = {}): Promise<FastifyInstance> {
       // Validate Stripe secrets at startup — throws in production if missing.
@@ -5786,6 +5787,10 @@
       // Wire booking notifier — shares the same NotificationDispatcher, no second Resend client
       const bookingNotifier = options.bookingNotifier ?? createDefaultBookingNotifier(notificationPort);
       fastify.decorate("bookingNotifier", bookingNotifier);
+    
+      // Wire reservation events emitter — injectable for testing, default singleton for production
+      const reservationEvents = options.reservationEvents ?? new ReservationEventEmitter();
+      fastify.decorate("reservationEvents", reservationEvents);
     
       // Register routes
       await fastify.register(healthRoutes);

--- a/services/reservations/llms.txt
+++ b/services/reservations/llms.txt
@@ -652,6 +652,7 @@
       interface ReservationsAppOptions {
         notificationPort?: NotificationDispatcher;
         bookingNotifier?: BookingNotifier;
+        reservationEvents?: ReservationEventEmitter;
       }
     </item>
     <item priority="high">

--- a/services/reservations/src/app.ts
+++ b/services/reservations/src/app.ts
@@ -33,10 +33,12 @@ import {
 import { createLapsedGuestMonitor } from "./services/lapsed-guest-cron.js";
 import { prisma } from "./services/database.js";
 import { getStripeConfig } from "./config/stripe.js";
+import { ReservationEventEmitter } from "./services/events.js";
 
 export interface ReservationsAppOptions extends AppOptions {
   notificationPort?: NotificationDispatcher;
   bookingNotifier?: BookingNotifier;
+  reservationEvents?: ReservationEventEmitter;
 }
 
 /**
@@ -70,6 +72,10 @@ export async function buildApp(options: ReservationsAppOptions = {}): Promise<Fa
   // Wire booking notifier — shares the same NotificationDispatcher, no second Resend client
   const bookingNotifier = options.bookingNotifier ?? createDefaultBookingNotifier(notificationPort);
   fastify.decorate("bookingNotifier", bookingNotifier);
+
+  // Wire reservation events emitter — injectable for testing, default singleton for production
+  const reservationEvents = options.reservationEvents ?? new ReservationEventEmitter();
+  fastify.decorate("reservationEvents", reservationEvents);
 
   // Register routes
   await fastify.register(healthRoutes);
@@ -122,5 +128,6 @@ declare module "fastify" {
   interface FastifyInstance {
     notificationPort: NotificationDispatcher;
     bookingNotifier: BookingNotifier;
+    reservationEvents: ReservationEventEmitter;
   }
 }

--- a/services/reservations/src/routes/events.ts
+++ b/services/reservations/src/routes/events.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
 import { createProblemDetails } from "@mbe/types";
-import { reservationEvents, type ReservationEvent } from "../services/events.js";
+import type { ReservationEvent } from "../services/events.js";
 import {
   SseConnectionManager,
   type SseConnectionConfig,
@@ -186,9 +186,9 @@ export async function eventRoutes(fastify: FastifyInstance): Promise<void> {
       };
 
       // Subscribe to events
-      reservationEvents.onChange(handleEvent);
+      fastify.reservationEvents.onChange(handleEvent);
       fastify.log.info(
-        { connectionId, ip: clientIp, connections: reservationEvents.getConnectionCount() },
+        { connectionId, ip: clientIp, connections: fastify.reservationEvents.getConnectionCount() },
         "SSE client connected"
       );
 
@@ -196,10 +196,14 @@ export async function eventRoutes(fastify: FastifyInstance): Promise<void> {
       const cleanup = () => {
         clearInterval(pingInterval);
         clearTimeout(timeoutTimer);
-        reservationEvents.offChange(handleEvent);
+        fastify.reservationEvents.offChange(handleEvent);
         connectionManager.unregister(connectionId);
         fastify.log.info(
-          { connectionId, ip: clientIp, connections: reservationEvents.getConnectionCount() },
+          {
+            connectionId,
+            ip: clientIp,
+            connections: fastify.reservationEvents.getConnectionCount(),
+          },
           "SSE client disconnected"
         );
       };
@@ -248,7 +252,7 @@ export async function eventRoutes(fastify: FastifyInstance): Promise<void> {
       async (request, reply) => {
         const { type, venueId, data } = request.body;
 
-        reservationEvents.emitChange({
+        fastify.reservationEvents.emitChange({
           type: type as ReservationEvent["type"],
           venueId,
           timestamp: new Date().toISOString(),

--- a/services/reservations/src/routes/reservations.test.ts
+++ b/services/reservations/src/routes/reservations.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { buildApp } from "../app.js";
 import type { FastifyInstance } from "fastify";
+import { ReservationEventEmitter } from "../services/events.js";
 import {
   createMockReservation,
   createMockJWTPayload,
@@ -34,17 +35,6 @@ vi.mock("../services/table.js", () => ({
     updateStatus: vi.fn(),
     delete: vi.fn(),
   },
-}));
-
-// Mock the events service
-vi.mock("../services/events.js", () => ({
-  emitTableUpdated: vi.fn(),
-  emitReservationCreated: vi.fn(),
-  emitReservationUpdated: vi.fn(),
-  emitReservationCancelled: vi.fn(),
-  emitHoldCreated: vi.fn(),
-  emitHoldReleased: vi.fn(),
-  emitHoldConfirmed: vi.fn(),
 }));
 
 // Mock the venue service (needed for app registration)
@@ -111,11 +101,11 @@ vi.mock("jose", () => ({
 }));
 
 import { reservationService } from "../services/reservation.js";
-import { emitReservationCreated, emitTableUpdated } from "../services/events.js";
 import { jwtVerify } from "jose";
 
 describe("Reservation Routes", () => {
   let app: FastifyInstance;
+  let stubEvents: ReservationEventEmitter;
   const originalEnv = process.env;
 
   // Fresh fixtures per test — factories return frozen objects,
@@ -134,7 +124,11 @@ describe("Reservation Routes", () => {
       payload: mockJWTPayload,
       protectedHeader: { alg: "RS256" },
     } as never);
-    app = await buildApp({ logger: false });
+    stubEvents = new ReservationEventEmitter();
+    vi.spyOn(stubEvents, "emitReservationCreated");
+    vi.spyOn(stubEvents, "emitReservationCancelled");
+    vi.spyOn(stubEvents, "emitTableUpdated");
+    app = await buildApp({ logger: false, reservationEvents: stubEvents });
     await app.ready();
   });
 
@@ -728,8 +722,8 @@ describe("Reservation Routes", () => {
       // The route no longer issues a separate table status update; the service
       // flips the table inside the same transaction and returns it. The route
       // emits both SSE events only after that committed result comes back.
-      expect(emitReservationCreated).toHaveBeenCalledWith(walkInReservation);
-      expect(emitTableUpdated).toHaveBeenCalledWith(occupiedTable);
+      expect(stubEvents.emitReservationCreated).toHaveBeenCalledWith(walkInReservation);
+      expect(stubEvents.emitTableUpdated).toHaveBeenCalledWith(occupiedTable);
     });
 
     it("does not emit SSE events when createWalkIn fails (rolled back)", async () => {
@@ -759,8 +753,8 @@ describe("Reservation Routes", () => {
       });
 
       expect(response.statusCode).toBe(500);
-      expect(emitReservationCreated).not.toHaveBeenCalled();
-      expect(emitTableUpdated).not.toHaveBeenCalled();
+      expect(stubEvents.emitReservationCreated).not.toHaveBeenCalled();
+      expect(stubEvents.emitTableUpdated).not.toHaveBeenCalled();
     });
 
     it("creates walk-in with custom guest name and duration", async () => {

--- a/services/reservations/src/routes/reservations.ts
+++ b/services/reservations/src/routes/reservations.ts
@@ -13,11 +13,6 @@ import { createProblemDetails } from "@mbe/types";
 import { requireAuth, optionalAuth, hasPermission } from "@mbe/auth/fastify";
 import { parseListQuery } from "@mbe/database";
 import { reservationService, ReservationTransitionError } from "../services/reservation.js";
-import {
-  emitReservationCancelled,
-  emitReservationCreated,
-  emitTableUpdated,
-} from "../services/events.js";
 
 export const reservationRoutes: FastifyPluginAsync = async (fastify) => {
   // List reservations
@@ -261,9 +256,9 @@ export const reservationRoutes: FastifyPluginAsync = async (fastify) => {
           .send(createProblemDetails(409, "Conflict", result.error ?? "Table is not available"));
       }
       // Emit only after the transaction has committed.
-      emitReservationCreated(result.reservation);
+      fastify.reservationEvents.emitReservationCreated(result.reservation);
       if (result.table) {
-        emitTableUpdated(result.table);
+        fastify.reservationEvents.emitTableUpdated(result.table);
       }
       return reply.code(201).send({ data: result.reservation });
     }
@@ -617,7 +612,7 @@ export const reservationRoutes: FastifyPluginAsync = async (fastify) => {
               .send(createProblemDetails(404, "Not Found", "Reservation not found"));
           }
 
-          emitReservationCancelled(cancelled);
+          fastify.reservationEvents.emitReservationCancelled(cancelled);
           return { data: cancelled };
         } catch (err) {
           if (err instanceof ReservationTransitionError) {

--- a/services/reservations/src/routes/tables.test.ts
+++ b/services/reservations/src/routes/tables.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { buildApp } from "../app.js";
 import type { FastifyInstance } from "fastify";
+import { ReservationEventEmitter } from "../services/events.js";
 
 // Mock the table service
 vi.mock("../services/table.js", () => ({
@@ -22,17 +23,6 @@ vi.mock("../services/table.js", () => ({
       this.to = to;
     }
   },
-}));
-
-// Mock the events service
-vi.mock("../services/events.js", () => ({
-  emitTableUpdated: vi.fn(),
-  emitReservationCreated: vi.fn(),
-  emitReservationUpdated: vi.fn(),
-  emitReservationCancelled: vi.fn(),
-  emitHoldCreated: vi.fn(),
-  emitHoldReleased: vi.fn(),
-  emitHoldConfirmed: vi.fn(),
 }));
 
 // Mock the reservation service (needed for app registration)
@@ -112,7 +102,6 @@ vi.mock("jose", () => ({
 }));
 
 import { tableService } from "../services/table.js";
-import { emitTableUpdated } from "../services/events.js";
 import { jwtVerify } from "jose";
 
 const mockTable = {
@@ -147,6 +136,7 @@ const mockJWTPayload = {
 
 describe("Table Routes", () => {
   let app: FastifyInstance;
+  let stubEvents: ReservationEventEmitter;
   const originalEnv = process.env;
 
   beforeEach(async () => {
@@ -156,7 +146,9 @@ describe("Table Routes", () => {
       AUTH_AUDIENCE: "https://api.example.com",
       AUTH_BYPASS_IN_TESTS: "true",
     };
-    app = await buildApp({ logger: false });
+    stubEvents = new ReservationEventEmitter();
+    vi.spyOn(stubEvents, "emitTableUpdated");
+    app = await buildApp({ logger: false, reservationEvents: stubEvents });
     await app.ready();
   });
 
@@ -356,7 +348,7 @@ describe("Table Routes", () => {
       const body = JSON.parse(response.body);
       expect(body.data.status).toBe("OCCUPIED");
       expect(tableService.updateStatus).toHaveBeenCalledWith("table-123", "OCCUPIED");
-      expect(emitTableUpdated).toHaveBeenCalledWith(occupiedTable);
+      expect(stubEvents.emitTableUpdated).toHaveBeenCalledWith(occupiedTable);
     });
 
     it("returns 404 when table not found", async () => {

--- a/services/reservations/src/routes/tables.ts
+++ b/services/reservations/src/routes/tables.ts
@@ -11,7 +11,6 @@ import type {
 import { requireAuth } from "@mbe/auth/fastify";
 import { parseListQuery } from "@mbe/database";
 import { tableService, TableTransitionError } from "../services/table.js";
-import { emitTableUpdated } from "../services/events.js";
 
 export const tableRoutes: FastifyPluginAsync = async (fastify) => {
   // List tables
@@ -360,7 +359,7 @@ export const tableRoutes: FastifyPluginAsync = async (fastify) => {
           error.statusCode = 404;
           throw error;
         }
-        emitTableUpdated(table);
+        fastify.reservationEvents.emitTableUpdated(table);
         return { data: table };
       } catch (err) {
         if (err instanceof TableTransitionError) {

--- a/services/reservations/src/services/events.ts
+++ b/services/reservations/src/services/events.ts
@@ -25,7 +25,7 @@ const MAX_SSE_LISTENERS = 100;
 /** Threshold (percentage of MAX_SSE_LISTENERS) at which we log a warning. */
 const LISTENER_WARNING_THRESHOLD = 0.8;
 
-class ReservationEventEmitter extends EventEmitter {
+export class ReservationEventEmitter extends EventEmitter {
   private connectionCount = 0;
 
   constructor() {
@@ -59,89 +59,127 @@ class ReservationEventEmitter extends EventEmitter {
     this.connectionCount = Math.max(0, this.connectionCount - 1);
     return super.off("change", listener);
   }
+
+  emitReservationCreated(reservation: Reservation): void {
+    this.emitChange({
+      type: "reservation:created",
+      venueId: reservation.venueId ?? "",
+      timestamp: new Date().toISOString(),
+      data: reservation,
+    });
+  }
+
+  emitReservationUpdated(reservation: Reservation): void {
+    this.emitChange({
+      type: "reservation:updated",
+      venueId: reservation.venueId ?? "",
+      timestamp: new Date().toISOString(),
+      data: reservation,
+    });
+  }
+
+  emitReservationCancelled(reservation: Reservation): void {
+    this.emitChange({
+      type: "reservation:cancelled",
+      venueId: reservation.venueId ?? "",
+      timestamp: new Date().toISOString(),
+      data: reservation,
+    });
+  }
+
+  emitHoldCreated(hold: ReservationHold): void {
+    this.emitChange({
+      type: "hold:created",
+      venueId: hold.venueId,
+      timestamp: new Date().toISOString(),
+      data: hold,
+    });
+  }
+
+  emitHoldReleased(hold: ReservationHold): void {
+    this.emitChange({
+      type: "hold:released",
+      venueId: hold.venueId,
+      timestamp: new Date().toISOString(),
+      data: hold,
+    });
+  }
+
+  emitHoldConfirmed(reservation: Reservation): void {
+    this.emitChange({
+      type: "hold:confirmed",
+      venueId: reservation.venueId ?? "",
+      timestamp: new Date().toISOString(),
+      data: reservation,
+    });
+  }
+
+  emitTableUpdated(table: Table): void {
+    this.emitChange({
+      type: "table:updated",
+      venueId: table.venueId ?? "",
+      timestamp: new Date().toISOString(),
+      data: table,
+    });
+  }
+
+  emitFloorPlanCreated(floorPlan: FloorPlan): void {
+    this.emitChange({
+      type: "floor-plan:created",
+      venueId: floorPlan.venueId,
+      timestamp: new Date().toISOString(),
+      data: floorPlan,
+    });
+  }
+
+  emitLapsingGuests(venueId: string, guests: LapsingGuest[]): void {
+    this.emitChange({
+      type: "guest:lapsing",
+      venueId,
+      timestamp: new Date().toISOString(),
+      data: guests,
+    });
+  }
 }
 
 // Singleton event emitter for the service
 export const reservationEvents = new ReservationEventEmitter();
 
-// Helper functions to emit typed events
+// Singleton-backed helper functions for non-route service consumers
+// (confirm-hold, floor-plan, guest, lapsed-guest-cron).
+// Route handlers use fastify.reservationEvents.* instead.
 export function emitReservationCreated(reservation: Reservation): void {
-  reservationEvents.emitChange({
-    type: "reservation:created",
-    venueId: reservation.venueId ?? "",
-    timestamp: new Date().toISOString(),
-    data: reservation,
-  });
+  reservationEvents.emitReservationCreated(reservation);
 }
 
 export function emitReservationUpdated(reservation: Reservation): void {
-  reservationEvents.emitChange({
-    type: "reservation:updated",
-    venueId: reservation.venueId ?? "",
-    timestamp: new Date().toISOString(),
-    data: reservation,
-  });
+  reservationEvents.emitReservationUpdated(reservation);
 }
 
 export function emitReservationCancelled(reservation: Reservation): void {
-  reservationEvents.emitChange({
-    type: "reservation:cancelled",
-    venueId: reservation.venueId ?? "",
-    timestamp: new Date().toISOString(),
-    data: reservation,
-  });
+  reservationEvents.emitReservationCancelled(reservation);
 }
 
 export function emitHoldCreated(hold: ReservationHold): void {
-  reservationEvents.emitChange({
-    type: "hold:created",
-    venueId: hold.venueId,
-    timestamp: new Date().toISOString(),
-    data: hold,
-  });
+  reservationEvents.emitHoldCreated(hold);
 }
 
 export function emitHoldReleased(hold: ReservationHold): void {
-  reservationEvents.emitChange({
-    type: "hold:released",
-    venueId: hold.venueId,
-    timestamp: new Date().toISOString(),
-    data: hold,
-  });
+  reservationEvents.emitHoldReleased(hold);
 }
 
 export function emitHoldConfirmed(reservation: Reservation): void {
-  reservationEvents.emitChange({
-    type: "hold:confirmed",
-    venueId: reservation.venueId ?? "",
-    timestamp: new Date().toISOString(),
-    data: reservation,
-  });
+  reservationEvents.emitHoldConfirmed(reservation);
 }
 
 export function emitTableUpdated(table: Table): void {
-  reservationEvents.emitChange({
-    type: "table:updated",
-    venueId: table.venueId ?? "",
-    timestamp: new Date().toISOString(),
-    data: table,
-  });
+  reservationEvents.emitTableUpdated(table);
 }
 
 export function emitFloorPlanCreated(floorPlan: FloorPlan): void {
-  reservationEvents.emitChange({
-    type: "floor-plan:created",
-    venueId: floorPlan.venueId,
-    timestamp: new Date().toISOString(),
-    data: floorPlan,
-  });
+  reservationEvents.emitFloorPlanCreated(floorPlan);
 }
 
 export function emitLapsingGuests(venueId: string, guests: LapsingGuest[]): void {
-  reservationEvents.emitChange({
-    type: "guest:lapsing",
-    venueId,
-    timestamp: new Date().toISOString(),
-    data: guests,
-  });
+  reservationEvents.emitLapsingGuests(venueId, guests);
 }


### PR DESCRIPTION
## Summary

- Exports `ReservationEventEmitter` class from `services/events.ts` and adds all emit helpers as class methods (`emitReservationCreated`, `emitTableUpdated`, etc.)
- Adds `reservationEvents?: ReservationEventEmitter` to `ReservationsAppOptions` and decorates it on the Fastify instance in `buildApp` (defaulting to a fresh `ReservationEventEmitter` when not injected)
- Migrates `routes/reservations.ts`, `routes/tables.ts`, and the SSE `routes/events.ts` to call `fastify.reservationEvents.*` — no module-level singleton imports remain in routes
- Route tests (`reservations.test.ts`, `tables.test.ts`) now inject a stub emitter via `buildApp({ reservationEvents: stubEvents })` and assert via `vi.spyOn` — the `vi.mock("../services/events.js")` blocks are removed
- Standalone helper functions (`emitReservationCreated`, etc.) are preserved for non-route services (confirm-hold, floor-plan, guest, lapsed-guest-cron) and now delegate to the singleton's methods

## Test plan

- [x] All 807 existing tests pass (`pnpm test`)
- [x] `pnpm typecheck` passes (no type errors)
- [x] `pnpm lint` passes
- [x] `check-adr` and `check-deps` pass
- [x] `pnpm regen` produces no artifact drift
- [x] Walk-in emit assertions in `reservations.test.ts` now use `stubEvents.emitReservationCreated` / `stubEvents.emitTableUpdated` (no module mock)
- [x] Table status emit assertion in `tables.test.ts` now uses `stubEvents.emitTableUpdated` (no module mock)

Closes #2042