### PR TITLE
feat(eval): golden task corpus expansion + per-category report breakdown

### DIFF
--- a/docs/agents/golden-task-authoring.md
+++ b/docs/agents/golden-task-authoring.md
@@ -1,0 +1,146 @@
+# Authoring Golden Tasks
+
+Golden tasks are fixed, versioned benchmark cases used by `mbe agent eval` to measure agent capability across task categories. This document explains the fixture shape, rubric fields, how scoring works, and the workflow for adding a new task.
+
+## Suite location
+
+All golden tasks live in:
+
+```
+packages/agent-core/eval-suite/
+```
+
+Each file is a single JSON object. The filename should match the task `id` (e.g. `fix-login-redirect.json` for id `fix-login-redirect`).
+
+## Task fixture shape
+
+```json
+{
+  "id": "unique-kebab-case-id",
+  "category": "bugfix",
+  "prompt": "The instruction handed verbatim to the agent.",
+  "fixtureRef": "services/reservations",
+  "rubric": {
+    "testsMustPass": true,
+    "typecheckMustPass": true,
+    "lintMustPass": false,
+    "judgeCriteria": ["Criterion 1 phrased as an observable outcome", "Criterion 2"]
+  },
+  "budget": {
+    "maxTurns": 40,
+    "maxCostUsd": 1.0
+  }
+}
+```
+
+### Fields
+
+| Field               | Type           | Required | Description                                                                                                                                            |
+| ------------------- | -------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `id`                | `string`       | yes      | Unique identifier across the suite. Used with `--task <id>` to run one task.                                                                           |
+| `category`          | `TaskCategory` | yes      | See [categories](#categories) below.                                                                                                                   |
+| `prompt`            | `string`       | yes      | The task description given to the agent. Write it as you would a real GitHub issue body: precise, self-contained, and free of ambiguity.               |
+| `fixtureRef`        | `string`       | yes      | The workspace-relative path of the package the agent works in (e.g. `services/reservations`). Verification scripts run with `--filter ./<fixtureRef>`. |
+| `rubric`            | `Rubric`       | no       | Defaults: `testsMustPass: true`, `typecheckMustPass: true`, `lintMustPass: false`, `judgeCriteria: []`.                                                |
+| `budget.maxTurns`   | `number`       | no       | Default 50. How many agent turns the task may consume.                                                                                                 |
+| `budget.maxCostUsd` | `number`       | no       | Default 1.00. Maximum spend allowed for this task.                                                                                                     |
+
+## Categories
+
+| Category       | When to use                                                                 |
+| -------------- | --------------------------------------------------------------------------- |
+| `bugfix`       | Fix an existing defect; typically includes a regression test.               |
+| `refactor`     | Restructure code without changing observable behaviour.                     |
+| `new-route`    | Add a new HTTP endpoint (or equivalent API surface) with tests.             |
+| `dep-bump`     | Update one or more dependency versions across the monorepo.                 |
+| `test-writing` | Add or expand tests for an under-tested module; no production code changes. |
+
+## Rubric fields
+
+### Deterministic checks
+
+These run automatically by the harness after the agent finishes:
+
+| Field               | Default | Meaning                                                                                                    |
+| ------------------- | ------- | ---------------------------------------------------------------------------------------------------------- |
+| `testsMustPass`     | `true`  | `pnpm --filter ./<fixtureRef> test` must exit 0.                                                           |
+| `typecheckMustPass` | `true`  | `pnpm --filter ./<fixtureRef> typecheck` must exit 0.                                                      |
+| `lintMustPass`      | `false` | `pnpm --filter ./<fixtureRef> lint` must exit 0. Set `true` for tasks where lint correctness is the point. |
+
+All deterministic checks that are `true` must pass, plus the agent must stay within `budget`, for `passed: true`.
+
+### `judgeCriteria`
+
+Free-text strings consumed by the LLM judge (added in a later slice). Each criterion should describe a single observable outcome:
+
+- Good: `"The fix gates the cancellation email on the guest notification opt-in"`
+- Bad: `"The code is clean"` (too vague for a judge to evaluate)
+
+Keep criteria to 3–6 items. More than 6 dilutes the signal.
+
+## How scoring works
+
+```
+score = satisfied_signals / applicable_signals   (0..1)
+passed = every applicable signal is satisfied
+```
+
+**Applicable signals:**
+
+- `withinBudget` — always applicable
+- `testsPass` — when `rubric.testsMustPass` is `true`
+- `typecheckPass` — when `rubric.typecheckMustPass` is `true`
+- `lintPass` — when `rubric.lintMustPass` is `true`
+- LLM judge signals — when `judgeCriteria` is non-empty (future slice)
+
+The `EvalReport` aggregates scores across all tasks and breaks them down by category:
+
+```json
+{
+  "aggregate": {
+    "total": 5,
+    "passRate": 0.8,
+    "byCategory": {
+      "bugfix": { "total": 1, "passRate": 1.0 },
+      "refactor": { "total": 1, "passRate": 1.0 },
+      "new-route": { "total": 1, "passRate": 1.0 },
+      "dep-bump": { "total": 1, "passRate": 0.0 },
+      "test-writing": { "total": 1, "passRate": 1.0 }
+    }
+  }
+}
+```
+
+Use per-category pass rates to identify where the agent is weakest. A category with consistent 0% pass rate signals a prompt-engineering or model-routing gap, not a code defect.
+
+## Writing a good prompt
+
+1. **Be self-contained.** The agent receives only the prompt and the repo. Do not rely on implied context.
+2. **Name specific files.** `"the buildPrBody function in services/agent/src/routes/sessions.ts"` is better than `"the PR body builder"`.
+3. **Include acceptance conditions.** List what the correct solution looks like in plain language. These become your `judgeCriteria`.
+4. **Scope to one concern.** A task that mixes a bugfix and a refactor is harder to score and harder to attribute failure.
+5. **Set a realistic budget.** A dep-bump that touches one file needs 20 turns; a new route with tests may need 40. Over-budgeting inflates cost metrics without improving results.
+
+## Adding a task — checklist
+
+1. Create `packages/agent-core/eval-suite/<id>.json` with the fixture above.
+2. Run `pnpm --dir packages/agent-core test` — the `loadSuite` test will reject malformed JSON or an invalid category immediately.
+3. Run `pnpm --dir packages/agent-core typecheck` to confirm the suite still builds.
+4. Run `mbe agent eval --task <id> --json` on a real agent session to baseline the expected score before merging.
+5. Open a PR. The CI `pnpm test` gate covers the harness tests; no extra CI job is required.
+
+## Running the suite
+
+```bash
+# Full suite
+mbe agent eval --suite packages/agent-core/eval-suite
+
+# One task
+mbe agent eval --task fix-login-redirect
+
+# Assert a minimum pass rate (exits 1 if below)
+mbe agent eval --threshold 70
+
+# JSON output (for dashboards)
+mbe agent eval --json | jq '.aggregate.byCategory'
+```

--- a/packages/agent-core/eval-suite/dep-bump-zod.json
+++ b/packages/agent-core/eval-suite/dep-bump-zod.json
@@ -1,0 +1,20 @@
+{
+  "id": "dep-bump-zod",
+  "category": "dep-bump",
+  "prompt": "Bump `zod` to the latest 3.x release across the monorepo. Update all `package.json` files that depend on `zod` to the new version, run `pnpm install --frozen-lockfile` to verify resolution, and confirm `pnpm typecheck` passes. Do not change any application code — only the version specifiers and the lockfile.",
+  "fixtureRef": "packages/agent-core",
+  "rubric": {
+    "testsMustPass": true,
+    "typecheckMustPass": true,
+    "lintMustPass": false,
+    "judgeCriteria": [
+      "All `package.json` files referencing `zod` use the same bumped version specifier",
+      "No application source files are modified — only `package.json` and `pnpm-lock.yaml`",
+      "The lockfile resolves consistently (no duplicate zod versions)"
+    ]
+  },
+  "budget": {
+    "maxTurns": 20,
+    "maxCostUsd": 0.5
+  }
+}

--- a/packages/agent-core/eval-suite/new-route-health-detail.json
+++ b/packages/agent-core/eval-suite/new-route-health-detail.json
@@ -1,0 +1,21 @@
+{
+  "id": "new-route-health-detail",
+  "category": "new-route",
+  "prompt": "Add a `GET /api/v1/reservations/health/detail` endpoint to `services/reservations` that returns a JSON object with `{ status: 'ok' | 'degraded', db: boolean, uptime: number }`. `db` must be the result of a lightweight `SELECT 1` via Prisma. Return HTTP 200 when healthy, 503 when degraded. Add integration tests that stub Prisma and assert both the healthy and degraded responses.",
+  "fixtureRef": "services/reservations",
+  "rubric": {
+    "testsMustPass": true,
+    "typecheckMustPass": true,
+    "lintMustPass": false,
+    "judgeCriteria": [
+      "The endpoint exists at the specified path and method",
+      "Response shape matches `{ status, db, uptime }` with correct types",
+      "Returns 503 when the Prisma query throws",
+      "Integration tests cover both the healthy and degraded paths"
+    ]
+  },
+  "budget": {
+    "maxTurns": 40,
+    "maxCostUsd": 1.0
+  }
+}

--- a/packages/agent-core/eval-suite/refactor-extract-helper.json
+++ b/packages/agent-core/eval-suite/refactor-extract-helper.json
@@ -1,0 +1,20 @@
+{
+  "id": "refactor-extract-helper",
+  "category": "refactor",
+  "prompt": "The `buildPrBody` function in `services/agent/src/routes/sessions.ts` has grown past 80 lines and mixes title-formatting, body-formatting, and label-lookup logic. Extract the label-lookup into a standalone pure function `resolveLabels(issue)` in the same file, add a unit test for it, and verify the existing tests still pass.",
+  "fixtureRef": "services/agent",
+  "rubric": {
+    "testsMustPass": true,
+    "typecheckMustPass": true,
+    "lintMustPass": false,
+    "judgeCriteria": [
+      "A pure `resolveLabels` function is extracted and exported",
+      "`buildPrBody` delegates to `resolveLabels` rather than inlining the logic",
+      "A unit test for `resolveLabels` is added covering at least the happy path and an empty-labels case"
+    ]
+  },
+  "budget": {
+    "maxTurns": 30,
+    "maxCostUsd": 0.75
+  }
+}

--- a/packages/agent-core/eval-suite/test-writing-circuit-breaker.json
+++ b/packages/agent-core/eval-suite/test-writing-circuit-breaker.json
@@ -1,0 +1,20 @@
+{
+  "id": "test-writing-circuit-breaker",
+  "category": "test-writing",
+  "prompt": "The `CircuitBreaker` class in `packages/agent-core/src/circuit-breaker.ts` has no unit tests. Write a test file `packages/agent-core/src/circuit-breaker.test.ts` that covers: (1) breaker starts CLOSED, (2) trips OPEN after reaching the failure threshold, (3) moves to HALF_OPEN after the reset timeout, (4) closes again on a successful call in HALF_OPEN state, and (5) re-opens on a failed call in HALF_OPEN state. Use vitest and fake timers for timeout tests.",
+  "fixtureRef": "packages/agent-core",
+  "rubric": {
+    "testsMustPass": true,
+    "typecheckMustPass": true,
+    "lintMustPass": false,
+    "judgeCriteria": [
+      "All five state-transition scenarios have at least one test case",
+      "Fake timers are used rather than real `setTimeout` / `sleep` calls",
+      "No new production code is added — only the test file"
+    ]
+  },
+  "budget": {
+    "maxTurns": 30,
+    "maxCostUsd": 0.75
+  }
+}

--- a/packages/agent-core/src/eval/eval-harness.test.ts
+++ b/packages/agent-core/src/eval/eval-harness.test.ts
@@ -112,6 +112,7 @@ describe("runEvalSuite", () => {
       meanCostUsd: 0,
       meanTurns: 0,
       stuckCount: 0,
+      byCategory: {},
     });
   });
 
@@ -126,5 +127,32 @@ describe("runEvalSuite", () => {
     });
     expect(report.aggregate.meanCostUsd).toBeCloseTo(0.3);
     expect(report.aggregate.meanTurns).toBe(6);
+  });
+
+  it("breaks down pass rate by category in aggregate.byCategory", async () => {
+    const tasks = [
+      makeTask("a", { category: "bugfix" }),
+      makeTask("b", { category: "bugfix" }),
+      makeTask("c", { category: "refactor" }),
+    ];
+    const report = await runEvalSuite(tasks, {
+      runId: "r",
+      runTask: runnerFrom({
+        a: { checks: PASS },
+        b: { checks: FAIL },
+        c: { checks: PASS },
+      }),
+    });
+
+    const byCategory = report.aggregate.byCategory;
+    expect(byCategory["bugfix"]).toEqual({ total: 2, passRate: 0.5 });
+    expect(byCategory["refactor"]).toEqual({ total: 1, passRate: 1 });
+    // categories not in the suite should not appear
+    expect(byCategory["dep-bump"]).toBeUndefined();
+  });
+
+  it("byCategory is empty object for empty suite", async () => {
+    const report = await runEvalSuite([], { runId: "r", runTask: runnerFrom({}) });
+    expect(report.aggregate.byCategory).toEqual({});
   });
 });

--- a/packages/agent-core/src/eval/eval-harness.ts
+++ b/packages/agent-core/src/eval/eval-harness.ts
@@ -1,4 +1,11 @@
-import type { EvalAggregate, EvalReport, Task, TaskRunner, TaskScore } from "./types.js";
+import type {
+  CategoryStats,
+  EvalAggregate,
+  EvalReport,
+  Task,
+  TaskRunner,
+  TaskScore,
+} from "./types.js";
 import { scoreTask } from "./task-scorer.js";
 
 export interface RunEvalSuiteOptions {
@@ -56,7 +63,15 @@ function failedScore(task: Task, err: unknown): TaskScore {
 function aggregate(scores: readonly TaskScore[]): EvalAggregate {
   const total = scores.length;
   if (total === 0) {
-    return { total: 0, passRate: 0, meanScore: 0, meanCostUsd: 0, meanTurns: 0, stuckCount: 0 };
+    return {
+      total: 0,
+      passRate: 0,
+      meanScore: 0,
+      meanCostUsd: 0,
+      meanTurns: 0,
+      stuckCount: 0,
+      byCategory: {},
+    };
   }
   const sum = (pick: (s: TaskScore) => number): number =>
     scores.reduce((acc, s) => acc + pick(s), 0);
@@ -69,5 +84,19 @@ function aggregate(scores: readonly TaskScore[]): EvalAggregate {
     // Tasks that failed to complete (crashed mid-run) — a proxy for "stuck"
     // until session stuckPattern is propagated in a later slice.
     stuckCount: scores.filter((s) => s.error !== undefined).length,
+    byCategory: aggregateByCategory(scores),
   };
+}
+
+function aggregateByCategory(scores: readonly TaskScore[]): Record<string, CategoryStats> {
+  const groups = new Map<string, { passed: number; total: number }>();
+  for (const s of scores) {
+    const prev = groups.get(s.category) ?? { passed: 0, total: 0 };
+    groups.set(s.category, { passed: prev.passed + (s.passed ? 1 : 0), total: prev.total + 1 });
+  }
+  const result: Record<string, CategoryStats> = {};
+  for (const [cat, { passed, total }] of groups) {
+    result[cat] = { total, passRate: passed / total };
+  }
+  return result;
 }

--- a/packages/agent-core/src/eval/types.ts
+++ b/packages/agent-core/src/eval/types.ts
@@ -90,6 +90,11 @@ export interface TaskScore {
   readonly error?: string;
 }
 
+export interface CategoryStats {
+  readonly total: number;
+  readonly passRate: number;
+}
+
 export interface EvalAggregate {
   readonly total: number;
   readonly passRate: number;
@@ -97,6 +102,8 @@ export interface EvalAggregate {
   readonly meanCostUsd: number;
   readonly meanTurns: number;
   readonly stuckCount: number;
+  /** Per-category pass rate, keyed by {@link TaskCategory}. Only categories present in the run appear. */
+  readonly byCategory: Readonly<Record<string, CategoryStats>>;
 }
 
 export interface EvalReport {

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -332,6 +332,7 @@ export type {
   TaskRunResult,
   TaskScore,
   TaskRunner,
+  CategoryStats,
   EvalAggregate,
   EvalReport,
 } from "./eval/types.js";

--- a/tools/cli/src/commands/agent-eval.ts
+++ b/tools/cli/src/commands/agent-eval.ts
@@ -156,4 +156,16 @@ function printReport(report: EvalReport): void {
   console.log(`Mean cost:   $${a.meanCostUsd.toFixed(2)}`);
   console.log(`Mean turns:  ${a.meanTurns.toFixed(1)}`);
   console.log(`Failed to complete: ${a.stuckCount}`);
+
+  const categories = Object.keys(a.byCategory).sort();
+  if (categories.length > 0) {
+    console.log("");
+    console.log("By category:");
+    for (const cat of categories) {
+      const stats = a.byCategory[cat];
+      console.log(
+        `  ${cat}: ${(stats.passRate * 100).toFixed(1)}% (${stats.total} task${stats.total === 1 ? "" : "s"})`
+      );
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Expands the eval suite from 1 seed task to 5, covering all `TaskCategory` values: `bugfix` (existing), `refactor`, `new-route`, `dep-bump`, `test-writing`
- Adds `byCategory: Record<string, CategoryStats>` to `EvalAggregate` so `mbe agent eval` reports per-category pass rates
- Updates `printReport` in `agent-eval.ts` to display the per-category breakdown
- Adds contributor docs at `docs/agents/golden-task-authoring.md` explaining fixture shape, rubric fields, scoring, and the authoring checklist

## Test plan

- [ ] `pnpm --dir packages/agent-core test` — 1139 tests pass including 2 new `byCategory` tests
- [ ] `pnpm --dir tools/cli test` — 385 tests pass
- [ ] `pnpm --dir packages/agent-core typecheck` — clean
- [ ] `pnpm --dir tools/cli typecheck` — clean (requires `agent-core` built first)
- [ ] `pnpm --filter @mbe/cli start check-adr` — no violations
- [ ] `pnpm --filter @mbe/cli start check-deps` — no mismatches
- [ ] `node scripts/detect-instruction-rot.mjs` — no rot detected

Closes #1948