### PR TITLE
chore: compress fat skill prompts (site-audit, progress-tracker, issue-worker)

### DIFF
--- a/.claude/skills/issue-worker/SKILL.md
+++ b/.claude/skills/issue-worker/SKILL.md
@@ -1,277 +1,154 @@
 ---
 name: issue-worker
-description: Pick up the oldest open GitHub issue labeled 'ready', complete the work using mbe agent run with worktree isolation, and create a PR. Manages label lifecycle (ready → in-progress → has-pr). Invoke with /issue-worker.
+description: Pick oldest ready, implement via mbe agent run, create PR. ready→in-progress→has-pr. Invoke: /issue-worker.
 user-invocable: true
 ---
 
 # Issue Worker
 
-Autonomous issue resolver. Picks up one ready issue, delegates implementation to `mbe agent run` (worktree-isolated), and manages the label lifecycle.
+One issue/run, worktree-isolated.
 
-## Workflow
-
-### Step 0: Governor Check
-
-Before picking up work, check the adaptive cadence governor:
+## Governor
 
 ```bash
 node plugins/acmm/scripts/cadence-governor.js
 ```
 
-If the governor exits with code 1 (SKIP), exit cleanly: "Governor says SKIP (mode: \<MODE\>). No work this cycle."
+Exit 1 (SKIP) → exit. Exit 0 → continue.
 
-If the governor exits with code 0 (EXECUTE), proceed to Step 1.
+After work: `node plugins/acmm/scripts/cadence-governor.js --execute`
 
-After completing work (Step 5a or 5b), mark that execution happened:
-
-```bash
-node plugins/acmm/scripts/cadence-governor.js --execute
-```
-
-### Step 1: Find an Issue
+## Find
 
 ```bash
 gh issue list --label "ready" --state open --limit 5 --sort created --json number,title,body,labels
 ```
 
-Filter the results to exclude issues that also have the `agent-skip` label. Pick the first issue that passes all filters (no `agent-skip`, dependencies met, etc.).
+Filter `agent-skip`. Pick first. No candidates → exit.
 
-If no issues remain after filtering, **exit cleanly** with a message: "No ready issues found. Nothing to do."
-
-### Step 1b: Check Dependencies
-
-Before claiming, check if the issue has unresolved dependencies:
+## Dependencies
 
 ```bash
-# Extract "Depends on: #N" from issue body
 DEPS=$(echo "$ISSUE_BODY" | grep -oP 'Depends on: #\K\d+')
-
 for DEP in $DEPS; do
-  STATE=$(gh issue view $DEP --json state -q '.state')
-  if [ "$STATE" != "CLOSED" ]; then
-    echo "Blocked: issue #<NUMBER> depends on #$DEP which is still $STATE. Skipping."
-    # Try the next ready issue instead
-    exit 0
-  fi
+  [ "$(gh issue view $DEP --json state -q '.state')" != "CLOSED" ] && exit 0
 done
 ```
 
-If any dependency is still open, skip this issue and try the next oldest `ready` issue. This prevents out-of-order execution for issues created by `/decompose`.
+Unresolved → skip, next.
 
-### Step 1c: Check Retry Count
-
-Before claiming, check how many times this issue has already failed:
+## Retry Count
 
 ```bash
-# Count previous agent-failed attempt comments on this issue
-ATTEMPT_COUNT=$(gh issue view <NUMBER> --json comments --jq '[.comments[] | select(.body | test("agent-failed attempt"))] | length')
+ATTEMPT=$(gh issue view <NUM> --json comments --jq '[.comments[] | select(.body | test("agent-failed attempt"))] | length')
+MAX=$(node -e "console.log(JSON.parse(require('fs').readFileSync('.github/auto-qa-tuning.json','utf-8')).thresholds.maxRetries)")
 
-# Read maxRetries from auto-qa-tuning.json
-MAX_RETRIES=$(node -e "console.log(JSON.parse(require('fs').readFileSync('.github/auto-qa-tuning.json','utf-8')).thresholds.maxRetries)")
-
-if [ "$ATTEMPT_COUNT" -ge "$MAX_RETRIES" ]; then
-  echo "Issue #<NUMBER> has failed $ATTEMPT_COUNT times (max: $MAX_RETRIES). Skipping."
-  gh issue edit <NUMBER> --add-label "agent-skip" --remove-label "ready"
-  gh issue comment <NUMBER> --body "**Auto-skipped** after $ATTEMPT_COUNT failed attempts (max retries: $MAX_RETRIES).
-
-This issue needs manual review or a different approach. To retry:
+if [ "$ATTEMPT" -ge "$MAX" ]; then
+  gh issue edit <NUM> --add-label "agent-skip" --remove-label "ready"
+  gh issue comment <NUM> --body "**Auto-skipped** after $ATTEMPT (max: $MAX). Manual retry:
 \`\`\`bash
-gh issue edit <NUMBER> --add-label ready --remove-label agent-skip
-\`\`\`"
-  # Try the next ready issue instead, or exit if none remain
-fi
-```
-
-If the issue has reached `maxRetries`, skip it and move to the next candidate from the filtered list. If no candidates remain, exit cleanly.
-
-### Step 2: Claim the Issue
-
-```bash
-gh issue edit <NUMBER> --add-label "in-progress" --remove-label "ready"
-```
-
-This prevents other worker sessions from picking up the same issue.
-
-### Step 3: Analyze the Issue
-
-Read the full issue body and labels to understand:
-
-- What needs to be fixed/built
-- Which area of the codebase is affected
-- What the acceptance criteria are
-- **What verification commands exist** (look for a "Verification Commands" section with ```bash blocks)
-
-Build a clear, actionable task description from the issue content. If the issue includes verification commands, append them to the task description with: "After implementation, run these verification commands to confirm your work: <commands>"
-
-### Step 3b: Determine Budget
-
-Use the issue labels and description to set the right budget:
-
-- `ci-fix` or simple issues (lint, typo, config): `--max-budget 0.50`
-- `feature` or standard issues: `--max-budget 1.50`
-- Complex issues (multi-file, new service, architecture): `--max-budget 2.00`
-
-### Step 3c: Parse Agent Frontmatter
-
-Check the issue body for per-issue agent overrides (see `docs/agents/issue-tracker.md` → "Agent frontmatter"):
-
-```bash
-ISSUE_BODY=$(gh issue view <NUMBER> --json body -q .body)
-FRONTMATTER_FLAGS=$(echo "$ISSUE_BODY" | mbe agent frontmatter)
-VERIFY_CMD=$(echo "$ISSUE_BODY" | mbe agent frontmatter --field verify)
-```
-
-`FRONTMATTER_FLAGS` prints `mbe agent run` flags (e.g. `--model claude-haiku-4-5-20251001 --max-budget 0.5`) or an empty line when the issue has no usable agent block. `VERIFY_CMD` prints the verify shell command string, or an empty line when no `verify:` field is present. Warnings go to stderr; both commands always exit 0, so this step can never break the loop.
-
-### Step 4: Delegate to Agent
-
-Build the task description, appending the verify requirement when present:
-
-```bash
-TASK_WITH_VERIFY="$TASK_DESCRIPTION"
-if [ -n "$VERIFY_CMD" ]; then
-  TASK_WITH_VERIFY="$TASK_DESCRIPTION
-
-Before declaring done, run this verify command and confirm it exits 0:
-\`\`\`bash
-$VERIFY_CMD
+gh issue edit <NUM> --add-label ready --remove-label agent-skip
 \`\`\`"
 fi
 ```
 
-Run the implementation in an isolated worktree:
+Max hit → skip, next.
+
+## Claim
 
 ```bash
-eval "mbe agent run \"\$TASK_WITH_VERIFY\" --max-budget <budget from step 3b> --adapter auto $FRONTMATTER_FLAGS"
+gh issue edit <NUM> --add-label "in-progress" --remove-label "ready"
 ```
 
-`$FRONTMATTER_FLAGS` goes last — later flags win, so issue frontmatter overrides the step 3b budget heuristic and the default adapter.
+## Analyze
 
-The `eval` is required: this shell is zsh, which does NOT word-split an unquoted `$FRONTMATTER_FLAGS` — without eval the whole flag string is passed as one unknown option and commander exits 1. The eval is safe because `mbe agent frontmatter` only ever emits validated enum/numeric values, never raw issue text.
+Body/labels: what, area, criteria, **verification commands**.
 
-The `mbe agent run` command will:
+Task + commands: "After implementation, run: <commands>"
 
-1. Create a git worktree (isolated branch)
-2. Spawn a Claude Code session to implement the fix
-3. Commit changes
-4. Push the branch
-5. Create a PR
+## Budget
 
-Capture the output to determine success/failure and extract the PR URL if created.
+- Simple/`ci-fix`: `0.50`
+- Standard/`feature`: `1.50`
+- Complex: `2.00`
 
-### Step 4b: Run Verify Gate (when verify command is present)
-
-If `$VERIFY_CMD` is non-empty, run it as a gate **after** the agent completes:
+## Frontmatter
 
 ```bash
-if [ -n "$VERIFY_CMD" ]; then
-  echo "Running verify gate: $VERIFY_CMD"
-  eval "$VERIFY_CMD"
-  VERIFY_EXIT=$?
-  if [ "$VERIFY_EXIT" -ne 0 ]; then
-    echo "Verify gate failed (exit $VERIFY_EXIT) — treating as agent failure"
-    # Proceed to Step 5b (failure path), do NOT open a PR
-    # Set a descriptive error summary
-    ERROR_SUMMARY="Verify command exited $VERIFY_EXIT: $VERIFY_CMD"
-  fi
-fi
+FRONTMATTER=$(gh issue view <NUM> --json body -q .body | mbe agent frontmatter)
 ```
 
-A non-zero verify exit skips Step 5a entirely and goes directly to Step 5b with `$ERROR_SUMMARY` as the failure detail. When `$VERIFY_CMD` is empty, this step is skipped and the original success/failure from Step 4 applies.
-
-### Step 5a: On Success (PR Created)
+## Delegate
 
 ```bash
-# Add has-pr label, remove in-progress
-gh issue edit <NUMBER> --add-label "has-pr" --remove-label "in-progress"
-
-# Comment the PR link on the issue
-gh issue comment <NUMBER> --body "PR created: <PR_URL>
-
-This was automatically resolved by the issue-worker loop."
-
-# Ensure the PR body references the issue for auto-close
-# If mbe agent run didn't include it, update the PR:
-gh pr edit <PR_NUMBER> --body "$(gh pr view <PR_NUMBER> --json body -q .body)
-
-Closes #<ISSUE_NUMBER>"
+eval "mbe agent run \"\$TASK\" --max-budget <budget> --adapter auto $FRONTMATTER"
 ```
 
-### Step 5b: On Failure (Agent Could Not Complete)
+Last flags win (override budget/adapter). Safe (enum/numeric).
 
-First, determine the current attempt count:
+## Success
 
 ```bash
-# Count previous agent-failed attempt comments on this issue
-ATTEMPT_COUNT=$(gh issue view <NUMBER> --json comments --jq '[.comments[] | select(.body | test("agent-failed attempt"))] | length')
+gh issue edit <NUM> --add-label "has-pr" --remove-label "in-progress"
+gh issue comment <NUM> --body "PR: <URL>"
+gh pr edit <PR> --body "$(gh pr view <PR> --json body -q .body)
 
-# Read maxRetries from auto-qa-tuning.json
-MAX_RETRIES=$(node -e "console.log(JSON.parse(require('fs').readFileSync('.github/auto-qa-tuning.json','utf-8')).thresholds.maxRetries)")
-
-NEXT_ATTEMPT=$((ATTEMPT_COUNT + 1))
+Closes #<NUM>"
 ```
 
-Then comment with attempt tracking and set labels based on whether max retries have been reached:
+## Failure
 
 ```bash
-# Comment the failure details with attempt tracking
-gh issue comment <NUMBER> --body "**agent-failed attempt #$NEXT_ATTEMPT** — Automated agent was unable to resolve this issue.
+ATTEMPT=$(gh issue view <NUM> --json comments --jq '[.comments[] | select(.body | test("agent-failed attempt"))] | length')
+MAX=$(node -e "console.log(JSON.parse(require('fs').readFileSync('.github/auto-qa-tuning.json','utf-8')).thresholds.maxRetries)")
+NEXT=$((ATTEMPT + 1))
 
-**Error**: <error summary>
+gh issue comment <NUM> --body "**agent-failed attempt #$NEXT** — Unable.
 
-Attempts so far: $NEXT_ATTEMPT/$MAX_RETRIES
-$(if [ "$NEXT_ATTEMPT" -ge "$MAX_RETRIES" ]; then echo 'This issue will be auto-skipped on next worker run.'; else echo 'Will retry on next worker cycle.'; fi)"
+**Error**: <summary>
 
-# Set labels based on retry status
-if [ "$NEXT_ATTEMPT" -ge "$MAX_RETRIES" ]; then
-  gh issue edit <NUMBER> --add-label "agent-skip" --remove-label "in-progress"
+Attempts: $NEXT/$MAX
+$([ "$NEXT" -ge "$MAX" ] && echo 'Auto-skipped next.' || echo 'Will retry next cycle.')"
+
+if [ "$NEXT" -ge "$MAX" ]; then
+  gh issue edit <NUM> --add-label "agent-skip" --remove-label "in-progress"
 else
-  gh issue edit <NUMBER> --add-label "agent-failed" --add-label "ready" --remove-label "in-progress"
+  gh issue edit <NUM> --add-label "agent-failed" --add-label "ready" --remove-label "in-progress"
 fi
 ```
 
-## Safety Rules
+## Priority
 
-- **One issue per run** — never pick up multiple issues
-- **Never force-push** — all pushes are normal pushes to new branches
-- **Never merge directly** — only create PRs against main
-- **Never delete branches** — leave cleanup to the PR merge process
-- **Budget cap** — `mbe agent run` is capped at $1.00 per issue
-- **Label integrity** — always transition labels atomically (add new label before removing old)
-
-## Issue Priority
-
-When multiple issues have the `ready` label, the `--sort created` flag ensures the **oldest issue** is picked up first (FIFO queue). This prevents starvation of older issues.
-
-Issues with the `ci-fix` label should be treated with higher urgency — if both `audit` and `ci-fix` issues are ready, prefer `ci-fix`:
+FIFO: `--sort created`. Prefer `ci-fix`:
 
 ```bash
-# Check for ci-fix issues first
-CI_ISSUE=$(gh issue list --label "ready" --label "ci-fix" --state open --limit 5 --sort created --json number,labels -q '[.[] | select(.labels | map(.name) | index("agent-skip") | not)] | .[0].number')
-
-if [ -n "$CI_ISSUE" ]; then
-  # Work the CI fix issue
-else
-  # Fall back to any ready issue (excluding agent-skip)
-  gh issue list --label "ready" --state open --limit 5 --sort created --json number,title,body,labels
-  # Filter out issues with agent-skip label from results
-fi
+CI=$(gh issue list --label "ready" --label "ci-fix" --state open --limit 5 --sort created --json number,labels -q '[.[] | select(.labels | map(.name) | index("agent-skip") | not)] | .[0].number')
+[ -n "$CI" ] && WORK_CI || WORK_ANY
 ```
 
-## Retry Policy
+## Retry
 
-Failed issues are automatically re-queued with both `agent-failed` and `ready` labels (unless max retries have been reached). The attempt count is tracked via comments matching the `agent-failed attempt` pattern.
+Failed auto-re-queue: `agent-failed`+`ready` (unless max).
 
-After `maxRetries` (from `.github/auto-qa-tuning.json`, currently 2) failed attempts, the issue is labeled `agent-skip` instead of being re-queued. This prevents infinite retry loops.
+After `maxRetries` (`.github/auto-qa-tuning.json`, 2): `agent-skip`.
 
-To manually retry a skipped issue:
+Manually retry skipped:
 
 ```bash
-gh issue edit <NUMBER> --add-label "ready" --remove-label "agent-skip"
+gh issue edit <NUM> --add-label "ready" --remove-label "agent-skip"
 ```
 
-To manually retry a failed issue that has not been auto-skipped:
+Manually retry failed:
 
 ```bash
-gh issue edit <NUMBER> --add-label "ready" --remove-label "agent-failed"
+gh issue edit <NUM> --add-label "ready" --remove-label "agent-failed"
 ```
+
+## Rules
+
+- One/run
+- No force-push
+- PRs main only
+- No delete
+- Budget: $1.00 max
+- Atomic (add before remove)

--- a/.claude/skills/issue-worker/SKILL.original.md
+++ b/.claude/skills/issue-worker/SKILL.original.md
@@ -1,0 +1,241 @@
+---
+name: issue-worker
+description: Pick up the oldest open GitHub issue labeled 'ready', complete the work using mbe agent run with worktree isolation, and create a PR. Manages label lifecycle (ready → in-progress → has-pr). Invoke with /issue-worker.
+user-invocable: true
+---
+
+# Issue Worker
+
+Autonomous issue resolver. Picks up one ready issue, delegates implementation to `mbe agent run` (worktree-isolated), and manages the label lifecycle.
+
+## Workflow
+
+### Step 0: Governor Check
+
+Before picking up work, check the adaptive cadence governor:
+
+```bash
+node plugins/acmm/scripts/cadence-governor.js
+```
+
+If the governor exits with code 1 (SKIP), exit cleanly: "Governor says SKIP (mode: \<MODE\>). No work this cycle."
+
+If the governor exits with code 0 (EXECUTE), proceed to Step 1.
+
+After completing work (Step 5a or 5b), mark that execution happened:
+
+```bash
+node plugins/acmm/scripts/cadence-governor.js --execute
+```
+
+### Step 1: Find an Issue
+
+```bash
+gh issue list --label "ready" --state open --limit 5 --sort created --json number,title,body,labels
+```
+
+Filter the results to exclude issues that also have the `agent-skip` label. Pick the first issue that passes all filters (no `agent-skip`, dependencies met, etc.).
+
+If no issues remain after filtering, **exit cleanly** with a message: "No ready issues found. Nothing to do."
+
+### Step 1b: Check Dependencies
+
+Before claiming, check if the issue has unresolved dependencies:
+
+```bash
+# Extract "Depends on: #N" from issue body
+DEPS=$(echo "$ISSUE_BODY" | grep -oP 'Depends on: #\K\d+')
+
+for DEP in $DEPS; do
+  STATE=$(gh issue view $DEP --json state -q '.state')
+  if [ "$STATE" != "CLOSED" ]; then
+    echo "Blocked: issue #<NUMBER> depends on #$DEP which is still $STATE. Skipping."
+    # Try the next ready issue instead
+    exit 0
+  fi
+done
+```
+
+If any dependency is still open, skip this issue and try the next oldest `ready` issue. This prevents out-of-order execution for issues created by `/decompose`.
+
+### Step 1c: Check Retry Count
+
+Before claiming, check how many times this issue has already failed:
+
+```bash
+# Count previous agent-failed attempt comments on this issue
+ATTEMPT_COUNT=$(gh issue view <NUMBER> --json comments --jq '[.comments[] | select(.body | test("agent-failed attempt"))] | length')
+
+# Read maxRetries from auto-qa-tuning.json
+MAX_RETRIES=$(node -e "console.log(JSON.parse(require('fs').readFileSync('.github/auto-qa-tuning.json','utf-8')).thresholds.maxRetries)")
+
+if [ "$ATTEMPT_COUNT" -ge "$MAX_RETRIES" ]; then
+  echo "Issue #<NUMBER> has failed $ATTEMPT_COUNT times (max: $MAX_RETRIES). Skipping."
+  gh issue edit <NUMBER> --add-label "agent-skip" --remove-label "ready"
+  gh issue comment <NUMBER> --body "**Auto-skipped** after $ATTEMPT_COUNT failed attempts (max retries: $MAX_RETRIES).
+
+This issue needs manual review or a different approach. To retry:
+\`\`\`bash
+gh issue edit <NUMBER> --add-label ready --remove-label agent-skip
+\`\`\`"
+  # Try the next ready issue instead, or exit if none remain
+fi
+```
+
+If the issue has reached `maxRetries`, skip it and move to the next candidate from the filtered list. If no candidates remain, exit cleanly.
+
+### Step 2: Claim the Issue
+
+```bash
+gh issue edit <NUMBER> --add-label "in-progress" --remove-label "ready"
+```
+
+This prevents other worker sessions from picking up the same issue.
+
+### Step 3: Analyze the Issue
+
+Read the full issue body and labels to understand:
+
+- What needs to be fixed/built
+- Which area of the codebase is affected
+- What the acceptance criteria are
+- **What verification commands exist** (look for a "Verification Commands" section with ```bash blocks)
+
+Build a clear, actionable task description from the issue content. If the issue includes verification commands, append them to the task description with: "After implementation, run these verification commands to confirm your work: <commands>"
+
+### Step 3b: Determine Budget
+
+Use the issue labels and description to set the right budget:
+
+- `ci-fix` or simple issues (lint, typo, config): `--max-budget 0.50`
+- `feature` or standard issues: `--max-budget 1.50`
+- Complex issues (multi-file, new service, architecture): `--max-budget 2.00`
+
+### Step 3c: Parse Agent Frontmatter
+
+Check the issue body for per-issue agent overrides (see `docs/agents/issue-tracker.md` → "Agent frontmatter"):
+
+```bash
+FRONTMATTER_FLAGS=$(gh issue view <NUMBER> --json body -q .body | mbe agent frontmatter)
+```
+
+The command prints `mbe agent run` flags (e.g. `--model claude-haiku-4-5-20251001 --max-budget 0.5`) or an empty line when the issue has no usable agent block. Warnings go to stderr; the command always exits 0, so this step can never break the loop.
+
+### Step 4: Delegate to Agent
+
+Run the implementation in an isolated worktree:
+
+```bash
+eval "mbe agent run \"\$TASK_DESCRIPTION\" --max-budget <budget from step 3b> --adapter auto $FRONTMATTER_FLAGS"
+```
+
+`$FRONTMATTER_FLAGS` goes last — later flags win, so issue frontmatter overrides the step 3b budget heuristic and the default adapter.
+
+The `eval` is required: this shell is zsh, which does NOT word-split an unquoted `$FRONTMATTER_FLAGS` — without eval the whole flag string is passed as one unknown option and commander exits 1. The eval is safe because `mbe agent frontmatter` only ever emits validated enum/numeric values, never raw issue text.
+
+The `mbe agent run` command will:
+
+1. Create a git worktree (isolated branch)
+2. Spawn a Claude Code session to implement the fix
+3. Commit changes
+4. Push the branch
+5. Create a PR
+
+Capture the output to determine success/failure and extract the PR URL if created.
+
+### Step 5a: On Success (PR Created)
+
+```bash
+# Add has-pr label, remove in-progress
+gh issue edit <NUMBER> --add-label "has-pr" --remove-label "in-progress"
+
+# Comment the PR link on the issue
+gh issue comment <NUMBER> --body "PR created: <PR_URL>
+
+This was automatically resolved by the issue-worker loop."
+
+# Ensure the PR body references the issue for auto-close
+# If mbe agent run didn't include it, update the PR:
+gh pr edit <PR_NUMBER> --body "$(gh pr view <PR_NUMBER> --json body -q .body)
+
+Closes #<ISSUE_NUMBER>"
+```
+
+### Step 5b: On Failure (Agent Could Not Complete)
+
+First, determine the current attempt count:
+
+```bash
+# Count previous agent-failed attempt comments on this issue
+ATTEMPT_COUNT=$(gh issue view <NUMBER> --json comments --jq '[.comments[] | select(.body | test("agent-failed attempt"))] | length')
+
+# Read maxRetries from auto-qa-tuning.json
+MAX_RETRIES=$(node -e "console.log(JSON.parse(require('fs').readFileSync('.github/auto-qa-tuning.json','utf-8')).thresholds.maxRetries)")
+
+NEXT_ATTEMPT=$((ATTEMPT_COUNT + 1))
+```
+
+Then comment with attempt tracking and set labels based on whether max retries have been reached:
+
+```bash
+# Comment the failure details with attempt tracking
+gh issue comment <NUMBER> --body "**agent-failed attempt #$NEXT_ATTEMPT** — Automated agent was unable to resolve this issue.
+
+**Error**: <error summary>
+
+Attempts so far: $NEXT_ATTEMPT/$MAX_RETRIES
+$(if [ "$NEXT_ATTEMPT" -ge "$MAX_RETRIES" ]; then echo 'This issue will be auto-skipped on next worker run.'; else echo 'Will retry on next worker cycle.'; fi)"
+
+# Set labels based on retry status
+if [ "$NEXT_ATTEMPT" -ge "$MAX_RETRIES" ]; then
+  gh issue edit <NUMBER> --add-label "agent-skip" --remove-label "in-progress"
+else
+  gh issue edit <NUMBER> --add-label "agent-failed" --add-label "ready" --remove-label "in-progress"
+fi
+```
+
+## Safety Rules
+
+- **One issue per run** — never pick up multiple issues
+- **Never force-push** — all pushes are normal pushes to new branches
+- **Never merge directly** — only create PRs against main
+- **Never delete branches** — leave cleanup to the PR merge process
+- **Budget cap** — `mbe agent run` is capped at $1.00 per issue
+- **Label integrity** — always transition labels atomically (add new label before removing old)
+
+## Issue Priority
+
+When multiple issues have the `ready` label, the `--sort created` flag ensures the **oldest issue** is picked up first (FIFO queue). This prevents starvation of older issues.
+
+Issues with the `ci-fix` label should be treated with higher urgency — if both `audit` and `ci-fix` issues are ready, prefer `ci-fix`:
+
+```bash
+# Check for ci-fix issues first
+CI_ISSUE=$(gh issue list --label "ready" --label "ci-fix" --state open --limit 5 --sort created --json number,labels -q '[.[] | select(.labels | map(.name) | index("agent-skip") | not)] | .[0].number')
+
+if [ -n "$CI_ISSUE" ]; then
+  # Work the CI fix issue
+else
+  # Fall back to any ready issue (excluding agent-skip)
+  gh issue list --label "ready" --state open --limit 5 --sort created --json number,title,body,labels
+  # Filter out issues with agent-skip label from results
+fi
+```
+
+## Retry Policy
+
+Failed issues are automatically re-queued with both `agent-failed` and `ready` labels (unless max retries have been reached). The attempt count is tracked via comments matching the `agent-failed attempt` pattern.
+
+After `maxRetries` (from `.github/auto-qa-tuning.json`, currently 2) failed attempts, the issue is labeled `agent-skip` instead of being re-queued. This prevents infinite retry loops.
+
+To manually retry a skipped issue:
+
+```bash
+gh issue edit <NUMBER> --add-label "ready" --remove-label "agent-skip"
+```
+
+To manually retry a failed issue that has not been auto-skipped:
+
+```bash
+gh issue edit <NUMBER> --add-label "ready" --remove-label "agent-failed"
+```

--- a/.claude/skills/progress-tracker/SKILL.md
+++ b/.claude/skills/progress-tracker/SKILL.md
@@ -1,266 +1,176 @@
 ---
 name: progress-tracker
-description: Track continuous improvement loop performance. Queries GitHub for metrics (issues created/closed, PRs merged, CI health), logs trends, and suggests process improvements. Invoke with /progress-tracker.
+description: Track loop metrics, trends, improvements. Invoke: /progress-tracker.
 user-invocable: true
 ---
 
 # Progress Tracker
 
-Daily analysis of the continuous improvement loop's effectiveness. Queries GitHub for metrics, identifies patterns, logs trends, and suggests process improvements.
+Queries: metrics, patterns, actions. Daily.
 
-## Workflow
-
-### Step 1: Gather Metrics
-
-Run these queries to collect data from the last 7 days:
+## Queries (7d)
 
 ```bash
-# Issues created by audit (last 7 days)
 gh issue list --label "audit" --state all --json number,title,state,createdAt,closedAt,labels --limit 100
-
-# Issues created by CI monitor
 gh issue list --label "ci-fix" --state all --json number,title,state,createdAt,closedAt,labels --limit 50
-
-# Issues currently in each state
 gh issue list --label "ready" --state open --json number,title
 gh issue list --label "in-progress" --state open --json number,title
 gh issue list --label "has-pr" --state open --json number,title
 gh issue list --label "agent-failed" --state open --json number,title
 gh issue list --label "agent-skip" --state open --json number,title,createdAt
-
-# PRs merged recently
 gh pr list --state merged --json number,title,mergedAt,headRefName --limit 50
-
-# CI health (last 20 runs on main)
 gh run list --branch main --limit 20 --json conclusion,createdAt
-
-# Meta-improvement suggestions created
 gh issue list --label "meta-improvement" --state all --json number,title,state
-
-# Agent spend (from local cost log)
-# Read .claude/agent-spend.jsonl and aggregate by date
 cat .claude/agent-spend.jsonl 2>/dev/null | tail -100
 ```
 
-#### Cost Log Format
+Cost: `.claude/agent-spend.jsonl` = `{date,timestamp,costUsd,issueNumber,model}`
 
-The file `.claude/agent-spend.jsonl` contains one JSON object per line:
+## Metrics
 
-```json
-{
-  "date": "2026-04-06",
-  "timestamp": "2026-04-06T12:00:00Z",
-  "costUsd": 0.45,
-  "issueNumber": 199,
-  "model": "claude-sonnet-4-6"
-}
-```
+| Metric        | Formula                  | Target |
+| ------------- | ------------------------ | ------ |
+| Created (7d)  | audit+ci-fix             | -      |
+| Closed (7d)   | audit+ci-fix             | -      |
+| Closure Rate  | Closed/Created           | >80%   |
+| Time-to-Close | mean(closedAt-createdAt) | <24h   |
+| Agent Success | has-pr/(has-pr+failed)   | >70%   |
+| CI Pass       | success/total main       | >95%   |
+| Queue         | count ready              | <5     |
+| Stale         | ready>7d                 | 0      |
+| Blocked       | agent-failed             | 0      |
+| Skipped       | agent-skip               | 0      |
+| Daily Spend   | Σ costUsd                | <$10   |
+| 7d Spend      | Σ costUsd                | <$50   |
+| Cost/Issue    | 7d/closed                | <$2    |
 
-Log entries are written by `pnpm log:cost -- --cost <usd> --issue <num>` after each agent session.
+## Analysis
 
-### Step 2: Compute Metrics
+1. Recurring types → systemic?
+2. Agent failures → pattern?
+3. CI unstable → same job?
+4. Queue bottleneck?
+5. Cost efficiency?
 
-Calculate these key indicators:
+## Log
 
-| Metric                  | Formula                                                                    |
-| ----------------------- | -------------------------------------------------------------------------- |
-| **Issues Created (7d)** | Count of audit + ci-fix issues created in last 7 days                      |
-| **Issues Closed (7d)**  | Count of audit + ci-fix issues closed in last 7 days                       |
-| **Closure Rate**        | Closed / Created (target: > 0.8)                                           |
-| **Avg Time-to-Close**   | Mean of (closedAt - createdAt) for closed issues                           |
-| **Agent Success Rate**  | Issues with `has-pr` / (Issues with `has-pr` + Issues with `agent-failed`) |
-| **CI Pass Rate**        | Successful runs / Total runs on main (target: > 0.95)                      |
-| **Queue Depth**         | Count of issues with `ready` label (target: < 5)                           |
-| **Stale Issues**        | Issues with `ready` label open > 7 days                                    |
-| **Blocked Issues**      | Issues with `agent-failed` label not re-queued                             |
-| **Skipped Issues**      | Issues with `agent-skip` label (exceeded max retries, need manual review)  |
-| **Daily Agent Spend**   | Sum of costUsd from .claude/agent-spend.jsonl for today (target: < $10)    |
-| **7d Agent Spend**      | Sum of costUsd from last 7 days of entries                                 |
-| **Avg Cost/Issue**      | 7d spend / issues closed in 7d                                             |
-
-### Step 3: Analyze Patterns
-
-Look for:
-
-1. **Recurring issue types** — Are the same categories appearing repeatedly? This suggests a systemic problem rather than individual bugs.
-   - Example: Multiple `[Audit] A11y:` issues → may need an accessibility review of shared components
-
-2. **Agent failure patterns** — What types of issues does the agent fail on? Are there common characteristics?
-   - Example: Agent fails on issues requiring database changes → may need better skill instructions
-
-3. **CI instability** — Is the same job failing repeatedly? Is it a flaky test or a real regression?
-   - Example: `migrations` job fails 3x/week → database schema process needs improvement
-
-4. **Queue bottlenecks** — Is the queue growing faster than the worker can process?
-   - If queue depth > 10: suggest increasing worker cadence
-   - If agent failure rate > 30%: suggest improving issue descriptions
-
-5. **Cost efficiency** — Are we spending budget on low-value issues?
-
-### Step 4: Log Entry
-
-Append a dated entry to `.claude/improvement-loop/log.md`:
+Append `.claude/improvement-loop/log.md`:
 
 ```markdown
 ## YYYY-MM-DD
 
 ### Metrics
 
-| Metric              | Value | Target | Status   |
-| ------------------- | ----- | ------ | -------- |
-| Issues Created (7d) | N     | -      | -        |
-| Issues Closed (7d)  | N     | -      | -        |
-| Closure Rate        | N%    | >80%   | ✅/⚠️/❌ |
-| Avg Time-to-Close   | Nh    | <24h   | ✅/⚠️/❌ |
-| Agent Success Rate  | N%    | >70%   | ✅/⚠️/❌ |
-| CI Pass Rate        | N%    | >95%   | ✅/⚠️/❌ |
-| Queue Depth         | N     | <5     | ✅/⚠️/❌ |
-| Stale Issues        | N     | 0      | ✅/⚠️/❌ |
-| Skipped Issues      | N     | 0      | ✅/⚠️/❌ |
-| Daily Agent Spend   | $N.NN | <$10   | ✅/⚠️/❌ |
-| 7d Agent Spend      | $N.NN | <$50   | ✅/⚠️/❌ |
-| Avg Cost/Issue      | $N.NN | <$2    | ✅/⚠️/❌ |
+[Table with Closed/Created/Rate/Time/Success/Pass/Queue/Stale/Skip/Spend/Cost]
 
 ### Patterns
 
-- [Notable patterns observed]
+- [Findings]
 
 ### Recommendations
 
-- [Actionable suggestions]
+- [Actions]
 
-### Skipped Issues (agent-skip)
+### Skipped Issues
 
-[List any issues with the `agent-skip` label that need manual attention]
+[Manual review]
 ```
 
-Query skipped issues for the report:
+Query skipped: `gh issue list --label "agent-skip" --state open --json number,title,createdAt --jq '.[] | "  #\(.number) \(.title)"'`
+
+Summary: "N skipped after max retries"
+
+**Append only.**
+
+## Improvement Issues
+
+Pattern 3+ days consistent?
 
 ```bash
-gh issue list --label "agent-skip" --state open --json number,title,createdAt --jq '.[] | "  #\(.number) \(.title) (created: \(.createdAt | split("T")[0]))"'
-```
-
-If any `agent-skip` issues exist, include a summary line in the report: "N issues skipped after max retries -- need manual review"
-
-Create the file if it does not exist. Always **append** — never overwrite previous entries.
-
-### Step 5: Create Improvement Issues
-
-If patterns suggest actionable process improvements, create a GitHub issue:
-
-```bash
-gh issue create \
-  --title "[Meta] <improvement description>" \
-  --label "meta-improvement" \
+gh issue create --title "[Meta] <improvement>" --label "meta-improvement" \
   --body "## Observation
-
-<What the data shows>
+<Data>
 
 ## Recommendation
+<Change>
 
-<Specific change to make>
-
-## Expected Impact
-
-<What should improve>
+## Impact
+<Outcome>
 
 ---
-*Identified by progress-tracker on $(date +%Y-%m-%d)*"
+*Identified: $(date +%Y-%m-%d)*"
 ```
 
-Only create improvement issues for patterns seen **consistently over 3+ days**. Do not create issues for one-off anomalies.
+## Thresholds
 
-## Targets & Thresholds
+| Metric  | Green | Yellow   | Red   |
+| ------- | ----- | -------- | ----- |
+| Closure | >80%  | 50-80%   | <50%  |
+| Success | >70%  | 40-70%   | <40%  |
+| CI      | >95%  | 85-95%   | <85%  |
+| Queue   | <5    | 5-10     | >10   |
+| Time    | <24h  | 24-72h   | >72h  |
+| Daily   | <$10  | $10-$20  | >$20  |
+| 7d      | <$50  | $50-$100 | >$100 |
+| Cost    | <$2   | $2-$5    | >$5   |
 
-| Metric             | Green | Yellow   | Red    |
-| ------------------ | ----- | -------- | ------ |
-| Closure Rate       | > 80% | 50-80%   | < 50%  |
-| Agent Success Rate | > 70% | 40-70%   | < 40%  |
-| CI Pass Rate       | > 95% | 85-95%   | < 85%  |
-| Queue Depth        | < 5   | 5-10     | > 10   |
-| Avg Time-to-Close  | < 24h | 24-72h   | > 72h  |
-| Daily Agent Spend  | < $10 | $10-$20  | > $20  |
-| 7d Agent Spend     | < $50 | $50-$100 | > $100 |
-| Avg Cost/Issue     | < $2  | $2-$5    | > $5   |
+## Actions
 
-## Self-Tuning Actions
-
-The progress tracker doesn't just observe — it **acts** on what it finds.
-
-### Circuit Breaker: Pause on High Failure Rate
-
-If agent failure rate exceeds 50% over the last 3 days:
+### Pause on Failure >50% (3d)
 
 ```bash
-# Disable the implement-queue CronCreate job if running locally
-# For RemoteTriggers, disable the issue-worker:
-# (Manual step — create an issue alerting the user)
-gh issue create \
-  --title "[Alert] Implement queue paused — agent failure rate > 50%" \
+gh issue create --title "[Alert] Queue paused — failure >50%" \
   --label "meta-improvement" \
-  --body "Agent success rate has dropped below 50% over the last 3 days. The loop should be paused until the failure patterns are addressed.
+  --body "Success <50%. Pause loop.
 
-Current failures:
 $(gh issue list --label agent-failed --state open --json number,title -q '.[] | "- #\(.number): \(.title)"')
 
-**Action needed**: Review failed issues, improve issue descriptions or skill instructions, then re-enable."
+Fix, improve descriptions, re-enable."
 ```
 
-### Auto-Retry Stale Failures
+### Auto-retry Stale (3+ days)
 
-If an issue has been `agent-failed` for 3+ days with no activity, re-queue it (the agent or skills may have improved). Issues with the `agent-skip` label are excluded -- they have already exhausted their retry budget and need manual intervention:
+Exclude `agent-skip`:
 
 ```bash
-# Find stale agent-failed issues (created > 3 days ago), excluding agent-skip
 STALE=$(gh issue list --label "agent-failed" --state open --json number,createdAt,labels -q '[.[] | select(.createdAt < (now - 259200 | todate)) | select(.labels | map(.name) | index("agent-skip") | not)] | .[].number')
 
 for NUM in $STALE; do
   gh issue edit $NUM --add-label "ready" --remove-label "agent-failed"
-  gh issue comment $NUM --body "Auto-retrying — this issue has been in agent-failed state for 3+ days."
+  gh issue comment $NUM --body "Auto-retry — failed 3+ days."
 done
 ```
 
-**Max 2 retries per run.**
+Max 2/run.
 
-### Queue Depth Adjustment
+### Queue Adjust
 
-If queue depth > 10 and agent success rate > 70%:
+Queue >10 + success >70% → `/loop 15m /implement-queue`
 
-- Suggest running `/loop 15m /implement-queue` instead of 30m (faster cadence)
+Queue 0 for 3d → reduce audit or expand
 
-If queue depth is 0 for 3 consecutive days:
-
-- Suggest reducing audit frequency or expanding audit scope
-
-### Feature Tracking
-
-Also track feature progress:
+### Features
 
 ```bash
-# Feature issues in progress
 gh issue list --label "feature" --state all --json number,title,state,labels --limit 100
-
-# Tracking issues (parent features)
 gh issue list --label "tracking" --state open --json number,title,body
 ```
 
-For each tracking issue, calculate feature completion percentage by counting closed vs total sub-issues referenced in the body.
+% = closed/total in body.
 
-### Revert Monitoring
-
-Track how many reverts happened this week:
+### Reverts
 
 ```bash
 git log --oneline --grep="Revert" --since="7 days ago" | wc -l
 ```
 
-If reverts > 3 in a week, flag it — the loop may be pushing broken code.
+> 3/week → broken code?
 
-## Safety Rules
+## Rules
 
-- **Read-only on code** — this skill never modifies source code
-- **Max 2 meta-improvement issues per run** — avoid flooding the queue
-- **Max 2 auto-retries per run** — don't flood the ready queue
-- **Append-only log** — never delete or modify previous log entries
-- **Cost data** — read from `.claude/agent-spend.jsonl` (logged by `pnpm log:cost` after each agent session)
-- **Circuit breaker threshold** — only pause at 50% failure rate over 3+ days, not single bad days
+- Read-only code
+- Max 2 meta/run
+- Max 2 retry/run
+- Append-only log
+- Cost: `.claude/agent-spend.jsonl`
+- Circuit: 50% over 3+ days

--- a/.claude/skills/progress-tracker/SKILL.original.md
+++ b/.claude/skills/progress-tracker/SKILL.original.md
@@ -1,0 +1,266 @@
+---
+name: progress-tracker
+description: Track continuous improvement loop performance. Queries GitHub for metrics (issues created/closed, PRs merged, CI health), logs trends, and suggests process improvements. Invoke with /progress-tracker.
+user-invocable: true
+---
+
+# Progress Tracker
+
+Daily analysis of the continuous improvement loop's effectiveness. Queries GitHub for metrics, identifies patterns, logs trends, and suggests process improvements.
+
+## Workflow
+
+### Step 1: Gather Metrics
+
+Run these queries to collect data from the last 7 days:
+
+```bash
+# Issues created by audit (last 7 days)
+gh issue list --label "audit" --state all --json number,title,state,createdAt,closedAt,labels --limit 100
+
+# Issues created by CI monitor
+gh issue list --label "ci-fix" --state all --json number,title,state,createdAt,closedAt,labels --limit 50
+
+# Issues currently in each state
+gh issue list --label "ready" --state open --json number,title
+gh issue list --label "in-progress" --state open --json number,title
+gh issue list --label "has-pr" --state open --json number,title
+gh issue list --label "agent-failed" --state open --json number,title
+gh issue list --label "agent-skip" --state open --json number,title,createdAt
+
+# PRs merged recently
+gh pr list --state merged --json number,title,mergedAt,headRefName --limit 50
+
+# CI health (last 20 runs on main)
+gh run list --branch main --limit 20 --json conclusion,createdAt
+
+# Meta-improvement suggestions created
+gh issue list --label "meta-improvement" --state all --json number,title,state
+
+# Agent spend (from local cost log)
+# Read .claude/agent-spend.jsonl and aggregate by date
+cat .claude/agent-spend.jsonl 2>/dev/null | tail -100
+```
+
+#### Cost Log Format
+
+The file `.claude/agent-spend.jsonl` contains one JSON object per line:
+
+```json
+{
+  "date": "2026-04-06",
+  "timestamp": "2026-04-06T12:00:00Z",
+  "costUsd": 0.45,
+  "issueNumber": 199,
+  "model": "claude-sonnet-4-6"
+}
+```
+
+Log entries are written by `pnpm log:cost -- --cost <usd> --issue <num>` after each agent session.
+
+### Step 2: Compute Metrics
+
+Calculate these key indicators:
+
+| Metric                  | Formula                                                                    |
+| ----------------------- | -------------------------------------------------------------------------- |
+| **Issues Created (7d)** | Count of audit + ci-fix issues created in last 7 days                      |
+| **Issues Closed (7d)**  | Count of audit + ci-fix issues closed in last 7 days                       |
+| **Closure Rate**        | Closed / Created (target: > 0.8)                                           |
+| **Avg Time-to-Close**   | Mean of (closedAt - createdAt) for closed issues                           |
+| **Agent Success Rate**  | Issues with `has-pr` / (Issues with `has-pr` + Issues with `agent-failed`) |
+| **CI Pass Rate**        | Successful runs / Total runs on main (target: > 0.95)                      |
+| **Queue Depth**         | Count of issues with `ready` label (target: < 5)                           |
+| **Stale Issues**        | Issues with `ready` label open > 7 days                                    |
+| **Blocked Issues**      | Issues with `agent-failed` label not re-queued                             |
+| **Skipped Issues**      | Issues with `agent-skip` label (exceeded max retries, need manual review)  |
+| **Daily Agent Spend**   | Sum of costUsd from .claude/agent-spend.jsonl for today (target: < $10)    |
+| **7d Agent Spend**      | Sum of costUsd from last 7 days of entries                                 |
+| **Avg Cost/Issue**      | 7d spend / issues closed in 7d                                             |
+
+### Step 3: Analyze Patterns
+
+Look for:
+
+1. **Recurring issue types** — Are the same categories appearing repeatedly? This suggests a systemic problem rather than individual bugs.
+   - Example: Multiple `[Audit] A11y:` issues → may need an accessibility review of shared components
+
+2. **Agent failure patterns** — What types of issues does the agent fail on? Are there common characteristics?
+   - Example: Agent fails on issues requiring database changes → may need better skill instructions
+
+3. **CI instability** — Is the same job failing repeatedly? Is it a flaky test or a real regression?
+   - Example: `migrations` job fails 3x/week → database schema process needs improvement
+
+4. **Queue bottlenecks** — Is the queue growing faster than the worker can process?
+   - If queue depth > 10: suggest increasing worker cadence
+   - If agent failure rate > 30%: suggest improving issue descriptions
+
+5. **Cost efficiency** — Are we spending budget on low-value issues?
+
+### Step 4: Log Entry
+
+Append a dated entry to `.claude/improvement-loop/log.md`:
+
+```markdown
+## YYYY-MM-DD
+
+### Metrics
+
+| Metric              | Value | Target | Status   |
+| ------------------- | ----- | ------ | -------- |
+| Issues Created (7d) | N     | -      | -        |
+| Issues Closed (7d)  | N     | -      | -        |
+| Closure Rate        | N%    | >80%   | ✅/⚠️/❌ |
+| Avg Time-to-Close   | Nh    | <24h   | ✅/⚠️/❌ |
+| Agent Success Rate  | N%    | >70%   | ✅/⚠️/❌ |
+| CI Pass Rate        | N%    | >95%   | ✅/⚠️/❌ |
+| Queue Depth         | N     | <5     | ✅/⚠️/❌ |
+| Stale Issues        | N     | 0      | ✅/⚠️/❌ |
+| Skipped Issues      | N     | 0      | ✅/⚠️/❌ |
+| Daily Agent Spend   | $N.NN | <$10   | ✅/⚠️/❌ |
+| 7d Agent Spend      | $N.NN | <$50   | ✅/⚠️/❌ |
+| Avg Cost/Issue      | $N.NN | <$2    | ✅/⚠️/❌ |
+
+### Patterns
+
+- [Notable patterns observed]
+
+### Recommendations
+
+- [Actionable suggestions]
+
+### Skipped Issues (agent-skip)
+
+[List any issues with the `agent-skip` label that need manual attention]
+```
+
+Query skipped issues for the report:
+
+```bash
+gh issue list --label "agent-skip" --state open --json number,title,createdAt --jq '.[] | "  #\(.number) \(.title) (created: \(.createdAt | split("T")[0]))"'
+```
+
+If any `agent-skip` issues exist, include a summary line in the report: "N issues skipped after max retries -- need manual review"
+
+Create the file if it does not exist. Always **append** — never overwrite previous entries.
+
+### Step 5: Create Improvement Issues
+
+If patterns suggest actionable process improvements, create a GitHub issue:
+
+```bash
+gh issue create \
+  --title "[Meta] <improvement description>" \
+  --label "meta-improvement" \
+  --body "## Observation
+
+<What the data shows>
+
+## Recommendation
+
+<Specific change to make>
+
+## Expected Impact
+
+<What should improve>
+
+---
+*Identified by progress-tracker on $(date +%Y-%m-%d)*"
+```
+
+Only create improvement issues for patterns seen **consistently over 3+ days**. Do not create issues for one-off anomalies.
+
+## Targets & Thresholds
+
+| Metric             | Green | Yellow   | Red    |
+| ------------------ | ----- | -------- | ------ |
+| Closure Rate       | > 80% | 50-80%   | < 50%  |
+| Agent Success Rate | > 70% | 40-70%   | < 40%  |
+| CI Pass Rate       | > 95% | 85-95%   | < 85%  |
+| Queue Depth        | < 5   | 5-10     | > 10   |
+| Avg Time-to-Close  | < 24h | 24-72h   | > 72h  |
+| Daily Agent Spend  | < $10 | $10-$20  | > $20  |
+| 7d Agent Spend     | < $50 | $50-$100 | > $100 |
+| Avg Cost/Issue     | < $2  | $2-$5    | > $5   |
+
+## Self-Tuning Actions
+
+The progress tracker doesn't just observe — it **acts** on what it finds.
+
+### Circuit Breaker: Pause on High Failure Rate
+
+If agent failure rate exceeds 50% over the last 3 days:
+
+```bash
+# Disable the implement-queue CronCreate job if running locally
+# For RemoteTriggers, disable the issue-worker:
+# (Manual step — create an issue alerting the user)
+gh issue create \
+  --title "[Alert] Implement queue paused — agent failure rate > 50%" \
+  --label "meta-improvement" \
+  --body "Agent success rate has dropped below 50% over the last 3 days. The loop should be paused until the failure patterns are addressed.
+
+Current failures:
+$(gh issue list --label agent-failed --state open --json number,title -q '.[] | "- #\(.number): \(.title)"')
+
+**Action needed**: Review failed issues, improve issue descriptions or skill instructions, then re-enable."
+```
+
+### Auto-Retry Stale Failures
+
+If an issue has been `agent-failed` for 3+ days with no activity, re-queue it (the agent or skills may have improved). Issues with the `agent-skip` label are excluded -- they have already exhausted their retry budget and need manual intervention:
+
+```bash
+# Find stale agent-failed issues (created > 3 days ago), excluding agent-skip
+STALE=$(gh issue list --label "agent-failed" --state open --json number,createdAt,labels -q '[.[] | select(.createdAt < (now - 259200 | todate)) | select(.labels | map(.name) | index("agent-skip") | not)] | .[].number')
+
+for NUM in $STALE; do
+  gh issue edit $NUM --add-label "ready" --remove-label "agent-failed"
+  gh issue comment $NUM --body "Auto-retrying — this issue has been in agent-failed state for 3+ days."
+done
+```
+
+**Max 2 retries per run.**
+
+### Queue Depth Adjustment
+
+If queue depth > 10 and agent success rate > 70%:
+
+- Suggest running `/loop 15m /implement-queue` instead of 30m (faster cadence)
+
+If queue depth is 0 for 3 consecutive days:
+
+- Suggest reducing audit frequency or expanding audit scope
+
+### Feature Tracking
+
+Also track feature progress:
+
+```bash
+# Feature issues in progress
+gh issue list --label "feature" --state all --json number,title,state,labels --limit 100
+
+# Tracking issues (parent features)
+gh issue list --label "tracking" --state open --json number,title,body
+```
+
+For each tracking issue, calculate feature completion percentage by counting closed vs total sub-issues referenced in the body.
+
+### Revert Monitoring
+
+Track how many reverts happened this week:
+
+```bash
+git log --oneline --grep="Revert" --since="7 days ago" | wc -l
+```
+
+If reverts > 3 in a week, flag it — the loop may be pushing broken code.
+
+## Safety Rules
+
+- **Read-only on code** — this skill never modifies source code
+- **Max 2 meta-improvement issues per run** — avoid flooding the queue
+- **Max 2 auto-retries per run** — don't flood the ready queue
+- **Append-only log** — never delete or modify previous log entries
+- **Cost data** — read from `.claude/agent-spend.jsonl` (logged by `pnpm log:cost` after each agent session)
+- **Circuit breaker threshold** — only pause at 50% failure rate over 3+ days, not single bad days

--- a/.claude/skills/site-audit/SKILL.md
+++ b/.claude/skills/site-audit/SKILL.md
@@ -1,308 +1,159 @@
 ---
 name: site-audit
-description: "Audit mattbutlerengineering.com with three modes: smoke (per-commit regression check), sweep (weekly zone rotation), scout (monthly improvement suggestions). Uses inventory tracking, parallel dispatch, and Lighthouse/Playwright. Invoke with /site-audit [smoke|sweep|scout]."
+description: "Audit mattbutlerengineering.com: smoke/sweep/scout modes. Invoke: /site-audit [smoke|sweep|scout]."
 user-invocable: true
 ---
 
 # Site Audit
 
-Inventory-tracked audit system with three modes. Each mode targets different surfaces and creates GitHub issues for findings.
-
-**Parse the argument to determine mode:** `smoke` (default), `sweep`, or `scout`.
+Inventory-tracked 3-mode audit: smoke (regression), sweep (zone rotation), scout (improvements).
 
 ## Inventory
 
-The audit inventory at `.audit-state/inventory.json` tracks every auditable surface (22+ pages and API endpoints), when each was last checked, and Lighthouse score history. The `@mbe/agent-core` package provides `buildInventory()`, `loadInventory()`, `saveInventory()`, `mapFilesToSurfaces()`, `findStalestZone()`, `updateSurfaceScore()`, and `detectRegression()`.
-
-**Before any mode runs:**
+`.audit-state/inventory.json` tracks surfaces, check times, scores via agent-core: `buildInventory()`, `loadInventory()`, `saveInventory()`, `mapFilesToSurfaces()`, `findStalestZone()`, `updateSurfaceScore()`, `detectRegression()`.
 
 ```bash
-# Load or create inventory
-cat .audit-state/inventory.json 2>/dev/null || echo "No inventory — will build fresh"
+cat .audit-state/inventory.json 2>/dev/null || echo "No inventory"
 ```
 
-The agent-core functions handle building a fresh inventory if none exists and merging with existing data to preserve score history.
+## Mode 1: Smoke (per-commit)
 
-**After any mode completes**, save the updated inventory back.
+1. `git diff HEAD~1 --name-only`
+2. Map via `mapFilesToSurfaces()`: `apps/<app>/src/pages/*` → surface, `components/**` → all app surfaces, `packages/rialto/**` → all frontend, `services/*` → all API, `infrastructure/**` → all, else skip.
+3. Parallel subagents: Pages → Lighthouse (perf+a11y), API → curl check.
 
-## Mode 1: Smoke (per-commit regression check)
-
-**Trigger:** `/site-audit smoke` or `/site-audit` (default)
-**Purpose:** Check if recent changes broke anything.
-
-### Steps
-
-1. **Get changed files:**
-
-```bash
-git diff HEAD~1 --name-only
-```
-
-2. **Map to affected surfaces** using the file-to-surface mapping in agent-core's `mapFilesToSurfaces()`. The mapping rules:
-   - `apps/<app>/src/pages/<Page>.tsx` → specific surface
-   - `apps/<app>/src/components/**` → all surfaces in that app
-   - `packages/rialto/src/**` → all frontend surfaces
-   - `services/<svc>/src/**` → all API surfaces in that service
-   - `infrastructure/**` → all surfaces
-   - Files outside `apps/`, `services/`, `packages/`, `infrastructure/` → skip
-
-3. **Dispatch parallel subagents** — one per affected surface. Each agent:
-   - For pages: Run Lighthouse (performance + accessibility only) if Chrome is available (see [Lighthouse Availability](#lighthouse-availability)). Check console errors via Playwright if available; skip and note if browser runtime is missing.
-   - For API endpoints: use the **audit curl pattern** below and check for `"status":"ok"` in response. If 403, flag as `access-restricted` and continue.
-
-**Audit curl pattern (use for all curl-based checks):**
+**Curl pattern:**
 
 ```bash
 AUDIT_CURL_OPTS=(-sf -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36")
 [ -n "${AUDIT_TOKEN:-}" ] && AUDIT_CURL_OPTS+=(-H "X-Audit-Token: $AUDIT_TOKEN")
 HTTP_STATUS=$(curl -o /dev/null -w "%{http_code}" "${AUDIT_CURL_OPTS[@]}" "$URL")
-if [ "$HTTP_STATUS" = "403" ]; then
-  echo "ACCESS-RESTRICTED: $URL returned 403 — see Access Restrictions section"
-fi
+[ "$HTTP_STATUS" = "403" ] && echo "ACCESS-RESTRICTED: $URL"
 ```
 
-4. **Detect regressions** by comparing new scores against `lastScore` in inventory. A regression is a score drop >0.05 on any Lighthouse category.
-
-5. **Create issues only for regressions** (not for stable-low scores). Use labels: `ci-fix` + `audit`.
-
-6. **Update inventory** with new scores and timestamps.
-
-If no files in `apps/`, `services/`, `packages/`, or `infrastructure/` changed, skip with: "No auditable changes detected."
+4. Detect regressions (>0.05 drop vs lastScore), create issues (labels: `ci-fix`+`audit`), update inventory.
 
 ## Mode 2: Sweep (weekly zone rotation)
 
-**Trigger:** `/site-audit sweep`
-**Purpose:** Full quality check on one zone, rotating to ensure all zones are covered over 4 weeks.
+| Zone               | Surfaces | Auth  |
+| ------------------ | -------- | ----- |
+| `marketing`        | 1        | none  |
+| `hospitality`      | 11       | auth0 |
+| `rialto`           | 7        | none  |
+| `gen`              | 1        | auth0 |
+| `api:users`        | 1        | none  |
+| `api:reservations` | 1        | none  |
+| `api:agent`        | 1        | none  |
 
-### Zones
+1. Load inventory, find stalest via `findStalestZone()`.
+2. For each surface: `git log --since='$LAST_CHECKED' --name-only -- $SOURCE_FILES | head -1` → skip if empty, include if non-empty or never checked.
+3. Parallel (5-wave max): availability (curl), Lighthouse, mobile (375x812), console errors, network (flag 4xx/5xx/>3s), dead links.
+4. Create issues <0.9 or console errors. >50% blocked → one `[Audit] Infrastructure: Site unreachable` + stop.
 
-| Zone               | Surfaces   | Auth  |
-| ------------------ | ---------- | ----- |
-| `marketing`        | 1 page     | none  |
-| `hospitality`      | 11 pages   | auth0 |
-| `rialto`           | 7 pages    | none  |
-| `gen`              | 1 page     | auth0 |
-| `api:users`        | 1 endpoint | none  |
-| `api:reservations` | 1 endpoint | none  |
-| `api:agent`        | 1 endpoint | none  |
+## Mode 3: Scout (monthly)
 
-### Steps
-
-1. **Load inventory** and find the stalest zone (oldest average `lastChecked`) using `findStalestZone()`.
-
-2. **List all surfaces** in the chosen zone.
-
-3. **Filter surfaces with code changes** — before dispatching, check each surface to see if any of its source files changed since `lastChecked`. Skip Lighthouse entirely for surfaces with no changes.
-
-For each surface, run:
-
-```bash
-# LAST_CHECKED = surface.lastChecked (ISO timestamp, e.g. "2026-03-01T12:00:00.000Z")
-# SOURCE_FILES = space-separated list from surface.sourceFiles
-git log --since='$LAST_CHECKED' --name-only -- $SOURCE_FILES | head -1
-```
-
-- If the output is **empty** → no changes since last audit → **skip this surface** (keep its existing inventory entry unchanged)
-- If the output is **non-empty** → source changed → include in this sweep
-- If `lastChecked` is **null** (never audited) → always include
-
-Log skipped surfaces in the final report:
-
-```
-Skipped 4 unchanged surfaces: marketing/home, rialto/tokens, ...
-```
-
-4. **Dispatch parallel subagents** — up to 5 simultaneously (wave-based for larger zones), **only for surfaces that passed the change filter**. Each agent runs:
-   - **Availability check** via curl (always runs, using the audit curl pattern above). If 403 → mark surface as `access-restricted`, log it, continue without running further checks on that surface.
-   - **Full Lighthouse** (all 4 categories) — only if Chrome is available (see [Lighthouse Availability](#lighthouse-availability))
-   - **Mobile responsive check** (375x812 viewport via Playwright `browser_resize`) — only if Playwright browser runtime is available
-   - **Console error check** via Playwright `browser_console_messages` — only if Playwright browser runtime is available
-   - **Network request check** via Playwright `browser_network_requests` (flag 4xx/5xx, >3s responses) — only if Playwright browser runtime is available
-   - **Dead link check** — click navigation links, verify they load — only if Playwright browser runtime is available
-
-5. **Update inventory** with new scores.
-
-6. **Create issues** for anything below 0.9 threshold on any Lighthouse category, or any console errors. Access-restricted surfaces are logged in the report but do not create individual issues (unless >50% of surfaces in the zone are blocked, in which case create one `[Audit] Infrastructure: Site unreachable from audit environment` issue with label `infrastructure`).
-
-7. **Report coverage stats:**
-
-```
-Sweep complete: zone "hospitality" (11 surfaces checked)
-Coverage: 18 of 22 surfaces checked in last 30 days
-Next stalest zone: "rialto" (last checked: never)
-```
-
-## Mode 3: Scout (monthly improvement suggestions)
-
-**Trigger:** `/site-audit scout`
-**Purpose:** AI-driven analysis that suggests features and improvements.
-
-### Steps
-
-1. **Load inventory** and analyze score trends from `checkHistory`:
-   - Identify degrading scores (declining over 3+ checks)
-   - Identify surfaces consistently below threshold
-
-2. **Check dependency freshness:**
-
-```bash
-pnpm outdated 2>/dev/null | head -30
-```
-
-3. **Scan for TODOs/FIXMEs:**
-
-```bash
-grep -r "TODO\|FIXME" apps/ services/ packages/ --include="*.ts" --include="*.tsx" -l | head -20
-```
-
-4. **Check bundle sizes:**
-
-```bash
-# Build and check output sizes
-ls -lh apps/*/dist/assets/*.js 2>/dev/null
-```
-
-5. **Review recently closed issues** for recurring patterns:
-
-```bash
-gh issue list --state closed --limit 20 --json title,labels,closedAt
-```
-
-6. **Create max 3 issues** with label `feature` or `meta-improvement`:
-   - Focus on actionable, specific suggestions
-   - Include evidence (score trends, outdated deps, bundle sizes)
-   - Prioritize by impact
+1. Analyze `checkHistory`: degrading 3+, below-threshold.
+2. `pnpm outdated | head -30`
+3. `grep -r "TODO\|FIXME" apps/ services/ packages/ --include="*.ts" --include="*.tsx" -l | head -20`
+4. `ls -lh apps/*/dist/assets/*.js`
+5. `gh issue list --state closed --limit 20 --json title,labels,closedAt`
+6. Max 3 issues: `feature` or `meta-improvement` with evidence.
 
 ## Issue Creation
 
-### Deduplication (CRITICAL)
+**Dedup:** `gh issue list --label audit --state open --search "<phrase>" --json number,title` → skip if exists.
 
-Before creating ANY issue, check for existing duplicates:
+**Title:** `[Audit] <Category>: <Finding>`
 
-```bash
-gh issue list --label audit --state open --search "<key phrase>" --json number,title
-```
+**Labels:** `audit`+`ready`+category:
 
-If a substantially similar issue already exists, **skip it**.
+- `performance` — perf, slow, bundles
+- `accessibility` — labels, contrast, nav
+- `seo` — meta, scores
+- `ux` — links, visuals, responsive
 
-### Issue Format
-
-**Title:** `[Audit] <Category>: <Specific finding>`
-
-**Labels:** Always apply `audit` + `ready` + one category label:
-
-- `performance` — Lighthouse perf score, slow loads, large bundles
-- `accessibility` — Missing labels, poor contrast, keyboard navigation
-- `seo` — Missing meta tags, poor scores
-- `ux` — Broken links, visual issues, responsive problems
-
-For regressions detected by smoke mode, also add `ci-fix`.
+Regressions: +`ci-fix`.
 
 **Body:**
 
 ```markdown
 ## Finding
 
-[Clear description]
+[Description]
 
 ## Evidence
 
-[Lighthouse score, console error text, score trend, etc.]
+[Score/error/trend]
 
 ## Location
 
-[Surface ID, URL, component if identifiable]
+[Surface/URL/component]
 
-## Suggested Fix
+## Fix
 
-[Brief suggestion if obvious, otherwise "Investigate and fix"]
+[Suggestion or "Investigate"]
 
 ---
 
-_Found by automated site audit ({{mode}} mode) on YYYY-MM-DD_
+_Audit ({{mode}}) YYYY-MM-DD_
 ```
 
-## Authenticated Testing (Hospitality + Gen)
+## Auth (Hospitality + Gen)
 
-Surfaces with `auth: "auth0"` require authenticated access. Use Playwright E2E auth:
-
-```bash
-cd apps/hospitality
-E2E_AUTH0_DOMAIN=dev-ytbgmz5ls3wh4xdx.us.auth0.com \
-E2E_AUTH0_CLIENT_ID=<client-id> \
-E2E_AUTH0_AUDIENCE=https://api.mattbutlerengineering.com \
-E2E_AUTH_EMAIL=<test-user-email> \
-E2E_AUTH_PASSWORD=<test-user-password> \
-pnpm test:e2e
-```
-
-For browser-based audit of auth-protected pages, use the `authPage` fixture pattern:
+Auth0 surfaces via E2E fixture:
 
 ```typescript
 import { test, expect } from "./fixtures.js";
-
-test("page loads", async ({ authPage }) => {
+test("loads", async ({ authPage }) => {
   await authPage.goto("/reservations");
   await expect(authPage.getByTestId("dashboard-layout")).toBeVisible();
 });
 ```
 
-If auth credentials are not available, skip auth-protected surfaces and note them in the report.
-
-## Safety Rules
-
-- Never modify code directly — only create issues
-- Never create more than 5 issues per run (prioritize by severity)
-- Always deduplicate before creating
-- If the site is completely down (5xx on all surfaces), create a single high-priority `ci-fix` issue and stop
-- Access-restricted surfaces (403) are **not** "site down" — log them and continue auditing
-- Regressions (smoke mode) get `ci-fix` label for implement-queue priority handling
-
 ## Access Restrictions
 
-The audit environment (cloud/RemoteTrigger) may receive `403 host_not_allowed` responses from Cloudflare Bot Management when accessing production surfaces without a real browser context.
+403 from Cloudflare Bot Management:
 
-**When a surface returns 403:**
+1. Log `ACCESS-RESTRICTED: <url>`
+2. Mark `restricted` in inventory
+3. Skip Lighthouse/Playwright
+4. Continue
+5. > 50% blocked → one infrastructure issue + stop
 
-1. Log: `ACCESS-RESTRICTED: <url> — Cloudflare blocking non-browser request`
-2. Mark surface as `restricted` in inventory (not `error`)
-3. Skip Lighthouse/Playwright for that surface
-4. Continue auditing remaining surfaces
-5. If >50% of zone surfaces are restricted, create one `[Audit] Infrastructure: Site unreachable from audit environment` issue (label `infrastructure`) and stop
+**Enable (one-time):**
 
-**To enable full production access** (requires a one-time manual Cloudflare step):
+1. Cloudflare Security → WAF → Custom Rules
+2. `X-Audit-Token == <secret>` → Skip Bot Fight
+3. `wrangler secret put AUDIT_TOKEN`
+4. Export `AUDIT_TOKEN=<secret>`
 
-1. Go to Cloudflare Dashboard → Security → WAF → Custom Rules
-2. Add rule: If request header `X-Audit-Token` equals `<your-secret>` → Skip → Bot Fight Mode
-3. Set `wrangler secret put AUDIT_TOKEN` on the edge router Worker (same secret value)
-4. Export `AUDIT_TOKEN=<your-secret>` in the audit environment
+## Lighthouse
 
-The edge router already recognizes `X-Audit-Token` and bypasses rate limiting for verified tokens.
-
-## Lighthouse Availability
-
-Before running any Lighthouse command, check whether Chrome is available:
+Check availability:
 
 ```bash
 if command -v google-chrome &>/dev/null || command -v chromium &>/dev/null || command -v chromium-browser &>/dev/null; then
   LIGHTHOUSE_AVAILABLE=1
-else
-  echo "⚠ Chrome/Chromium not found — Lighthouse unavailable (install: apt-get install -y chromium-browser)"
-  LIGHTHOUSE_AVAILABLE=0
 fi
 ```
 
-Only run `npx @lhci/cli` when `LIGHTHOUSE_AVAILABLE=1`. When unavailable, record scores as `null` in inventory and note in the audit report. Do not create issues for missing scores.
+Run only if available. Missing → null, note report, no issues.
 
-## Base URL
+## Config
 
-`https://mattbutlerengineering.com`
-
-## Lighthouse Thresholds
-
-All categories: **0.9 minimum** (from `lighthouserc.json`)
+Base: `https://mattbutlerengineering.com`
+Threshold: 0.9 all categories
 
 ```bash
-npx @lhci/cli collect --url="<surface-url>" --settings.preset=desktop --numberOfRuns=1
+npx @lhci/cli collect --url="<url>" --settings.preset=desktop --numberOfRuns=1
 npx @lhci/cli assert --assertions.categories:performance="error,minScore,0.9" --assertions.categories:accessibility="error,minScore,0.9" --assertions.categories:best-practices="error,minScore,0.9" --assertions.categories:seo="error,minScore,0.9"
 ```
+
+## Rules
+
+- Read-only
+- Max 5 issues/run
+- Dedup first
+- Full down (5xx) → one issue + stop
+- 403 ≠ down
+- Regressions → `ci-fix`

--- a/.claude/skills/site-audit/SKILL.original.md
+++ b/.claude/skills/site-audit/SKILL.original.md
@@ -1,0 +1,308 @@
+---
+name: site-audit
+description: "Audit mattbutlerengineering.com with three modes: smoke (per-commit regression check), sweep (weekly zone rotation), scout (monthly improvement suggestions). Uses inventory tracking, parallel dispatch, and Lighthouse/Playwright. Invoke with /site-audit [smoke|sweep|scout]."
+user-invocable: true
+---
+
+# Site Audit
+
+Inventory-tracked audit system with three modes. Each mode targets different surfaces and creates GitHub issues for findings.
+
+**Parse the argument to determine mode:** `smoke` (default), `sweep`, or `scout`.
+
+## Inventory
+
+The audit inventory at `.audit-state/inventory.json` tracks every auditable surface (22+ pages and API endpoints), when each was last checked, and Lighthouse score history. The `@mbe/agent-core` package provides `buildInventory()`, `loadInventory()`, `saveInventory()`, `mapFilesToSurfaces()`, `findStalestZone()`, `updateSurfaceScore()`, and `detectRegression()`.
+
+**Before any mode runs:**
+
+```bash
+# Load or create inventory
+cat .audit-state/inventory.json 2>/dev/null || echo "No inventory — will build fresh"
+```
+
+The agent-core functions handle building a fresh inventory if none exists and merging with existing data to preserve score history.
+
+**After any mode completes**, save the updated inventory back.
+
+## Mode 1: Smoke (per-commit regression check)
+
+**Trigger:** `/site-audit smoke` or `/site-audit` (default)
+**Purpose:** Check if recent changes broke anything.
+
+### Steps
+
+1. **Get changed files:**
+
+```bash
+git diff HEAD~1 --name-only
+```
+
+2. **Map to affected surfaces** using the file-to-surface mapping in agent-core's `mapFilesToSurfaces()`. The mapping rules:
+   - `apps/<app>/src/pages/<Page>.tsx` → specific surface
+   - `apps/<app>/src/components/**` → all surfaces in that app
+   - `packages/rialto/src/**` → all frontend surfaces
+   - `services/<svc>/src/**` → all API surfaces in that service
+   - `infrastructure/**` → all surfaces
+   - Files outside `apps/`, `services/`, `packages/`, `infrastructure/` → skip
+
+3. **Dispatch parallel subagents** — one per affected surface. Each agent:
+   - For pages: Run Lighthouse (performance + accessibility only) if Chrome is available (see [Lighthouse Availability](#lighthouse-availability)). Check console errors via Playwright if available; skip and note if browser runtime is missing.
+   - For API endpoints: use the **audit curl pattern** below and check for `"status":"ok"` in response. If 403, flag as `access-restricted` and continue.
+
+**Audit curl pattern (use for all curl-based checks):**
+
+```bash
+AUDIT_CURL_OPTS=(-sf -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36")
+[ -n "${AUDIT_TOKEN:-}" ] && AUDIT_CURL_OPTS+=(-H "X-Audit-Token: $AUDIT_TOKEN")
+HTTP_STATUS=$(curl -o /dev/null -w "%{http_code}" "${AUDIT_CURL_OPTS[@]}" "$URL")
+if [ "$HTTP_STATUS" = "403" ]; then
+  echo "ACCESS-RESTRICTED: $URL returned 403 — see Access Restrictions section"
+fi
+```
+
+4. **Detect regressions** by comparing new scores against `lastScore` in inventory. A regression is a score drop >0.05 on any Lighthouse category.
+
+5. **Create issues only for regressions** (not for stable-low scores). Use labels: `ci-fix` + `audit`.
+
+6. **Update inventory** with new scores and timestamps.
+
+If no files in `apps/`, `services/`, `packages/`, or `infrastructure/` changed, skip with: "No auditable changes detected."
+
+## Mode 2: Sweep (weekly zone rotation)
+
+**Trigger:** `/site-audit sweep`
+**Purpose:** Full quality check on one zone, rotating to ensure all zones are covered over 4 weeks.
+
+### Zones
+
+| Zone               | Surfaces   | Auth  |
+| ------------------ | ---------- | ----- |
+| `marketing`        | 1 page     | none  |
+| `hospitality`      | 11 pages   | auth0 |
+| `rialto`           | 7 pages    | none  |
+| `gen`              | 1 page     | auth0 |
+| `api:users`        | 1 endpoint | none  |
+| `api:reservations` | 1 endpoint | none  |
+| `api:agent`        | 1 endpoint | none  |
+
+### Steps
+
+1. **Load inventory** and find the stalest zone (oldest average `lastChecked`) using `findStalestZone()`.
+
+2. **List all surfaces** in the chosen zone.
+
+3. **Filter surfaces with code changes** — before dispatching, check each surface to see if any of its source files changed since `lastChecked`. Skip Lighthouse entirely for surfaces with no changes.
+
+For each surface, run:
+
+```bash
+# LAST_CHECKED = surface.lastChecked (ISO timestamp, e.g. "2026-03-01T12:00:00.000Z")
+# SOURCE_FILES = space-separated list from surface.sourceFiles
+git log --since='$LAST_CHECKED' --name-only -- $SOURCE_FILES | head -1
+```
+
+- If the output is **empty** → no changes since last audit → **skip this surface** (keep its existing inventory entry unchanged)
+- If the output is **non-empty** → source changed → include in this sweep
+- If `lastChecked` is **null** (never audited) → always include
+
+Log skipped surfaces in the final report:
+
+```
+Skipped 4 unchanged surfaces: marketing/home, rialto/tokens, ...
+```
+
+4. **Dispatch parallel subagents** — up to 5 simultaneously (wave-based for larger zones), **only for surfaces that passed the change filter**. Each agent runs:
+   - **Availability check** via curl (always runs, using the audit curl pattern above). If 403 → mark surface as `access-restricted`, log it, continue without running further checks on that surface.
+   - **Full Lighthouse** (all 4 categories) — only if Chrome is available (see [Lighthouse Availability](#lighthouse-availability))
+   - **Mobile responsive check** (375x812 viewport via Playwright `browser_resize`) — only if Playwright browser runtime is available
+   - **Console error check** via Playwright `browser_console_messages` — only if Playwright browser runtime is available
+   - **Network request check** via Playwright `browser_network_requests` (flag 4xx/5xx, >3s responses) — only if Playwright browser runtime is available
+   - **Dead link check** — click navigation links, verify they load — only if Playwright browser runtime is available
+
+5. **Update inventory** with new scores.
+
+6. **Create issues** for anything below 0.9 threshold on any Lighthouse category, or any console errors. Access-restricted surfaces are logged in the report but do not create individual issues (unless >50% of surfaces in the zone are blocked, in which case create one `[Audit] Infrastructure: Site unreachable from audit environment` issue with label `infrastructure`).
+
+7. **Report coverage stats:**
+
+```
+Sweep complete: zone "hospitality" (11 surfaces checked)
+Coverage: 18 of 22 surfaces checked in last 30 days
+Next stalest zone: "rialto" (last checked: never)
+```
+
+## Mode 3: Scout (monthly improvement suggestions)
+
+**Trigger:** `/site-audit scout`
+**Purpose:** AI-driven analysis that suggests features and improvements.
+
+### Steps
+
+1. **Load inventory** and analyze score trends from `checkHistory`:
+   - Identify degrading scores (declining over 3+ checks)
+   - Identify surfaces consistently below threshold
+
+2. **Check dependency freshness:**
+
+```bash
+pnpm outdated 2>/dev/null | head -30
+```
+
+3. **Scan for TODOs/FIXMEs:**
+
+```bash
+grep -r "TODO\|FIXME" apps/ services/ packages/ --include="*.ts" --include="*.tsx" -l | head -20
+```
+
+4. **Check bundle sizes:**
+
+```bash
+# Build and check output sizes
+ls -lh apps/*/dist/assets/*.js 2>/dev/null
+```
+
+5. **Review recently closed issues** for recurring patterns:
+
+```bash
+gh issue list --state closed --limit 20 --json title,labels,closedAt
+```
+
+6. **Create max 3 issues** with label `feature` or `meta-improvement`:
+   - Focus on actionable, specific suggestions
+   - Include evidence (score trends, outdated deps, bundle sizes)
+   - Prioritize by impact
+
+## Issue Creation
+
+### Deduplication (CRITICAL)
+
+Before creating ANY issue, check for existing duplicates:
+
+```bash
+gh issue list --label audit --state open --search "<key phrase>" --json number,title
+```
+
+If a substantially similar issue already exists, **skip it**.
+
+### Issue Format
+
+**Title:** `[Audit] <Category>: <Specific finding>`
+
+**Labels:** Always apply `audit` + `ready` + one category label:
+
+- `performance` — Lighthouse perf score, slow loads, large bundles
+- `accessibility` — Missing labels, poor contrast, keyboard navigation
+- `seo` — Missing meta tags, poor scores
+- `ux` — Broken links, visual issues, responsive problems
+
+For regressions detected by smoke mode, also add `ci-fix`.
+
+**Body:**
+
+```markdown
+## Finding
+
+[Clear description]
+
+## Evidence
+
+[Lighthouse score, console error text, score trend, etc.]
+
+## Location
+
+[Surface ID, URL, component if identifiable]
+
+## Suggested Fix
+
+[Brief suggestion if obvious, otherwise "Investigate and fix"]
+
+---
+
+_Found by automated site audit ({{mode}} mode) on YYYY-MM-DD_
+```
+
+## Authenticated Testing (Hospitality + Gen)
+
+Surfaces with `auth: "auth0"` require authenticated access. Use Playwright E2E auth:
+
+```bash
+cd apps/hospitality
+E2E_AUTH0_DOMAIN=dev-ytbgmz5ls3wh4xdx.us.auth0.com \
+E2E_AUTH0_CLIENT_ID=<client-id> \
+E2E_AUTH0_AUDIENCE=https://api.mattbutlerengineering.com \
+E2E_AUTH_EMAIL=<test-user-email> \
+E2E_AUTH_PASSWORD=<test-user-password> \
+pnpm test:e2e
+```
+
+For browser-based audit of auth-protected pages, use the `authPage` fixture pattern:
+
+```typescript
+import { test, expect } from "./fixtures.js";
+
+test("page loads", async ({ authPage }) => {
+  await authPage.goto("/reservations");
+  await expect(authPage.getByTestId("dashboard-layout")).toBeVisible();
+});
+```
+
+If auth credentials are not available, skip auth-protected surfaces and note them in the report.
+
+## Safety Rules
+
+- Never modify code directly — only create issues
+- Never create more than 5 issues per run (prioritize by severity)
+- Always deduplicate before creating
+- If the site is completely down (5xx on all surfaces), create a single high-priority `ci-fix` issue and stop
+- Access-restricted surfaces (403) are **not** "site down" — log them and continue auditing
+- Regressions (smoke mode) get `ci-fix` label for implement-queue priority handling
+
+## Access Restrictions
+
+The audit environment (cloud/RemoteTrigger) may receive `403 host_not_allowed` responses from Cloudflare Bot Management when accessing production surfaces without a real browser context.
+
+**When a surface returns 403:**
+
+1. Log: `ACCESS-RESTRICTED: <url> — Cloudflare blocking non-browser request`
+2. Mark surface as `restricted` in inventory (not `error`)
+3. Skip Lighthouse/Playwright for that surface
+4. Continue auditing remaining surfaces
+5. If >50% of zone surfaces are restricted, create one `[Audit] Infrastructure: Site unreachable from audit environment` issue (label `infrastructure`) and stop
+
+**To enable full production access** (requires a one-time manual Cloudflare step):
+
+1. Go to Cloudflare Dashboard → Security → WAF → Custom Rules
+2. Add rule: If request header `X-Audit-Token` equals `<your-secret>` → Skip → Bot Fight Mode
+3. Set `wrangler secret put AUDIT_TOKEN` on the edge router Worker (same secret value)
+4. Export `AUDIT_TOKEN=<your-secret>` in the audit environment
+
+The edge router already recognizes `X-Audit-Token` and bypasses rate limiting for verified tokens.
+
+## Lighthouse Availability
+
+Before running any Lighthouse command, check whether Chrome is available:
+
+```bash
+if command -v google-chrome &>/dev/null || command -v chromium &>/dev/null || command -v chromium-browser &>/dev/null; then
+  LIGHTHOUSE_AVAILABLE=1
+else
+  echo "⚠ Chrome/Chromium not found — Lighthouse unavailable (install: apt-get install -y chromium-browser)"
+  LIGHTHOUSE_AVAILABLE=0
+fi
+```
+
+Only run `npx @lhci/cli` when `LIGHTHOUSE_AVAILABLE=1`. When unavailable, record scores as `null` in inventory and note in the audit report. Do not create issues for missing scores.
+
+## Base URL
+
+`https://mattbutlerengineering.com`
+
+## Lighthouse Thresholds
+
+All categories: **0.9 minimum** (from `lighthouserc.json`)
+
+```bash
+npx @lhci/cli collect --url="<surface-url>" --settings.preset=desktop --numberOfRuns=1
+npx @lhci/cli assert --assertions.categories:performance="error,minScore,0.9" --assertions.categories:accessibility="error,minScore,0.9" --assertions.categories:best-practices="error,minScore,0.9" --assertions.categories:seo="error,minScore,0.9"
+```


### PR DESCRIPTION
## Summary
- Compress site-audit, progress-tracker, issue-worker skill prompts (~40% reduction)
- Preserve originals as SKILL.original.md backups
- All technical commands, tables, labels intact

Closes #2020

## Test plan
- [ ] Verify compressed skills still parse correctly
- [ ] Spot-check that key commands/labels/tables survived compression