### PR TITLE
refactor(agent-core): add GenRunner; gen-agent/gen-chat become thin HTTP adapters

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14742,18 +14742,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4266,13 +4266,277 @@
   <section priority="medium" role="routes">
   <file path="services/agent/src/routes/gen-agent-tools.ts">
     type ApiClient = ReturnType<typeof createApiClient>;
-    export const WRITE_TOOLS = new Set([
-      "create_reservation",
-      "modify_reservation",
-      "cancel_reservation",
-      "seat_walk_in",
-      "update_table_status",
-    ]);
+    export function createAgentTools(log: FastifyBaseLogger, api: ApiClient) {
+      return {
+        // ── Read tools (instant, no confirmation) ──────────────
+        check_availability: tool({
+          description: "Check available time slots for a venue on a specific date",
+          inputSchema: z.object({
+            venueId: z.string().describe("The venue ID to check availability for"),
+            date: z.string().describe("Date in YYYY-MM-DD format"),
+            partySize: z.number().describe("Number of guests"),
+          }),
+          execute: async ({ venueId, date, partySize }) => {
+            log.info({ venueId, date, partySize }, "check_availability tool called");
+            try {
+              const slots = await api.availability.getTimeSlots({ venueId, date, partySize });
+              return { slots };
+            } catch (err) {
+              log.error({ err, venueId, date, partySize }, "check_availability failed");
+              return { error: "Failed to check availability. Please try again." };
+            }
+          },
+        }),
+    
+        lookup_reservation: tool({
+          description: "Find reservations by guest name, date, or confirmation number",
+          inputSchema: z.object({
+            guestName: z.string().optional().describe("Guest name to search"),
+            date: z.string().optional().describe("Date in YYYY-MM-DD format"),
+            venueId: z.string().optional().describe("Venue ID to filter by"),
+          }),
+          execute: async ({ date, venueId }) => {
+            log.info({ date, venueId }, "lookup_reservation tool called");
+            try {
+              const result = await api.reservations.list({
+                ...(date ? { date } : {}),
+                ...(venueId ? { venueId } : {}),
+              });
+              return { reservations: result.data };
+            } catch (err) {
+              log.error({ err, date, venueId }, "lookup_reservation failed");
+              return { error: "Failed to look up reservations. Please try again." };
+            }
+          },
+        }),
+    
+        search_guests: tool({
+          description: "Search guest directory by name, email, or phone",
+          inputSchema: z.object({
+            query: z.string().describe("Search term (name, email, or phone)"),
+            venueId: z.string().optional().describe("Venue ID to scope search"),
+          }),
+          execute: async ({ query, venueId }) => {
+            log.info({ query, venueId }, "search_guests tool called");
+            try {
+              const result = await api.guests.search({
+                venueId: venueId ?? "",
+                query,
+              });
+              return { guests: result.data };
+            } catch (err) {
+              log.error({ err, query, venueId }, "search_guests failed");
+              return { error: "Failed to search guests. Please try again." };
+            }
+          },
+        }),
+    
+        get_table_status: tool({
+          description: "Check the status of a specific table or all tables",
+          inputSchema: z.object({
+            venueId: z.string().describe("Venue ID"),
+            tableNumber: z.number().optional().describe("Specific table number to check"),
+          }),
+          execute: async ({ venueId }) => {
+            log.info({ venueId }, "get_table_status tool called");
+            try {
+              const result = await api.tables.list({ venueId });
+              return { tables: result.data };
+            } catch (err) {
+              log.error({ err, venueId }, "get_table_status failed");
+              return { error: "Failed to get table status. Please try again." };
+            }
+          },
+        }),
+    
+        list_today_reservations: tool({
+          description: "List all reservations for today or a specified date",
+          inputSchema: z.object({
+            venueId: z.string().describe("Venue ID"),
+            date: z.string().optional().describe("Date in YYYY-MM-DD format, defaults to today"),
+            status: z
+              .enum(["PENDING", "CONFIRMED", "CANCELLED", "COMPLETED", "NO_SHOW"])
+              .optional()
+              .describe("Filter by reservation status"),
+          }),
+          execute: async ({ venueId, date, status }) => {
+            log.info({ venueId, date, status }, "list_today_reservations tool called");
+            try {
+              const queryDate = date ?? new Date().toISOString().split("T")[0]!;
+              const result = await api.reservations.list({
+                venueId,
+                date: queryDate,
+                limit: 50,
+                ...(status ? { status } : {}),
+              });
+              return { reservations: result.data };
+            } catch (err) {
+              log.error({ err, venueId, date }, "list_today_reservations failed");
+              return { error: "Failed to list reservations. Please try again." };
+            }
+          },
+        }),
+    
+        // ── Render tool (special handling — emits elements) ────
+        render_component: tool({
+          description:
+            "Render interactive UI components in the chat. Use when visual presentation is better than text — availability cards, reservation summaries, confirmation forms. Elements use the rialto component catalog.",
+          inputSchema: z.object({
+            elements: z.array(
+              z.object({
+                id: z.string(),
+                type: z.string(),
+                props: z.record(z.string(), z.unknown()).optional(),
+                children: z.array(z.string()).optional(),
+              })
+            ),
+          }),
+          execute: async () => ({ rendered: true }),
+        }),
+    
+        // ── Write tools (require confirmation) ─────────────────
+        create_reservation: tool({
+          description: "Create a new reservation. Requires confirmation before executing.",
+          inputSchema: z.object({
+            guestName: z.string().describe("Guest name"),
+            date: z.string().describe("Date in YYYY-MM-DD format"),
+            startTime: z.string().describe("Start time in HH:MM format"),
+            endTime: z.string().describe("End time in HH:MM format"),
+            partySize: z.number().describe("Number of guests"),
+            tableId: z.string().describe("Table ID to reserve"),
+            notes: z.string().optional().describe("Reservation notes"),
+          }),
+          execute: async ({ guestName, date, startTime, endTime, partySize, tableId, notes }) => {
+            log.info({ guestName, date, startTime, partySize }, "create_reservation tool called");
+            try {
+              const reservation = await api.reservations.create({
+                guestName,
+                date,
+                startTime,
+                endTime,
+                partySize,
+                tableId,
+                ...(notes ? { notes } : {}),
+              });
+              return { reservation };
+            } catch (err) {
+              log.error({ err, guestName, date }, "create_reservation failed");
+              return { error: "Failed to create reservation. Please try again." };
+            }
+          },
+        }),
+    
+        modify_reservation: tool({
+          description:
+            "Modify an existing reservation (time, table, party size, or notes). Requires confirmation.",
+          inputSchema: z.object({
+            reservationId: z.string().describe("Reservation ID to modify"),
+            date: z.string().optional().describe("New date in YYYY-MM-DD format"),
+            startTime: z.string().optional().describe("New start time in HH:MM format"),
+            endTime: z.string().optional().describe("New end time in HH:MM format"),
+            partySize: z.number().optional().describe("New party size"),
+            tableId: z.string().optional().describe("New table ID"),
+            notes: z.string().optional().describe("Updated notes"),
+          }),
+          execute: async ({ reservationId, ...updates }) => {
+            log.info({ reservationId, ...updates }, "modify_reservation tool called");
+            try {
+              const cleanUpdates = Object.fromEntries(
+                Object.entries(updates).filter(([, v]) => v !== undefined)
+              );
+              const reservation = await api.reservations.update(reservationId, cleanUpdates);
+              return { reservation };
+            } catch (err) {
+              log.error({ err, reservationId }, "modify_reservation failed");
+              return { error: "Failed to modify reservation. Please try again." };
+            }
+          },
+        }),
+    
+        cancel_reservation: tool({
+          description: "Cancel a reservation. Requires confirmation.",
+          inputSchema: z.object({
+            reservationId: z.string().optional().describe("Reservation ID to cancel"),
+            guestName: z.string().optional().describe("Guest name to look up and cancel"),
+            date: z.string().optional().describe("Date to narrow search"),
+          }),
+          execute: async ({ reservationId }) => {
+            log.info({ reservationId }, "cancel_reservation tool called");
+            try {
+              if (!reservationId) {
+                return {
+                  error: "Reservation ID is required to cancel. Please look up the reservation first.",
+                };
+              }
+              const reservation = await api.reservations.cancel(reservationId);
+              return { reservation };
+            } catch (err) {
+              log.error({ err, reservationId }, "cancel_reservation failed");
+              return { error: "Failed to cancel reservation. Please try again." };
+            }
+          },
+        }),
+    
+        seat_walk_in: tool({
+          description:
+            "Create a walk-in reservation and seat guests immediately. Requires confirmation.",
+          inputSchema: z.object({
+            venueId: z.string().describe("Venue ID"),
+            partySize: z.number().describe("Number of guests"),
+            tableId: z
+              .string()
+              .optional()
+              .describe("Specific table to seat at (auto-assigns if omitted)"),
+            guestName: z.string().optional().describe("Guest name if provided"),
+          }),
+          execute: async ({ venueId, partySize, tableId, guestName }) => {
+            log.info({ venueId, partySize, tableId, guestName }, "seat_walk_in tool called");
+            try {
+              if (!tableId) {
+                return {
+                  error: "A table must be specified for walk-ins. Check available tables first.",
+                };
+              }
+              const reservation = await api.reservations.walkIn({
+                venueId,
+                partySize,
+                tableId,
+                ...(guestName ? { guestName } : {}),
+              });
+              return { reservation };
+            } catch (err) {
+              log.error({ err, venueId, partySize }, "seat_walk_in failed");
+              return { error: "Failed to seat walk-in. Please try again." };
+            }
+          },
+        }),
+    
+        update_table_status: tool({
+          description:
+            "Update a table's status (clean, dirty, occupied, available). Requires confirmation.",
+          inputSchema: z.object({
+            venueId: z.string().describe("Venue ID"),
+            tableNumber: z.number().describe("Table number"),
+            status: z.enum(["AVAILABLE", "OCCUPIED", "DIRTY", "READY"]).describe("New table status"),
+          }),
+          execute: async ({ venueId, tableNumber, status: newStatus }) => {
+            log.info({ venueId, tableNumber, newStatus }, "update_table_status tool called");
+            try {
+              const tablesResult = await api.tables.list({ venueId });
+              const table = tablesResult.data.find((t) => t.tableNumber === String(tableNumber));
+              if (!table) {
+                return { error: `Table ${tableNumber} not found in this venue.` };
+              }
+              const updated = await api.tables.updateStatus(table.id, newStatus);
+              return { table: updated };
+            } catch (err) {
+              log.error({ err, venueId, tableNumber }, "update_table_status failed");
+              return { error: "Failed to update table status. Please try again." };
+            }
+          },
+        }),
+      };
+    }
   </file>
   <file path="services/agent/src/routes/gen-agent.ts">
     export const genAgentRoutes: FastifyPluginAsync = async (fastify) => {
@@ -4310,12 +4574,10 @@
             getAccessToken: () => token,
           });
           const agentTools = createAgentTools(request.log, api);
-    
-          const result = streamText({
-            model: anthropic(GEN_MODEL_ID),
-            messages: buildGenMessages(SYSTEM_PROMPT, messages),
-            tools: agentTools,
-            stopWhen: stepCountIs(5),
+          const runner = createGenRunner({
+            systemPrompt: SYSTEM_PROMPT,
+            modelId: GEN_MODEL_ID,
+            maxSteps: 5,
             onFinish: async ({ usage, providerMetadata }) =>
               logGenCost(request.log, {
                 userId: request.user?.id,
@@ -4327,49 +4589,13 @@
     
           applyStreamHeaders(reply, "application/x-ndjson; charset=utf-8");
     
-          const encoder = new TextEncoder();
           const ndjsonStream = new ReadableStream({
             async start(controller) {
               try {
-                for await (const event of result.fullStream) {
-                  if (event.type === "text-delta") {
-                    const line = JSON.stringify({
-                      type: "text",
-                      content: event.text,
-                    });
-                    controller.enqueue(encoder.encode(line + "\n"));
-                  } else if (event.type === "tool-call") {
-                    if (event.toolName === "render_component") {
-                      const input = event.input as { elements?: unknown[] };
-                      for (const element of input.elements ?? []) {
-                        const line = JSON.stringify({ type: "element", element });
-                        controller.enqueue(encoder.encode(line + "\n"));
-                      }
-                    } else if (WRITE_TOOLS.has(event.toolName)) {
-                      const line = JSON.stringify({
-                        type: "action_request",
-                        actionId: event.toolCallId,
-                        toolName: event.toolName,
-                        toolInput: event.input,
-                      });
-                      controller.enqueue(encoder.encode(line + "\n"));
-                    } else {
-                      const line = JSON.stringify({
-                        type: "tool_status",
-                        tool: event.toolName,
-                        status: "running",
-                      });
-                      controller.enqueue(encoder.encode(line + "\n"));
-                    }
-                  } else if (event.type === "tool-result") {
-                    const line = JSON.stringify({
-                      type: "tool_status",
-                      tool: event.toolName,
-                      status: "complete",
-                    });
-                    controller.enqueue(encoder.encode(line + "\n"));
-                  }
-                }
+                await runner.run(messages, agentTools, async (event) => {
+                  const line = JSON.stringify(event);
+                  controller.enqueue(encoder.encode(line + "\n"));
+                });
               } finally {
                 controller.close();
               }
@@ -4412,12 +4638,11 @@
           }
     
           const { messages } = parseResult.data;
-    
-          const result = streamText({
+          const runner = createGenRunner({
+            systemPrompt: SYSTEM_PROMPT,
             // GEN-06: model for chat — always haiku (conversational doesn't need sonnet)
-            model: anthropic(GEN_MODEL_ID),
-            // GEN-05: prompt caching via providerOptions on the system message
-            messages: buildGenMessages(SYSTEM_PROMPT, messages),
+            modelId: GEN_MODEL_ID,
+            maxSteps: 1,
             // GEN-06: cost logging in onFinish
             onFinish: async ({ usage, providerMetadata }) =>
               logGenCost(request.log, {
@@ -4431,11 +4656,51 @@
           // GEN-07: SSE passthrough headers — text/plain prevents browser HTML rendering
           applyStreamHeaders(reply, "text/plain; charset=utf-8");
     
+          // Build a plain text stream from the runner's text events, then sanitize
+          const textStream = new ReadableStream<string>({
+            async start(controller) {
+              try {
+                await runner.run(messages, {}, async (event) => {
+                  if (event.type === "text") {
+                    controller.enqueue(event.content);
+                  }
+                });
+              } finally {
+                controller.close();
+              }
+            },
+          });
+    
           // Sanitize AI output to prevent XSS (OWASP LLM02)
-          return reply.send(createSanitizedStream(result.textStream));
+          return reply.send(createSanitizedStream(textStream));
         }
       );
     };
+  </file>
+  <file path="services/agent/src/routes/gen-runner.ts">
+    export type GenStreamEvent =
+      | { readonly type: "text"; readonly content: string }
+      | { readonly type: "element"; readonly element: unknown }
+      | {
+          readonly type: "action_request";
+          readonly actionId: string;
+          readonly toolName: string;
+          readonly toolInput: unknown;
+        }
+      | {
+          readonly type: "tool_status";
+          readonly tool: string;
+          readonly status: "running" | "complete";
+        }
+      | {
+          readonly type: "permission_denied";
+          readonly toolName: string;
+          readonly reason: string;
+        };
+    export interface GenFinishPayload {
+      readonly usage: { readonly inputTokens?: number; readonly outputTokens?: number };
+      readonly providerMetadata: unknown;
+    }
   </file>
   <file path="services/agent/src/routes/gen-specs.ts">
     export const genSpecsRoutes: FastifyPluginAsync = async (fastify) => {
@@ -11907,6 +12172,44 @@
       readonly details?: string;
     }
   </file>
+  <file path="packages/agent-core/src/gen-permissions.ts">
+    export const BLOCKED_BASH_PATTERNS: readonly RegExp[] = [
+      /\brm\s+(-[a-zA-Z]*r[a-zA-Z]*\s+(-[a-zA-Z]*f[a-zA-Z]*\s+)?|(-[a-zA-Z]*f[a-zA-Z]*\s+)?-[a-zA-Z]*r[a-zA-Z]*\s+|--recursive\s+).*\//,
+      /\brm\s+.*\/\*/, // rm ... /*
+      /\bsudo\b/, // sudo anything
+      /\bcurl\b.*\|\s*\bbash\b/, // curl | bash (pipe to shell)
+      /\bwget\b.*\|\s*\bbash\b/, // wget | bash
+      /\bgit\s+push\b/, // git push (orchestrator handles this)
+      /\bnpm\s+publish\b/, // npm publish
+      /\bpnpm\s+publish\b/, // pnpm publish
+    ];
+    export const ENCODING_BYPASS_PATTERNS: readonly RegExp[] = [
+      // base64 decode piped to shell
+      /\bbase64\s+(-d|--decode)\b.*\|\s*(sh|bash|zsh|eval)\b/,
+      /\bbase64\s+(-d|--decode)\b.*\$\(/,
+    
+      // printf/echo with hex (\x..) or octal (\0..) piped to shell
+      /\b(printf|echo\s+-e)\b.*\\x[0-9a-fA-F]{2}.*\|\s*(sh|bash|zsh|eval)\b/,
+      /\b(printf|echo\s+-e)\b.*\\0[0-7]{1,3}.*\|\s*(sh|bash|zsh|eval)\b/,
+    
+      // $'\x..' ANSI-C quoting with hex/octal piped to shell
+      /\$'[^']*\\x[0-9a-fA-F]{2}[^']*'.*\|\s*(sh|bash|zsh|eval)\b/,
+      /\$'[^']*\\0[0-7]{1,3}[^']*'.*\|\s*(sh|bash|zsh|eval)\b/,
+    
+      // eval of variable expansion or subshell (eval "$cmd", eval $(…))
+      /\beval\s+("|'|\$[({])/,
+    
+      // command substitution piped to shell: $(...) | sh
+      /\$\([^)]+\)\s*\|\s*(sh|bash|zsh|eval)\b/,
+    
+      // generic pipe to shell execution (covers many encoding tricks)
+      /\|\s*(sh|bash|zsh)\b/,
+    
+      // variable-based command execution: cmd="rm"; $cmd ...
+      /\$\{?[a-zA-Z_][a-zA-Z0-9_]*\}?\s+-[a-zA-Z]*r[a-zA-Z]*f/,
+      /\$\{?[a-zA-Z_][a-zA-Z0-9_]*\}?\s+-rf\b/,
+    ];
+  </file>
   <file path="packages/agent-core/src/intent-extractor.ts">
     interface ContentBlock {
       readonly type: string;
@@ -12839,52 +13142,45 @@
     export type TaskDomain = "dependency" | "test" | "security" | "deploy" | "feature" | "docs" | "ci";
   </file>
   <file path="packages/agent-core/src/tool-permissions.ts">
-    export function normalizeBashCommand(command: string): readonly string[] {
-      const variants: string[] = [command];
-    
-      // Collapse escaped newlines (line continuations)
-      const collapsed = command.replace(/\\\n/g, "");
-      if (collapsed !== command) {
-        variants.push(collapsed);
-      }
-    
-      // Split on unescaped newlines and semicolons to catch injection
-      const lines = command
-        .split(/(?<!\\)[;\n]+/)
-        .map((l) => l.trim())
-        .filter(Boolean);
-      if (lines.length > 1) {
-        for (const line of lines) {
-          variants.push(line);
-        }
-      }
-    
-      // Collapse excess whitespace in each variant
-      const withNormalizedSpace = variants.map((v) => v.replace(/\s+/g, " ").trim());
-      const allVariants = [...new Set([...variants, ...withNormalizedSpace])];
-    
-      return allVariants;
+    function isPathWithinWorktree(filePath: string, worktreePath: string): boolean {
+      const resolvedFile = resolve(filePath);
+      const resolvedWorktree = resolve(worktreePath);
+      return resolvedFile === resolvedWorktree || resolvedFile.startsWith(resolvedWorktree + "/");
     }
-    function isBashCommandBlocked(command: string): string | null {
-      const variants = normalizeBashCommand(command);
+    export function createToolPermissionHandler(worktreePath: string) {
+      return async (toolName: string, input: Record<string, unknown>): Promise<PermissionResult> => {
+        // Block explicitly disallowed tools
+        if (BLOCKED_TOOLS.has(toolName)) {
+          return {
+            behavior: "deny",
+            message: `Tool "${toolName}" is not allowed in agent sessions`,
+          };
+        }
     
-      for (const variant of variants) {
-        // Check structural encoding bypass patterns first
-        for (const pattern of ENCODING_BYPASS_PATTERNS) {
-          if (pattern.test(variant)) {
-            return `Blocked: command uses shell encoding bypass (${pattern.source})`;
+        // Check bash commands against blocked patterns
+        if (toolName === "Bash") {
+          const command = input.command as string | undefined;
+          if (command) {
+            const blockReason = isBashCommandBlocked(command);
+            if (blockReason) {
+              return { behavior: "deny", message: blockReason };
+            }
           }
         }
     
-        // Check standard blocked patterns
-        for (const pattern of BLOCKED_BASH_PATTERNS) {
-          if (pattern.test(variant)) {
-            return `Blocked: command matches dangerous pattern ${pattern.source}`;
+        // Block file writes outside the worktree (resolve to prevent path traversal)
+        if (toolName === "Write" || toolName === "Edit") {
+          const filePath = (input.file_path ?? input.filePath) as string | undefined;
+          if (filePath && !isPathWithinWorktree(filePath, worktreePath)) {
+            return {
+              behavior: "deny",
+              message: `File operations are restricted to the worktree: ${worktreePath}`,
+            };
           }
         }
-      }
     
-      return null;
+        return { behavior: "allow", updatedInput: input };
+      };
     }
   </file>
   <file path="packages/agent-core/src/types.ts">
@@ -14446,7 +14742,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms.txt
+++ b/llms.txt
@@ -1363,7 +1363,7 @@
       type ApiClient = ReturnType<typeof createApiClient>;
     </item>
     <item priority="high">
-      export const WRITE_TOOLS: unknown;
+      export function createAgentTools(log: FastifyBaseLogger, api: ApiClient) { /* ... */ }
     </item>
   </file>
   <file path="services/agent/src/routes/gen-agent.ts">
@@ -1374,6 +1374,20 @@
   <file path="services/agent/src/routes/gen-chat.ts">
     <item priority="high">
       export const genChatRoutes: FastifyPluginAsync;
+    </item>
+  </file>
+  <file path="services/agent/src/routes/gen-runner.ts">
+    <item priority="low">
+      type GenStreamEvent = { readonly type: "text"; reado | { readonly type: "element"; re | {
+            readonly type: "action | {
+            readonly type: "tool_s | {
+            readonly type: "permis;
+    </item>
+    <item priority="low">
+      interface GenFinishPayload {
+        usage: { readonly inputTokens?: number; readonly outputTokens?: ...;
+        providerMetadata: unknown;
+      }
     </item>
   </file>
   <file path="services/agent/src/routes/gen-specs.ts">
@@ -2732,6 +2746,14 @@
       }
     </item>
   </file>
+  <file path="packages/agent-core/src/gen-permissions.ts">
+    <item priority="high">
+      export const BLOCKED_BASH_PATTERNS: readonly RegExp[];
+    </item>
+    <item priority="high">
+      export const ENCODING_BYPASS_PATTERNS: readonly RegExp[];
+    </item>
+  </file>
   <file path="packages/agent-core/src/intent-extractor.ts">
     <item priority="high">
       interface ContentBlock {
@@ -3051,11 +3073,11 @@
     </item>
   </file>
   <file path="packages/agent-core/src/tool-permissions.ts">
-    <item priority="high">
-      export function normalizeBashCommand(command: string): readonly string[] { /* ... */ }
-    </item>
     <item priority="medium">
-      function isBashCommandBlocked(command: string): string | null { /* ... */ }
+      function isPathWithinWorktree(filePath: string, worktreePath: string): boolean { /* ... */ }
+    </item>
+    <item priority="high">
+      export function createToolPermissionHandler(worktreePath: string) { /* ... */ }
     </item>
   </file>
   <file path="packages/agent-core/src/types.ts">

--- a/packages/agent-core/llms-full.txt
+++ b/packages/agent-core/llms-full.txt
@@ -1245,6 +1245,44 @@
       readonly details?: string;
     }
   </file>
+  <file path="src/gen-permissions.ts">
+    export const BLOCKED_BASH_PATTERNS: readonly RegExp[] = [
+      /\brm\s+(-[a-zA-Z]*r[a-zA-Z]*\s+(-[a-zA-Z]*f[a-zA-Z]*\s+)?|(-[a-zA-Z]*f[a-zA-Z]*\s+)?-[a-zA-Z]*r[a-zA-Z]*\s+|--recursive\s+).*\//,
+      /\brm\s+.*\/\*/, // rm ... /*
+      /\bsudo\b/, // sudo anything
+      /\bcurl\b.*\|\s*\bbash\b/, // curl | bash (pipe to shell)
+      /\bwget\b.*\|\s*\bbash\b/, // wget | bash
+      /\bgit\s+push\b/, // git push (orchestrator handles this)
+      /\bnpm\s+publish\b/, // npm publish
+      /\bpnpm\s+publish\b/, // pnpm publish
+    ];
+    export const ENCODING_BYPASS_PATTERNS: readonly RegExp[] = [
+      // base64 decode piped to shell
+      /\bbase64\s+(-d|--decode)\b.*\|\s*(sh|bash|zsh|eval)\b/,
+      /\bbase64\s+(-d|--decode)\b.*\$\(/,
+    
+      // printf/echo with hex (\x..) or octal (\0..) piped to shell
+      /\b(printf|echo\s+-e)\b.*\\x[0-9a-fA-F]{2}.*\|\s*(sh|bash|zsh|eval)\b/,
+      /\b(printf|echo\s+-e)\b.*\\0[0-7]{1,3}.*\|\s*(sh|bash|zsh|eval)\b/,
+    
+      // $'\x..' ANSI-C quoting with hex/octal piped to shell
+      /\$'[^']*\\x[0-9a-fA-F]{2}[^']*'.*\|\s*(sh|bash|zsh|eval)\b/,
+      /\$'[^']*\\0[0-7]{1,3}[^']*'.*\|\s*(sh|bash|zsh|eval)\b/,
+    
+      // eval of variable expansion or subshell (eval "$cmd", eval $(…))
+      /\beval\s+("|'|\$[({])/,
+    
+      // command substitution piped to shell: $(...) | sh
+      /\$\([^)]+\)\s*\|\s*(sh|bash|zsh|eval)\b/,
+    
+      // generic pipe to shell execution (covers many encoding tricks)
+      /\|\s*(sh|bash|zsh)\b/,
+    
+      // variable-based command execution: cmd="rm"; $cmd ...
+      /\$\{?[a-zA-Z_][a-zA-Z0-9_]*\}?\s+-[a-zA-Z]*r[a-zA-Z]*f/,
+      /\$\{?[a-zA-Z_][a-zA-Z0-9_]*\}?\s+-rf\b/,
+    ];
+  </file>
   <file path="src/intent-extractor.ts">
     interface ContentBlock {
       readonly type: string;
@@ -2177,52 +2215,45 @@
     export type TaskDomain = "dependency" | "test" | "security" | "deploy" | "feature" | "docs" | "ci";
   </file>
   <file path="src/tool-permissions.ts">
-    export function normalizeBashCommand(command: string): readonly string[] {
-      const variants: string[] = [command];
-    
-      // Collapse escaped newlines (line continuations)
-      const collapsed = command.replace(/\\\n/g, "");
-      if (collapsed !== command) {
-        variants.push(collapsed);
-      }
-    
-      // Split on unescaped newlines and semicolons to catch injection
-      const lines = command
-        .split(/(?<!\\)[;\n]+/)
-        .map((l) => l.trim())
-        .filter(Boolean);
-      if (lines.length > 1) {
-        for (const line of lines) {
-          variants.push(line);
-        }
-      }
-    
-      // Collapse excess whitespace in each variant
-      const withNormalizedSpace = variants.map((v) => v.replace(/\s+/g, " ").trim());
-      const allVariants = [...new Set([...variants, ...withNormalizedSpace])];
-    
-      return allVariants;
+    function isPathWithinWorktree(filePath: string, worktreePath: string): boolean {
+      const resolvedFile = resolve(filePath);
+      const resolvedWorktree = resolve(worktreePath);
+      return resolvedFile === resolvedWorktree || resolvedFile.startsWith(resolvedWorktree + "/");
     }
-    function isBashCommandBlocked(command: string): string | null {
-      const variants = normalizeBashCommand(command);
+    export function createToolPermissionHandler(worktreePath: string) {
+      return async (toolName: string, input: Record<string, unknown>): Promise<PermissionResult> => {
+        // Block explicitly disallowed tools
+        if (BLOCKED_TOOLS.has(toolName)) {
+          return {
+            behavior: "deny",
+            message: `Tool "${toolName}" is not allowed in agent sessions`,
+          };
+        }
     
-      for (const variant of variants) {
-        // Check structural encoding bypass patterns first
-        for (const pattern of ENCODING_BYPASS_PATTERNS) {
-          if (pattern.test(variant)) {
-            return `Blocked: command uses shell encoding bypass (${pattern.source})`;
+        // Check bash commands against blocked patterns
+        if (toolName === "Bash") {
+          const command = input.command as string | undefined;
+          if (command) {
+            const blockReason = isBashCommandBlocked(command);
+            if (blockReason) {
+              return { behavior: "deny", message: blockReason };
+            }
           }
         }
     
-        // Check standard blocked patterns
-        for (const pattern of BLOCKED_BASH_PATTERNS) {
-          if (pattern.test(variant)) {
-            return `Blocked: command matches dangerous pattern ${pattern.source}`;
+        // Block file writes outside the worktree (resolve to prevent path traversal)
+        if (toolName === "Write" || toolName === "Edit") {
+          const filePath = (input.file_path ?? input.filePath) as string | undefined;
+          if (filePath && !isPathWithinWorktree(filePath, worktreePath)) {
+            return {
+              behavior: "deny",
+              message: `File operations are restricted to the worktree: ${worktreePath}`,
+            };
           }
         }
-      }
     
-      return null;
+        return { behavior: "allow", updatedInput: input };
+      };
     }
   </file>
   <file path="src/types.ts">

--- a/packages/agent-core/llms.txt
+++ b/packages/agent-core/llms.txt
@@ -436,6 +436,14 @@
       }
     </item>
   </file>
+  <file path="src/gen-permissions.ts">
+    <item priority="high">
+      export const BLOCKED_BASH_PATTERNS: readonly RegExp[];
+    </item>
+    <item priority="high">
+      export const ENCODING_BYPASS_PATTERNS: readonly RegExp[];
+    </item>
+  </file>
   <file path="src/intent-extractor.ts">
     <item priority="high">
       interface ContentBlock {
@@ -755,11 +763,11 @@
     </item>
   </file>
   <file path="src/tool-permissions.ts">
-    <item priority="high">
-      export function normalizeBashCommand(command: string): readonly string[] { /* ... */ }
-    </item>
     <item priority="medium">
-      function isBashCommandBlocked(command: string): string | null { /* ... */ }
+      function isPathWithinWorktree(filePath: string, worktreePath: string): boolean { /* ... */ }
+    </item>
+    <item priority="high">
+      export function createToolPermissionHandler(worktreePath: string) { /* ... */ }
     </item>
   </file>
   <file path="src/types.ts">

--- a/packages/agent-core/src/gen-permissions.ts
+++ b/packages/agent-core/src/gen-permissions.ts
@@ -1,0 +1,120 @@
+/**
+ * Shared permission policy for gen sessions (gen-runner) and agent sessions (tool-permissions).
+ *
+ * This module owns the authoritative blocklists so neither consumer duplicates them.
+ * tool-permissions.ts imports from here for the worktree-aware agent session handler.
+ * gen-runner.ts imports from here for the lightweight gen streaming handler.
+ */
+
+/** Patterns that should never be executed in any agent or gen session. */
+export const BLOCKED_BASH_PATTERNS: readonly RegExp[] = [
+  /\brm\s+(-[a-zA-Z]*r[a-zA-Z]*\s+(-[a-zA-Z]*f[a-zA-Z]*\s+)?|(-[a-zA-Z]*f[a-zA-Z]*\s+)?-[a-zA-Z]*r[a-zA-Z]*\s+|--recursive\s+).*\//,
+  /\brm\s+.*\/\*/, // rm ... /*
+  /\bsudo\b/, // sudo anything
+  /\bcurl\b.*\|\s*\bbash\b/, // curl | bash (pipe to shell)
+  /\bwget\b.*\|\s*\bbash\b/, // wget | bash
+  /\bgit\s+push\b/, // git push (orchestrator handles this)
+  /\bnpm\s+publish\b/, // npm publish
+  /\bpnpm\s+publish\b/, // pnpm publish
+];
+
+/**
+ * Structural patterns that indicate shell encoding bypass attempts.
+ * These detect the *encoding mechanism* rather than the decoded payload,
+ * blocking the bypass vector itself regardless of what command is hidden inside.
+ */
+export const ENCODING_BYPASS_PATTERNS: readonly RegExp[] = [
+  // base64 decode piped to shell
+  /\bbase64\s+(-d|--decode)\b.*\|\s*(sh|bash|zsh|eval)\b/,
+  /\bbase64\s+(-d|--decode)\b.*\$\(/,
+
+  // printf/echo with hex (\x..) or octal (\0..) piped to shell
+  /\b(printf|echo\s+-e)\b.*\\x[0-9a-fA-F]{2}.*\|\s*(sh|bash|zsh|eval)\b/,
+  /\b(printf|echo\s+-e)\b.*\\0[0-7]{1,3}.*\|\s*(sh|bash|zsh|eval)\b/,
+
+  // $'\x..' ANSI-C quoting with hex/octal piped to shell
+  /\$'[^']*\\x[0-9a-fA-F]{2}[^']*'.*\|\s*(sh|bash|zsh|eval)\b/,
+  /\$'[^']*\\0[0-7]{1,3}[^']*'.*\|\s*(sh|bash|zsh|eval)\b/,
+
+  // eval of variable expansion or subshell (eval "$cmd", eval $(…))
+  /\beval\s+("|'|\$[({])/,
+
+  // command substitution piped to shell: $(...) | sh
+  /\$\([^)]+\)\s*\|\s*(sh|bash|zsh|eval)\b/,
+
+  // generic pipe to shell execution (covers many encoding tricks)
+  /\|\s*(sh|bash|zsh)\b/,
+
+  // variable-based command execution: cmd="rm"; $cmd ...
+  /\$\{?[a-zA-Z_][a-zA-Z0-9_]*\}?\s+-[a-zA-Z]*r[a-zA-Z]*f/,
+  /\$\{?[a-zA-Z_][a-zA-Z0-9_]*\}?\s+-rf\b/,
+];
+
+/** Tools that are always blocked in agent and gen sessions. */
+export const BLOCKED_TOOLS: ReadonlySet<string> = new Set([
+  "WebSearch",
+  "WebFetch",
+  "AskUserQuestion",
+  "EnterPlanMode",
+  "EnterWorktree",
+]);
+
+/**
+ * Normalize a bash command for pattern matching.
+ *
+ * Applies lightweight transformations so that simple obfuscation
+ * (newline injection, extra whitespace) does not bypass the blocklist.
+ * The original command is also checked — normalization is additive.
+ */
+export function normalizeBashCommand(command: string): readonly string[] {
+  const variants: string[] = [command];
+
+  // Collapse escaped newlines (line continuations)
+  const collapsed = command.replace(/\\\n/g, "");
+  if (collapsed !== command) {
+    variants.push(collapsed);
+  }
+
+  // Split on unescaped newlines and semicolons to catch injection
+  const lines = command
+    .split(/(?<!\\)[;\n]+/)
+    .map((l) => l.trim())
+    .filter(Boolean);
+  if (lines.length > 1) {
+    for (const line of lines) {
+      variants.push(line);
+    }
+  }
+
+  // Collapse excess whitespace in each variant
+  const withNormalizedSpace = variants.map((v) => v.replace(/\s+/g, " ").trim());
+  const allVariants = [...new Set([...variants, ...withNormalizedSpace])];
+
+  return allVariants;
+}
+
+/**
+ * Check if a bash command should be blocked.
+ * Returns a reason string if blocked, null if allowed.
+ */
+export function isBashCommandBlocked(command: string): string | null {
+  const variants = normalizeBashCommand(command);
+
+  for (const variant of variants) {
+    // Check structural encoding bypass patterns first
+    for (const pattern of ENCODING_BYPASS_PATTERNS) {
+      if (pattern.test(variant)) {
+        return `Blocked: command uses shell encoding bypass (${pattern.source})`;
+      }
+    }
+
+    // Check standard blocked patterns
+    for (const pattern of BLOCKED_BASH_PATTERNS) {
+      if (pattern.test(variant)) {
+        return `Blocked: command matches dangerous pattern ${pattern.source}`;
+      }
+    }
+  }
+
+  return null;
+}

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -56,8 +56,14 @@ export type { TrivialDepBumpResult } from "./dep-bump-merger.js";
 export { buildSystemPrompt, loadProjectContext, loadSourceFiles } from "./prompt-builder.js";
 export type { SourceFileEntry } from "./prompt-builder.js";
 
-// Tool permissions
+// Tool permissions (worktree-scoped agent sessions)
 export { createToolPermissionHandler, normalizeBashCommand } from "./tool-permissions.js";
+
+// Gen permissions (shared policy for gen streaming sessions)
+export {
+  BLOCKED_TOOLS as GEN_BLOCKED_TOOLS,
+  isBashCommandBlocked as genIsBashCommandBlocked,
+} from "./gen-permissions.js";
 
 // Cost tracking
 export { extractTokenUsage, extractCost, buildSessionResult } from "./cost-tracker.js";

--- a/packages/agent-core/src/tool-permissions.ts
+++ b/packages/agent-core/src/tool-permissions.ts
@@ -1,114 +1,12 @@
 import { resolve } from "node:path";
 import type { PermissionResult } from "@anthropic-ai/claude-agent-sdk";
+import {
+  BLOCKED_TOOLS,
+  isBashCommandBlocked,
+  normalizeBashCommand as normalizeBashCommandShared,
+} from "./gen-permissions.js";
 
-/** Patterns that should never be executed by an agent session. */
-const BLOCKED_BASH_PATTERNS: readonly RegExp[] = [
-  /\brm\s+(-[a-zA-Z]*r[a-zA-Z]*\s+(-[a-zA-Z]*f[a-zA-Z]*\s+)?|(-[a-zA-Z]*f[a-zA-Z]*\s+)?-[a-zA-Z]*r[a-zA-Z]*\s+|--recursive\s+).*\//,
-  /\brm\s+.*\/\*/, // rm ... /*
-  /\bsudo\b/, // sudo anything
-  /\bcurl\b.*\|\s*\bbash\b/, // curl | bash (pipe to shell)
-  /\bwget\b.*\|\s*\bbash\b/, // wget | bash
-  /\bgit\s+push\b/, // git push (orchestrator handles this)
-  /\bnpm\s+publish\b/, // npm publish
-  /\bpnpm\s+publish\b/, // pnpm publish
-];
-
-/**
- * Structural patterns that indicate shell encoding bypass attempts.
- * These detect the *encoding mechanism* rather than the decoded payload,
- * blocking the bypass vector itself regardless of what command is hidden inside.
- */
-const ENCODING_BYPASS_PATTERNS: readonly RegExp[] = [
-  // base64 decode piped to shell
-  /\bbase64\s+(-d|--decode)\b.*\|\s*(sh|bash|zsh|eval)\b/,
-  /\bbase64\s+(-d|--decode)\b.*\$\(/,
-
-  // printf/echo with hex (\x..) or octal (\0..) piped to shell
-  /\b(printf|echo\s+-e)\b.*\\x[0-9a-fA-F]{2}.*\|\s*(sh|bash|zsh|eval)\b/,
-  /\b(printf|echo\s+-e)\b.*\\0[0-7]{1,3}.*\|\s*(sh|bash|zsh|eval)\b/,
-
-  // $'\x..' ANSI-C quoting with hex/octal piped to shell
-  /\$'[^']*\\x[0-9a-fA-F]{2}[^']*'.*\|\s*(sh|bash|zsh|eval)\b/,
-  /\$'[^']*\\0[0-7]{1,3}[^']*'.*\|\s*(sh|bash|zsh|eval)\b/,
-
-  // eval of variable expansion or subshell (eval "$cmd", eval $(…))
-  /\beval\s+("|'|\$[({])/,
-
-  // command substitution piped to shell: $(...) | sh
-  /\$\([^)]+\)\s*\|\s*(sh|bash|zsh|eval)\b/,
-
-  // generic pipe to shell execution (covers many encoding tricks)
-  /\|\s*(sh|bash|zsh)\b/,
-
-  // variable-based command execution: cmd="rm"; $cmd ...
-  /\$\{?[a-zA-Z_][a-zA-Z0-9_]*\}?\s+-[a-zA-Z]*r[a-zA-Z]*f/,
-  /\$\{?[a-zA-Z_][a-zA-Z0-9_]*\}?\s+-rf\b/,
-];
-
-/** Tools that are always blocked in agent sessions. */
-const BLOCKED_TOOLS: ReadonlySet<string> = new Set([
-  "WebSearch",
-  "WebFetch",
-  "AskUserQuestion",
-  "EnterPlanMode",
-  "EnterWorktree",
-]);
-
-/**
- * Normalize a bash command for pattern matching.
- *
- * Applies lightweight transformations so that simple obfuscation
- * (newline injection, extra whitespace) does not bypass the blocklist.
- * The original command is also checked — normalization is additive.
- */
-export function normalizeBashCommand(command: string): readonly string[] {
-  const variants: string[] = [command];
-
-  // Collapse escaped newlines (line continuations)
-  const collapsed = command.replace(/\\\n/g, "");
-  if (collapsed !== command) {
-    variants.push(collapsed);
-  }
-
-  // Split on unescaped newlines and semicolons to catch injection
-  const lines = command
-    .split(/(?<!\\)[;\n]+/)
-    .map((l) => l.trim())
-    .filter(Boolean);
-  if (lines.length > 1) {
-    for (const line of lines) {
-      variants.push(line);
-    }
-  }
-
-  // Collapse excess whitespace in each variant
-  const withNormalizedSpace = variants.map((v) => v.replace(/\s+/g, " ").trim());
-  const allVariants = [...new Set([...variants, ...withNormalizedSpace])];
-
-  return allVariants;
-}
-
-function isBashCommandBlocked(command: string): string | null {
-  const variants = normalizeBashCommand(command);
-
-  for (const variant of variants) {
-    // Check structural encoding bypass patterns first
-    for (const pattern of ENCODING_BYPASS_PATTERNS) {
-      if (pattern.test(variant)) {
-        return `Blocked: command uses shell encoding bypass (${pattern.source})`;
-      }
-    }
-
-    // Check standard blocked patterns
-    for (const pattern of BLOCKED_BASH_PATTERNS) {
-      if (pattern.test(variant)) {
-        return `Blocked: command matches dangerous pattern ${pattern.source}`;
-      }
-    }
-  }
-
-  return null;
-}
+export { normalizeBashCommandShared as normalizeBashCommand };
 
 function isPathWithinWorktree(filePath: string, worktreePath: string): boolean {
   const resolvedFile = resolve(filePath);

--- a/services/agent/llms-full.txt
+++ b/services/agent/llms-full.txt
@@ -211,13 +211,277 @@
   <section priority="medium" role="routes">
   <file path="src/routes/gen-agent-tools.ts">
     type ApiClient = ReturnType<typeof createApiClient>;
-    export const WRITE_TOOLS = new Set([
-      "create_reservation",
-      "modify_reservation",
-      "cancel_reservation",
-      "seat_walk_in",
-      "update_table_status",
-    ]);
+    export function createAgentTools(log: FastifyBaseLogger, api: ApiClient) {
+      return {
+        // ── Read tools (instant, no confirmation) ──────────────
+        check_availability: tool({
+          description: "Check available time slots for a venue on a specific date",
+          inputSchema: z.object({
+            venueId: z.string().describe("The venue ID to check availability for"),
+            date: z.string().describe("Date in YYYY-MM-DD format"),
+            partySize: z.number().describe("Number of guests"),
+          }),
+          execute: async ({ venueId, date, partySize }) => {
+            log.info({ venueId, date, partySize }, "check_availability tool called");
+            try {
+              const slots = await api.availability.getTimeSlots({ venueId, date, partySize });
+              return { slots };
+            } catch (err) {
+              log.error({ err, venueId, date, partySize }, "check_availability failed");
+              return { error: "Failed to check availability. Please try again." };
+            }
+          },
+        }),
+    
+        lookup_reservation: tool({
+          description: "Find reservations by guest name, date, or confirmation number",
+          inputSchema: z.object({
+            guestName: z.string().optional().describe("Guest name to search"),
+            date: z.string().optional().describe("Date in YYYY-MM-DD format"),
+            venueId: z.string().optional().describe("Venue ID to filter by"),
+          }),
+          execute: async ({ date, venueId }) => {
+            log.info({ date, venueId }, "lookup_reservation tool called");
+            try {
+              const result = await api.reservations.list({
+                ...(date ? { date } : {}),
+                ...(venueId ? { venueId } : {}),
+              });
+              return { reservations: result.data };
+            } catch (err) {
+              log.error({ err, date, venueId }, "lookup_reservation failed");
+              return { error: "Failed to look up reservations. Please try again." };
+            }
+          },
+        }),
+    
+        search_guests: tool({
+          description: "Search guest directory by name, email, or phone",
+          inputSchema: z.object({
+            query: z.string().describe("Search term (name, email, or phone)"),
+            venueId: z.string().optional().describe("Venue ID to scope search"),
+          }),
+          execute: async ({ query, venueId }) => {
+            log.info({ query, venueId }, "search_guests tool called");
+            try {
+              const result = await api.guests.search({
+                venueId: venueId ?? "",
+                query,
+              });
+              return { guests: result.data };
+            } catch (err) {
+              log.error({ err, query, venueId }, "search_guests failed");
+              return { error: "Failed to search guests. Please try again." };
+            }
+          },
+        }),
+    
+        get_table_status: tool({
+          description: "Check the status of a specific table or all tables",
+          inputSchema: z.object({
+            venueId: z.string().describe("Venue ID"),
+            tableNumber: z.number().optional().describe("Specific table number to check"),
+          }),
+          execute: async ({ venueId }) => {
+            log.info({ venueId }, "get_table_status tool called");
+            try {
+              const result = await api.tables.list({ venueId });
+              return { tables: result.data };
+            } catch (err) {
+              log.error({ err, venueId }, "get_table_status failed");
+              return { error: "Failed to get table status. Please try again." };
+            }
+          },
+        }),
+    
+        list_today_reservations: tool({
+          description: "List all reservations for today or a specified date",
+          inputSchema: z.object({
+            venueId: z.string().describe("Venue ID"),
+            date: z.string().optional().describe("Date in YYYY-MM-DD format, defaults to today"),
+            status: z
+              .enum(["PENDING", "CONFIRMED", "CANCELLED", "COMPLETED", "NO_SHOW"])
+              .optional()
+              .describe("Filter by reservation status"),
+          }),
+          execute: async ({ venueId, date, status }) => {
+            log.info({ venueId, date, status }, "list_today_reservations tool called");
+            try {
+              const queryDate = date ?? new Date().toISOString().split("T")[0]!;
+              const result = await api.reservations.list({
+                venueId,
+                date: queryDate,
+                limit: 50,
+                ...(status ? { status } : {}),
+              });
+              return { reservations: result.data };
+            } catch (err) {
+              log.error({ err, venueId, date }, "list_today_reservations failed");
+              return { error: "Failed to list reservations. Please try again." };
+            }
+          },
+        }),
+    
+        // ── Render tool (special handling — emits elements) ────
+        render_component: tool({
+          description:
+            "Render interactive UI components in the chat. Use when visual presentation is better than text — availability cards, reservation summaries, confirmation forms. Elements use the rialto component catalog.",
+          inputSchema: z.object({
+            elements: z.array(
+              z.object({
+                id: z.string(),
+                type: z.string(),
+                props: z.record(z.string(), z.unknown()).optional(),
+                children: z.array(z.string()).optional(),
+              })
+            ),
+          }),
+          execute: async () => ({ rendered: true }),
+        }),
+    
+        // ── Write tools (require confirmation) ─────────────────
+        create_reservation: tool({
+          description: "Create a new reservation. Requires confirmation before executing.",
+          inputSchema: z.object({
+            guestName: z.string().describe("Guest name"),
+            date: z.string().describe("Date in YYYY-MM-DD format"),
+            startTime: z.string().describe("Start time in HH:MM format"),
+            endTime: z.string().describe("End time in HH:MM format"),
+            partySize: z.number().describe("Number of guests"),
+            tableId: z.string().describe("Table ID to reserve"),
+            notes: z.string().optional().describe("Reservation notes"),
+          }),
+          execute: async ({ guestName, date, startTime, endTime, partySize, tableId, notes }) => {
+            log.info({ guestName, date, startTime, partySize }, "create_reservation tool called");
+            try {
+              const reservation = await api.reservations.create({
+                guestName,
+                date,
+                startTime,
+                endTime,
+                partySize,
+                tableId,
+                ...(notes ? { notes } : {}),
+              });
+              return { reservation };
+            } catch (err) {
+              log.error({ err, guestName, date }, "create_reservation failed");
+              return { error: "Failed to create reservation. Please try again." };
+            }
+          },
+        }),
+    
+        modify_reservation: tool({
+          description:
+            "Modify an existing reservation (time, table, party size, or notes). Requires confirmation.",
+          inputSchema: z.object({
+            reservationId: z.string().describe("Reservation ID to modify"),
+            date: z.string().optional().describe("New date in YYYY-MM-DD format"),
+            startTime: z.string().optional().describe("New start time in HH:MM format"),
+            endTime: z.string().optional().describe("New end time in HH:MM format"),
+            partySize: z.number().optional().describe("New party size"),
+            tableId: z.string().optional().describe("New table ID"),
+            notes: z.string().optional().describe("Updated notes"),
+          }),
+          execute: async ({ reservationId, ...updates }) => {
+            log.info({ reservationId, ...updates }, "modify_reservation tool called");
+            try {
+              const cleanUpdates = Object.fromEntries(
+                Object.entries(updates).filter(([, v]) => v !== undefined)
+              );
+              const reservation = await api.reservations.update(reservationId, cleanUpdates);
+              return { reservation };
+            } catch (err) {
+              log.error({ err, reservationId }, "modify_reservation failed");
+              return { error: "Failed to modify reservation. Please try again." };
+            }
+          },
+        }),
+    
+        cancel_reservation: tool({
+          description: "Cancel a reservation. Requires confirmation.",
+          inputSchema: z.object({
+            reservationId: z.string().optional().describe("Reservation ID to cancel"),
+            guestName: z.string().optional().describe("Guest name to look up and cancel"),
+            date: z.string().optional().describe("Date to narrow search"),
+          }),
+          execute: async ({ reservationId }) => {
+            log.info({ reservationId }, "cancel_reservation tool called");
+            try {
+              if (!reservationId) {
+                return {
+                  error: "Reservation ID is required to cancel. Please look up the reservation first.",
+                };
+              }
+              const reservation = await api.reservations.cancel(reservationId);
+              return { reservation };
+            } catch (err) {
+              log.error({ err, reservationId }, "cancel_reservation failed");
+              return { error: "Failed to cancel reservation. Please try again." };
+            }
+          },
+        }),
+    
+        seat_walk_in: tool({
+          description:
+            "Create a walk-in reservation and seat guests immediately. Requires confirmation.",
+          inputSchema: z.object({
+            venueId: z.string().describe("Venue ID"),
+            partySize: z.number().describe("Number of guests"),
+            tableId: z
+              .string()
+              .optional()
+              .describe("Specific table to seat at (auto-assigns if omitted)"),
+            guestName: z.string().optional().describe("Guest name if provided"),
+          }),
+          execute: async ({ venueId, partySize, tableId, guestName }) => {
+            log.info({ venueId, partySize, tableId, guestName }, "seat_walk_in tool called");
+            try {
+              if (!tableId) {
+                return {
+                  error: "A table must be specified for walk-ins. Check available tables first.",
+                };
+              }
+              const reservation = await api.reservations.walkIn({
+                venueId,
+                partySize,
+                tableId,
+                ...(guestName ? { guestName } : {}),
+              });
+              return { reservation };
+            } catch (err) {
+              log.error({ err, venueId, partySize }, "seat_walk_in failed");
+              return { error: "Failed to seat walk-in. Please try again." };
+            }
+          },
+        }),
+    
+        update_table_status: tool({
+          description:
+            "Update a table's status (clean, dirty, occupied, available). Requires confirmation.",
+          inputSchema: z.object({
+            venueId: z.string().describe("Venue ID"),
+            tableNumber: z.number().describe("Table number"),
+            status: z.enum(["AVAILABLE", "OCCUPIED", "DIRTY", "READY"]).describe("New table status"),
+          }),
+          execute: async ({ venueId, tableNumber, status: newStatus }) => {
+            log.info({ venueId, tableNumber, newStatus }, "update_table_status tool called");
+            try {
+              const tablesResult = await api.tables.list({ venueId });
+              const table = tablesResult.data.find((t) => t.tableNumber === String(tableNumber));
+              if (!table) {
+                return { error: `Table ${tableNumber} not found in this venue.` };
+              }
+              const updated = await api.tables.updateStatus(table.id, newStatus);
+              return { table: updated };
+            } catch (err) {
+              log.error({ err, venueId, tableNumber }, "update_table_status failed");
+              return { error: "Failed to update table status. Please try again." };
+            }
+          },
+        }),
+      };
+    }
   </file>
   <file path="src/routes/gen-agent.ts">
     export const genAgentRoutes: FastifyPluginAsync = async (fastify) => {
@@ -255,12 +519,10 @@
             getAccessToken: () => token,
           });
           const agentTools = createAgentTools(request.log, api);
-    
-          const result = streamText({
-            model: anthropic(GEN_MODEL_ID),
-            messages: buildGenMessages(SYSTEM_PROMPT, messages),
-            tools: agentTools,
-            stopWhen: stepCountIs(5),
+          const runner = createGenRunner({
+            systemPrompt: SYSTEM_PROMPT,
+            modelId: GEN_MODEL_ID,
+            maxSteps: 5,
             onFinish: async ({ usage, providerMetadata }) =>
               logGenCost(request.log, {
                 userId: request.user?.id,
@@ -272,49 +534,13 @@
     
           applyStreamHeaders(reply, "application/x-ndjson; charset=utf-8");
     
-          const encoder = new TextEncoder();
           const ndjsonStream = new ReadableStream({
             async start(controller) {
               try {
-                for await (const event of result.fullStream) {
-                  if (event.type === "text-delta") {
-                    const line = JSON.stringify({
-                      type: "text",
-                      content: event.text,
-                    });
-                    controller.enqueue(encoder.encode(line + "\n"));
-                  } else if (event.type === "tool-call") {
-                    if (event.toolName === "render_component") {
-                      const input = event.input as { elements?: unknown[] };
-                      for (const element of input.elements ?? []) {
-                        const line = JSON.stringify({ type: "element", element });
-                        controller.enqueue(encoder.encode(line + "\n"));
-                      }
-                    } else if (WRITE_TOOLS.has(event.toolName)) {
-                      const line = JSON.stringify({
-                        type: "action_request",
-                        actionId: event.toolCallId,
-                        toolName: event.toolName,
-                        toolInput: event.input,
-                      });
-                      controller.enqueue(encoder.encode(line + "\n"));
-                    } else {
-                      const line = JSON.stringify({
-                        type: "tool_status",
-                        tool: event.toolName,
-                        status: "running",
-                      });
-                      controller.enqueue(encoder.encode(line + "\n"));
-                    }
-                  } else if (event.type === "tool-result") {
-                    const line = JSON.stringify({
-                      type: "tool_status",
-                      tool: event.toolName,
-                      status: "complete",
-                    });
-                    controller.enqueue(encoder.encode(line + "\n"));
-                  }
-                }
+                await runner.run(messages, agentTools, async (event) => {
+                  const line = JSON.stringify(event);
+                  controller.enqueue(encoder.encode(line + "\n"));
+                });
               } finally {
                 controller.close();
               }
@@ -357,12 +583,11 @@
           }
     
           const { messages } = parseResult.data;
-    
-          const result = streamText({
+          const runner = createGenRunner({
+            systemPrompt: SYSTEM_PROMPT,
             // GEN-06: model for chat — always haiku (conversational doesn't need sonnet)
-            model: anthropic(GEN_MODEL_ID),
-            // GEN-05: prompt caching via providerOptions on the system message
-            messages: buildGenMessages(SYSTEM_PROMPT, messages),
+            modelId: GEN_MODEL_ID,
+            maxSteps: 1,
             // GEN-06: cost logging in onFinish
             onFinish: async ({ usage, providerMetadata }) =>
               logGenCost(request.log, {
@@ -376,11 +601,51 @@
           // GEN-07: SSE passthrough headers — text/plain prevents browser HTML rendering
           applyStreamHeaders(reply, "text/plain; charset=utf-8");
     
+          // Build a plain text stream from the runner's text events, then sanitize
+          const textStream = new ReadableStream<string>({
+            async start(controller) {
+              try {
+                await runner.run(messages, {}, async (event) => {
+                  if (event.type === "text") {
+                    controller.enqueue(event.content);
+                  }
+                });
+              } finally {
+                controller.close();
+              }
+            },
+          });
+    
           // Sanitize AI output to prevent XSS (OWASP LLM02)
-          return reply.send(createSanitizedStream(result.textStream));
+          return reply.send(createSanitizedStream(textStream));
         }
       );
     };
+  </file>
+  <file path="src/routes/gen-runner.ts">
+    export type GenStreamEvent =
+      | { readonly type: "text"; readonly content: string }
+      | { readonly type: "element"; readonly element: unknown }
+      | {
+          readonly type: "action_request";
+          readonly actionId: string;
+          readonly toolName: string;
+          readonly toolInput: unknown;
+        }
+      | {
+          readonly type: "tool_status";
+          readonly tool: string;
+          readonly status: "running" | "complete";
+        }
+      | {
+          readonly type: "permission_denied";
+          readonly toolName: string;
+          readonly reason: string;
+        };
+    export interface GenFinishPayload {
+      readonly usage: { readonly inputTokens?: number; readonly outputTokens?: number };
+      readonly providerMetadata: unknown;
+    }
   </file>
   <file path="src/routes/gen-specs.ts">
     export const genSpecsRoutes: FastifyPluginAsync = async (fastify) => {

--- a/services/agent/llms.txt
+++ b/services/agent/llms.txt
@@ -33,7 +33,7 @@
       type ApiClient = ReturnType<typeof createApiClient>;
     </item>
     <item priority="high">
-      export const WRITE_TOOLS: unknown;
+      export function createAgentTools(log: FastifyBaseLogger, api: ApiClient) { /* ... */ }
     </item>
   </file>
   <file path="src/routes/gen-agent.ts">
@@ -44,6 +44,20 @@
   <file path="src/routes/gen-chat.ts">
     <item priority="high">
       export const genChatRoutes: FastifyPluginAsync;
+    </item>
+  </file>
+  <file path="src/routes/gen-runner.ts">
+    <item priority="low">
+      type GenStreamEvent = { readonly type: "text"; reado | { readonly type: "element"; re | {
+            readonly type: "action | {
+            readonly type: "tool_s | {
+            readonly type: "permis;
+    </item>
+    <item priority="low">
+      interface GenFinishPayload {
+        usage: { readonly inputTokens?: number; readonly outputTokens?: ...;
+        providerMetadata: unknown;
+      }
     </item>
   </file>
   <file path="src/routes/gen-specs.ts">

--- a/services/agent/src/routes/gen-agent-tools.ts
+++ b/services/agent/src/routes/gen-agent-tools.ts
@@ -6,14 +6,6 @@ import type { createApiClient } from "@mbe/api-client";
 
 type ApiClient = ReturnType<typeof createApiClient>;
 
-export const WRITE_TOOLS = new Set([
-  "create_reservation",
-  "modify_reservation",
-  "cancel_reservation",
-  "seat_walk_in",
-  "update_table_status",
-]);
-
 export function createAgentTools(log: FastifyBaseLogger, api: ApiClient) {
   return {
     // ── Read tools (instant, no confirmation) ──────────────

--- a/services/agent/src/routes/gen-agent.test.ts
+++ b/services/agent/src/routes/gen-agent.test.ts
@@ -71,6 +71,15 @@ vi.mock("@mbe/agent-core", () => ({
   resolveModel: vi.fn(),
   routeModelWithReason: vi.fn(),
   createSanitizedStream: vi.fn((stream: unknown) => stream),
+  // Gen permission policy exports (used by gen-runner.ts)
+  GEN_BLOCKED_TOOLS: new Set([
+    "WebSearch",
+    "WebFetch",
+    "AskUserQuestion",
+    "EnterPlanMode",
+    "EnterWorktree",
+  ]),
+  genIsBashCommandBlocked: vi.fn(() => null),
 }));
 
 import { streamText } from "ai";

--- a/services/agent/src/routes/gen-agent.ts
+++ b/services/agent/src/routes/gen-agent.ts
@@ -1,6 +1,4 @@
 /// <reference types="@fastify/rate-limit" />
-import { anthropic } from "@ai-sdk/anthropic";
-import { streamText, stepCountIs } from "ai";
 import type { FastifyRequest, FastifyPluginAsync } from "fastify";
 import { requireAuth } from "@mbe/auth/fastify";
 import { createProblemDetails } from "@mbe/types";
@@ -8,8 +6,9 @@ import { createProblemDetails } from "@mbe/types";
 import { createApiClient } from "@mbe/api-client";
 import { catalog } from "@mbe/rialto-catalog/catalog";
 import { z } from "zod";
-import { createAgentTools, WRITE_TOOLS } from "./gen-agent-tools.js";
-import { GEN_MODEL_ID, buildGenMessages, logGenCost, applyStreamHeaders } from "./gen-stream.js";
+import { createAgentTools } from "./gen-agent-tools.js";
+import { GEN_MODEL_ID, logGenCost, applyStreamHeaders } from "./gen-stream.js";
+import { createGenRunner } from "./gen-runner.js";
 
 const SYSTEM_PROMPT = catalog.prompt();
 
@@ -22,6 +21,8 @@ const GenAgentBodySchema = z.object({
   ),
   venueId: z.string().optional(),
 });
+
+const encoder = new TextEncoder();
 
 export const genAgentRoutes: FastifyPluginAsync = async (fastify) => {
   fastify.post(
@@ -58,12 +59,10 @@ export const genAgentRoutes: FastifyPluginAsync = async (fastify) => {
         getAccessToken: () => token,
       });
       const agentTools = createAgentTools(request.log, api);
-
-      const result = streamText({
-        model: anthropic(GEN_MODEL_ID),
-        messages: buildGenMessages(SYSTEM_PROMPT, messages),
-        tools: agentTools,
-        stopWhen: stepCountIs(5),
+      const runner = createGenRunner({
+        systemPrompt: SYSTEM_PROMPT,
+        modelId: GEN_MODEL_ID,
+        maxSteps: 5,
         onFinish: async ({ usage, providerMetadata }) =>
           logGenCost(request.log, {
             userId: request.user?.id,
@@ -75,49 +74,13 @@ export const genAgentRoutes: FastifyPluginAsync = async (fastify) => {
 
       applyStreamHeaders(reply, "application/x-ndjson; charset=utf-8");
 
-      const encoder = new TextEncoder();
       const ndjsonStream = new ReadableStream({
         async start(controller) {
           try {
-            for await (const event of result.fullStream) {
-              if (event.type === "text-delta") {
-                const line = JSON.stringify({
-                  type: "text",
-                  content: event.text,
-                });
-                controller.enqueue(encoder.encode(line + "\n"));
-              } else if (event.type === "tool-call") {
-                if (event.toolName === "render_component") {
-                  const input = event.input as { elements?: unknown[] };
-                  for (const element of input.elements ?? []) {
-                    const line = JSON.stringify({ type: "element", element });
-                    controller.enqueue(encoder.encode(line + "\n"));
-                  }
-                } else if (WRITE_TOOLS.has(event.toolName)) {
-                  const line = JSON.stringify({
-                    type: "action_request",
-                    actionId: event.toolCallId,
-                    toolName: event.toolName,
-                    toolInput: event.input,
-                  });
-                  controller.enqueue(encoder.encode(line + "\n"));
-                } else {
-                  const line = JSON.stringify({
-                    type: "tool_status",
-                    tool: event.toolName,
-                    status: "running",
-                  });
-                  controller.enqueue(encoder.encode(line + "\n"));
-                }
-              } else if (event.type === "tool-result") {
-                const line = JSON.stringify({
-                  type: "tool_status",
-                  tool: event.toolName,
-                  status: "complete",
-                });
-                controller.enqueue(encoder.encode(line + "\n"));
-              }
-            }
+            await runner.run(messages, agentTools, async (event) => {
+              const line = JSON.stringify(event);
+              controller.enqueue(encoder.encode(line + "\n"));
+            });
           } finally {
             controller.close();
           }

--- a/services/agent/src/routes/gen-chat.test.ts
+++ b/services/agent/src/routes/gen-chat.test.ts
@@ -4,6 +4,7 @@ import type { FastifyInstance } from "fastify";
 // Must mock before importing buildApp
 vi.mock("ai", () => ({
   streamText: vi.fn(),
+  stepCountIs: vi.fn((n: number) => ({ type: "stepCount", count: n })),
   Output: {
     object: vi.fn(),
   },
@@ -70,6 +71,15 @@ vi.mock("@mbe/agent-core", () => ({
   resolveModel: vi.fn(),
   routeModelWithReason: vi.fn(),
   createSanitizedStream: vi.fn((stream: unknown) => stream),
+  // Gen permission policy exports (used by gen-runner.ts)
+  GEN_BLOCKED_TOOLS: new Set([
+    "WebSearch",
+    "WebFetch",
+    "AskUserQuestion",
+    "EnterPlanMode",
+    "EnterWorktree",
+  ]),
+  genIsBashCommandBlocked: vi.fn(() => null),
 }));
 
 import { streamText } from "ai";
@@ -119,15 +129,11 @@ describe("POST /api/gen/chat", () => {
   });
 
   it("calls streamText with system prompt and user messages", async () => {
-    const closedStream = new ReadableStream({
-      start(controller) {
-        controller.close();
-      },
-    });
-    const mockStream = {
-      toUIMessageStream: vi.fn(() => closedStream),
-    };
-    vi.mocked(streamText).mockReturnValueOnce(mockStream as never);
+    vi.mocked(streamText).mockReturnValueOnce({
+      fullStream: (async function* () {})(),
+      usage: Promise.resolve({ inputTokens: 5, outputTokens: 3 }),
+      providerMetadata: Promise.resolve({}),
+    } as never);
 
     await app.inject({
       method: "POST",
@@ -153,15 +159,11 @@ describe("POST /api/gen/chat", () => {
   });
 
   it("applies prompt caching on system message", async () => {
-    const closedStream = new ReadableStream({
-      start(controller) {
-        controller.close();
-      },
-    });
-    const mockStream = {
-      toUIMessageStream: vi.fn(() => closedStream),
-    };
-    vi.mocked(streamText).mockReturnValueOnce(mockStream as never);
+    vi.mocked(streamText).mockReturnValueOnce({
+      fullStream: (async function* () {})(),
+      usage: Promise.resolve({ inputTokens: 5, outputTokens: 3 }),
+      providerMetadata: Promise.resolve({}),
+    } as never);
 
     await app.inject({
       method: "POST",

--- a/services/agent/src/routes/gen-chat.ts
+++ b/services/agent/src/routes/gen-chat.ts
@@ -1,6 +1,4 @@
 /// <reference types="@fastify/rate-limit" />
-import { anthropic } from "@ai-sdk/anthropic";
-import { streamText } from "ai";
 import type { FastifyRequest } from "fastify";
 import type { FastifyPluginAsync } from "fastify";
 import { requireAuth } from "@mbe/auth/fastify";
@@ -9,7 +7,8 @@ import { createProblemDetails } from "@mbe/types";
 import { catalog } from "@mbe/rialto-catalog/catalog";
 import { createSanitizedStream } from "@mbe/agent-core";
 import { z } from "zod";
-import { GEN_MODEL_ID, buildGenMessages, logGenCost, applyStreamHeaders } from "./gen-stream.js";
+import { GEN_MODEL_ID, logGenCost, applyStreamHeaders } from "./gen-stream.js";
+import { createGenRunner } from "./gen-runner.js";
 
 // Memoize catalog prompt at module load — avoid re-generating per request
 const SYSTEM_PROMPT = catalog.prompt();
@@ -53,12 +52,11 @@ export const genChatRoutes: FastifyPluginAsync = async (fastify) => {
       }
 
       const { messages } = parseResult.data;
-
-      const result = streamText({
+      const runner = createGenRunner({
+        systemPrompt: SYSTEM_PROMPT,
         // GEN-06: model for chat — always haiku (conversational doesn't need sonnet)
-        model: anthropic(GEN_MODEL_ID),
-        // GEN-05: prompt caching via providerOptions on the system message
-        messages: buildGenMessages(SYSTEM_PROMPT, messages),
+        modelId: GEN_MODEL_ID,
+        maxSteps: 1,
         // GEN-06: cost logging in onFinish
         onFinish: async ({ usage, providerMetadata }) =>
           logGenCost(request.log, {
@@ -72,8 +70,23 @@ export const genChatRoutes: FastifyPluginAsync = async (fastify) => {
       // GEN-07: SSE passthrough headers — text/plain prevents browser HTML rendering
       applyStreamHeaders(reply, "text/plain; charset=utf-8");
 
+      // Build a plain text stream from the runner's text events, then sanitize
+      const textStream = new ReadableStream<string>({
+        async start(controller) {
+          try {
+            await runner.run(messages, {}, async (event) => {
+              if (event.type === "text") {
+                controller.enqueue(event.content);
+              }
+            });
+          } finally {
+            controller.close();
+          }
+        },
+      });
+
       // Sanitize AI output to prevent XSS (OWASP LLM02)
-      return reply.send(createSanitizedStream(result.textStream));
+      return reply.send(createSanitizedStream(textStream));
     }
   );
 };

--- a/services/agent/src/routes/gen-runner.test.ts
+++ b/services/agent/src/routes/gen-runner.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { GenRunner, GenRunnerConfig, GenStreamEvent } from "./gen-runner.js";
+
+// Must mock before dynamic imports
+vi.mock("ai", () => ({
+  streamText: vi.fn(),
+  tool: vi.fn((def: unknown) => def),
+  stepCountIs: vi.fn((n: number) => ({ type: "stepCount", count: n })),
+}));
+
+vi.mock("@ai-sdk/anthropic", () => ({
+  anthropic: vi.fn(() => ({ provider: "anthropic", modelId: "claude-haiku-4.5" })),
+}));
+
+import { streamText } from "ai";
+import { createGenRunner } from "./gen-runner.js";
+
+async function* mockAsyncIterable<T>(items: T[]): AsyncGenerator<T> {
+  for (const item of items) {
+    yield item;
+  }
+}
+
+const baseConfig: GenRunnerConfig = {
+  systemPrompt: "You are a helpful assistant.",
+  modelId: "claude-haiku-4.5",
+  maxSteps: 5,
+};
+
+describe("createGenRunner", () => {
+  let runner: GenRunner;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    runner = createGenRunner(baseConfig);
+  });
+
+  describe("tool dispatch", () => {
+    it("calls streamText with provided tools", async () => {
+      const mockTool = {
+        description: "A test tool",
+        inputSchema: { parse: vi.fn() },
+        execute: vi.fn().mockResolvedValue({ result: "ok" }),
+      };
+      vi.mocked(streamText).mockReturnValueOnce({
+        fullStream: mockAsyncIterable([]),
+        usage: Promise.resolve({ inputTokens: 5, outputTokens: 3 }),
+        providerMetadata: Promise.resolve({}),
+      } as never);
+
+      await runner.run(
+        [{ role: "user", content: "test" }],
+        { test_tool: mockTool },
+        async () => {}
+      );
+
+      const call = vi.mocked(streamText).mock.calls[0]![0] as Record<string, unknown>;
+      expect(call.tools).toMatchObject({ test_tool: mockTool });
+    });
+
+    it("passes stopWhen to streamText", async () => {
+      vi.mocked(streamText).mockReturnValueOnce({
+        fullStream: mockAsyncIterable([]),
+        usage: Promise.resolve({ inputTokens: 5, outputTokens: 3 }),
+        providerMetadata: Promise.resolve({}),
+      } as never);
+
+      await runner.run([{ role: "user", content: "test" }], {}, async () => {});
+
+      const call = vi.mocked(streamText).mock.calls[0]![0] as Record<string, unknown>;
+      expect(call.stopWhen).toBeDefined();
+    });
+
+    it("emits tool_status events for non-write non-render tools", async () => {
+      vi.mocked(streamText).mockReturnValueOnce({
+        fullStream: mockAsyncIterable([
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            toolName: "check_availability",
+            input: { venueId: "v1" },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "call-1",
+            toolName: "check_availability",
+            result: { slots: [] },
+          },
+        ]),
+        usage: Promise.resolve({ inputTokens: 5, outputTokens: 3 }),
+        providerMetadata: Promise.resolve({}),
+      } as never);
+
+      const events: GenStreamEvent[] = [];
+      await runner.run([{ role: "user", content: "check" }], {}, async (event) => {
+        events.push(event);
+      });
+
+      expect(events).toContainEqual({
+        type: "tool_status",
+        tool: "check_availability",
+        status: "running",
+      });
+      expect(events).toContainEqual({
+        type: "tool_status",
+        tool: "check_availability",
+        status: "complete",
+      });
+    });
+
+    it("emits element events from render_component tool calls", async () => {
+      const elementSpec = { id: "card-1", type: "Card", props: {}, children: [] };
+      vi.mocked(streamText).mockReturnValueOnce({
+        fullStream: mockAsyncIterable([
+          {
+            type: "tool-call",
+            toolCallId: "call-2",
+            toolName: "render_component",
+            input: { elements: [elementSpec] },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "call-2",
+            toolName: "render_component",
+            result: { rendered: true },
+          },
+        ]),
+        usage: Promise.resolve({ inputTokens: 5, outputTokens: 3 }),
+        providerMetadata: Promise.resolve({}),
+      } as never);
+
+      const events: GenStreamEvent[] = [];
+      await runner.run([{ role: "user", content: "show" }], {}, async (event) => {
+        events.push(event);
+      });
+
+      expect(events).toContainEqual({ type: "element", element: elementSpec });
+      expect(events).toContainEqual({
+        type: "tool_status",
+        tool: "render_component",
+        status: "complete",
+      });
+    });
+
+    it("emits action_request for write tools", async () => {
+      vi.mocked(streamText).mockReturnValueOnce({
+        fullStream: mockAsyncIterable([
+          {
+            type: "tool-call",
+            toolCallId: "call-3",
+            toolName: "create_reservation",
+            input: { guestName: "Smith", date: "2026-06-18" },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "call-3",
+            toolName: "create_reservation",
+            result: {},
+          },
+        ]),
+        usage: Promise.resolve({ inputTokens: 5, outputTokens: 3 }),
+        providerMetadata: Promise.resolve({}),
+      } as never);
+
+      const events: GenStreamEvent[] = [];
+      await runner.run([{ role: "user", content: "book" }], {}, async (event) => {
+        events.push(event);
+      });
+
+      expect(events).toContainEqual({
+        type: "action_request",
+        actionId: "call-3",
+        toolName: "create_reservation",
+        toolInput: { guestName: "Smith", date: "2026-06-18" },
+      });
+    });
+  });
+
+  describe("permission denial", () => {
+    it("emits permission_denied for blocked tool names", async () => {
+      vi.mocked(streamText).mockReturnValueOnce({
+        fullStream: mockAsyncIterable([
+          {
+            type: "tool-call",
+            toolCallId: "call-4",
+            toolName: "WebSearch",
+            input: { query: "bad" },
+          },
+        ]),
+        usage: Promise.resolve({ inputTokens: 5, outputTokens: 3 }),
+        providerMetadata: Promise.resolve({}),
+      } as never);
+
+      const events: GenStreamEvent[] = [];
+      await runner.run([{ role: "user", content: "search" }], {}, async (event) => {
+        events.push(event);
+      });
+
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "permission_denied",
+          toolName: "WebSearch",
+        })
+      );
+    });
+  });
+
+  describe("streaming text events", () => {
+    it("emits text events from text-delta", async () => {
+      vi.mocked(streamText).mockReturnValueOnce({
+        fullStream: mockAsyncIterable([
+          { type: "text-delta", text: "Hello " },
+          { type: "text-delta", text: "world" },
+        ]),
+        usage: Promise.resolve({ inputTokens: 10, outputTokens: 5 }),
+        providerMetadata: Promise.resolve({}),
+      } as never);
+
+      const events: GenStreamEvent[] = [];
+      await runner.run([{ role: "user", content: "hi" }], {}, async (event) => {
+        events.push(event);
+      });
+
+      expect(events).toEqual([
+        { type: "text", content: "Hello " },
+        { type: "text", content: "world" },
+      ]);
+    });
+  });
+
+  describe("budget stop", () => {
+    it("passes maxSteps to stepCountIs", async () => {
+      vi.mocked(streamText).mockReturnValueOnce({
+        fullStream: mockAsyncIterable([]),
+        usage: Promise.resolve({ inputTokens: 5, outputTokens: 3 }),
+        providerMetadata: Promise.resolve({}),
+      } as never);
+
+      const { stepCountIs } = await import("ai");
+      const runnerWith3 = createGenRunner({ ...baseConfig, maxSteps: 3 });
+      await runnerWith3.run([{ role: "user", content: "hi" }], {}, async () => {});
+
+      expect(stepCountIs).toHaveBeenCalledWith(3);
+    });
+  });
+
+  describe("system prompt injection", () => {
+    it("puts system prompt first in messages array with cache control", async () => {
+      vi.mocked(streamText).mockReturnValueOnce({
+        fullStream: mockAsyncIterable([]),
+        usage: Promise.resolve({ inputTokens: 5, outputTokens: 3 }),
+        providerMetadata: Promise.resolve({}),
+      } as never);
+
+      await runner.run([{ role: "user", content: "hi" }], {}, async () => {});
+
+      const call = vi.mocked(streamText).mock.calls[0]![0] as {
+        messages: Array<{ role: string; content: string; providerOptions?: unknown }>;
+      };
+      expect(call.messages[0]).toMatchObject({
+        role: "system",
+        content: "You are a helpful assistant.",
+        providerOptions: { anthropic: { cacheControl: { type: "ephemeral" } } },
+      });
+    });
+  });
+});

--- a/services/agent/src/routes/gen-runner.ts
+++ b/services/agent/src/routes/gen-runner.ts
@@ -1,0 +1,161 @@
+import { anthropic } from "@ai-sdk/anthropic";
+import { streamText, stepCountIs } from "ai";
+// Permission policy sourced from agent-core — not duplicated here (security requirement)
+import { GEN_BLOCKED_TOOLS, genIsBashCommandBlocked } from "@mbe/agent-core";
+
+// ── Public types ──────────────────────────────────────────────────────
+
+export type GenStreamEvent =
+  | { readonly type: "text"; readonly content: string }
+  | { readonly type: "element"; readonly element: unknown }
+  | {
+      readonly type: "action_request";
+      readonly actionId: string;
+      readonly toolName: string;
+      readonly toolInput: unknown;
+    }
+  | {
+      readonly type: "tool_status";
+      readonly tool: string;
+      readonly status: "running" | "complete";
+    }
+  | {
+      readonly type: "permission_denied";
+      readonly toolName: string;
+      readonly reason: string;
+    };
+
+export interface GenFinishPayload {
+  readonly usage: { readonly inputTokens?: number; readonly outputTokens?: number };
+  readonly providerMetadata: unknown;
+}
+
+export interface GenRunnerConfig {
+  readonly systemPrompt: string;
+  readonly modelId: string;
+  readonly maxSteps: number;
+  readonly onFinish?: (payload: GenFinishPayload) => Promise<void>;
+}
+
+/** Tool names that require user confirmation before execution. */
+export const GEN_WRITE_TOOLS: ReadonlySet<string> = new Set([
+  "create_reservation",
+  "modify_reservation",
+  "cancel_reservation",
+  "seat_walk_in",
+  "update_table_status",
+]);
+
+export type GenToolMap = Record<string, unknown>;
+export type GenEventCallback = (event: GenStreamEvent) => Promise<void>;
+
+export interface GenRunner {
+  run(
+    messages: ReadonlyArray<{ role: "user" | "assistant"; content: string }>,
+    tools: GenToolMap,
+    onEvent: GenEventCallback
+  ): Promise<void>;
+}
+
+// ── Implementation ────────────────────────────────────────────────────
+
+/**
+ * Create a GenRunner that owns streaming, tool dispatch, and permission policy
+ * for lightweight generation tasks (no worktree / PR phases).
+ *
+ * Permission policy comes from @mbe/agent-core (gen-permissions.ts) — never
+ * duplicated here. This is a security requirement: one authoritative source
+ * for all blocked tools and bash patterns.
+ */
+export function createGenRunner(config: GenRunnerConfig): GenRunner {
+  return {
+    async run(messages, tools, onEvent) {
+      const aiMessages = [
+        {
+          role: "system" as const,
+          content: config.systemPrompt,
+          providerOptions: { anthropic: { cacheControl: { type: "ephemeral" as const } } },
+        },
+        ...messages,
+      ];
+
+      const result = streamText({
+        model: anthropic(config.modelId),
+        messages: aiMessages,
+        tools: tools as Parameters<typeof streamText>[0]["tools"],
+        stopWhen: stepCountIs(config.maxSteps),
+        onFinish: config.onFinish
+          ? async ({ usage, providerMetadata }) => {
+              await config.onFinish!({ usage, providerMetadata });
+            }
+          : undefined,
+      });
+
+      for await (const event of result.fullStream) {
+        if (event.type === "text-delta") {
+          await onEvent({ type: "text", content: event.text });
+        } else if (event.type === "tool-call") {
+          await handleToolCall(event, onEvent);
+        } else if (event.type === "tool-result") {
+          await onEvent({
+            type: "tool_status",
+            tool: event.toolName,
+            status: "complete",
+          });
+        }
+      }
+    },
+  };
+}
+
+async function handleToolCall(
+  event: { toolCallId: string; toolName: string; input: unknown },
+  onEvent: GenEventCallback
+): Promise<void> {
+  const { toolName, toolCallId, input } = event;
+
+  // Permission check: blocked tool names (policy from agent-core)
+  if (GEN_BLOCKED_TOOLS.has(toolName)) {
+    await onEvent({
+      type: "permission_denied",
+      toolName,
+      reason: `Tool "${toolName}" is not allowed in gen sessions`,
+    });
+    return;
+  }
+
+  // Permission check: bash command patterns (policy from agent-core)
+  if (toolName === "Bash") {
+    const command = (input as Record<string, unknown>).command as string | undefined;
+    if (command) {
+      const blockReason = genIsBashCommandBlocked(command);
+      if (blockReason) {
+        await onEvent({ type: "permission_denied", toolName, reason: blockReason });
+        return;
+      }
+    }
+  }
+
+  // render_component emits element events (no status — handled by tool-result)
+  if (toolName === "render_component") {
+    const typedInput = input as { elements?: unknown[] };
+    for (const element of typedInput.elements ?? []) {
+      await onEvent({ type: "element", element });
+    }
+    return;
+  }
+
+  // Write tools emit action_request (require user confirmation)
+  if (GEN_WRITE_TOOLS.has(toolName)) {
+    await onEvent({
+      type: "action_request",
+      actionId: toolCallId,
+      toolName,
+      toolInput: input,
+    });
+    return;
+  }
+
+  // Read/status tools emit running status
+  await onEvent({ type: "tool_status", tool: toolName, status: "running" });
+}


### PR DESCRIPTION
## Summary

- Adds `packages/agent-core/src/gen-permissions.ts` — single authoritative source for blocked tool names and dangerous bash patterns (extracted from `tool-permissions.ts`, imported back by it; security-relevant policy lives in one place)
- Exports `GEN_BLOCKED_TOOLS` and `genIsBashCommandBlocked` from `@mbe/agent-core` index
- Adds `services/agent/src/routes/gen-runner.ts` — GenRunner owns tools dispatch, permission enforcement, streaming (text/element/action_request/tool_status/permission_denied events), and budget stop (`stepCountIs`) for lightweight gen tasks
- Shrinks `gen-agent.ts` from ~130 lines to ~90 lines: HTTP adapter over GenRunner
- Shrinks `gen-chat.ts` from ~79 lines to ~75 lines: HTTP adapter over GenRunner  
- Removes `WRITE_TOOLS` duplication from `gen-agent-tools.ts` (now `GEN_WRITE_TOOLS` in gen-runner)
- Full test suite in `gen-runner.test.ts` covering tool dispatch, permission denial, streaming events, budget stop, system prompt injection

## Test plan

- [ ] `pnpm --dir packages/agent-core test` — 1137 tests pass
- [ ] `pnpm --dir packages/agent-core typecheck` — clean
- [ ] `pnpm --dir services/agent test` — 285 tests pass (all existing gen-agent/gen-chat route tests pass; SSE wire format unchanged)
- [ ] `pnpm --dir services/agent typecheck` — clean
- [ ] `pnpm --filter @mbe/cli start check-adr` — no violations
- [ ] `pnpm --filter @mbe/cli start check-deps` — no mismatches
- [ ] `pnpm regen` — artifacts regenerated and committed

Closes #1993