### PR TITLE
test(agent-core): characterization tests for task-signal-registry and cli-adapter

### DIFF
--- a/packages/agent-core/src/__tests__/cli-adapter.test.ts
+++ b/packages/agent-core/src/__tests__/cli-adapter.test.ts
@@ -1,0 +1,396 @@
+/**
+ * Characterization tests for cli-adapter.ts (interface contract) and the
+ * concrete adapters that implement AgentAdapter.
+ *
+ * Tests pin:
+ *  - AdapterConfig / AdapterResult shape via usage in concrete implementations
+ *  - Each supported adapter's name and command/args construction
+ *  - ClaudeAdapter availability logic (env-var gated)
+ *  - Unknown-adapter / all-unavailable error path via FailoverRouter
+ *
+ * No real CLIs are spawned — child_process is mocked.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock child_process before any adapter imports
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+// Mock session-runner (used by ClaudeAdapter.run) to avoid pulling in the full SDK
+vi.mock("../session-runner.js", () => ({
+  runSession: vi.fn(),
+}));
+
+import { execFile } from "node:child_process";
+import type { AgentAdapter, AdapterConfig, AdapterResult } from "../cli-adapter.js";
+import { GeminiCliAdapter } from "../adapters/gemini-adapter.js";
+import { OpenCodeAdapter } from "../adapters/opencode-adapter.js";
+import { ClaudeAdapter } from "../adapters/claude-adapter.js";
+import { FailoverRouter, AllAdaptersUnavailableError } from "../failover-router.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+type ExecFileCallback = (err: Error | null, result: { stdout: string; stderr: string }) => void;
+
+function setupExecFileMock(
+  responses: Record<string, { stdout?: string; stderr?: string; error?: boolean }[]>
+) {
+  const callCounts: Record<string, number> = {};
+
+  vi.mocked(execFile).mockImplementation(((...args: unknown[]) => {
+    const cmd = args[0] as string;
+    const cmdArgs = args[1] as string[];
+    const callback = args[args.length - 1] as ExecFileCallback;
+
+    let key = cmd;
+    if (cmd === "git" && cmdArgs) {
+      const subcommand = cmdArgs.find((a) => a !== "-C" && !a.startsWith("/"));
+      if (subcommand) key = `git-${subcommand}`;
+    }
+
+    callCounts[key] = (callCounts[key] ?? 0) + 1;
+    const responseList = responses[key] ?? [{ stdout: "", stderr: "" }];
+    const idx = Math.min(callCounts[key] - 1, responseList.length - 1);
+    const response = responseList[idx];
+
+    if (response.error) {
+      const err = new Error("command failed") as Error & { stdout: string; stderr: string };
+      err.stdout = response.stdout ?? "";
+      err.stderr = response.stderr ?? "";
+      callback(err, { stdout: "", stderr: "" });
+    } else {
+      callback(null, { stdout: response.stdout ?? "", stderr: response.stderr ?? "" });
+    }
+
+    return {} as ReturnType<typeof execFile>;
+  }) as typeof execFile);
+}
+
+function makeConfig(overrides: Partial<AdapterConfig> = {}): AdapterConfig {
+  return {
+    taskDescription: "Fix the auth bug",
+    worktreePath: "/tmp/worktree-test",
+    repoPath: "/tmp/repo",
+    baseBranch: "main",
+    ...overrides,
+  };
+}
+
+function makeResult(overrides: Partial<AdapterResult> = {}): AdapterResult {
+  return {
+    success: true,
+    hasChanges: false,
+    rateLimited: false,
+    durationMs: 42,
+    ...overrides,
+  };
+}
+
+// ── AgentAdapter interface contract ───────────────────────────────────
+
+describe("AgentAdapter interface — contract shape", () => {
+  it("GeminiCliAdapter satisfies AgentAdapter", () => {
+    const adapter: AgentAdapter = new GeminiCliAdapter();
+    expect(typeof adapter.name).toBe("string");
+    expect(typeof adapter.isAvailable).toBe("function");
+    expect(typeof adapter.run).toBe("function");
+  });
+
+  it("OpenCodeAdapter satisfies AgentAdapter", () => {
+    const adapter: AgentAdapter = new OpenCodeAdapter();
+    expect(typeof adapter.name).toBe("string");
+    expect(typeof adapter.isAvailable).toBe("function");
+    expect(typeof adapter.run).toBe("function");
+  });
+
+  it("ClaudeAdapter satisfies AgentAdapter", () => {
+    const adapter: AgentAdapter = new ClaudeAdapter();
+    expect(typeof adapter.name).toBe("string");
+    expect(typeof adapter.isAvailable).toBe("function");
+    expect(typeof adapter.run).toBe("function");
+  });
+});
+
+// ── AdapterResult shape ───────────────────────────────────────────────
+
+describe("AdapterResult — shape from concrete adapter", () => {
+  let adapter: GeminiCliAdapter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adapter = new GeminiCliAdapter();
+  });
+
+  it("result has all required fields: success, hasChanges, rateLimited, durationMs", async () => {
+    setupExecFileMock({
+      gemini: [{ stdout: "done" }],
+      "git-status": [{ stdout: "" }],
+    });
+
+    const result = await adapter.run(makeConfig());
+
+    expect(result).toMatchObject({
+      success: expect.any(Boolean),
+      hasChanges: expect.any(Boolean),
+      rateLimited: expect.any(Boolean),
+      durationMs: expect.any(Number),
+    } satisfies Record<keyof AdapterResult, unknown>);
+  });
+
+  it("result.error is undefined on success", async () => {
+    setupExecFileMock({
+      gemini: [{ stdout: "done" }],
+      "git-status": [{ stdout: "" }],
+    });
+
+    const result = await adapter.run(makeConfig());
+    expect(result.error).toBeUndefined();
+  });
+
+  it("result.error is a string on failure", async () => {
+    setupExecFileMock({
+      gemini: [{ error: true, stderr: "gemini crashed" }],
+      "git-status": [{ stdout: "" }],
+    });
+
+    const result = await adapter.run(makeConfig());
+    expect(result.error).toBeTypeOf("string");
+  });
+});
+
+// ── Adapter selection — names ─────────────────────────────────────────
+
+describe("adapter names (selection keys)", () => {
+  it("GeminiCliAdapter.name === 'gemini'", () => {
+    expect(new GeminiCliAdapter().name).toBe("gemini");
+  });
+
+  it("OpenCodeAdapter.name === 'opencode'", () => {
+    expect(new OpenCodeAdapter().name).toBe("opencode");
+  });
+
+  it("ClaudeAdapter.name === 'claude'", () => {
+    expect(new ClaudeAdapter().name).toBe("claude");
+  });
+});
+
+// ── GeminiCliAdapter — argument construction ──────────────────────────
+
+describe("GeminiCliAdapter — argument construction", () => {
+  let adapter: GeminiCliAdapter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adapter = new GeminiCliAdapter();
+  });
+
+  it("constructs args as [-p, taskDescription, --yolo]", async () => {
+    setupExecFileMock({
+      gemini: [{ stdout: "" }],
+      "git-status": [{ stdout: "" }],
+    });
+
+    await adapter.run(makeConfig({ taskDescription: "add feature X" }));
+
+    const call = vi.mocked(execFile).mock.calls.find((c) => c[0] === "gemini");
+    expect(call).toBeDefined();
+    expect(call![1]).toEqual(["-p", "add feature X", "--yolo"]);
+  });
+
+  it("invokes 'gemini' binary", async () => {
+    setupExecFileMock({
+      gemini: [{ stdout: "" }],
+      "git-status": [{ stdout: "" }],
+    });
+
+    await adapter.run(makeConfig());
+
+    const call = vi.mocked(execFile).mock.calls.find((c) => c[0] === "gemini");
+    expect(call).toBeDefined();
+    expect(call![0]).toBe("gemini");
+  });
+
+  it("passes worktreePath as cwd", async () => {
+    setupExecFileMock({
+      gemini: [{ stdout: "" }],
+      "git-status": [{ stdout: "" }],
+    });
+
+    await adapter.run(makeConfig({ worktreePath: "/tmp/my-worktree" }));
+
+    const call = vi.mocked(execFile).mock.calls.find((c) => c[0] === "gemini");
+    expect(call![2]).toMatchObject({ cwd: "/tmp/my-worktree" });
+  });
+
+  it("checks availability via 'which gemini'", async () => {
+    setupExecFileMock({ which: [{ stdout: "/usr/bin/gemini" }] });
+    const available = await adapter.isAvailable();
+    expect(available).toBe(true);
+    expect(execFile).toHaveBeenCalledWith("which", ["gemini"], expect.any(Function));
+  });
+});
+
+// ── OpenCodeAdapter — argument construction ───────────────────────────
+
+describe("OpenCodeAdapter — argument construction", () => {
+  let adapter: OpenCodeAdapter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adapter = new OpenCodeAdapter();
+  });
+
+  it("constructs args as [run, taskDescription]", async () => {
+    setupExecFileMock({
+      opencode: [{ stdout: "" }],
+      "git-status": [{ stdout: "" }],
+    });
+
+    await adapter.run(makeConfig({ taskDescription: "refactor auth module" }));
+
+    const call = vi.mocked(execFile).mock.calls.find((c) => c[0] === "opencode");
+    expect(call).toBeDefined();
+    expect(call![1]).toEqual(["run", "refactor auth module"]);
+  });
+
+  it("invokes 'opencode' binary", async () => {
+    setupExecFileMock({
+      opencode: [{ stdout: "" }],
+      "git-status": [{ stdout: "" }],
+    });
+
+    await adapter.run(makeConfig());
+
+    const call = vi.mocked(execFile).mock.calls.find((c) => c[0] === "opencode");
+    expect(call).toBeDefined();
+    expect(call![0]).toBe("opencode");
+  });
+
+  it("passes worktreePath as cwd", async () => {
+    setupExecFileMock({
+      opencode: [{ stdout: "" }],
+      "git-status": [{ stdout: "" }],
+    });
+
+    await adapter.run(makeConfig({ worktreePath: "/tmp/opencode-tree" }));
+
+    const call = vi.mocked(execFile).mock.calls.find((c) => c[0] === "opencode");
+    expect(call![2]).toMatchObject({ cwd: "/tmp/opencode-tree" });
+  });
+
+  it("checks availability via 'which opencode'", async () => {
+    setupExecFileMock({ which: [{ stdout: "/usr/bin/opencode" }] });
+    const available = await adapter.isAvailable();
+    expect(available).toBe(true);
+    expect(execFile).toHaveBeenCalledWith("which", ["opencode"], expect.any(Function));
+  });
+});
+
+// ── ClaudeAdapter — availability ──────────────────────────────────────
+
+describe("ClaudeAdapter — availability", () => {
+  const ORIGINAL_KEY = process.env["ANTHROPIC_API_KEY"];
+
+  afterEach(() => {
+    if (ORIGINAL_KEY === undefined) {
+      delete process.env["ANTHROPIC_API_KEY"];
+    } else {
+      process.env["ANTHROPIC_API_KEY"] = ORIGINAL_KEY;
+    }
+  });
+
+  it("isAvailable returns true when ANTHROPIC_API_KEY is set", async () => {
+    process.env["ANTHROPIC_API_KEY"] = "sk-ant-test-key";
+    const adapter = new ClaudeAdapter();
+    expect(await adapter.isAvailable()).toBe(true);
+  });
+
+  it("isAvailable returns false when ANTHROPIC_API_KEY is missing", async () => {
+    delete process.env["ANTHROPIC_API_KEY"];
+    const adapter = new ClaudeAdapter();
+    expect(await adapter.isAvailable()).toBe(false);
+  });
+
+  it("isAvailable returns false when ANTHROPIC_API_KEY is empty string", async () => {
+    process.env["ANTHROPIC_API_KEY"] = "";
+    const adapter = new ClaudeAdapter();
+    expect(await adapter.isAvailable()).toBe(false);
+  });
+});
+
+// ── Unknown adapter / all-unavailable error path ──────────────────────
+
+describe("unknown adapter / all adapters unavailable — error path", () => {
+  it("FailoverRouter throws AllAdaptersUnavailableError when all adapters unavailable", async () => {
+    const unavailableAdapter: AgentAdapter = {
+      name: "unavailable-adapter",
+      isAvailable: vi.fn().mockResolvedValue(false),
+      run: vi.fn().mockResolvedValue(makeResult()),
+    };
+
+    const router = new FailoverRouter([unavailableAdapter]);
+
+    await expect(router.route(makeConfig())).rejects.toThrow(AllAdaptersUnavailableError);
+  });
+
+  it("AllAdaptersUnavailableError is an Error subclass", async () => {
+    const unavailableAdapter: AgentAdapter = {
+      name: "gone",
+      isAvailable: vi.fn().mockResolvedValue(false),
+      run: vi.fn().mockResolvedValue(makeResult()),
+    };
+
+    const router = new FailoverRouter([unavailableAdapter]);
+
+    let caught: unknown;
+    try {
+      await router.route(makeConfig());
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught).toBeInstanceOf(AllAdaptersUnavailableError);
+  });
+
+  it("FailoverRouter routes to the first available adapter when multiple are configured", async () => {
+    const first: AgentAdapter = {
+      name: "first",
+      isAvailable: vi.fn().mockResolvedValue(true),
+      run: vi.fn().mockResolvedValue(makeResult({ success: true })),
+    };
+    const second: AgentAdapter = {
+      name: "second",
+      isAvailable: vi.fn().mockResolvedValue(true),
+      run: vi.fn().mockResolvedValue(makeResult({ success: true })),
+    };
+
+    const router = new FailoverRouter([first, second]);
+    await router.route(makeConfig());
+
+    // First adapter should be used; second should not be called
+    expect(first.run).toHaveBeenCalledOnce();
+    expect(second.run).not.toHaveBeenCalled();
+  });
+
+  it("FailoverRouter falls over to next adapter when first is unavailable", async () => {
+    const unavailable: AgentAdapter = {
+      name: "unavailable",
+      isAvailable: vi.fn().mockResolvedValue(false),
+      run: vi.fn(),
+    };
+    const available: AgentAdapter = {
+      name: "available",
+      isAvailable: vi.fn().mockResolvedValue(true),
+      run: vi.fn().mockResolvedValue(makeResult({ success: true })),
+    };
+
+    const router = new FailoverRouter([unavailable, available]);
+    await router.route(makeConfig());
+
+    expect(unavailable.run).not.toHaveBeenCalled();
+    expect(available.run).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/agent-core/src/__tests__/task-signal-registry.test.ts
+++ b/packages/agent-core/src/__tests__/task-signal-registry.test.ts
@@ -1,0 +1,330 @@
+import { describe, it, expect } from "vitest";
+import { classifyTask } from "../task-signal-registry.js";
+import type { TaskTier, TaskDomain, TaskSignals } from "../task-signal-registry.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function tier(description: string, titlePrefix?: string): TaskTier {
+  return classifyTask(description, titlePrefix).tier;
+}
+
+function domains(description: string, titlePrefix?: string): readonly TaskDomain[] {
+  return classifyTask(description, titlePrefix).domains;
+}
+
+function bundles(description: string, titlePrefix?: string): readonly string[] {
+  return classifyTask(description, titlePrefix).contextBundles;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("classifyTask — tier classification", () => {
+  // ── trivial (title-prefix signals) ─────────────────────────────────
+
+  describe("trivial tier — matching title prefix", () => {
+    it("chore(deps): prefix → trivial", () => {
+      expect(tier("bump lodash from 4.17.20 to 4.17.21", "chore(deps): ")).toBe("trivial");
+    });
+
+    it("chore(deps-dev): prefix → trivial", () => {
+      expect(tier("bump typescript to 5.4", "chore(deps-dev): ")).toBe("trivial");
+    });
+
+    it("fix(security): prefix → trivial", () => {
+      expect(tier("patch CVE-2024-1234 in axios", "fix(security): ")).toBe("trivial");
+    });
+
+    it("docs: prefix → trivial", () => {
+      expect(tier("update README", "docs: ")).toBe("trivial");
+    });
+
+    it("test: prefix → trivial", () => {
+      expect(tier("add unit tests for auth module", "test: ")).toBe("trivial");
+    });
+
+    it("chore(lint): prefix → trivial", () => {
+      expect(tier("fix lint warnings", "chore(lint): ")).toBe("trivial");
+    });
+
+    it("chore(style): prefix → trivial", () => {
+      expect(tier("reformat files", "chore(style): ")).toBe("trivial");
+    });
+
+    it("non-matching title prefix → not trivial (falls through to description-based)", () => {
+      // Unrecognized prefix — tier falls through to classifyTier(description)
+      expect(tier("bump a package", "random-prefix: ")).not.toBe("trivial");
+    });
+
+    it("trivial tier takes priority over complex description", () => {
+      // Even if the description would be classified complex, the title prefix wins
+      expect(tier("architect a new multi-service infrastructure migration", "chore(deps): ")).toBe(
+        "trivial"
+      );
+    });
+  });
+
+  // ── complex tier ───────────────────────────────────────────────────
+
+  describe("complex tier — description keywords", () => {
+    const complexCases: string[] = [
+      "feat: add new payment system",
+      "implement oauth2 flow",
+      "design the new database schema",
+      "architect the messaging layer",
+      "new service for notifications",
+      "migration from REST to GraphQL",
+      "architecture review needed",
+      "refactor the auth module",
+      "design system overhaul",
+      "infrastructure changes",
+      "breaking change to the API",
+      "api design for v2 endpoints",
+      "system design document",
+      "schema change for users table",
+      "multi-service coordination",
+      "cross-cutting concern: logging",
+    ];
+
+    for (const description of complexCases) {
+      it(`"${description}" → complex`, () => {
+        expect(tier(description)).toBe("complex");
+      });
+    }
+  });
+
+  // ── simple tier ────────────────────────────────────────────────────
+
+  describe("simple tier — description keywords", () => {
+    const simpleCases: string[] = [
+      "fix lint errors",
+      "fix typo in README",
+      "rename the helper function",
+      "bump version to 2.0.0",
+      "update dep to latest",
+      "fix import path",
+    ];
+
+    for (const description of simpleCases) {
+      it(`"${description}" → simple`, () => {
+        expect(tier(description)).toBe("simple");
+      });
+    }
+  });
+
+  // ── standard tier (default) ────────────────────────────────────────
+
+  describe("standard tier — no signals match", () => {
+    it("generic description with no keywords → standard", () => {
+      expect(tier("update the user profile page")).toBe("standard");
+    });
+
+    it("empty description → standard", () => {
+      expect(tier("")).toBe("standard");
+    });
+
+    it("description with no tier signals → standard", () => {
+      expect(tier("add tooltip to the button component")).toBe("standard");
+    });
+  });
+
+  // ── priority ordering ──────────────────────────────────────────────
+
+  describe("tier priority: complex > simple > standard", () => {
+    it("description matching both complex and simple patterns → complex wins", () => {
+      // 'feat' (complex) + 'bump' (simple) in same description
+      expect(tier("feat: bump the API version to add new endpoints")).toBe("complex");
+    });
+  });
+});
+
+// ── Domain classification ─────────────────────────────────────────────
+
+describe("classifyTask — domain classification", () => {
+  describe("dependency domain", () => {
+    it("'depend' keyword → dependency domain", () => {
+      expect(domains("update npm dependencies")).toContain("dependency");
+    });
+
+    it("'bump' keyword → dependency domain", () => {
+      expect(domains("bump lodash to latest")).toContain("dependency");
+    });
+
+    it("'upgrade' keyword → dependency domain", () => {
+      expect(domains("upgrade react to v19")).toContain("dependency");
+    });
+
+    it("'update dep' phrase → dependency domain", () => {
+      expect(domains("update dep axios to 1.7.0")).toContain("dependency");
+    });
+  });
+
+  describe("deploy domain", () => {
+    it("'deploy' keyword → deploy domain", () => {
+      expect(domains("deploy the marketing site")).toContain("deploy");
+    });
+
+    it("'wrangler' keyword → deploy domain", () => {
+      expect(domains("fix wrangler config")).toContain("deploy");
+    });
+
+    it("'digitalocean' keyword → deploy domain", () => {
+      expect(domains("configure digitalocean app spec")).toContain("deploy");
+    });
+
+    it("'doctl' keyword → deploy domain", () => {
+      expect(domains("run doctl deployment")).toContain("deploy");
+    });
+  });
+
+  describe("security domain", () => {
+    it("'security' keyword → security domain", () => {
+      expect(domains("security vulnerability in auth")).toContain("security");
+    });
+
+    it("'audit' keyword → security domain", () => {
+      expect(domains("run a dependency audit")).toContain("security");
+    });
+
+    it("'auth' keyword → security domain", () => {
+      expect(domains("fix auth session handling")).toContain("security");
+    });
+
+    it("'authorization' keyword → security domain", () => {
+      expect(domains("add authorization middleware")).toContain("security");
+    });
+  });
+
+  describe("test domain", () => {
+    it("'test' keyword → test domain", () => {
+      expect(domains("write test coverage for login")).toContain("test");
+    });
+
+    it("'vitest' keyword → test domain", () => {
+      expect(domains("configure vitest for the package")).toContain("test");
+    });
+
+    it("'mock' keyword → test domain", () => {
+      expect(domains("mock the stripe API in tests")).toContain("test");
+    });
+  });
+
+  describe("title-prefix domain contributions", () => {
+    it("chore(deps): prefix → adds dependency domain", () => {
+      expect(domains("bump lodash", "chore(deps): ")).toContain("dependency");
+    });
+
+    it("fix(security): prefix → adds security domain", () => {
+      expect(domains("patch CVE", "fix(security): ")).toContain("security");
+    });
+
+    it("docs: prefix → adds docs domain", () => {
+      expect(domains("update README", "docs: ")).toContain("docs");
+    });
+
+    it("test: prefix → adds test domain", () => {
+      expect(domains("add coverage", "test: ")).toContain("test");
+    });
+
+    it("chore(lint): prefix → no extra domain (lint-only signal)", () => {
+      // chore(lint) is trivial but carries no domain
+      const result = domains("fix lint warnings", "chore(lint): ");
+      expect(result).not.toContain("dependency");
+      expect(result).not.toContain("security");
+    });
+  });
+
+  describe("multiple domains from one description", () => {
+    it("description with both deploy and security keywords → both domains", () => {
+      const result = domains("deploy auth service with security audit");
+      expect(result).toContain("deploy");
+      expect(result).toContain("security");
+    });
+
+    it("no matching keywords → empty domains array", () => {
+      expect(domains("update the color scheme")).toHaveLength(0);
+    });
+  });
+});
+
+// ── Context bundle classification ─────────────────────────────────────
+
+describe("classifyTask — contextBundles", () => {
+  it("dependency domain → dependency-bump.md bundle", () => {
+    expect(bundles("bump lodash to latest")).toContain(".agent/contexts/dependency-bump.md");
+  });
+
+  it("deploy domain → deploy-fixes.md bundle", () => {
+    expect(bundles("deploy the marketing site")).toContain(".agent/contexts/deploy-fixes.md");
+  });
+
+  it("security domain → security-audit.md bundle", () => {
+    expect(bundles("fix auth vulnerability")).toContain(".agent/contexts/security-audit.md");
+  });
+
+  it("test domain → testing-patterns.md bundle", () => {
+    expect(bundles("write test coverage")).toContain(".agent/contexts/testing-patterns.md");
+  });
+
+  it("type/typescript keywords → type-safety.md bundle", () => {
+    expect(bundles("fix TypeScript any types")).toContain(".agent/contexts/type-safety.md");
+  });
+
+  it("'type' keyword → type-safety.md bundle", () => {
+    expect(bundles("resolve type inference issue")).toContain(".agent/contexts/type-safety.md");
+  });
+
+  it("'any' keyword → type-safety.md bundle", () => {
+    expect(bundles("replace any with proper types")).toContain(".agent/contexts/type-safety.md");
+  });
+
+  it("description with no matching keywords → no bundles", () => {
+    expect(bundles("update the homepage color scheme")).toHaveLength(0);
+  });
+
+  it("multiple domains → multiple bundles, deduplicated", () => {
+    const result = bundles("deploy auth service with security audit");
+    expect(result).toContain(".agent/contexts/deploy-fixes.md");
+    expect(result).toContain(".agent/contexts/security-audit.md");
+    // Deduplication — no repeats
+    const unique = new Set(result);
+    expect(unique.size).toBe(result.length);
+  });
+});
+
+// ── Return shape ──────────────────────────────────────────────────────
+
+describe("classifyTask — return shape", () => {
+  it("returns a frozen object", () => {
+    const result = classifyTask("update auth");
+    expect(Object.isFrozen(result)).toBe(true);
+  });
+
+  it("domains array is frozen", () => {
+    const result = classifyTask("update auth");
+    expect(Object.isFrozen(result.domains)).toBe(true);
+  });
+
+  it("contextBundles array is frozen", () => {
+    const result = classifyTask("update auth");
+    expect(Object.isFrozen(result.contextBundles)).toBe(true);
+  });
+
+  it("always has tier, domains, contextBundles properties", () => {
+    const result: TaskSignals = classifyTask("some task");
+    expect(result).toHaveProperty("tier");
+    expect(result).toHaveProperty("domains");
+    expect(result).toHaveProperty("contextBundles");
+  });
+
+  it("is pure — same input returns same output", () => {
+    const a = classifyTask("fix auth security issue");
+    const b = classifyTask("fix auth security issue");
+    expect(a.tier).toBe(b.tier);
+    expect([...a.domains]).toEqual([...b.domains]);
+    expect([...a.contextBundles]).toEqual([...b.contextBundles]);
+  });
+
+  it("titlePrefix is optional — omitting it does not throw", () => {
+    expect(() => classifyTask("some task")).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/__tests__/task-signal-registry.test.ts`: 60 characterization tests pinning the `classifyTask()` pure function — tier classification (trivial/complex/simple/standard), domain classification (dependency/deploy/security/test/docs), context bundle assignment, title-prefix domain contributions, priority ordering, and immutable return shape
- Adds `src/__tests__/cli-adapter.test.ts`: 24 characterization tests pinning the `AgentAdapter` interface contract — adapter names (claude/gemini/opencode), GeminiCliAdapter and OpenCodeAdapter command/args construction, ClaudeAdapter env-var availability gating, and the `AllAdaptersUnavailableError` path when all adapters are unavailable
- No real CLIs are spawned; `node:child_process` and `session-runner` are fully mocked

## Gate results

- `pnpm --dir packages/agent-core test`: new tests 84/84 pass; pre-existing 4 failures in gate-runner and worktree-phase are timeout flakes unrelated to this change (present on main before this PR)
- `pnpm --dir packages/agent-core typecheck`: clean
- `pnpm --dir packages/agent-core lint`: clean
- `pnpm --filter @mbe/cli start check-adr`: no violations
- `pnpm --filter @mbe/cli start check-deps`: no violations
- `node scripts/detect-instruction-rot.mjs`: no rot detected

## Test plan

- [ ] Verify `pnpm --dir packages/agent-core test` shows the two new test files passing (task-signal-registry: 70 tests, cli-adapter: 24 tests)
- [ ] Verify no real CLI processes are spawned during test run

Closes #2107