### PR TITLE
fix(ci): use compact jq output for GITHUB_OUTPUT in deploy-static

### DIFF
--- a/.github/workflows/deploy-static.yml
+++ b/.github/workflows/deploy-static.yml
@@ -302,8 +302,8 @@ jobs:
           else
             echo "deploy_result=success" >> "$GITHUB_OUTPUT"
           fi
-          # Build apps_deployed JSON for the action
-          APPS=$(jq -n \
+          # Build apps_deployed JSON for the action (compact output required for GITHUB_OUTPUT)
+          APPS=$(jq -cn \
             --arg marketing "$MARKETING_DEPLOYED" \
             --arg hospitality "$HOSPITALITY_DEPLOYED" \
             --arg rialto "$RIALTO_DEPLOYED" \


### PR DESCRIPTION
## Summary

- `jq -n` produces pretty-printed multi-line JSON; writing it to `GITHUB_OUTPUT` as `key=value` fails with `Invalid format` because the file protocol requires single-line values
- Changed `jq -n` → `jq -cn` in the "Derive deploy result" step of the `report-health` job so the `apps_deployed` JSON is compact (single-line)
- The composite action `report-deploy-health` already uses `--argjson apps_deployed` which correctly parses the JSON string; this fix makes the input valid

## Root cause

The `deploy-static.yml` `report-health` job's "Derive deploy result" step builds a JSON object and writes it to `$GITHUB_OUTPUT`:

```bash
APPS=$(jq -n \ ...)   # pretty-prints: multi-line JSON
echo "apps_deployed=$APPS" >> "$GITHUB_OUTPUT"   # FAILS: newlines in value
```

GitHub Actions `GITHUB_OUTPUT` uses `key=value` format; multi-line values must use the heredoc delimiter syntax. Switching to `jq -cn` (compact) keeps the value on one line and satisfies the format requirement.

## Test plan

- [ ] Confirm `deploy-static.yml` CI run passes the "Report Deploy Health / Derive deploy result" step after this merges
- [ ] Check `gh run list --workflow deploy-static.yml --limit 3` shows no `Invalid format` failures

## Context

The `deploy-services.yml` workflow doesn't have this issue (its `report-health` job passes the result directly without building intermediate JSON). This fix is scoped to the static deploy pipeline only.

Closes #2002