### PR TITLE
docs(skills): default automation loops to --adapter auto with failover docs

### DIFF
--- a/.claude/skills/ci-monitor/SKILL.md
+++ b/.claude/skills/ci-monitor/SKILL.md
@@ -133,6 +133,8 @@ Security rules: never hardcode secrets, no SQL injection, no XSS. Never modify .
   --max-budget 0.75 --adapter auto
 ```
 
+`--adapter auto` enables rate-limit failover: if Claude returns 429, the adapter cascade tries gemini then opencode before giving up. Opus-tier tasks (deep architecture analysis) should pin `--adapter claude` to stay on the Claude provider.
+
 Note the PR number from agent output for Step 2d.
 
 #### 2d: Validate the Fix (Reviewer Agent Contract)
@@ -264,6 +266,8 @@ mbe agent run "Fix failing CI checks on PR #<NUMBER> [type: <classified type>]:
 Fix the root cause, run pnpm lint && pnpm typecheck && pnpm test on affected packages, then push the fix to the same branch." \
   --max-budget 0.50 --adapter auto
 ```
+
+`--adapter auto` enables rate-limit failover (claude → gemini → opencode on 429). These PR fix runs are haiku/sonnet-tier — opus-tier tasks should pin `--adapter claude`.
 
 Track result as before. On fix-PR CI failure, increment `CONSECUTIVE_FAILURES`.
 

--- a/.claude/skills/implement-queue/SKILL.md
+++ b/.claude/skills/implement-queue/SKILL.md
@@ -74,6 +74,11 @@ It honors an explicit `model:` in the issue's ```yaml agent block, otherwise rou
 
 Dispatch one subagent per issue — **all in a single message** — using the Agent tool with `subagent_type: "implement-queue-worker"`, `isolation: "worktree"`, and `model:` set to the resolved **tier** from `check-model` (`opus`/`sonnet`/`haiku` — the Agent `model:` parameter is a tier enum, not a full model ID). (If `check-model` fails for an issue, omit `model:` — the worker's `sonnet` default applies.)
 
+**Adapter by tier** — when the worker prompt calls `mbe agent run` internally (e.g. for sub-tasks):
+
+- `haiku` / `sonnet` tiers: use `--adapter auto` — enables rate-limit failover cascade (claude → gemini → opencode on 429), preventing stalls on busy days.
+- `opus` tier: pin `--adapter claude` — stays on the Claude provider; failover to gemini/opencode is inappropriate for deep architecture tasks.
+
 Each agent prompt MUST include:
 
 1. The issue number, title, and full body.

--- a/.claude/skills/issue-worker/SKILL.md
+++ b/.claude/skills/issue-worker/SKILL.md
@@ -86,6 +86,8 @@ eval "mbe agent run \"\$TASK\" --max-budget <budget> --adapter auto $FRONTMATTER
 
 Last flags win (override budget/adapter). Safe (enum/numeric).
 
+`--adapter auto` enables rate-limit failover: claude → gemini → opencode on 429. Applies to haiku/sonnet-tier runs. Opus-tier issues should include `--adapter claude` in their frontmatter `agent:` block to stay on the Claude provider.
+
 ## Success
 
 ```bash


### PR DESCRIPTION
## Summary

- `ci-monitor`, `issue-worker`, and `implement-queue` (ship-loop replacement) skill instructions now explicitly document `--adapter auto` for all haiku/sonnet-tier `mbe agent run` invocations
- Failover cascade behavior documented after each invocation: claude → gemini → opencode on 429
- Opus-tier tasks documented to pin `--adapter claude` to stay on the Claude provider
- `--adapter auto` flag confirmed accepted end-to-end via `mbe agent run --help` smoke check

## Test plan

- [ ] Verify `mbe agent run --help` shows `--adapter <type>` with `auto` as a valid value
- [ ] Review three skill files for correct `--adapter auto` on haiku/sonnet-tier calls
- [ ] Confirm opus-tier guidance in implement-queue Phase 2 adapter section
- [ ] Confirm no TypeScript code was changed (pure skill doc update)

Closes #2018