### PR TITLE
refactor(hospitality): extract SseClient from useSSESync — separate transport from domain

### DIFF
--- a/apps/hospitality/llms-full.txt
+++ b/apps/hospitality/llms-full.txt
@@ -374,6 +374,27 @@
     export const VENUE_BY_SLUG_QUERY_KEY = "venueBySlug" as const;
   </file>
   </section>
+  <section priority="medium" role="lib">
+  <file path="src/lib/sse-client.ts">
+    export type EventSourceFactory = (url: string) => EventSource;
+    export interface SseClientOptions {
+      /** Base URL for the SSE stream (query params appended by SseClient). */
+      url: string;
+      /** Named event types to listen for (e.g. "reservation:created"). */
+      eventTypes: readonly string[];
+      /** Called with a parsed event payload on each successfully parsed message. */
+      onEvent: (type: string, payload: unknown) => void;
+      /** Called when a parse error occurs or the connection errors. */
+      onError: (error: Error) => void;
+      /** Called when the EventSource opens successfully. */
+      onConnected?: () => void;
+      /** Called when the EventSource closes due to an error. */
+      onDisconnected?: () => void;
+      /** Injectable factory — defaults to `(url) => new EventSource(url)`. */
+      eventSourceFactory?: EventSourceFactory;
+    }
+  </file>
+  </section>
   <section priority="medium" role="src">
   <file path="src/nav-sections.ts">
     export interface NavItem {

--- a/apps/hospitality/llms.txt
+++ b/apps/hospitality/llms.txt
@@ -284,6 +284,22 @@
     </item>
   </file>
   </section>
+  <section priority="medium" role="lib">
+  <file path="src/lib/sse-client.ts">
+    <item priority="low">
+      type EventSourceFactory = (url: string) => EventSource;
+    </item>
+    <item priority="low">
+      interface SseClientOptions {
+        url: string;
+        eventTypes: readonly string[];
+        onEvent: (type: string, payload: unknown) => void;
+        onError: (error: Error) => void;
+        onConnected?: () => void;
+      }
+    </item>
+  </file>
+  </section>
   <section priority="medium" role="src">
   <file path="src/nav-sections.ts">
     <item priority="low">

--- a/apps/hospitality/src/hooks/useSSESync.tsx
+++ b/apps/hospitality/src/hooks/useSSESync.tsx
@@ -5,6 +5,8 @@
  * connection-status, and event feed. Replaces the former useReservationEvents +
  * useReservationQuerySync + useSSEStatus + useSSEEventFeed split.
  *
+ * Transport (backoff, resumption, parse-error surfacing) is delegated to SseClient.
+ *
  * Usage:
  *   // In DashboardLayout — mount once per app session:
  *   <SSESyncProvider>...</SSESyncProvider>
@@ -26,7 +28,6 @@ import {
   useMemo,
   useState,
   useEffect,
-  useLayoutEffect,
   useCallback,
   useRef,
   type MutableRefObject,
@@ -37,6 +38,7 @@ import { useToast } from "@mattbutlerengineering/rialto";
 import { useVenue } from "../contexts/VenueContext.js";
 import { RESERVATIONS_QUERY_KEY } from "./useReservations.js";
 import { TABLES_QUERY_KEY } from "./useTables.js";
+import { SseClient } from "../lib/sse-client.js";
 import type { Reservation, Table, ReservationHold, LapsingGuest } from "@mbe/types";
 
 /* ── Types ─────────────────────────────────────────────────────── */
@@ -68,17 +70,21 @@ type SSEConnectionAction =
   | { type: "disconnected" }
   | { type: "error"; error: Error };
 
-/* ── Backoff constants ──────────────────────────────────────────── */
-
-const INITIAL_BACKOFF_MS = 1_000;
-const MAX_BACKOFF_MS = 30_000;
-const RATE_LIMIT_COOLDOWN_MS = 60_000;
-const MAX_BACKOFF_ATTEMPTS = 8;
-
 /* ── Toast rate limiter ──────────────────────────────────────────── */
 
 const TOAST_WINDOW_MS = 10_000;
 const TOAST_MAX = 3;
+
+const SSE_EVENT_TYPES: readonly ReservationEventType[] = [
+  "reservation:created",
+  "reservation:updated",
+  "reservation:cancelled",
+  "hold:created",
+  "hold:released",
+  "hold:confirmed",
+  "table:updated",
+  "guest:lapsing",
+];
 
 /* ── Context ────────────────────────────────────────────────────── */
 
@@ -113,13 +119,14 @@ export function SSESyncProvider({ children }: { children: ReactNode }) {
   });
 
   // Stable Set — useMemo gives a stable reference without touching .current in render
-   
   const feedListeners = useMemo(() => new Set<(event: ReservationEvent) => void>(), []);
 
   const toastTimestampsRef = useRef<number[]>([]);
 
   return (
-    <SSESyncContext.Provider value={{ connectionState, dispatchConnection, feedListeners, toastTimestampsRef }}>
+    <SSESyncContext.Provider
+      value={{ connectionState, dispatchConnection, feedListeners, toastTimestampsRef }}
+    >
       {children}
     </SSESyncContext.Provider>
   );
@@ -134,7 +141,7 @@ function useSSESyncContext(): SSESyncContextValue {
 /* ── useSSESync ─────────────────────────────────────────────────── */
 
 /**
- * Owns the EventSource lifecycle. Call once inside DashboardLayoutInner.
+ * Owns the EventSource lifecycle via SseClient. Call once inside DashboardLayoutInner.
  * Returns reconnect() for manual reconnect (e.g. retry button).
  */
 export function useSSESync(): { reconnect: () => void } {
@@ -143,185 +150,174 @@ export function useSSESync(): { reconnect: () => void } {
   const { toast } = useToast();
   const { selectedVenueId } = useVenue();
 
-  const eventSourceRef = useRef<EventSource | null>(null);
-  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const reconnectAttempts = useRef(0);
-  const connectRef = useRef<(() => void) | null>(null);
-
-  // Keep refs to avoid reconnecting on closure changes
+  // Keep refs to avoid recreating SseClient on closure changes
   const queryClientRef = useRef(queryClient);
   const toastRef = useRef(toast);
   const dispatchRef = useRef(dispatchConnection);
+  const selectedVenueIdRef = useRef(selectedVenueId);
 
   useEffect(() => {
     queryClientRef.current = queryClient;
     toastRef.current = toast;
     dispatchRef.current = dispatchConnection;
+    selectedVenueIdRef.current = selectedVenueId;
   });
 
-  // feedListeners is a stable Set (useMemo in provider) — safe to close over directly
-  const broadcastEvent = useCallback(
-    (event: ReservationEvent) => {
-      for (const listener of feedListeners) {
-        listener(event);
-      }
-    },
-    [feedListeners]
-  );
-
-  const makeEvent = useCallback(
-    (type: ReservationEvent["type"], data: ReservationEvent["data"]): ReservationEvent => ({
-      type,
-      venueId: selectedVenueId ?? "",
-      timestamp: new Date().toISOString(),
-      data,
-    }),
-    [selectedVenueId]
-  );
-
-  const canShowToast = useCallback(() => {
+  const canShowToast = useCallback((): boolean => {
     const now = Date.now();
-    toastTimestampsRef.current = toastTimestampsRef.current.filter((t) => now - t < TOAST_WINDOW_MS);
+    toastTimestampsRef.current = toastTimestampsRef.current.filter(
+      (t) => now - t < TOAST_WINDOW_MS
+    );
     if (toastTimestampsRef.current.length >= TOAST_MAX) return false;
     toastTimestampsRef.current = [...toastTimestampsRef.current, now];
     return true;
   }, [toastTimestampsRef]);
 
-  const closeConnection = useCallback(() => {
-    if (reconnectTimeoutRef.current) {
-      clearTimeout(reconnectTimeoutRef.current);
-      reconnectTimeoutRef.current = null;
-    }
-    if (eventSourceRef.current) {
-      eventSourceRef.current.close();
-      eventSourceRef.current = null;
-    }
-  }, []);
-
-  const connect = useCallback(() => {
-    // Close any existing connection first to prevent duplicates
-    if (eventSourceRef.current) {
-      eventSourceRef.current.close();
-      eventSourceRef.current = null;
-    }
-
-    const baseUrl = import.meta.env.VITE_API_URL ?? "";
-    const url = new URL(`${baseUrl}/api/v1/events/stream`);
-    if (selectedVenueId) {
-      url.searchParams.set("venueId", selectedVenueId);
-    }
-
-    const eventSource = new EventSource(url.toString());
-    eventSourceRef.current = eventSource;
-
-    eventSource.onopen = () => {
-      dispatchRef.current({ type: "connected" });
-      reconnectAttempts.current = 0;
-    };
-
-    eventSource.onerror = () => {
-      // Close immediately to prevent browser auto-reconnect racing with our backoff
-      eventSource.close();
-      eventSourceRef.current = null;
-
-      const err = new Error("SSE connection error");
-      dispatchRef.current({ type: "error", error: err });
-
-      const attempts = reconnectAttempts.current;
-      const delay =
-        attempts >= MAX_BACKOFF_ATTEMPTS
-          ? RATE_LIMIT_COOLDOWN_MS
-          : Math.min(INITIAL_BACKOFF_MS * Math.pow(2, attempts), MAX_BACKOFF_MS);
-      reconnectAttempts.current = attempts + 1;
-
-      reconnectTimeoutRef.current = setTimeout(() => {
-        connectRef.current?.();
-      }, delay);
-    };
-
-    eventSource.addEventListener("connected", () => {
-      dispatchRef.current({ type: "connected" });
-    });
-
-    eventSource.addEventListener("reservation:created", (event) => {
-      const payload = JSON.parse(event.data) as ReservationEvent;
-      const reservation = payload.data as Reservation;
-      queryClientRef.current.invalidateQueries({ queryKey: [RESERVATIONS_QUERY_KEY] });
-      broadcastEvent(makeEvent("reservation:created", reservation));
-      if (canShowToast()) {
-        toastRef.current({
-          title: "New reservation",
-          description: `${reservation.guestName ?? "Guest"} — ${new Date(reservation.startTime).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`,
-          variant: "accent",
-          duration: 5000,
-        });
-      }
-    });
-
-    eventSource.addEventListener("reservation:updated", (event) => {
-      const payload = JSON.parse(event.data) as ReservationEvent;
-      queryClientRef.current.invalidateQueries({ queryKey: [RESERVATIONS_QUERY_KEY] });
-      broadcastEvent(makeEvent("reservation:updated", payload.data as Reservation));
-    });
-
-    eventSource.addEventListener("reservation:cancelled", (event) => {
-      const payload = JSON.parse(event.data) as ReservationEvent;
-      const reservation = payload.data as Reservation;
-      queryClientRef.current.invalidateQueries({ queryKey: [RESERVATIONS_QUERY_KEY] });
-      broadcastEvent(makeEvent("reservation:cancelled", reservation));
-      if (canShowToast()) {
-        toastRef.current({
-          title: "Reservation cancelled",
-          description: `${reservation.guestName ?? "Guest"}'s reservation was cancelled`,
-          variant: "error",
-          duration: 5000,
-        });
-      }
-    });
-
-    eventSource.addEventListener("hold:created", (event) => {
-      const payload = JSON.parse(event.data) as ReservationEvent;
-      broadcastEvent(makeEvent("hold:created", payload.data as ReservationHold));
-    });
-
-    eventSource.addEventListener("hold:released", (event) => {
-      const payload = JSON.parse(event.data) as ReservationEvent;
-      broadcastEvent(makeEvent("hold:released", payload.data as ReservationHold));
-    });
-
-    eventSource.addEventListener("hold:confirmed", (event) => {
-      const payload = JSON.parse(event.data) as ReservationEvent;
-      queryClientRef.current.invalidateQueries({ queryKey: [RESERVATIONS_QUERY_KEY] });
-      broadcastEvent(makeEvent("hold:confirmed", payload.data as Reservation));
-    });
-
-    eventSource.addEventListener("table:updated", (event) => {
-      const payload = JSON.parse(event.data) as ReservationEvent;
-      queryClientRef.current.invalidateQueries({ queryKey: [TABLES_QUERY_KEY] });
-      broadcastEvent(makeEvent("table:updated", payload.data as Table));
-    });
-
-    eventSource.addEventListener("guest:lapsing", (event) => {
-      const payload = JSON.parse(event.data) as ReservationEvent;
-      broadcastEvent(makeEvent("guest:lapsing", payload.data as LapsingGuest[]));
-    });
-  }, [selectedVenueId, broadcastEvent, makeEvent, canShowToast]);
-
-  // Keep connectRef in sync so the backoff timeout calls the latest connect
-  useLayoutEffect(() => {
-    connectRef.current = connect;
+  const canShowToastRef = useRef(canShowToast);
+  useEffect(() => {
+    canShowToastRef.current = canShowToast;
   });
 
+  const makeEvent = useCallback(
+    (type: ReservationEvent["type"], data: ReservationEvent["data"]): ReservationEvent => ({
+      type,
+      venueId: selectedVenueIdRef.current ?? "",
+      timestamp: new Date().toISOString(),
+      data,
+    }),
+    []
+  );
+
+  const handleEvent = useCallback(
+    (type: string, payload: unknown) => {
+      const event = payload as ReservationEvent;
+      const eventType = type as ReservationEventType;
+
+      switch (eventType) {
+        case "reservation:created": {
+          const reservation = event.data as Reservation;
+          queryClientRef.current.invalidateQueries({ queryKey: [RESERVATIONS_QUERY_KEY] });
+          for (const listener of feedListeners) {
+            listener(makeEvent("reservation:created", reservation));
+          }
+          if (canShowToastRef.current()) {
+            toastRef.current({
+              title: "New reservation",
+              description: `${reservation.guestName ?? "Guest"} — ${new Date(reservation.startTime).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`,
+              variant: "accent",
+              duration: 5000,
+            });
+          }
+          break;
+        }
+        case "reservation:updated": {
+          queryClientRef.current.invalidateQueries({ queryKey: [RESERVATIONS_QUERY_KEY] });
+          for (const listener of feedListeners) {
+            listener(makeEvent("reservation:updated", event.data as Reservation));
+          }
+          break;
+        }
+        case "reservation:cancelled": {
+          const reservation = event.data as Reservation;
+          queryClientRef.current.invalidateQueries({ queryKey: [RESERVATIONS_QUERY_KEY] });
+          for (const listener of feedListeners) {
+            listener(makeEvent("reservation:cancelled", reservation));
+          }
+          if (canShowToastRef.current()) {
+            toastRef.current({
+              title: "Reservation cancelled",
+              description: `${reservation.guestName ?? "Guest"}&apos;s reservation was cancelled`,
+              variant: "error",
+              duration: 5000,
+            });
+          }
+          break;
+        }
+        case "hold:created": {
+          for (const listener of feedListeners) {
+            listener(makeEvent("hold:created", event.data as ReservationHold));
+          }
+          break;
+        }
+        case "hold:released": {
+          for (const listener of feedListeners) {
+            listener(makeEvent("hold:released", event.data as ReservationHold));
+          }
+          break;
+        }
+        case "hold:confirmed": {
+          queryClientRef.current.invalidateQueries({ queryKey: [RESERVATIONS_QUERY_KEY] });
+          for (const listener of feedListeners) {
+            listener(makeEvent("hold:confirmed", event.data as Reservation));
+          }
+          break;
+        }
+        case "table:updated": {
+          queryClientRef.current.invalidateQueries({ queryKey: [TABLES_QUERY_KEY] });
+          for (const listener of feedListeners) {
+            listener(makeEvent("table:updated", event.data as Table));
+          }
+          break;
+        }
+        case "guest:lapsing": {
+          for (const listener of feedListeners) {
+            listener(makeEvent("guest:lapsing", event.data as LapsingGuest[]));
+          }
+          break;
+        }
+      }
+    },
+    [feedListeners, makeEvent]
+  );
+
+  const handleEventRef = useRef(handleEvent);
   useEffect(() => {
-    connect();
-    return closeConnection;
-  }, [connect, closeConnection]);
+    handleEventRef.current = handleEvent;
+  });
+
+  const clientRef = useRef<SseClient | null>(null);
+
+  const buildClient = useCallback((venueId: string | undefined): SseClient => {
+    const baseUrl = import.meta.env.VITE_API_URL ?? "";
+    const url = new URL(`${baseUrl}/api/v1/events/stream`);
+    if (venueId) {
+      url.searchParams.set("venueId", venueId);
+    }
+    return new SseClient({
+      url: url.toString(),
+      eventTypes: SSE_EVENT_TYPES,
+      onEvent: (type, payload) => handleEventRef.current(type, payload),
+      onError: (error) => {
+        dispatchRef.current({ type: "error", error });
+      },
+      onConnected: () => {
+        dispatchRef.current({ type: "connected" });
+      },
+      onDisconnected: () => {
+        dispatchRef.current({ type: "disconnected" });
+      },
+    });
+  }, []);
+
+  useEffect(() => {
+    const client = buildClient(selectedVenueId ?? undefined);
+    clientRef.current = client;
+    client.connect();
+
+    return () => {
+      client.disconnect();
+      clientRef.current = null;
+    };
+  }, [selectedVenueId, buildClient]);
 
   const reconnect = useCallback(() => {
-    closeConnection();
-    reconnectAttempts.current = 0;
-    connect();
-  }, [connect, closeConnection]);
+    clientRef.current?.disconnect();
+    dispatchRef.current({ type: "disconnected" });
+
+    const client = buildClient(selectedVenueIdRef.current ?? undefined);
+    clientRef.current = client;
+    client.connect();
+  }, [buildClient]);
 
   return { reconnect };
 }

--- a/apps/hospitality/src/lib/sse-client.test.ts
+++ b/apps/hospitality/src/lib/sse-client.test.ts
@@ -1,0 +1,409 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { SseClient } from "./sse-client.js";
+import type { SseClientOptions } from "./sse-client.js";
+
+/* ── Mock EventSource factory ──────────────────────────────────── */
+
+type EventSourceListener = (event: MessageEvent) => void;
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+
+  url: string;
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  readyState = 0;
+  private listeners = new Map<string, EventSourceListener[]>();
+
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: EventSourceListener): void {
+    const existing = this.listeners.get(type) ?? [];
+    this.listeners.set(type, [...existing, listener]);
+  }
+
+  removeEventListener(type: string, listener: EventSourceListener): void {
+    const existing = this.listeners.get(type) ?? [];
+    this.listeners.set(
+      type,
+      existing.filter((l) => l !== listener)
+    );
+  }
+
+  close(): void {
+    this.readyState = 2;
+  }
+
+  simulateOpen(): void {
+    this.readyState = 1;
+    this.onopen?.();
+  }
+
+  simulateError(): void {
+    this.onerror?.();
+  }
+
+  simulateEvent(type: string, data: unknown, lastEventId?: string): void {
+    const listeners = this.listeners.get(type) ?? [];
+    const event = new MessageEvent(type, {
+      data: JSON.stringify(data),
+      lastEventId: lastEventId ?? "",
+    });
+    for (const listener of listeners) {
+      listener(event);
+    }
+  }
+}
+
+function latestEs(): MockEventSource {
+  return MockEventSource.instances[MockEventSource.instances.length - 1];
+}
+
+function makeFactory(): (url: string) => MockEventSource {
+  return (url: string) => new MockEventSource(url);
+}
+
+/* ── Setup ─────────────────────────────────────────────────────── */
+
+beforeEach(() => {
+  MockEventSource.instances = [];
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+/* ── Tests: connection lifecycle ───────────────────────────────── */
+
+describe("SseClient — connection lifecycle", () => {
+  it("creates an EventSource at the given URL on connect()", () => {
+    const client = new SseClient({
+      url: "http://localhost/stream",
+      eventTypes: [],
+      onEvent: vi.fn(),
+      onError: vi.fn(),
+      eventSourceFactory: makeFactory(),
+    });
+
+    client.connect();
+
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(latestEs().url).toBe("http://localhost/stream");
+  });
+
+  it("closes the EventSource on disconnect()", () => {
+    const client = new SseClient({
+      url: "http://localhost/stream",
+      eventTypes: [],
+      onEvent: vi.fn(),
+      onError: vi.fn(),
+      eventSourceFactory: makeFactory(),
+    });
+
+    client.connect();
+    const es = latestEs();
+    client.disconnect();
+
+    expect(es.readyState).toBe(2);
+  });
+
+  it("does not create duplicate EventSources on repeated connect() calls", () => {
+    const client = new SseClient({
+      url: "http://localhost/stream",
+      eventTypes: [],
+      onEvent: vi.fn(),
+      onError: vi.fn(),
+      eventSourceFactory: makeFactory(),
+    });
+
+    client.connect();
+    client.connect();
+
+    expect(MockEventSource.instances).toHaveLength(1);
+  });
+});
+
+/* ── Tests: backoff progression ───────────────────────────────── */
+
+describe("SseClient — backoff progression", () => {
+  function makeClient(opts?: Partial<SseClientOptions>): SseClient {
+    return new SseClient({
+      url: "http://localhost/stream",
+      eventTypes: [],
+      onEvent: vi.fn(),
+      onError: vi.fn(),
+      eventSourceFactory: makeFactory(),
+      ...opts,
+    });
+  }
+
+  it("reconnects after first error at INITIAL_BACKOFF_MS (1000ms)", () => {
+    const client = makeClient();
+    client.connect();
+
+    vi.runAllTicks();
+    latestEs().simulateError();
+    expect(MockEventSource.instances).toHaveLength(1);
+
+    vi.advanceTimersByTime(1000);
+    expect(MockEventSource.instances).toHaveLength(2);
+  });
+
+  it("doubles backoff on consecutive errors (exponential)", () => {
+    const client = makeClient();
+    client.connect();
+
+    // First error → reconnects at 1000ms
+    latestEs().simulateError();
+    vi.advanceTimersByTime(1000);
+    expect(MockEventSource.instances).toHaveLength(2);
+
+    // Second error → reconnects at 2000ms
+    latestEs().simulateError();
+    vi.advanceTimersByTime(1999);
+    expect(MockEventSource.instances).toHaveLength(2);
+    vi.advanceTimersByTime(1);
+    expect(MockEventSource.instances).toHaveLength(3);
+  });
+
+  it("caps backoff at MAX_BACKOFF_MS (30000ms)", () => {
+    const client = makeClient();
+    client.connect();
+
+    // Drive many errors through the backoff ceiling
+    for (let i = 0; i < 10; i++) {
+      latestEs().simulateError();
+      vi.advanceTimersByTime(30_001);
+    }
+
+    const countBefore = MockEventSource.instances.length;
+    latestEs().simulateError();
+
+    // Should reconnect within 30s (not longer, indicating it's capped)
+    vi.advanceTimersByTime(30_000);
+    expect(MockEventSource.instances.length).toBeGreaterThan(countBefore);
+  });
+
+  it("resets backoff after successful connection", () => {
+    const client = makeClient();
+    client.connect();
+
+    // Cause an error + reconnect cycle
+    latestEs().simulateError();
+    vi.advanceTimersByTime(1000);
+
+    // Simulate successful open (resets attempts)
+    latestEs().simulateOpen();
+
+    // Next error should be back to 1000ms
+    latestEs().simulateError();
+    const countBefore = MockEventSource.instances.length;
+
+    vi.advanceTimersByTime(999);
+    expect(MockEventSource.instances.length).toBe(countBefore);
+
+    vi.advanceTimersByTime(1);
+    expect(MockEventSource.instances.length).toBe(countBefore + 1);
+  });
+});
+
+/* ── Tests: rate-limit cooldown ───────────────────────────────── */
+
+describe("SseClient — rate-limit cooldown", () => {
+  it("uses RATE_LIMIT_COOLDOWN_MS after MAX_BACKOFF_ATTEMPTS consecutive failures", () => {
+    const client = new SseClient({
+      url: "http://localhost/stream",
+      eventTypes: [],
+      onEvent: vi.fn(),
+      onError: vi.fn(),
+      eventSourceFactory: makeFactory(),
+    });
+    client.connect();
+
+    // MAX_BACKOFF_ATTEMPTS = 8; exhaust all attempts
+    for (let i = 0; i < 8; i++) {
+      latestEs().simulateError();
+      vi.advanceTimersByTime(30_001);
+    }
+
+    const countBefore = MockEventSource.instances.length;
+    latestEs().simulateError();
+
+    // 30s is NOT enough (60s cooldown is active)
+    vi.advanceTimersByTime(30_000);
+    expect(MockEventSource.instances.length).toBe(countBefore);
+
+    // After 60s total, it reconnects
+    vi.advanceTimersByTime(30_001);
+    expect(MockEventSource.instances.length).toBe(countBefore + 1);
+  });
+});
+
+/* ── Tests: Last-Event-ID resumption ──────────────────────────── */
+
+describe("SseClient — Last-Event-ID resumption", () => {
+  it("includes lastEventId in URL on reconnect when server sent one", () => {
+    const client = new SseClient({
+      url: "http://localhost/stream",
+      eventTypes: ["reservation:created"],
+      onEvent: vi.fn(),
+      onError: vi.fn(),
+      eventSourceFactory: makeFactory(),
+    });
+    client.connect();
+
+    // Server sends an event with a lastEventId
+    latestEs().simulateEvent(
+      "reservation:created",
+      { type: "reservation:created", venueId: "v1", timestamp: "2026-01-01T00:00:00Z", data: {} },
+      "evt-42"
+    );
+
+    // Simulate error → triggers reconnect
+    latestEs().simulateError();
+    vi.advanceTimersByTime(1000);
+
+    // Reconnected URL should contain the lastEventId
+    expect(latestEs().url).toContain("lastEventId=evt-42");
+  });
+
+  it("does not include lastEventId if no events were received", () => {
+    const client = new SseClient({
+      url: "http://localhost/stream",
+      eventTypes: [],
+      onEvent: vi.fn(),
+      onError: vi.fn(),
+      eventSourceFactory: makeFactory(),
+    });
+    client.connect();
+
+    latestEs().simulateError();
+    vi.advanceTimersByTime(1000);
+
+    expect(latestEs().url).not.toContain("lastEventId");
+  });
+});
+
+/* ── Tests: parse-error surfaced ──────────────────────────────── */
+
+describe("SseClient — parse errors surfaced via onError", () => {
+  it("calls onError when event data is invalid JSON", () => {
+    const onError = vi.fn();
+    const onEvent = vi.fn();
+
+    const client = new SseClient({
+      url: "http://localhost/stream",
+      eventTypes: ["reservation:created"],
+      onEvent,
+      onError,
+      eventSourceFactory: makeFactory(),
+    });
+    client.connect();
+
+    // Manually dispatch a raw event with invalid JSON
+    const es = latestEs();
+    const badEvent = new MessageEvent("reservation:created", { data: "not-json{{" });
+    // Trigger the listener directly
+    const listeners = (es as unknown as { listeners: Map<string, ((e: MessageEvent) => void)[]> })
+      .listeners;
+    const handlers = listeners?.get?.("reservation:created") ?? [];
+    for (const h of handlers) {
+      h(badEvent);
+    }
+
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
+  });
+
+  it("does NOT call onEvent when event data is invalid JSON", () => {
+    const onError = vi.fn();
+    const onEvent = vi.fn();
+
+    const client = new SseClient({
+      url: "http://localhost/stream",
+      eventTypes: ["reservation:created"],
+      onEvent,
+      onError,
+      eventSourceFactory: makeFactory(),
+    });
+    client.connect();
+
+    const es = latestEs();
+    const badEvent = new MessageEvent("reservation:created", { data: "not-json{{" });
+    const listeners = (es as unknown as { listeners: Map<string, ((e: MessageEvent) => void)[]> })
+      .listeners;
+    const handlers = listeners?.get?.("reservation:created") ?? [];
+    for (const h of handlers) {
+      h(badEvent);
+    }
+
+    expect(onEvent).not.toHaveBeenCalled();
+  });
+
+  it("calls onEvent normally when event data is valid JSON", () => {
+    const onEvent = vi.fn();
+    const onError = vi.fn();
+
+    const client = new SseClient({
+      url: "http://localhost/stream",
+      eventTypes: ["reservation:created"],
+      onEvent,
+      onError,
+      eventSourceFactory: makeFactory(),
+    });
+    client.connect();
+
+    latestEs().simulateEvent("reservation:created", {
+      type: "reservation:created",
+      venueId: "v1",
+      timestamp: "2026-01-01T00:00:00Z",
+      data: { id: "r1" },
+    });
+
+    expect(onEvent).toHaveBeenCalledOnce();
+    expect(onError).not.toHaveBeenCalled();
+  });
+});
+
+/* ── Tests: onConnected/onDisconnected callbacks ──────────────── */
+
+describe("SseClient — connection callbacks", () => {
+  it("calls onConnected when EventSource opens", () => {
+    const onConnected = vi.fn();
+    const client = new SseClient({
+      url: "http://localhost/stream",
+      eventTypes: [],
+      onEvent: vi.fn(),
+      onError: vi.fn(),
+      onConnected,
+      eventSourceFactory: makeFactory(),
+    });
+
+    client.connect();
+    latestEs().simulateOpen();
+
+    expect(onConnected).toHaveBeenCalledOnce();
+  });
+
+  it("calls onDisconnected when EventSource errors", () => {
+    const onDisconnected = vi.fn();
+    const client = new SseClient({
+      url: "http://localhost/stream",
+      eventTypes: [],
+      onEvent: vi.fn(),
+      onError: vi.fn(),
+      onDisconnected,
+      eventSourceFactory: makeFactory(),
+    });
+
+    client.connect();
+    latestEs().simulateError();
+
+    expect(onDisconnected).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/hospitality/src/lib/sse-client.ts
+++ b/apps/hospitality/src/lib/sse-client.ts
@@ -1,0 +1,148 @@
+/**
+ * SseClient — pure transport layer for Server-Sent Events.
+ *
+ * Owns: connection lifecycle, exponential backoff, rate-limit cooldown,
+ * Last-Event-ID resumption, typed event parsing with error surfacing.
+ *
+ * React-free. Accepts an injectable EventSource factory so tests can
+ * exercise all behaviour without a live server.
+ */
+
+/* ── Backoff constants ──────────────────────────────────────────── */
+
+const INITIAL_BACKOFF_MS = 1_000;
+const MAX_BACKOFF_MS = 30_000;
+const RATE_LIMIT_COOLDOWN_MS = 60_000;
+const MAX_BACKOFF_ATTEMPTS = 8;
+
+/* ── Types ──────────────────────────────────────────────────────── */
+
+export type EventSourceFactory = (url: string) => EventSource;
+
+export interface SseClientOptions {
+  /** Base URL for the SSE stream (query params appended by SseClient). */
+  url: string;
+  /** Named event types to listen for (e.g. "reservation:created"). */
+  eventTypes: readonly string[];
+  /** Called with a parsed event payload on each successfully parsed message. */
+  onEvent: (type: string, payload: unknown) => void;
+  /** Called when a parse error occurs or the connection errors. */
+  onError: (error: Error) => void;
+  /** Called when the EventSource opens successfully. */
+  onConnected?: () => void;
+  /** Called when the EventSource closes due to an error. */
+  onDisconnected?: () => void;
+  /** Injectable factory — defaults to `(url) => new EventSource(url)`. */
+  eventSourceFactory?: EventSourceFactory;
+}
+
+/* ── SseClient ──────────────────────────────────────────────────── */
+
+export class SseClient {
+  private readonly options: Required<SseClientOptions>;
+  private eventSource: EventSource | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectAttempts = 0;
+  private lastEventId: string | null = null;
+
+  constructor(options: SseClientOptions) {
+    this.options = {
+      onConnected: () => undefined,
+      onDisconnected: () => undefined,
+      eventSourceFactory: (url: string) => new EventSource(url),
+      ...options,
+    };
+  }
+
+  /** Open the SSE connection. No-op if already connected. */
+  connect(): void {
+    if (this.eventSource !== null) return;
+    this.openConnection();
+  }
+
+  /** Close the connection and cancel any pending reconnect. */
+  disconnect(): void {
+    this.clearReconnectTimer();
+    this.closeEventSource();
+  }
+
+  private openConnection(): void {
+    const url = this.buildUrl();
+    const es = this.options.eventSourceFactory(url);
+    this.eventSource = es;
+
+    es.onopen = () => {
+      this.reconnectAttempts = 0;
+      this.options.onConnected();
+    };
+
+    es.onerror = () => {
+      es.close();
+      this.eventSource = null;
+      this.options.onError(new Error("SSE connection error"));
+      this.options.onDisconnected();
+      this.scheduleReconnect();
+    };
+
+    for (const type of this.options.eventTypes) {
+      es.addEventListener(type, (event: MessageEvent) => {
+        // Track Last-Event-ID for resumption
+        if (event.lastEventId) {
+          this.lastEventId = event.lastEventId;
+        }
+        this.handleRawEvent(type, event.data as string);
+      });
+    }
+  }
+
+  private handleRawEvent(type: string, rawData: string): void {
+    let payload: unknown;
+    try {
+      payload = JSON.parse(rawData);
+    } catch (err) {
+      this.options.onError(
+        err instanceof Error
+          ? err
+          : new Error(`Failed to parse SSE event "${type}": ${String(err)}`)
+      );
+      return;
+    }
+    this.options.onEvent(type, payload);
+  }
+
+  private scheduleReconnect(): void {
+    const attempts = this.reconnectAttempts;
+    const delay =
+      attempts >= MAX_BACKOFF_ATTEMPTS
+        ? RATE_LIMIT_COOLDOWN_MS
+        : Math.min(INITIAL_BACKOFF_MS * Math.pow(2, attempts), MAX_BACKOFF_MS);
+    this.reconnectAttempts = attempts + 1;
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.openConnection();
+    }, delay);
+  }
+
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  private closeEventSource(): void {
+    if (this.eventSource !== null) {
+      this.eventSource.close();
+      this.eventSource = null;
+    }
+  }
+
+  private buildUrl(): string {
+    const url = new URL(this.options.url);
+    if (this.lastEventId !== null) {
+      url.searchParams.set("lastEventId", this.lastEventId);
+    }
+    return url.toString();
+  }
+}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3404,6 +3404,25 @@
   </file>
   </section>
   <section priority="medium" role="lib">
+  <file path="apps/hospitality/src/lib/sse-client.ts">
+    export type EventSourceFactory = (url: string) => EventSource;
+    export interface SseClientOptions {
+      /** Base URL for the SSE stream (query params appended by SseClient). */
+      url: string;
+      /** Named event types to listen for (e.g. "reservation:created"). */
+      eventTypes: readonly string[];
+      /** Called with a parsed event payload on each successfully parsed message. */
+      onEvent: (type: string, payload: unknown) => void;
+      /** Called when a parse error occurs or the connection errors. */
+      onError: (error: Error) => void;
+      /** Called when the EventSource opens successfully. */
+      onConnected?: () => void;
+      /** Called when the EventSource closes due to an error. */
+      onDisconnected?: () => void;
+      /** Injectable factory — defaults to `(url) => new EventSource(url)`. */
+      eventSourceFactory?: EventSourceFactory;
+    }
+  </file>
   <file path="services/agent/src/lib/verified-webhook.ts">
     export interface VerifiedWebhookOptions {
       header: string;
@@ -14793,7 +14812,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14826,18 +14826,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms.txt
+++ b/llms.txt
@@ -1188,6 +1188,20 @@
   </file>
   </section>
   <section priority="medium" role="lib">
+  <file path="apps/hospitality/src/lib/sse-client.ts">
+    <item priority="low">
+      type EventSourceFactory = (url: string) => EventSource;
+    </item>
+    <item priority="low">
+      interface SseClientOptions {
+        url: string;
+        eventTypes: readonly string[];
+        onEvent: (type: string, payload: unknown) => void;
+        onError: (error: Error) => void;
+        onConnected?: () => void;
+      }
+    </item>
+  </file>
   <file path="services/agent/src/lib/verified-webhook.ts">
     <item priority="low">
       interface VerifiedWebhookOptions {


### PR DESCRIPTION
## Summary

- Extracts pure SSE transport into `apps/hospitality/src/lib/sse-client.ts` (`SseClient` class): connection lifecycle, exponential backoff (1s→30s), 60s rate-limit cooldown after MAX_BACKOFF_ATTEMPTS, Last-Event-ID resumption, typed event parsing
- Parse errors are now surfaced via `onError` callback instead of being silently swallowed
- `SseClient` accepts an injectable `EventSourceFactory` — unit tests exercise all backoff/parse/resumption paths without React or a live server
- `useSSESync` becomes a thin domain adapter: all existing exports (`SSESyncProvider`, `useSSESync`, `useSSEStatus`, `useSSEEventFeed`) remain interface-stable — no consumer pages changed

## Gate results

- `pnpm lint` — 0 errors (202 pre-existing warnings, unchanged)
- `pnpm typecheck` — clean
- `pnpm test` — 77/77 test files pass (15 new SseClient unit tests added)
- `check-adr` / `check-deps` — no violations
- `pnpm regen` — no drift; `detect-instruction-rot` clean

## Test plan

- [ ] Verify all 15 new SseClient tests pass: backoff progression, rate-limit cooldown, Last-Event-ID resumption, parse-error surfacing, connection callbacks
- [ ] Verify 13 existing useSSESync tests pass with delegated transport
- [ ] Confirm consumer pages (DashboardLayout, HomePage, TimelinePage) unchanged

Closes #2054