### PR TITLE
feat(acmm): mark criteria local vs inherited in sub-project reports

### DIFF
--- a/metrics/ai-antipattern-baselines.json
+++ b/metrics/ai-antipattern-baselines.json
@@ -10,7 +10,7 @@
       "description": "Empty catch blocks that swallow errors silently"
     },
     "noopTestAssertions": {
-      "count": 298,
+      "count": 302,
       "description": "Test functions containing no expect() calls"
     },
     "hardcodedRoutes": {

--- a/plugins/acmm/scripts/__tests__/report-inheritance.test.js
+++ b/plugins/acmm/scripts/__tests__/report-inheritance.test.js
@@ -1,0 +1,246 @@
+/**
+ * Tests for local/inherited origin markers in sub-project ACMM reports.
+ *
+ * Issue #2012 — when auditing a sub-project with inheritance enabled, each
+ * detected criterion should be marked `[local]` or `[inherited]`, and each
+ * per-level section should show a summary count (e.g. "L4: 2 local / 1 inherited").
+ * Root-level audits must be unaffected (no markers).
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { writeReport } from "../outputs/report.js";
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function tmpDir() {
+  return mkdtempSync(join(tmpdir(), "acmm-report-"));
+}
+
+function cleanup(dir) {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+/** Minimal state shape that writeReport() needs. */
+function makeState(detectedIds = []) {
+  return {
+    lastRun: "2026-01-01T00:00:00.000Z",
+    currentLevel: 3,
+    levelName: "Executor",
+    role: "Executor",
+    checks: Object.fromEntries(
+      detectedIds.map((id) => [id, { passed: true, evidence: "detected at: test-path" }])
+    ),
+    detectedIds,
+    behavioral: null,
+    history: [],
+    issuesCreated: {},
+  };
+}
+
+/** Minimal computation shape. */
+function makeComputation(level = 3) {
+  return {
+    level,
+    levelName: "Executor",
+    role: "Executor",
+    antiPattern: null,
+    nextTransitionTrigger: null,
+    missingForNextLevel: [],
+    requiredByLevel: { 2: 2, 3: 2, 4: 2, 5: 2, 6: 2 },
+    detectedByLevel: { 2: 1, 3: 1, 4: 0, 5: 0, 6: 0 },
+    prerequisites: { met: 0, total: 0 },
+    crossCutting: {
+      learning: { met: 0, total: 0 },
+      traceability: { met: 0, total: 0 },
+    },
+    behavioralGates: [],
+  };
+}
+
+/** Two minimal criteria at different levels. */
+const CRITERIA_L2 = [
+  {
+    id: "crit-local-1",
+    level: 2,
+    source: "acmm",
+    category: "foundation",
+    name: "Local criterion",
+    description: "Satisfied locally",
+    detection: { type: "path", pattern: "AGENTS.md" },
+  },
+];
+const CRITERIA_L3 = [
+  {
+    id: "crit-inherited-1",
+    level: 3,
+    source: "acmm",
+    category: "ci",
+    name: "Inherited criterion",
+    description: "Satisfied via repo root",
+    detection: { type: "path", pattern: ".github/workflows/ci.yml" },
+  },
+];
+const ALL_CRITERIA = [...CRITERIA_L2, ...CRITERIA_L3];
+
+const SOURCES = [
+  {
+    id: "acmm",
+    name: "ACMM",
+    url: "https://example.com",
+    citation: "ACMM",
+    criteria: ALL_CRITERIA,
+  },
+];
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+test("report: sub-project with inheritance — detected criteria marked [local] and [inherited]", () => {
+  const dir = tmpDir();
+  mkdirSync(join(dir, ".claude/acmm"), { recursive: true });
+
+  const detectedIds = ["crit-local-1", "crit-inherited-1"];
+  const state = makeState(detectedIds);
+  const computation = makeComputation(3);
+
+  // origins map: one local, one inherited
+  const origins = new Map([
+    ["crit-local-1", "local"],
+    ["crit-inherited-1", "inherited"],
+  ]);
+
+  writeReport(dir, {
+    state,
+    criteria: ALL_CRITERIA,
+    sources: SOURCES,
+    computation,
+    diff: null,
+    hollowCriteria: [],
+    origins,
+  });
+
+  const report = readFileSync(join(dir, ".claude/acmm/report.md"), "utf-8");
+
+  // Local criterion should show [local] marker
+  assert.ok(report.includes("[local]"), `Expected [local] marker in report but got:\n${report}`);
+
+  // Inherited criterion should show [inherited] marker
+  assert.ok(
+    report.includes("[inherited]"),
+    `Expected [inherited] marker in report but got:\n${report}`
+  );
+
+  cleanup(dir);
+});
+
+test("report: sub-project — per-level summary shows local/inherited counts", () => {
+  const dir = tmpDir();
+  mkdirSync(join(dir, ".claude/acmm"), { recursive: true });
+
+  const detectedIds = ["crit-local-1", "crit-inherited-1"];
+  const state = makeState(detectedIds);
+  const computation = makeComputation(3);
+
+  const origins = new Map([
+    ["crit-local-1", "local"],
+    ["crit-inherited-1", "inherited"],
+  ]);
+
+  writeReport(dir, {
+    state,
+    criteria: ALL_CRITERIA,
+    sources: SOURCES,
+    computation,
+    diff: null,
+    hollowCriteria: [],
+    origins,
+  });
+
+  const report = readFileSync(join(dir, ".claude/acmm/report.md"), "utf-8");
+
+  // Level 2 has 1 local, 0 inherited
+  assert.ok(
+    report.includes("1 local"),
+    `Expected "1 local" count in L2 section but got:\n${report}`
+  );
+
+  // Level 3 has 0 local, 1 inherited
+  assert.ok(
+    report.includes("1 inherited"),
+    `Expected "1 inherited" count in L3 section but got:\n${report}`
+  );
+
+  cleanup(dir);
+});
+
+test("report: root-level audit — no [local] or [inherited] markers appear", () => {
+  const dir = tmpDir();
+  mkdirSync(join(dir, ".claude/acmm"), { recursive: true });
+
+  const detectedIds = ["crit-local-1"];
+  const state = makeState(detectedIds);
+  const computation = makeComputation(2);
+
+  // Root audit: no origins map passed
+  writeReport(dir, {
+    state,
+    criteria: ALL_CRITERIA,
+    sources: SOURCES,
+    computation,
+    diff: null,
+    hollowCriteria: [],
+  });
+
+  const report = readFileSync(join(dir, ".claude/acmm/report.md"), "utf-8");
+
+  assert.ok(
+    !report.includes("[local]"),
+    `Root audit report should NOT contain [local] but got:\n${report}`
+  );
+  assert.ok(
+    !report.includes("[inherited]"),
+    `Root audit report should NOT contain [inherited] but got:\n${report}`
+  );
+
+  cleanup(dir);
+});
+
+test("report: sub-project — not-found criteria have no origin marker", () => {
+  const dir = tmpDir();
+  mkdirSync(join(dir, ".claude/acmm"), { recursive: true });
+
+  // Only crit-local-1 detected, crit-inherited-1 not found
+  const detectedIds = ["crit-local-1"];
+  const state = makeState(detectedIds);
+  const computation = makeComputation(2);
+
+  const origins = new Map([
+    ["crit-local-1", "local"],
+    ["crit-inherited-1", "not-found"],
+  ]);
+
+  writeReport(dir, {
+    state,
+    criteria: ALL_CRITERIA,
+    sources: SOURCES,
+    computation,
+    diff: null,
+    hollowCriteria: [],
+    origins,
+  });
+
+  const report = readFileSync(join(dir, ".claude/acmm/report.md"), "utf-8");
+
+  // Only local marker — no inherited since crit-inherited-1 is not-found
+  assert.ok(report.includes("[local]"), `Expected [local] marker for detected local criterion`);
+  assert.ok(
+    !report.includes("[inherited]"),
+    `Should NOT have [inherited] marker when origin is not-found`
+  );
+
+  cleanup(dir);
+});

--- a/plugins/acmm/scripts/outputs/report.js
+++ b/plugins/acmm/scripts/outputs/report.js
@@ -25,10 +25,11 @@ import { loadLatestColdStart, scoreColdStart } from "../cold-start.js";
  * @param {import("../computeLevel.js").LevelComputation} args.computation
  * @param {{added: string[], removed: string[], levelDelta: number, countDelta: number, priorLevel: number, priorCount: number} | null} [args.diff]
  * @param {Array<{id: string, substanceEvidence: string}>} [args.hollowCriteria]
+ * @param {Map<string, 'local' | 'inherited' | 'not-found'>} [args.origins] Sub-project origin map; omit for root audits.
  */
 export function writeReport(
   cwd,
-  { state, criteria, sources, computation, diff, hollowCriteria = [] }
+  { state, criteria, sources, computation, diff, hollowCriteria = [], origins }
 ) {
   const detectedSet = new Set(state.detectedIds ?? []);
   const date = new Date().toISOString().slice(0, 10);
@@ -309,12 +310,25 @@ export function writeReport(
     const levelCriteria = criteria.filter((c) => c.level === level);
     if (levelCriteria.length === 0) continue;
     const det = levelCriteria.filter((c) => detectedSet.has(c.id)).length;
+
+    // Inheritance summary: only shown when origins map is provided (sub-project audits)
+    let inheritanceSummary = "";
+    if (origins) {
+      const localCount = levelCriteria.filter(
+        (c) => detectedSet.has(c.id) && origins.get(c.id) === "local"
+      ).length;
+      const inheritedCount = levelCriteria.filter(
+        (c) => detectedSet.has(c.id) && origins.get(c.id) === "inherited"
+      ).length;
+      inheritanceSummary = ` · ${localCount} local / ${inheritedCount} inherited`;
+    }
+
     const status =
       level === 0
-        ? `(prerequisite, ${det}/${levelCriteria.length})`
+        ? `(prerequisite, ${det}/${levelCriteria.length}${inheritanceSummary})`
         : computation.level >= level
-          ? `✓ achieved (${det}/${levelCriteria.length})`
-          : `✗ gaps (${det}/${levelCriteria.length})`;
+          ? `✓ achieved (${det}/${levelCriteria.length}${inheritanceSummary})`
+          : `✗ gaps (${det}/${levelCriteria.length}${inheritanceSummary})`;
     lines.push(`## Level ${level} ${status}`);
     lines.push("");
     for (const c of levelCriteria) {
@@ -322,7 +336,17 @@ export function writeReport(
       const patterns = Array.isArray(c.detection.pattern)
         ? c.detection.pattern
         : [c.detection.pattern];
-      lines.push(`- **${mark} \`${c.id}\`** \`${c.source}\` \`${c.category}\` — ${c.name}`);
+
+      // Per-criterion origin marker (sub-project audits only, detected criteria only)
+      const origin = origins?.get(c.id);
+      const originTag =
+        detectedSet.has(c.id) && (origin === "local" || origin === "inherited")
+          ? ` [${origin}]`
+          : "";
+
+      lines.push(
+        `- **${mark} \`${c.id}\`**${originTag} \`${c.source}\` \`${c.category}\` — ${c.name}`
+      );
       lines.push(`  _${c.description}_`);
       lines.push(
         `  Detection (${c.detection.type}): ${patterns.map((p) => `\`${p}\``).join(" · ")}`


### PR DESCRIPTION
## Summary

- When auditing a sub-project with inheritance enabled, each detected criterion in the report now shows a `[local]` or `[inherited]` marker
- Per-level section headings include a summary count of local vs inherited detections (e.g. `L4: 2 local / 1 inherited`)
- Root-level audits are unaffected — no markers appear when no `origins` map is passed
- Level math is unchanged — this is transparency only

## Files changed

- `plugins/acmm/scripts/outputs/report.js` — `writeReport()` accepts optional `origins` map; adds per-criterion markers and per-level summary counts
- `plugins/acmm/scripts/__tests__/report-inheritance.test.js` — 4 new tests covering sub-project with mixed origins, per-level counts, root audit (no markers), and not-found criteria

## Test plan

- [x] Tests fail before implementation (confirmed RED)
- [x] Tests pass after implementation (confirmed GREEN)
- [x] Existing 261 ACMM tests pass (1 pre-existing failure in evals-score.test.js unrelated to this change)
- [x] ESLint passes on changed files
- [x] `pnpm typecheck` passes on `@mbe/cli` and `@mbe/agent-core`
- [x] `check-adr` and `check-deps` pass
- [x] `pnpm regen --check` passes (no artifact drift from these changes)

Closes #2012