### PR TITLE
feat(tooling): @mbe/gh-client — shared gh wrapper + label state machine

### DIFF
--- a/docs/architecture/dependency-graph.md
+++ b/docs/architecture/dependency-graph.md
@@ -25,6 +25,7 @@ flowchart TD
     auth["auth"]
     config["config"]
     database["database"]
+    gh_client["gh-client"]
     jobs["jobs"]
     mcp_server["mcp-server"]
     notifications["notifications"]
@@ -104,6 +105,7 @@ flowchart TD
   auth --> types
   auth --> config
   database --> config
+  gh_client --> config
   jobs --> config
   mcp_server --> config
   notifications --> api_client
@@ -150,6 +152,7 @@ flowchart TD
   class auth shared
   class config shared
   class database shared
+  class gh_client shared
   class jobs shared
   class mcp_server shared
   class notifications shared

--- a/infrastructure/worker/dep-graph.json
+++ b/infrastructure/worker/dep-graph.json
@@ -66,6 +66,11 @@
       "path": "packages/database"
     },
     {
+      "name": "@mbe/gh-client",
+      "type": "package",
+      "path": "packages/gh-client"
+    },
+    {
       "name": "@mbe/jobs",
       "type": "package",
       "path": "packages/jobs"
@@ -129,6 +134,11 @@
       "name": "@mbe/infrastructure",
       "type": "tool",
       "path": "infrastructure/pulumi"
+    },
+    {
+      "name": "@mbe/scripts",
+      "type": "package",
+      "path": "scripts"
     }
   ],
   "edges": [
@@ -448,6 +458,11 @@
       "type": "devDependency"
     },
     {
+      "from": "@mbe/gh-client",
+      "to": "@mbe/config",
+      "type": "devDependency"
+    },
+    {
       "from": "@mbe/jobs",
       "to": "@mbe/config",
       "type": "devDependency"
@@ -591,6 +606,11 @@
       "from": "@mbe/infrastructure",
       "to": "@mbe/config",
       "type": "devDependency"
+    },
+    {
+      "from": "@mbe/scripts",
+      "to": "@mbe/gh-client",
+      "type": "dependency"
     }
   ]
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -13770,6 +13770,44 @@
       getPoolMetrics: ReturnType<typeof vi.fn>;
     }
   </file>
+  <file path="packages/gh-client/src/client.ts">
+    export interface GhClientOptions extends ExecRunnerOptions {
+      runner?: ExecRunner;
+    }
+    function buildLabelArgs(transition: LabelTransition): string[] {
+      const args: string[] = [];
+      for (const label of transition.add) {
+        args.push("--add-label", label);
+      }
+      for (const label of transition.remove) {
+        args.push("--remove-label", label);
+      }
+      return args;
+    }
+  </file>
+  <file path="packages/gh-client/src/exec-runner.ts">
+    export type ExecRunner = (
+      cmd: string,
+      args: string[],
+      opts: { encoding: "utf-8"; timeout: number }
+    ) => string;
+    export interface ExecRunnerOptions {
+      /** Injected runner — defaults to node's execFileSync. */
+      runner?: ExecRunner;
+      /** Timeout in milliseconds. Defaults to 15 000. */
+      timeoutMs?: number;
+    }
+  </file>
+  <file path="packages/gh-client/src/label-machine.ts">
+    export const COORDINATION_LABELS = {
+      READY: "ready",
+      IN_PROGRESS: "in-progress",
+      HAS_PR: "has-pr",
+      AGENT_FAILED: "agent-failed",
+      AGENT_SKIP: "agent-skip",
+    } as const;
+    export type CoordinationLabel = (typeof COORDINATION_LABELS)[keyof typeof COORDINATION_LABELS];
+  </file>
   <file path="packages/jobs/src/job-types.ts">
     export const JOB_TYPES = {
       BOOKING_REMINDER: "booking-reminder",
@@ -14473,7 +14511,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14511,18 +14511,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms.txt
+++ b/llms.txt
@@ -3432,6 +3432,38 @@
       }
     </item>
   </file>
+  <file path="packages/gh-client/src/client.ts">
+    <item priority="low">
+      interface GhClientOptions {
+        runner?: ExecRunner;
+      }
+    </item>
+    <item priority="medium">
+      function buildLabelArgs(transition: LabelTransition): string[] { /* ... */ }
+    </item>
+  </file>
+  <file path="packages/gh-client/src/exec-runner.ts">
+    <item priority="low">
+      type ExecRunner = (
+        cmd: string,
+        args: string[],
+        opts: { encoding: "u...;
+    </item>
+    <item priority="low">
+      interface ExecRunnerOptions {
+        runner?: ExecRunner;
+        timeoutMs?: number;
+      }
+    </item>
+  </file>
+  <file path="packages/gh-client/src/label-machine.ts">
+    <item priority="high">
+      export const COORDINATION_LABELS: unknown;
+    </item>
+    <item priority="low">
+      type CoordinationLabel = (typeof COORDINATION_LABELS)[keyof typeof COORDINATION_LA...;
+    </item>
+  </file>
   <file path="packages/jobs/src/job-types.ts">
     <item priority="high">
       export const JOB_TYPES: unknown;

--- a/packages/gh-client/llms-full.txt
+++ b/packages/gh-client/llms-full.txt
@@ -1,0 +1,42 @@
+<codebase path="packages/gh-client">
+  <section priority="medium" role="src">
+  <file path="src/client.ts">
+    export interface GhClientOptions extends ExecRunnerOptions {
+      runner?: ExecRunner;
+    }
+    function buildLabelArgs(transition: LabelTransition): string[] {
+      const args: string[] = [];
+      for (const label of transition.add) {
+        args.push("--add-label", label);
+      }
+      for (const label of transition.remove) {
+        args.push("--remove-label", label);
+      }
+      return args;
+    }
+  </file>
+  <file path="src/exec-runner.ts">
+    export type ExecRunner = (
+      cmd: string,
+      args: string[],
+      opts: { encoding: "utf-8"; timeout: number }
+    ) => string;
+    export interface ExecRunnerOptions {
+      /** Injected runner — defaults to node's execFileSync. */
+      runner?: ExecRunner;
+      /** Timeout in milliseconds. Defaults to 15 000. */
+      timeoutMs?: number;
+    }
+  </file>
+  <file path="src/label-machine.ts">
+    export const COORDINATION_LABELS = {
+      READY: "ready",
+      IN_PROGRESS: "in-progress",
+      HAS_PR: "has-pr",
+      AGENT_FAILED: "agent-failed",
+      AGENT_SKIP: "agent-skip",
+    } as const;
+    export type CoordinationLabel = (typeof COORDINATION_LABELS)[keyof typeof COORDINATION_LABELS];
+  </file>
+  </section>
+</codebase>

--- a/packages/gh-client/llms.txt
+++ b/packages/gh-client/llms.txt
@@ -1,0 +1,36 @@
+<codebase path="packages/gh-client">
+  <section priority="medium" role="src">
+  <file path="src/client.ts">
+    <item priority="low">
+      interface GhClientOptions {
+        runner?: ExecRunner;
+      }
+    </item>
+    <item priority="medium">
+      function buildLabelArgs(transition: LabelTransition): string[] { /* ... */ }
+    </item>
+  </file>
+  <file path="src/exec-runner.ts">
+    <item priority="low">
+      type ExecRunner = (
+        cmd: string,
+        args: string[],
+        opts: { encoding: "u...;
+    </item>
+    <item priority="low">
+      interface ExecRunnerOptions {
+        runner?: ExecRunner;
+        timeoutMs?: number;
+      }
+    </item>
+  </file>
+  <file path="src/label-machine.ts">
+    <item priority="high">
+      export const COORDINATION_LABELS: unknown;
+    </item>
+    <item priority="low">
+      type CoordinationLabel = (typeof COORDINATION_LABELS)[keyof typeof COORDINATION_LA...;
+    </item>
+  </file>
+  </section>
+</codebase>

--- a/packages/gh-client/package.json
+++ b/packages/gh-client/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@mbe/gh-client",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "node": "./dist/index.js",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "lint": "eslint src/",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "@mbe/config": "workspace:*",
+    "@types/node": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "license": "MIT"
+}

--- a/packages/gh-client/src/client.test.ts
+++ b/packages/gh-client/src/client.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from "vitest";
+import { createGhClient } from "./client.js";
+import type { ExecRunner } from "./exec-runner.js";
+
+function makeMockRunner(responses: Record<string, string> = {}): ExecRunner {
+  return vi.fn().mockImplementation((_cmd: string, args: string[]) => {
+    const key = args.join(" ");
+    if (key in responses) return responses[key];
+    return "";
+  });
+}
+
+describe("createGhClient", () => {
+  describe("issue facet", () => {
+    it("issue.list returns parsed JSON array", () => {
+      const items = [{ number: 1, title: "test" }];
+      const runner = makeMockRunner({
+        "issue list --json number,title": JSON.stringify(items),
+      });
+      const client = createGhClient({ runner });
+      const result = client.issue.list(["--json", "number,title"]);
+      expect(result).toEqual(items);
+    });
+
+    it("issue.view returns parsed JSON object", () => {
+      const prData = { number: 5, title: "my pr" };
+      const runner = makeMockRunner({
+        "issue view 5 --json title": JSON.stringify(prData),
+      });
+      const client = createGhClient({ runner });
+      expect(client.issue.view(5, ["--json", "title"])).toEqual(prData);
+    });
+
+    it("issue.create returns the created issue URL string", () => {
+      const runner = makeMockRunner({
+        "issue create --title New issue --body Body": "https://github.com/owner/repo/issues/99",
+      });
+      const client = createGhClient({ runner });
+      const result = client.issue.create(["--title", "New issue", "--body", "Body"]);
+      expect(result).toBe("https://github.com/owner/repo/issues/99");
+    });
+
+    it("issue.comment runs gh issue comment", () => {
+      const runner = makeMockRunner({ "issue comment 7 --body hello": "" });
+      const client = createGhClient({ runner });
+      client.issue.comment(7, "hello");
+      expect(runner).toHaveBeenCalledWith("gh", ["issue", "comment", "7", "--body", "hello"], {
+        encoding: "utf-8",
+        timeout: 15_000,
+      });
+    });
+
+    it("issue.reopen runs gh issue reopen", () => {
+      const runner = makeMockRunner({ "issue reopen 3": "" });
+      const client = createGhClient({ runner });
+      client.issue.reopen(3);
+      expect(runner).toHaveBeenCalledWith("gh", ["issue", "reopen", "3"], expect.any(Object));
+    });
+  });
+
+  describe("pr facet", () => {
+    it("pr.view returns parsed JSON object", () => {
+      const prData = { number: 1, title: "fix: something" };
+      const runner = makeMockRunner({
+        "pr view 1 --json title": JSON.stringify(prData),
+      });
+      const client = createGhClient({ runner });
+      expect(client.pr.view(1, ["--json", "title"])).toEqual(prData);
+    });
+
+    it("pr.create returns the PR URL", () => {
+      const runner = makeMockRunner({
+        "pr create --title My PR --body Body": "https://github.com/owner/repo/pull/42",
+      });
+      const client = createGhClient({ runner });
+      const url = client.pr.create(["--title", "My PR", "--body", "Body"]);
+      expect(url).toBe("https://github.com/owner/repo/pull/42");
+    });
+  });
+
+  describe("label facet", () => {
+    it("label.apply applies add/remove transitions", () => {
+      const runner = makeMockRunner({
+        "issue edit 10 --add-label has-pr --remove-label in-progress --remove-label ready": "",
+      });
+      const client = createGhClient({ runner });
+      client.label.apply({ issueNumber: 10, add: ["has-pr"], remove: ["in-progress", "ready"] });
+      expect(runner).toHaveBeenCalledWith(
+        "gh",
+        [
+          "issue",
+          "edit",
+          "10",
+          "--add-label",
+          "has-pr",
+          "--remove-label",
+          "in-progress",
+          "--remove-label",
+          "ready",
+        ],
+        expect.any(Object)
+      );
+    });
+
+    it("label.apply handles add-only transition", () => {
+      const runner = makeMockRunner({ "issue edit 2 --add-label ready": "" });
+      const client = createGhClient({ runner });
+      client.label.apply({ issueNumber: 2, add: ["ready"], remove: [] });
+      expect(runner).toHaveBeenCalledWith(
+        "gh",
+        ["issue", "edit", "2", "--add-label", "ready"],
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe("workflow facet", () => {
+    it("workflow.runs returns parsed JSON array", () => {
+      const runs = [{ status: "completed", conclusion: "success" }];
+      const runner = makeMockRunner({
+        "run list --limit 10 --json status,conclusion": JSON.stringify(runs),
+      });
+      const client = createGhClient({ runner });
+      expect(client.workflow.runs(["--limit", "10", "--json", "status,conclusion"])).toEqual(runs);
+    });
+  });
+});

--- a/packages/gh-client/src/client.ts
+++ b/packages/gh-client/src/client.ts
@@ -1,0 +1,84 @@
+import { createExecRunner } from "./exec-runner.js";
+import type { ExecRunner, ExecRunnerOptions } from "./exec-runner.js";
+import type { LabelTransition } from "./label-machine.js";
+
+export interface GhClientOptions extends ExecRunnerOptions {
+  runner?: ExecRunner;
+}
+
+function buildLabelArgs(transition: LabelTransition): string[] {
+  const args: string[] = [];
+  for (const label of transition.add) {
+    args.push("--add-label", label);
+  }
+  for (const label of transition.remove) {
+    args.push("--remove-label", label);
+  }
+  return args;
+}
+
+/**
+ * Creates a typed gh CLI client with { pr, issue, label, workflow } facets.
+ * The runner is injectable for testing; defaults to execFileSync.
+ */
+export function createGhClient(opts: GhClientOptions = {}) {
+  const run = createExecRunner(opts);
+
+  const issue = {
+    list(args: string[]): unknown[] {
+      const raw = run("gh", ["issue", "list", ...args]);
+      return JSON.parse(raw) as unknown[];
+    },
+
+    view(number: number, args: string[] = []): unknown {
+      const raw = run("gh", ["issue", "view", String(number), ...args]);
+      return JSON.parse(raw);
+    },
+
+    create(args: string[]): string {
+      return run("gh", ["issue", "create", ...args]);
+    },
+
+    comment(number: number, body: string): void {
+      run("gh", ["issue", "comment", String(number), "--body", body]);
+    },
+
+    reopen(number: number): void {
+      run("gh", ["issue", "reopen", String(number)]);
+    },
+
+    edit(number: number, args: string[]): void {
+      run("gh", ["issue", "edit", String(number), ...args]);
+    },
+  };
+
+  const pr = {
+    view(number: number, args: string[] = []): unknown {
+      const raw = run("gh", ["pr", "view", String(number), ...args]);
+      return JSON.parse(raw);
+    },
+
+    create(args: string[]): string {
+      return run("gh", ["pr", "create", ...args]);
+    },
+  };
+
+  const label = {
+    apply(transition: LabelTransition): void {
+      const labelArgs = buildLabelArgs(transition);
+      if (labelArgs.length === 0) return;
+      run("gh", ["issue", "edit", String(transition.issueNumber), ...labelArgs]);
+    },
+  };
+
+  const workflow = {
+    runs(args: string[]): unknown[] {
+      const raw = run("gh", ["run", "list", ...args]);
+      return JSON.parse(raw) as unknown[];
+    },
+  };
+
+  return { issue, pr, label, workflow };
+}
+
+export type GhClient = ReturnType<typeof createGhClient>;

--- a/packages/gh-client/src/exec-runner.test.ts
+++ b/packages/gh-client/src/exec-runner.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from "vitest";
+import { createExecRunner, type ExecRunner } from "./exec-runner.js";
+
+describe("createExecRunner", () => {
+  it("returns trimmed stdout on success", () => {
+    const mockRunner: ExecRunner = vi.fn().mockReturnValue("  result output  ");
+    const run = createExecRunner({ runner: mockRunner });
+    expect(run("gh", ["issue", "list"])).toBe("result output");
+    expect(mockRunner).toHaveBeenCalledWith("gh", ["issue", "list"], {
+      encoding: "utf-8",
+      timeout: 15_000,
+    });
+  });
+
+  it("uses custom timeout when provided", () => {
+    const mockRunner: ExecRunner = vi.fn().mockReturnValue("ok");
+    const run = createExecRunner({ runner: mockRunner, timeoutMs: 30_000 });
+    run("gh", ["pr", "view", "1"]);
+    expect(mockRunner).toHaveBeenCalledWith("gh", ["pr", "view", "1"], {
+      encoding: "utf-8",
+      timeout: 30_000,
+    });
+  });
+
+  it("throws GhCommandError with original message on failure", () => {
+    const mockRunner: ExecRunner = vi.fn().mockImplementation(() => {
+      throw new Error("Process exited with code 1");
+    });
+    const run = createExecRunner({ runner: mockRunner });
+    expect(() => run("gh", ["issue", "view", "999"])).toThrow("Process exited with code 1");
+  });
+
+  it("rethrows non-Error throws as-is", () => {
+    const mockRunner: ExecRunner = vi.fn().mockImplementation(() => {
+      throw "string error";
+    });
+    const run = createExecRunner({ runner: mockRunner });
+    expect(() => run("gh", ["run", "list"])).toThrow("string error");
+  });
+});

--- a/packages/gh-client/src/exec-runner.ts
+++ b/packages/gh-client/src/exec-runner.ts
@@ -1,0 +1,28 @@
+import { execFileSync } from "node:child_process";
+
+/** Signature-compatible with execFileSync for injection in tests. */
+export type ExecRunner = (
+  cmd: string,
+  args: string[],
+  opts: { encoding: "utf-8"; timeout: number }
+) => string;
+
+export interface ExecRunnerOptions {
+  /** Injected runner — defaults to node's execFileSync. */
+  runner?: ExecRunner;
+  /** Timeout in milliseconds. Defaults to 15 000. */
+  timeoutMs?: number;
+}
+
+/**
+ * Creates a gh exec wrapper with centralized timeout and error handling.
+ * Returns the trimmed stdout string on success; throws on failure.
+ */
+export function createExecRunner(opts: ExecRunnerOptions = {}) {
+  const runner = opts.runner ?? (execFileSync as ExecRunner);
+  const timeout = opts.timeoutMs ?? 15_000;
+
+  return function run(cmd: string, args: string[]): string {
+    return (runner(cmd, args, { encoding: "utf-8", timeout }) as string).trim();
+  };
+}

--- a/packages/gh-client/src/index.ts
+++ b/packages/gh-client/src/index.ts
@@ -1,0 +1,13 @@
+export { createGhClient } from "./client.js";
+export type { GhClient, GhClientOptions } from "./client.js";
+export { createExecRunner } from "./exec-runner.js";
+export type { ExecRunner, ExecRunnerOptions } from "./exec-runner.js";
+export {
+  COORDINATION_LABELS,
+  markInProgress,
+  markHasPr,
+  markFailed,
+  markSkip,
+  markReady,
+} from "./label-machine.js";
+export type { LabelTransition, CoordinationLabel } from "./label-machine.js";

--- a/packages/gh-client/src/label-machine.test.ts
+++ b/packages/gh-client/src/label-machine.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import {
+  markInProgress,
+  markHasPr,
+  markFailed,
+  markSkip,
+  markReady,
+  COORDINATION_LABELS,
+} from "./label-machine.js";
+import type { LabelTransition } from "./label-machine.js";
+
+describe("COORDINATION_LABELS", () => {
+  it("exports the canonical label set", () => {
+    expect(COORDINATION_LABELS.READY).toBe("ready");
+    expect(COORDINATION_LABELS.IN_PROGRESS).toBe("in-progress");
+    expect(COORDINATION_LABELS.HAS_PR).toBe("has-pr");
+    expect(COORDINATION_LABELS.AGENT_FAILED).toBe("agent-failed");
+    expect(COORDINATION_LABELS.AGENT_SKIP).toBe("agent-skip");
+  });
+});
+
+describe("markInProgress", () => {
+  it("removes ready, adds in-progress", () => {
+    const t = markInProgress(42);
+    expect(t).toMatchObject<LabelTransition>({
+      issueNumber: 42,
+      add: ["in-progress"],
+      remove: ["ready"],
+    });
+  });
+});
+
+describe("markHasPr", () => {
+  it("removes in-progress and ready, adds has-pr", () => {
+    const t = markHasPr(7);
+    expect(t.issueNumber).toBe(7);
+    expect(t.add).toContain("has-pr");
+    expect(t.remove).toContain("in-progress");
+    expect(t.remove).toContain("ready");
+  });
+});
+
+describe("markFailed", () => {
+  it("removes in-progress and ready, adds agent-failed", () => {
+    const t = markFailed(3);
+    expect(t.add).toContain("agent-failed");
+    expect(t.remove).toContain("in-progress");
+    expect(t.remove).toContain("ready");
+  });
+});
+
+describe("markSkip", () => {
+  it("removes in-progress, ready, and agent-failed, adds agent-skip", () => {
+    const t = markSkip(5);
+    expect(t.add).toContain("agent-skip");
+    expect(t.remove).toContain("in-progress");
+    expect(t.remove).toContain("ready");
+    expect(t.remove).toContain("agent-failed");
+  });
+});
+
+describe("markReady", () => {
+  it("removes has-pr, in-progress, and agent-failed, adds ready", () => {
+    const t = markReady(10);
+    expect(t.add).toContain("ready");
+    expect(t.remove).toContain("has-pr");
+    expect(t.remove).toContain("in-progress");
+    expect(t.remove).toContain("agent-failed");
+  });
+});

--- a/packages/gh-client/src/label-machine.ts
+++ b/packages/gh-client/src/label-machine.ts
@@ -1,0 +1,70 @@
+/** Canonical coordination labels used by the ship-loop state machine. */
+export const COORDINATION_LABELS = {
+  READY: "ready",
+  IN_PROGRESS: "in-progress",
+  HAS_PR: "has-pr",
+  AGENT_FAILED: "agent-failed",
+  AGENT_SKIP: "agent-skip",
+} as const;
+
+export type CoordinationLabel = (typeof COORDINATION_LABELS)[keyof typeof COORDINATION_LABELS];
+
+/** Represents a label transition: labels to add and labels to remove. */
+export interface LabelTransition {
+  issueNumber: number;
+  add: string[];
+  remove: string[];
+}
+
+/** ready → in-progress */
+export function markInProgress(issueNumber: number): LabelTransition {
+  return {
+    issueNumber,
+    add: [COORDINATION_LABELS.IN_PROGRESS],
+    remove: [COORDINATION_LABELS.READY],
+  };
+}
+
+/** in-progress → has-pr */
+export function markHasPr(issueNumber: number): LabelTransition {
+  return {
+    issueNumber,
+    add: [COORDINATION_LABELS.HAS_PR],
+    remove: [COORDINATION_LABELS.IN_PROGRESS, COORDINATION_LABELS.READY],
+  };
+}
+
+/** in-progress → agent-failed */
+export function markFailed(issueNumber: number): LabelTransition {
+  return {
+    issueNumber,
+    add: [COORDINATION_LABELS.AGENT_FAILED],
+    remove: [COORDINATION_LABELS.IN_PROGRESS, COORDINATION_LABELS.READY],
+  };
+}
+
+/** agent-failed → agent-skip (exhausted retries) */
+export function markSkip(issueNumber: number): LabelTransition {
+  return {
+    issueNumber,
+    add: [COORDINATION_LABELS.AGENT_SKIP],
+    remove: [
+      COORDINATION_LABELS.IN_PROGRESS,
+      COORDINATION_LABELS.READY,
+      COORDINATION_LABELS.AGENT_FAILED,
+    ],
+  };
+}
+
+/** has-pr/agent-failed → ready (re-queue) */
+export function markReady(issueNumber: number): LabelTransition {
+  return {
+    issueNumber,
+    add: [COORDINATION_LABELS.READY],
+    remove: [
+      COORDINATION_LABELS.HAS_PR,
+      COORDINATION_LABELS.IN_PROGRESS,
+      COORDINATION_LABELS.AGENT_FAILED,
+    ],
+  };
+}

--- a/packages/gh-client/tsconfig.json
+++ b/packages/gh-client/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@mbe/config/typescript/node",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/gh-client/vitest.config.ts
+++ b/packages/gh-client/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts", "src/index.ts"],
+      thresholds: {
+        lines: 80,
+        branches: 75,
+        functions: 80,
+        statements: 80,
+      },
+    },
+  },
+});

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,18 +337,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,7 +337,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -733,6 +733,24 @@ importers:
         specifier: "catalog:"
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
+  packages/gh-client:
+    devDependencies:
+      "@mbe/config":
+        specifier: workspace:*
+        version: link:../config
+      "@types/node":
+        specifier: "catalog:"
+        version: 25.9.3
+      "@vitest/coverage-v8":
+        specifier: "catalog:"
+        version: 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.9)
+      typescript:
+        specifier: "catalog:"
+        version: 6.0.3
+      vitest:
+        specifier: "catalog:"
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+
   packages/jobs:
     dependencies:
       bullmq:
@@ -1186,6 +1204,16 @@ importers:
       typescript:
         specifier: "catalog:"
         version: 6.0.3
+      vitest:
+        specifier: "catalog:"
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+
+  scripts:
+    dependencies:
+      "@mbe/gh-client":
+        specifier: workspace:*
+        version: link:../packages/gh-client
+    devDependencies:
       vitest:
         specifier: "catalog:"
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
   - "packages/*"
   - "tools/*"
   - "infrastructure/pulumi"
+  - "scripts"
 
 catalog:
   zod: "^4.4.3"

--- a/scripts/__tests__/instruction-evolver.test.mjs
+++ b/scripts/__tests__/instruction-evolver.test.mjs
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { mkdtempSync, writeFileSync, readFileSync, rmSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -15,6 +15,14 @@ function makeTmpDir() {
 }
 
 describe("detectPatterns", () => {
+  beforeAll(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-23T12:00:00Z"));
+  });
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
   it("detects recurring failure pattern (3+ occurrences)", () => {
     const metrics = [
       { timestamp: "2026-05-20T10:00:00Z", fp_rate: 35, agent_success_rate: 60 },

--- a/scripts/__tests__/threshold-tuner.test.mjs
+++ b/scripts/__tests__/threshold-tuner.test.mjs
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import {
   computePerSensorMetrics,
   computeWeeklyChange,
@@ -109,6 +109,14 @@ describe("computePerSensorMetrics", () => {
 // ---------------------------------------------------------------------------
 
 describe("computeWeeklyChange", () => {
+  beforeAll(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
   it("returns 0 when no changes in log", () => {
     expect(computeWeeklyChange([], "ci-fix")).toBe(0);
   });
@@ -314,6 +322,14 @@ describe("applyAdjustments — applies adjustments", () => {
 });
 
 describe("applyAdjustments — guard rails", () => {
+  beforeAll(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
   it("never drops sensitivity below the hard floor (0.1)", () => {
     const tuningAtFloor = {
       ...SEED_TUNING,

--- a/scripts/chaos-agent.mjs
+++ b/scripts/chaos-agent.mjs
@@ -21,9 +21,12 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { createGhClient } from "@mbe/gh-client";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
+
+const ghClient = createGhClient();
 
 const BUG_TYPES = {
   "console-error": {
@@ -53,15 +56,6 @@ const BUG_TYPES = {
 };
 
 const TARGET_APPS = ["apps/marketing", "apps/hospitality", "apps/rialto-web"];
-
-function gh(...args) {
-  try {
-    return execFileSync("gh", args, { encoding: "utf-8" }).trim();
-  } catch (e) {
-    console.error(`gh command failed: ${e.message}`);
-    return null;
-  }
-}
 
 function findTargetFile(type) {
   const app = TARGET_APPS[Math.floor(Math.random() * TARGET_APPS.length)];
@@ -159,20 +153,22 @@ function main() {
       
       Labels: \`chaos-audit\`, \`ready\`, \`audit\``;
 
-      gh(
-        "pr",
-        "create",
-        "--title",
-        `chaos: synthetic ${type} bug in ${path.basename(targetFile)}`,
-        "--body",
-        prBody,
-        "--label",
-        "chaos-audit",
-        "--label",
-        "ready",
-        "--label",
-        "audit"
-      );
+      try {
+        ghClient.pr.create([
+          "--title",
+          `chaos: synthetic ${type} bug in ${path.basename(targetFile)}`,
+          "--body",
+          prBody,
+          "--label",
+          "chaos-audit",
+          "--label",
+          "ready",
+          "--label",
+          "audit",
+        ]);
+      } catch (e) {
+        console.error(`gh command failed: ${e.message}`);
+      }
     }
   } else {
     console.error("Failed to inject bug.");

--- a/scripts/collect-ai-issue-feedback.mjs
+++ b/scripts/collect-ai-issue-feedback.mjs
@@ -13,10 +13,10 @@
  *   node scripts/collect-ai-issue-feedback.mjs --json       # output raw JSON to stdout
  */
 
-import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { createGhClient } from "@mbe/gh-client";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
@@ -148,12 +148,7 @@ export function readFeedbackFile() {
 // CLI / main
 // ---------------------------------------------------------------------------
 
-function gh(...ghArgs) {
-  return execFileSync("gh", ghArgs, {
-    encoding: "utf-8",
-    timeout: 30_000,
-  }).trim();
-}
+const ghClient = createGhClient({ timeoutMs: 30_000 });
 
 function safe(fn, fallback = null) {
   try {
@@ -170,22 +165,22 @@ export async function run() {
 
   // Query closed issues with AI-associated labels (last 90 days)
   const labelQuery = CATEGORIES.map((c) => `label:${c}`).join(" ");
-  const raw = safe(() =>
-    gh(
-      "issue",
-      "list",
-      "--state",
-      "closed",
-      "--limit",
-      "200",
-      "--json",
-      "number,state,labels,createdAt,closedAt,stateReason,linkedBranches",
-      "--search",
-      labelQuery
-    )
+  const issuesRaw = safe(
+    () =>
+      ghClient.issue.list([
+        "--state",
+        "closed",
+        "--limit",
+        "200",
+        "--json",
+        "number,state,labels,createdAt,closedAt,stateReason,linkedBranches",
+        "--search",
+        labelQuery,
+      ]),
+    null
   );
 
-  if (!raw) {
+  if (!issuesRaw) {
     const error = { error: "Failed to query GitHub issues" };
     if (JSON_ONLY) {
       process.stdout.write(JSON.stringify(error, null, 2) + "\n");
@@ -197,7 +192,6 @@ export async function run() {
 
   // gh issue list --json linkedBranches doesn't give PR state directly,
   // so we also query PRs to match
-  const issuesRaw = safe(() => JSON.parse(raw), []);
 
   // For each issue, try to find linked PRs via search
   const issues = issuesRaw.map((issue) => ({

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@mbe/scripts",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "cd .. && vitest run --config scripts/vitest.config.mjs"
+  },
+  "dependencies": {
+    "@mbe/gh-client": "workspace:*"
+  },
+  "devDependencies": {
+    "vitest": "catalog:"
+  }
+}

--- a/scripts/process-metrics.mjs
+++ b/scripts/process-metrics.mjs
@@ -16,10 +16,10 @@
  *   metrics/process-metrics-weekly.json    — weekly aggregation with rolling 4-week trend
  */
 
-import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync, mkdirSync, existsSync, appendFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { createGhClient } from "@mbe/gh-client";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
@@ -32,6 +32,8 @@ const args = process.argv.slice(2);
 const DRY_RUN = args.includes("--dry-run");
 const JSON_ONLY = args.includes("--json");
 
+const ghClient = createGhClient();
+
 /* ── Helpers ─────────────────────────────────────────── */
 
 function safe(fn, fallback = null) {
@@ -40,13 +42,6 @@ function safe(fn, fallback = null) {
   } catch {
     return fallback;
   }
-}
-
-function gh(...ghArgs) {
-  return execFileSync("gh", ghArgs, {
-    encoding: "utf-8",
-    timeout: 15_000,
-  }).trim();
 }
 
 export function readJsonl(filePath) {
@@ -243,48 +238,41 @@ export function generateWeeklySummary(entries) {
 
 function fetchClosedIssues() {
   const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-  const raw = safe(() =>
-    gh(
-      "issue",
-      "list",
-      "--state",
-      "closed",
-      "--label",
-      "has-pr",
-      "--limit",
-      "50",
-      "--json",
-      "number,createdAt,closedAt,labels,state"
-    )
+  const issues = safe(
+    () =>
+      ghClient.issue.list([
+        "--state",
+        "closed",
+        "--label",
+        "has-pr",
+        "--limit",
+        "50",
+        "--json",
+        "number,createdAt,closedAt,labels,state",
+      ]),
+    []
   );
-  if (!raw) return [];
-
-  const issues = safe(() => JSON.parse(raw), []);
   return issues.filter((i) => i.closedAt && new Date(i.closedAt) >= sevenDaysAgo);
 }
 
 function fetchAllRecentIssues() {
-  const raw = safe(() =>
-    gh(
-      "issue",
-      "list",
-      "--state",
-      "all",
-      "--limit",
-      "100",
-      "--json",
-      "number,labels,state,createdAt,closedAt"
-    )
+  return safe(
+    () =>
+      ghClient.issue.list([
+        "--state",
+        "all",
+        "--limit",
+        "100",
+        "--json",
+        "number,labels,state,createdAt,closedAt",
+      ]),
+    []
   );
-  if (!raw) return [];
-  return safe(() => JSON.parse(raw), []);
 }
 
 function fetchIssueComments(issueNumbers) {
   return issueNumbers.map((num) => {
-    const raw = safe(() =>
-      gh("issue", "view", String(num), "--json", "comments", "--jq", ".comments")
-    );
+    const raw = safe(() => ghClient.issue.view(num, ["--json", "comments", "--jq", ".comments"]));
     const comments = safe(() => JSON.parse(raw), []);
     return { issueNumber: num, comments: comments ?? [] };
   });

--- a/scripts/revert-rca.mjs
+++ b/scripts/revert-rca.mjs
@@ -11,21 +11,14 @@
  *   node scripts/revert-rca.mjs --pr <number> --revert-sha <sha>
  */
 
-import { execFileSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { createGhClient } from "@mbe/gh-client";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
 
-function gh(...args) {
-  try {
-    return execFileSync("gh", args, { encoding: "utf-8" }).trim();
-  } catch (e) {
-    console.error(`gh command failed: ${e.message}`);
-    return null;
-  }
-}
+const ghClient = createGhClient();
 
 function main() {
   const args = process.argv.slice(2);
@@ -43,13 +36,13 @@ function main() {
   console.log(`Triggering RCA for reverted PR #${prNumber}...`);
 
   // Fetch original PR details
-  const prJson = gh("pr", "view", prNumber, "--json", "title,body,author,headRefName,labels");
-  if (!prJson) {
-    console.error(`Could not find PR #${prNumber}`);
+  let pr;
+  try {
+    pr = ghClient.pr.view(Number(prNumber), ["--json", "title,body,author,headRefName,labels"]);
+  } catch (e) {
+    console.error(`Could not find PR #${prNumber}: ${e.message}`);
     process.exit(1);
   }
-
-  const pr = JSON.parse(prJson);
 
   // Check if it's an agent PR (based on labels or author)
   const isAgent =
@@ -84,20 +77,23 @@ The AI-generated PR #${prNumber} was reverted in commit ${revertSha}.
 
 Labels: \`meta-improvement\`, \`ready\`, \`critical\``;
 
-  const newIssue = gh(
-    "issue",
-    "create",
-    "--title",
-    rcaTitle,
-    "--body",
-    rcaBody,
-    "--label",
-    "meta-improvement",
-    "--label",
-    "ready",
-    "--label",
-    "critical"
-  );
+  let newIssue;
+  try {
+    newIssue = ghClient.issue.create([
+      "--title",
+      rcaTitle,
+      "--body",
+      rcaBody,
+      "--label",
+      "meta-improvement",
+      "--label",
+      "ready",
+      "--label",
+      "critical",
+    ]);
+  } catch (e) {
+    console.error(`gh command failed: ${e.message}`);
+  }
 
   if (newIssue) {
     console.log(`Created RCA issue: ${newIssue}`);

--- a/scripts/sensor-report.mjs
+++ b/scripts/sensor-report.mjs
@@ -12,10 +12,10 @@
  *   node scripts/sensor-report.mjs --json       # output raw JSON to stdout
  */
 
-import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync, statSync } from "node:fs";
 import { dirname, resolve, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { createGhClient } from "@mbe/gh-client";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
@@ -36,19 +36,14 @@ const THRESHOLDS = {
 const now = new Date();
 const sevenDaysAgo = new Date(now - 7 * 24 * 60 * 60 * 1000);
 
+const ghClient = createGhClient();
+
 function safe(fn, fallback = null) {
   try {
     return fn();
   } catch {
     return fallback;
   }
-}
-
-function gh(...ghArgs) {
-  return execFileSync("gh", ghArgs, {
-    encoding: "utf-8",
-    timeout: 15_000,
-  }).trim();
 }
 
 function readJson(path) {
@@ -126,12 +121,11 @@ function collectAgentCost() {
 }
 
 function collectCiHealth() {
-  const raw = safe(() =>
-    gh("run", "list", "--limit", "30", "--json", "status,conclusion,createdAt,name")
+  const runs = safe(
+    () => ghClient.workflow.runs(["--limit", "30", "--json", "status,conclusion,createdAt,name"]),
+    null
   );
-  if (!raw) return { available: false };
-
-  const runs = safe(() => JSON.parse(raw), []);
+  if (!runs) return { available: false };
   if (runs.length === 0) return { available: false };
 
   const completed = runs.filter((r) => r.status === "completed");
@@ -175,21 +169,19 @@ function collectLighthouse() {
 }
 
 function collectGitHubIssues() {
-  const raw = safe(() =>
-    gh(
-      "issue",
-      "list",
-      "--state",
-      "all",
-      "--limit",
-      "50",
-      "--json",
-      "number,state,labels,createdAt,closedAt"
-    )
+  const issues = safe(
+    () =>
+      ghClient.issue.list([
+        "--state",
+        "all",
+        "--limit",
+        "50",
+        "--json",
+        "number,state,labels,createdAt,closedAt",
+      ]),
+    null
   );
-  if (!raw) return { available: false };
-
-  const issues = safe(() => JSON.parse(raw), []);
+  if (!issues) return { available: false };
   const recentIssues = issues.filter((i) => new Date(i.createdAt) >= sevenDaysAgo);
   const recentClosed = issues.filter((i) => i.closedAt && new Date(i.closedAt) >= sevenDaysAgo);
   const openReady = issues.filter(

--- a/scripts/verify-fixes.mjs
+++ b/scripts/verify-fixes.mjs
@@ -13,10 +13,10 @@
  *   node scripts/verify-fixes.mjs --hours 72   # custom lookback window
  */
 
-import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync, mkdirSync, existsSync, appendFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { createGhClient } from "@mbe/gh-client";
 import { run as runThresholdTuner } from "./threshold-tuner.mjs";
 import { getAllLabels } from "./sensors-registry.mjs";
 
@@ -32,19 +32,14 @@ const MAX_VERIFICATIONS = 5;
 
 const SENSOR_LABELS = getAllLabels();
 
+const ghClient = createGhClient();
+
 function safe(fn, fallback = null) {
   try {
     return fn();
   } catch {
     return fallback;
   }
-}
-
-function gh(...ghArgs) {
-  return execFileSync("gh", ghArgs, {
-    encoding: "utf-8",
-    timeout: 15_000,
-  }).trim();
 }
 
 function readJson(path) {
@@ -56,21 +51,18 @@ function readJson(path) {
 function findClosedIssuesWithSensorLabels() {
   const cutoff = new Date(Date.now() - LOOKBACK_HOURS * 60 * 60 * 1000);
 
-  const raw = safe(() =>
-    gh(
-      "issue",
-      "list",
-      "--state",
-      "closed",
-      "--limit",
-      "30",
-      "--json",
-      "number,title,labels,closedAt,body"
-    )
+  const issues = safe(
+    () =>
+      ghClient.issue.list([
+        "--state",
+        "closed",
+        "--limit",
+        "30",
+        "--json",
+        "number,title,labels,closedAt,body",
+      ]),
+    []
   );
-  if (!raw) return [];
-
-  const issues = safe(() => JSON.parse(raw), []);
 
   return issues
     .filter((issue) => {
@@ -85,12 +77,19 @@ function findClosedIssuesWithSensorLabels() {
 /* ── Sensor-specific verifiers ───────────────────────── */
 
 function verifyCiFix() {
-  const raw = safe(() =>
-    gh("run", "list", "--limit", "10", "--branch", "main", "--json", "status,conclusion,createdAt")
+  const runs = safe(
+    () =>
+      ghClient.workflow.runs([
+        "--limit",
+        "10",
+        "--branch",
+        "main",
+        "--json",
+        "status,conclusion,createdAt",
+      ]),
+    null
   );
-  if (!raw) return { verified: false, reason: "Could not query CI runs" };
-
-  const runs = safe(() => JSON.parse(raw), []);
+  if (!runs) return { verified: false, reason: "Could not query CI runs" };
   const completed = runs.filter((r) => r.status === "completed");
   const passed = completed.filter((r) => r.conclusion === "success");
   const passRate = completed.length > 0 ? Math.round((passed.length / completed.length) * 100) : 0;
@@ -184,12 +183,13 @@ function verifySentry() {
 }
 
 function verifyBug() {
-  const raw = safe(() =>
-    gh("run", "list", "--limit", "5", "--branch", "main", "--json", "status,conclusion")
+  const runs = safe(
+    () =>
+      ghClient.workflow.runs(["--limit", "5", "--branch", "main", "--json", "status,conclusion"]),
+    null
   );
-  if (!raw) return { verified: false, reason: "Could not verify — CI unavailable" };
+  if (!runs) return { verified: false, reason: "Could not verify — CI unavailable" };
 
-  const runs = safe(() => JSON.parse(raw), []);
   const latestCompleted = runs.find((r) => r.status === "completed");
 
   if (latestCompleted?.conclusion === "success") {
@@ -269,21 +269,17 @@ for (const issue of issues) {
     const verb = result.verified ? "Verified" : "Not verified";
     const comment = `## ${emoji} Fix Verification (automated)\n\n**${verb}** — ${result.reason}\n\n_Checked ${LOOKBACK_HOURS}h after close by [\`scripts/verify-fixes.mjs\`](../blob/main/scripts/verify-fixes.mjs)_`;
 
-    safe(() => gh("issue", "comment", String(issue.number), "--body", comment));
+    safe(() => ghClient.issue.comment(issue.number, comment));
 
     if (!result.verified) {
       safe(() =>
-        gh(
-          "issue",
-          "edit",
-          String(issue.number),
-          "--remove-label",
-          "has-pr",
-          "--add-label",
-          "ready"
-        )
+        ghClient.label.apply({
+          issueNumber: issue.number,
+          add: ["ready"],
+          remove: ["has-pr"],
+        })
       );
-      safe(() => gh("issue", "reopen", String(issue.number)));
+      safe(() => ghClient.issue.reopen(issue.number));
       console.log(`     ↻ Reopened #${issue.number} for re-triage\n`);
     }
   }


### PR DESCRIPTION
## Summary

- Introduces `@mbe/gh-client` — a new shared package exposing `createGhClient()` with typed `{ pr, issue, label, workflow }` facets and injectable `ExecRunner` for testability
- Adds canonical label state machine (`ready → in-progress → has-pr / agent-failed → agent-skip`) with typed transition helpers
- Migrates 6 automation scripts (chaos-agent, revert-rca, process-metrics, sensor-report, verify-fixes, collect-ai-issue-feedback) off their local `gh()` copies to the shared client
- Fixes 6 pre-existing test failures in threshold-tuner and instruction-evolver tests caused by rolling `Date.now()` windows advancing past May 2026 fixture dates

## Test plan

- [ ] `@mbe/gh-client` unit tests: 20 tests across exec-runner, label-machine, and client facets — all pass
- [ ] Scripts test suite: 312 tests across 22 test files — all pass
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test` for `@mbe/gh-client` all clean
- [ ] Architecture audit (`check-adr`, `check-deps`) passes
- [ ] `pnpm regen` regenerated llms.txt artifacts — no drift
- [ ] Instruction rot check clean

Closes #1995