### PR TITLE
fix: rialto @vitest/coverage-v8 use catalog instead of pinned version

### DIFF
--- a/packages/rialto/package.json
+++ b/packages/rialto/package.json
@@ -366,7 +366,7 @@
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "catalog:",
     "@vitest/browser-playwright": "^4.1.8",
-    "@vitest/coverage-v8": "^4.1.8",
+    "@vitest/coverage-v8": "catalog:",
     "axe-core": "^4.12.0",
     "eslint-plugin-storybook": "^10.4.2",
     "framer-motion": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -736,20 +736,20 @@ importers:
 
   packages/gh-client:
     devDependencies:
-      "@mbe/config":
+      '@mbe/config':
         specifier: workspace:*
         version: link:../config
-      "@types/node":
-        specifier: "catalog:"
+      '@types/node':
+        specifier: 'catalog:'
         version: 25.9.3
-      "@vitest/coverage-v8":
-        specifier: "catalog:"
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
         version: 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.9)
       typescript:
-        specifier: "catalog:"
+        specifier: 'catalog:'
         version: 6.0.3
       vitest:
-        specifier: "catalog:"
+        specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/jobs:
@@ -963,7 +963,7 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
       '@vitest/coverage-v8':
-        specifier: ^4.1.8
+        specifier: 'catalog:'
         version: 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.9)
       axe-core:
         specifier: ^4.12.0
@@ -1211,12 +1211,12 @@ importers:
 
   scripts:
     dependencies:
-      "@mbe/gh-client":
+      '@mbe/gh-client':
         specifier: workspace:*
         version: link:../packages/gh-client
     devDependencies:
       vitest:
-        specifier: "catalog:"
+        specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   services/agent:


### PR DESCRIPTION
Fixes #1980

## Summary
- Changed rialto's `@vitest/coverage-v8` dependency from hardcoded `^4.1.8` to use the catalog reference `catalog:`
- This aligns rialto with all other ~14 consumers which use the catalog pattern
- Future catalog bumps will now automatically apply to rialto, preventing cross-package version mismatches

## Verification
- All 1683 rialto tests pass
- Typecheck passes with no errors
- Lockfile updated
- All affected packages pass pre-push checks