### PR TITLE
refactor(rialto-web): PageRegistry — derive nav, routes, and sitemap from page metadata

### DIFF
--- a/apps/rialto-web/llms-full.txt
+++ b/apps/rialto-web/llms-full.txt
@@ -15,16 +15,26 @@
   </section>
   <section priority="medium" role="data">
   <file path="src/data/nav-sections.ts">
+    export const NAV_SECTIONS = REGISTRY_NAV_SECTIONS;
+    export const COMPONENT_COUNT = NAV_SECTIONS.reduce(
+      (total, section) => total + section.items.length,
+      0
+    );
+  </file>
+  <file path="src/data/page-registry.ts">
+    export interface PageEntry {
+      id: string;
+      label: string;
+      category: string;
+      path: string;
+      comingSoon?: boolean;
+      load: () => Promise<unknown>;
+    }
     export interface NavItem {
       id: string;
       label: string;
       path: string;
-      /** When true, item is rendered in a muted style with a "coming soon" indicator. */
       comingSoon?: boolean;
-    }
-    export interface NavSection {
-      label: string;
-      items: NavItem[];
     }
   </file>
   <file path="src/data/tapechart-fixtures.ts">

--- a/apps/rialto-web/llms.txt
+++ b/apps/rialto-web/llms.txt
@@ -19,18 +19,29 @@
   </section>
   <section priority="medium" role="data">
   <file path="src/data/nav-sections.ts">
+    <item priority="high">
+      export const NAV_SECTIONS: unknown;
+    </item>
+    <item priority="high">
+      export const COMPONENT_COUNT: unknown;
+    </item>
+  </file>
+  <file path="src/data/page-registry.ts">
+    <item priority="low">
+      interface PageEntry {
+        id: string;
+        label: string;
+        category: string;
+        path: string;
+        comingSoon?: boolean;
+      }
+    </item>
     <item priority="low">
       interface NavItem {
         id: string;
         label: string;
         path: string;
         comingSoon?: boolean;
-      }
-    </item>
-    <item priority="low">
-      interface NavSection {
-        label: string;
-        items: NavItem[];
       }
     </item>
   </file>

--- a/apps/rialto-web/src/data/nav-sections.ts
+++ b/apps/rialto-web/src/data/nav-sections.ts
@@ -1,200 +1,21 @@
 /**
- * Navigation sections data — single source of truth for sidebar and route generation.
+ * Nav sections — derived from the PageRegistry.
  *
- * Each section maps to a functional category of components.
- * Each item's `id` is kebab-case and `path` is `/components/{id}`.
- *
- * Sections derived from App.tsx section numbers and titles.
+ * The canonical page inventory lives in page-registry.ts.
+ * This file derives the nav structure from it and re-exports the
+ * types/constants that the rest of the app depends on.
  */
 
-export interface NavItem {
-  id: string;
-  label: string;
-  path: string;
-  /** When true, item is rendered in a muted style with a "coming soon" indicator. */
-  comingSoon?: boolean;
-}
+import { REGISTRY_NAV_SECTIONS } from "./page-registry.js";
+import type { NavItem } from "./page-registry.js";
 
-export interface NavSection {
-  label: string;
-  items: NavItem[];
-}
+export type { NavItem, NavSection } from "./page-registry.js";
 
 // ---------------------------------------------------------------------------
-// Forms (sections 01–09 in App.tsx)
-// ---------------------------------------------------------------------------
-const FORMS: NavSection = {
-  label: "Forms",
-  items: [
-    { id: "button", label: "Button", path: "/components/button" },
-    { id: "input", label: "Input", path: "/components/input" },
-    { id: "textarea", label: "TextArea", path: "/components/textarea" },
-    { id: "number-input", label: "Number Input", path: "/components/number-input" },
-    { id: "checkbox-radio", label: "Checkbox & Radio", path: "/components/checkbox-radio" },
-    { id: "toggle", label: "Toggle", path: "/components/toggle" },
-    { id: "master-override", label: "Master Override", path: "/components/master-override" },
-    { id: "slider", label: "Slider", path: "/components/slider" },
-    { id: "select", label: "Select", path: "/components/select" },
-    { id: "pin-input", label: "Pin Input", path: "/components/pin-input" },
-    { id: "segmented-control", label: "Segmented Control", path: "/components/segmented-control" },
-    { id: "autocomplete", label: "Autocomplete", path: "/components/autocomplete" },
-    { id: "input-group", label: "Input Group", path: "/components/input-group" },
-  ],
-};
-
-// ---------------------------------------------------------------------------
-// Data Display (sections 10–18 in App.tsx)
-// ---------------------------------------------------------------------------
-const DATA_DISPLAY: NavSection = {
-  label: "Data Display",
-  items: [
-    { id: "card", label: "Card", path: "/components/card" },
-    { id: "table", label: "Table", path: "/components/table" },
-    { id: "badge", label: "Badge", path: "/components/badge" },
-    { id: "tag", label: "Tag", path: "/components/tag" },
-    { id: "avatar", label: "Avatar", path: "/components/avatar" },
-    { id: "stat", label: "Stat", path: "/components/stat" },
-    { id: "data-list", label: "Data List", path: "/components/data-list" },
-    { id: "meter", label: "Meter", path: "/components/meter" },
-    { id: "kbd", label: "Kbd", path: "/components/kbd" },
-    { id: "flip-dot", label: "Flip Dot", path: "/components/flip-dot" },
-    { id: "split-flap", label: "Split Flap", path: "/components/split-flap" },
-    { id: "chalkboard", label: "Chalkboard", path: "/components/chalkboard" },
-    { id: "ferrofluid", label: "Ferrofluid", path: "/components/ferrofluid" },
-    { id: "tape-chart", label: "Tape Chart", path: "/components/tape-chart" },
-  ],
-};
-
-// ---------------------------------------------------------------------------
-// Navigation (sections 19–25 in App.tsx)
-// ---------------------------------------------------------------------------
-const NAVIGATION: NavSection = {
-  label: "Navigation",
-  items: [
-    { id: "tabs", label: "Tabs", path: "/components/tabs" },
-    { id: "breadcrumb", label: "Breadcrumb", path: "/components/breadcrumb" },
-    { id: "steps", label: "Steps", path: "/components/steps" },
-    { id: "pagination", label: "Pagination", path: "/components/pagination" },
-    { id: "navigation-menu", label: "Navigation Menu", path: "/components/navigation-menu" },
-    { id: "tree", label: "Tree", path: "/components/tree" },
-    { id: "sidebar", label: "Sidebar", path: "/components/sidebar" },
-    { id: "navbar", label: "Navbar", path: "/components/navbar" },
-  ],
-};
-
-// ---------------------------------------------------------------------------
-// Feedback (sections 26–30 in App.tsx)
-// ---------------------------------------------------------------------------
-const FEEDBACK: NavSection = {
-  label: "Feedback",
-  items: [
-    { id: "toast", label: "Toast", path: "/components/toast" },
-    { id: "alert", label: "Alert", path: "/components/alert" },
-    { id: "banner", label: "Banner", path: "/components/banner" },
-    { id: "progress", label: "Progress", path: "/components/progress" },
-    { id: "spinner", label: "Spinner", path: "/components/spinner" },
-    { id: "skeleton", label: "Skeleton", path: "/components/skeleton" },
-    { id: "empty-state", label: "Empty State", path: "/components/empty-state" },
-  ],
-};
-
-// ---------------------------------------------------------------------------
-// Overlays (sections 31–39 in App.tsx)
-// ---------------------------------------------------------------------------
-const OVERLAYS: NavSection = {
-  label: "Overlays",
-  items: [
-    { id: "dialog", label: "Dialog", path: "/components/dialog" },
-    { id: "confirm-dialog", label: "Confirm Dialog", path: "/components/confirm-dialog" },
-    { id: "drawer", label: "Drawer", path: "/components/drawer" },
-    { id: "command-palette", label: "Command Palette", path: "/components/command-palette" },
-    { id: "tooltip", label: "Tooltip", path: "/components/tooltip" },
-    { id: "popover", label: "Popover", path: "/components/popover" },
-    { id: "hover-card", label: "Hover Card", path: "/components/hover-card" },
-    { id: "dropdown-menu", label: "Dropdown Menu", path: "/components/dropdown-menu" },
-    { id: "context-menu", label: "Context Menu", path: "/components/context-menu" },
-    { id: "disabled-tooltip", label: "Disabled Tooltip", path: "/components/disabled-tooltip" },
-  ],
-};
-
-// ---------------------------------------------------------------------------
-// Layout (sections 40–48 in App.tsx)
-// ---------------------------------------------------------------------------
-const LAYOUT: NavSection = {
-  label: "Layout",
-  items: [
-    { id: "divider", label: "Divider", path: "/components/divider" },
-    { id: "text", label: "Text", path: "/components/text" },
-    { id: "stack", label: "Stack", path: "/components/stack" },
-    { id: "collapsible", label: "Collapsible", path: "/components/collapsible" },
-    { id: "accordion", label: "Accordion", path: "/components/accordion" },
-    { id: "aspect-ratio", label: "Aspect Ratio", path: "/components/aspect-ratio" },
-    { id: "split-screen-exit", label: "Split Screen Exit", path: "/components/split-screen-exit" },
-    { id: "scroll-area", label: "Scroll Area", path: "/components/scroll-area" },
-    { id: "timeline", label: "Timeline", path: "/components/timeline" },
-    { id: "hero", label: "Hero", path: "/components/hero" },
-    { id: "footer", label: "Footer", path: "/components/footer" },
-    { id: "page-header", label: "Page Header", path: "/components/page-header" },
-  ],
-};
-
-// ---------------------------------------------------------------------------
-// Tokens (sections 49–55 in App.tsx)
-// ---------------------------------------------------------------------------
-const TOKENS: NavSection = {
-  label: "Tokens",
-  items: [
-    { id: "motion", label: "Motion", path: "/components/motion", comingSoon: true },
-    { id: "typography", label: "Typography", path: "/components/typography", comingSoon: true },
-    { id: "color", label: "Color", path: "/components/color", comingSoon: true },
-    { id: "spacing", label: "Spacing", path: "/components/spacing", comingSoon: true },
-    { id: "radius", label: "Radius", path: "/components/radius", comingSoon: true },
-    { id: "shadows", label: "Shadows", path: "/components/shadows", comingSoon: true },
-    { id: "surfaces", label: "Surfaces", path: "/components/surfaces", comingSoon: true },
-    {
-      id: "icon-vocabulary",
-      label: "Icon Vocabulary",
-      path: "/components/icon-vocabulary",
-      comingSoon: true,
-    },
-  ],
-};
-
-// ---------------------------------------------------------------------------
-// Dashboard
-// ---------------------------------------------------------------------------
-const DASHBOARD: NavSection = {
-  label: "Dashboard",
-  items: [{ id: "acmm-dashboard", label: "ACMM Dashboard", path: "/dashboard" }],
-};
-
-// ---------------------------------------------------------------------------
-// Examples
-// ---------------------------------------------------------------------------
-const EXAMPLES: NavSection = {
-  label: "Examples",
-  items: [
-    { id: "example-dashboard", label: "Dashboard", path: "/examples/dashboard" },
-    { id: "example-settings", label: "Settings", path: "/examples/settings" },
-    { id: "example-form", label: "Form States", path: "/examples/form" },
-  ],
-};
-
-// ---------------------------------------------------------------------------
-// Public exports
+// NAV_SECTIONS — derived from the registry (replaces hand-written list)
 // ---------------------------------------------------------------------------
 
-export const NAV_SECTIONS: NavSection[] = [
-  DASHBOARD,
-  FORMS,
-  DATA_DISPLAY,
-  NAVIGATION,
-  FEEDBACK,
-  OVERLAYS,
-  LAYOUT,
-  TOKENS,
-  EXAMPLES,
-];
+export const NAV_SECTIONS = REGISTRY_NAV_SECTIONS;
 
 /** Total number of showcased components across all sections. */
 export const COMPONENT_COUNT = NAV_SECTIONS.reduce(
@@ -202,8 +23,13 @@ export const COMPONENT_COUNT = NAV_SECTIONS.reduce(
   0
 );
 
+// ---------------------------------------------------------------------------
+// Demo pages — full-page demos, not component showcases.
+// These are separate from the registry (no lazy-load component, just links).
+// ---------------------------------------------------------------------------
+
 /** Full-page demo routes (not component showcases). */
-export const DEMO_PAGES = [
+export const DEMO_PAGES: readonly NavItem[] = [
   { id: "sign-in", label: "Sign In", path: "/demos/login" },
   { id: "sign-up", label: "Sign Up", path: "/demos/signup" },
   { id: "dashboard", label: "Dashboard", path: "/demos/dashboard" },

--- a/apps/rialto-web/src/data/page-registry.test.ts
+++ b/apps/rialto-web/src/data/page-registry.test.ts
@@ -1,10 +1,101 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   PAGE_REGISTRY,
   buildNavSections,
   buildSitemapPaths,
+  REGISTRY_NAV_SECTIONS,
+  REGISTRY_SITEMAP_PATHS,
   type PageEntry,
+  type NavSection,
+  type NavItem,
 } from "./page-registry.js";
+
+// ---------------------------------------------------------------------------
+// Mock all page modules so load() calls resolve without rendering components.
+// Each factory returns a minimal module with a named export matching the
+// pattern the load() arrow expects.
+// ---------------------------------------------------------------------------
+
+vi.mock("../pages/forms/ButtonPage.js", () => ({ ButtonPage: () => null }));
+vi.mock("../pages/forms/InputPage.js", () => ({ InputPage: () => null }));
+vi.mock("../pages/forms/TextAreaPage.js", () => ({ TextAreaPage: () => null }));
+vi.mock("../pages/forms/NumberInputPage.js", () => ({ NumberInputPage: () => null }));
+vi.mock("../pages/forms/CheckboxRadioPage.js", () => ({ CheckboxRadioPage: () => null }));
+vi.mock("../pages/forms/TogglePage.js", () => ({ TogglePage: () => null }));
+vi.mock("../pages/forms/MasterOverridePage.js", () => ({ MasterOverridePage: () => null }));
+vi.mock("../pages/forms/SliderPage.js", () => ({ SliderPage: () => null }));
+vi.mock("../pages/forms/SelectPage.js", () => ({ SelectPage: () => null }));
+vi.mock("../pages/forms/PinInputPage.js", () => ({ PinInputPage: () => null }));
+vi.mock("../pages/forms/SegmentedControlPage.js", () => ({ SegmentedControlPage: () => null }));
+vi.mock("../pages/forms/AutocompletePage.js", () => ({ AutocompletePage: () => null }));
+vi.mock("../pages/forms/InputGroupPage.js", () => ({ InputGroupPage: () => null }));
+vi.mock("../pages/data/CardPage.js", () => ({ CardPage: () => null }));
+vi.mock("../pages/data/TablePage.js", () => ({ TablePage: () => null }));
+vi.mock("../pages/data/BadgePage.js", () => ({ BadgePage: () => null }));
+vi.mock("../pages/data/TagPage.js", () => ({ TagPage: () => null }));
+vi.mock("../pages/data/AvatarPage.js", () => ({ AvatarPage: () => null }));
+vi.mock("../pages/data/StatPage.js", () => ({ StatPage: () => null }));
+vi.mock("../pages/data/DataListPage.js", () => ({ DataListPage: () => null }));
+vi.mock("../pages/data/MeterPage.js", () => ({ MeterPage: () => null }));
+vi.mock("../pages/data/KbdPage.js", () => ({ KbdPage: () => null }));
+vi.mock("../pages/data/FlipDotPage.js", () => ({ FlipDotPage: () => null }));
+vi.mock("../pages/data/SplitFlapPage.js", () => ({ SplitFlapPage: () => null }));
+vi.mock("../pages/data/ChalkboardPage.js", () => ({ ChalkboardPage: () => null }));
+vi.mock("../pages/data/FerrofluidPage.js", () => ({ FerrofluidPage: () => null }));
+vi.mock("../pages/data/TapeChartPage.js", () => ({ TapeChartPage: () => null }));
+vi.mock("../pages/data/TreePage.js", () => ({ TreePage: () => null }));
+vi.mock("../pages/data/TimelinePage.js", () => ({ TimelinePage: () => null }));
+vi.mock("../pages/navigation/TabsPage.js", () => ({ TabsPage: () => null }));
+vi.mock("../pages/navigation/BreadcrumbPage.js", () => ({ BreadcrumbPage: () => null }));
+vi.mock("../pages/navigation/StepsPage.js", () => ({ StepsPage: () => null }));
+vi.mock("../pages/navigation/PaginationPage.js", () => ({ PaginationPage: () => null }));
+vi.mock("../pages/navigation/NavigationMenuPage.js", () => ({
+  NavigationMenuPage: () => null,
+}));
+vi.mock("../pages/navigation/SidebarPage.js", () => ({ SidebarPage: () => null }));
+vi.mock("../pages/navigation/NavbarPage.js", () => ({ NavbarPage: () => null }));
+vi.mock("../pages/feedback/ToastPage.js", () => ({ ToastPage: () => null }));
+vi.mock("../pages/feedback/AlertPage.js", () => ({ AlertPage: () => null }));
+vi.mock("../pages/feedback/BannerPage.js", () => ({ BannerPage: () => null }));
+vi.mock("../pages/feedback/ProgressPage.js", () => ({ ProgressPage: () => null }));
+vi.mock("../pages/feedback/SpinnerPage.js", () => ({ SpinnerPage: () => null }));
+vi.mock("../pages/feedback/SkeletonPage.js", () => ({ SkeletonPage: () => null }));
+vi.mock("../pages/feedback/EmptyStatePage.js", () => ({ EmptyStatePage: () => null }));
+vi.mock("../pages/overlays/DialogPage.js", () => ({ DialogPage: () => null }));
+vi.mock("../pages/overlays/ConfirmDialogPage.js", () => ({ ConfirmDialogPage: () => null }));
+vi.mock("../pages/overlays/DrawerPage.js", () => ({ DrawerPage: () => null }));
+vi.mock("../pages/overlays/CommandPalettePage.js", () => ({ CommandPalettePage: () => null }));
+vi.mock("../pages/overlays/TooltipPage.js", () => ({ TooltipPage: () => null }));
+vi.mock("../pages/overlays/PopoverPage.js", () => ({ PopoverPage: () => null }));
+vi.mock("../pages/overlays/HoverCardPage.js", () => ({ HoverCardPage: () => null }));
+vi.mock("../pages/overlays/DropdownMenuPage.js", () => ({ DropdownMenuPage: () => null }));
+vi.mock("../pages/overlays/ContextMenuPage.js", () => ({ ContextMenuPage: () => null }));
+vi.mock("../pages/overlays/DisabledTooltipPage.js", () => ({ DisabledTooltipPage: () => null }));
+vi.mock("../pages/layout/DividerPage.js", () => ({ DividerPage: () => null }));
+vi.mock("../pages/layout/TextPage.js", () => ({ TextPage: () => null }));
+vi.mock("../pages/layout/StackPage.js", () => ({ StackPage: () => null }));
+vi.mock("../pages/layout/CollapsiblePage.js", () => ({ CollapsiblePage: () => null }));
+vi.mock("../pages/layout/AccordionPage.js", () => ({ AccordionPage: () => null }));
+vi.mock("../pages/layout/AspectRatioPage.js", () => ({ AspectRatioPage: () => null }));
+vi.mock("../pages/layout/SplitScreenExitPage.js", () => ({ SplitScreenExitPage: () => null }));
+vi.mock("../pages/layout/ScrollAreaPage.js", () => ({ ScrollAreaPage: () => null }));
+vi.mock("../pages/layout/HeroPage.js", () => ({ HeroPage: () => null }));
+vi.mock("../pages/layout/FooterPage.js", () => ({ FooterPage: () => null }));
+vi.mock("../pages/layout/PageHeaderPage.js", () => ({ PageHeaderPage: () => null }));
+vi.mock("../pages/dashboard/Dashboard.js", () => ({ Dashboard: () => null }));
+vi.mock("../pages/examples/DashboardExamplePage.js", () => ({
+  DashboardExamplePage: () => null,
+}));
+vi.mock("../pages/examples/SettingsExamplePage.js", () => ({
+  SettingsExamplePage: () => null,
+}));
+vi.mock("../pages/examples/FormStatesExamplePage.js", () => ({
+  FormStatesExamplePage: () => null,
+}));
+
+// ---------------------------------------------------------------------------
+// Structure tests
+// ---------------------------------------------------------------------------
 
 describe("PageRegistry — structure", () => {
   it("PAGE_REGISTRY is a non-empty array", () => {
@@ -32,6 +123,11 @@ describe("PageRegistry — structure", () => {
     expect(new Set(ids).size).toBe(ids.length);
   });
 
+  it("paths are globally unique", () => {
+    const paths = PAGE_REGISTRY.map((e) => e.path);
+    expect(new Set(paths).size).toBe(paths.length);
+  });
+
   it("paths start with /components/, /examples/, or /dashboard", () => {
     for (const entry of PAGE_REGISTRY) {
       expect(
@@ -43,7 +139,82 @@ describe("PageRegistry — structure", () => {
       ).toBe(true);
     }
   });
+
+  it("ids use kebab-case only", () => {
+    for (const entry of PAGE_REGISTRY) {
+      expect(entry.id, `${entry.id} uses non-kebab characters`).toMatch(/^[a-z0-9-]+$/);
+    }
+  });
+
+  it("comingSoon entries all have non-empty labels", () => {
+    const comingSoon = PAGE_REGISTRY.filter((e) => e.comingSoon);
+    expect(comingSoon.length).toBeGreaterThan(0);
+    for (const entry of comingSoon) {
+      expect(entry.label).toBeTruthy();
+    }
+  });
+
+  it("non-comingSoon entries have real dynamic imports (not stub resolvers)", () => {
+    // comingSoon entries use Promise.resolve({}) as a stub; all others should use import()
+    const real = PAGE_REGISTRY.filter((e) => !e.comingSoon);
+    expect(real.length).toBeGreaterThan(0);
+    for (const entry of real) {
+      expect(typeof entry.load).toBe("function");
+    }
+  });
+
+  it("categories include Forms, Data Display, Navigation, Feedback, Overlays, Layout", () => {
+    const categories = new Set(PAGE_REGISTRY.map((e) => e.category));
+    expect(categories.has("Forms")).toBe(true);
+    expect(categories.has("Data Display")).toBe(true);
+    expect(categories.has("Navigation")).toBe(true);
+    expect(categories.has("Feedback")).toBe(true);
+    expect(categories.has("Overlays")).toBe(true);
+    expect(categories.has("Layout")).toBe(true);
+  });
 });
+
+// ---------------------------------------------------------------------------
+// Load function tests — call every entry's load() to exercise the factories
+// ---------------------------------------------------------------------------
+
+describe("PageRegistry — load factories", () => {
+  it("all load() functions return a Promise", async () => {
+    for (const entry of PAGE_REGISTRY) {
+      const result = entry.load();
+      expect(result, `${entry.id}.load() did not return a Promise`).toBeInstanceOf(Promise);
+    }
+  });
+
+  it("comingSoon entries resolve to an empty object", async () => {
+    const comingSoon = PAGE_REGISTRY.filter((e) => e.comingSoon);
+    for (const entry of comingSoon) {
+      const mod = await entry.load();
+      expect(mod, `${entry.id} comingSoon load() should resolve to {}`).toEqual({});
+    }
+  });
+
+  it("non-comingSoon entries resolve to an object with a default export", async () => {
+    const real = PAGE_REGISTRY.filter((e) => !e.comingSoon);
+    for (const entry of real) {
+      const mod = (await entry.load()) as Record<string, unknown>;
+      expect(mod, `${entry.id} load() resolved to non-object: ${JSON.stringify(mod)}`).toBeTruthy();
+      expect("default" in mod, `${entry.id} load() did not produce a {default} shape`).toBe(true);
+    }
+  });
+
+  it("every load() resolves without throwing", async () => {
+    await Promise.all(
+      PAGE_REGISTRY.map((entry) =>
+        expect(entry.load(), `${entry.id}.load() should not reject`).resolves.toBeTruthy()
+      )
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Nav derivation tests
+// ---------------------------------------------------------------------------
 
 describe("PageRegistry — nav derivation", () => {
   it("buildNavSections returns non-empty array", () => {
@@ -73,7 +244,134 @@ describe("PageRegistry — nav derivation", () => {
       expect(item.path).toBe(`/components/${item.id}`);
     }
   });
+
+  it("preserves category order of first appearance", () => {
+    const entries: PageEntry[] = [
+      {
+        id: "b",
+        label: "B",
+        category: "Beta",
+        path: "/components/b",
+        load: () => Promise.resolve({}),
+      },
+      {
+        id: "a",
+        label: "A",
+        category: "Alpha",
+        path: "/components/a",
+        load: () => Promise.resolve({}),
+      },
+      {
+        id: "b2",
+        label: "B2",
+        category: "Beta",
+        path: "/components/b2",
+        load: () => Promise.resolve({}),
+      },
+    ];
+    const sections = buildNavSections(entries);
+    expect(sections[0]!.label).toBe("Beta");
+    expect(sections[1]!.label).toBe("Alpha");
+  });
+
+  it("groups multiple entries in the same category into one section", () => {
+    const entries: PageEntry[] = [
+      {
+        id: "a",
+        label: "A",
+        category: "Forms",
+        path: "/components/a",
+        load: () => Promise.resolve({}),
+      },
+      {
+        id: "b",
+        label: "B",
+        category: "Forms",
+        path: "/components/b",
+        load: () => Promise.resolve({}),
+      },
+      {
+        id: "c",
+        label: "C",
+        category: "Layout",
+        path: "/components/c",
+        load: () => Promise.resolve({}),
+      },
+    ];
+    const sections = buildNavSections(entries);
+    expect(sections).toHaveLength(2);
+    expect(sections[0]!.items).toHaveLength(2);
+    expect(sections[1]!.items).toHaveLength(1);
+  });
+
+  it("propagates comingSoon flag to nav items", () => {
+    const entries: PageEntry[] = [
+      {
+        id: "motion",
+        label: "Motion",
+        category: "Tokens",
+        path: "/components/motion",
+        comingSoon: true,
+        load: () => Promise.resolve({}),
+      },
+      {
+        id: "button",
+        label: "Button",
+        category: "Forms",
+        path: "/components/button",
+        load: () => Promise.resolve({}),
+      },
+    ];
+    const sections = buildNavSections(entries);
+    const tokensSection = sections.find((s) => s.label === "Tokens")!;
+    const formsSection = sections.find((s) => s.label === "Forms")!;
+
+    expect(tokensSection.items[0]!.comingSoon).toBe(true);
+    expect(formsSection.items[0]!.comingSoon).toBeUndefined();
+  });
+
+  it("omits comingSoon key from nav items without the flag", () => {
+    const entries: PageEntry[] = [
+      {
+        id: "x",
+        label: "X",
+        category: "C",
+        path: "/components/x",
+        load: () => Promise.resolve({}),
+      },
+    ];
+    const sections = buildNavSections(entries);
+    expect("comingSoon" in sections[0]!.items[0]!).toBe(false);
+  });
+
+  it("handles single-entry registry correctly", () => {
+    const entries: PageEntry[] = [
+      {
+        id: "solo",
+        label: "Solo",
+        category: "Single",
+        path: "/components/solo",
+        load: () => Promise.resolve({}),
+      },
+    ];
+    const sections = buildNavSections(entries);
+    expect(sections).toHaveLength(1);
+    expect(sections[0]!.items).toHaveLength(1);
+    expect(sections[0]!.items[0]!.id).toBe("solo");
+  });
+
+  it("REGISTRY_NAV_SECTIONS is derived from PAGE_REGISTRY and non-empty", () => {
+    expect(Array.isArray(REGISTRY_NAV_SECTIONS)).toBe(true);
+    expect(REGISTRY_NAV_SECTIONS.length).toBeGreaterThan(0);
+    // Must match what buildNavSections produces from PAGE_REGISTRY
+    const derived = buildNavSections(PAGE_REGISTRY);
+    expect(REGISTRY_NAV_SECTIONS).toEqual(derived);
+  });
 });
+
+// ---------------------------------------------------------------------------
+// Sitemap path tests
+// ---------------------------------------------------------------------------
 
 describe("PageRegistry — sitemap paths", () => {
   it("buildSitemapPaths returns all page paths", () => {
@@ -83,7 +381,40 @@ describe("PageRegistry — sitemap paths", () => {
       expect(paths, `${entry.path} not in sitemap paths`).toContain(entry.path);
     }
   });
+
+  it("buildSitemapPaths preserves registry order", () => {
+    const paths = buildSitemapPaths(PAGE_REGISTRY);
+    PAGE_REGISTRY.forEach((entry, i) => {
+      expect(paths[i]).toBe(entry.path);
+    });
+  });
+
+  it("buildSitemapPaths works on a custom subset", () => {
+    const subset: PageEntry[] = [
+      {
+        id: "a",
+        label: "A",
+        category: "C",
+        path: "/components/a",
+        load: () => Promise.resolve({}),
+      },
+      { id: "b", label: "B", category: "C", path: "/examples/b", load: () => Promise.resolve({}) },
+    ];
+    expect(buildSitemapPaths(subset)).toEqual(["/components/a", "/examples/b"]);
+  });
+
+  it("buildSitemapPaths returns empty array for empty input", () => {
+    expect(buildSitemapPaths([])).toEqual([]);
+  });
+
+  it("REGISTRY_SITEMAP_PATHS matches PAGE_REGISTRY paths", () => {
+    expect(REGISTRY_SITEMAP_PATHS).toEqual(PAGE_REGISTRY.map((e) => e.path));
+  });
 });
+
+// ---------------------------------------------------------------------------
+// Validation guard tests
+// ---------------------------------------------------------------------------
 
 describe("PageRegistry — missing metadata guard", () => {
   it("fails loudly when an entry lacks id", () => {
@@ -93,7 +424,7 @@ describe("PageRegistry — missing metadata guard", () => {
       path: "/components/test",
       load: () => Promise.resolve({}),
     } as unknown as PageEntry;
-    expect(() => buildNavSections([badEntry])).toThrow();
+    expect(() => buildNavSections([badEntry])).toThrow('missing required field "id"');
   });
 
   it("fails loudly when an entry lacks label", () => {
@@ -103,7 +434,7 @@ describe("PageRegistry — missing metadata guard", () => {
       path: "/components/test",
       load: () => Promise.resolve({}),
     } as unknown as PageEntry;
-    expect(() => buildNavSections([badEntry])).toThrow();
+    expect(() => buildNavSections([badEntry])).toThrow(/"label"/);
   });
 
   it("fails loudly when an entry lacks category", () => {
@@ -113,6 +444,99 @@ describe("PageRegistry — missing metadata guard", () => {
       path: "/components/test",
       load: () => Promise.resolve({}),
     } as unknown as PageEntry;
+    expect(() => buildNavSections([badEntry])).toThrow(/"category"/);
+  });
+
+  it("fails on first invalid entry in a mixed list", () => {
+    const good: PageEntry = {
+      id: "good",
+      label: "Good",
+      category: "Forms",
+      path: "/components/good",
+      load: () => Promise.resolve({}),
+    };
+    const bad = {
+      label: "Bad",
+      category: "Forms",
+      path: "/components/bad",
+      load: () => Promise.resolve({}),
+    } as unknown as PageEntry;
+    expect(() => buildNavSections([good, bad])).toThrow();
+  });
+
+  it("throws for empty id string (falsy)", () => {
+    const badEntry = {
+      id: "",
+      label: "Test",
+      category: "Forms",
+      path: "/components/test",
+      load: () => Promise.resolve({}),
+    } as unknown as PageEntry;
     expect(() => buildNavSections([badEntry])).toThrow();
+  });
+
+  it("throws for empty label string (falsy)", () => {
+    const badEntry = {
+      id: "test",
+      label: "",
+      category: "Forms",
+      path: "/components/test",
+      load: () => Promise.resolve({}),
+    } as unknown as PageEntry;
+    expect(() => buildNavSections([badEntry])).toThrow();
+  });
+
+  it("throws for empty category string (falsy)", () => {
+    const badEntry = {
+      id: "test",
+      label: "Test",
+      category: "",
+      path: "/components/test",
+      load: () => Promise.resolve({}),
+    } as unknown as PageEntry;
+    expect(() => buildNavSections([badEntry])).toThrow();
+  });
+
+  it("accepts empty array without throwing", () => {
+    expect(() => buildNavSections([])).not.toThrow();
+    expect(buildNavSections([])).toEqual([]);
+  });
+
+  it("PAGE_REGISTRY itself passes validation (no throw)", () => {
+    expect(() => buildNavSections(PAGE_REGISTRY)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NavItem / NavSection type shape tests
+// ---------------------------------------------------------------------------
+
+describe("PageRegistry — derived type shapes", () => {
+  it("NavSection has label string and items array", () => {
+    const sections: NavSection[] = buildNavSections(PAGE_REGISTRY);
+    for (const section of sections) {
+      expect(typeof section.label).toBe("string");
+      expect(Array.isArray(section.items)).toBe(true);
+    }
+  });
+
+  it("NavItem has id, label, path — all strings", () => {
+    const sections: NavSection[] = buildNavSections(PAGE_REGISTRY);
+    for (const section of sections) {
+      for (const item of section.items as NavItem[]) {
+        expect(typeof item.id).toBe("string");
+        expect(typeof item.label).toBe("string");
+        expect(typeof item.path).toBe("string");
+      }
+    }
+  });
+
+  it("NavItem does not carry the load factory", () => {
+    const sections: NavSection[] = buildNavSections(PAGE_REGISTRY);
+    for (const section of sections) {
+      for (const item of section.items) {
+        expect("load" in item).toBe(false);
+      }
+    }
   });
 });

--- a/apps/rialto-web/src/data/page-registry.test.ts
+++ b/apps/rialto-web/src/data/page-registry.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import {
+  PAGE_REGISTRY,
+  buildNavSections,
+  buildSitemapPaths,
+  type PageEntry,
+} from "./page-registry.js";
+
+describe("PageRegistry — structure", () => {
+  it("PAGE_REGISTRY is a non-empty array", () => {
+    expect(Array.isArray(PAGE_REGISTRY)).toBe(true);
+    expect(PAGE_REGISTRY.length).toBeGreaterThan(0);
+  });
+
+  it("every entry has id, label, category, and path", () => {
+    for (const entry of PAGE_REGISTRY) {
+      expect(entry.id, `${entry.id} missing id`).toBeTruthy();
+      expect(entry.label, `${entry.id} missing label`).toBeTruthy();
+      expect(entry.category, `${entry.id} missing category`).toBeTruthy();
+      expect(entry.path, `${entry.id} missing path`).toBeTruthy();
+    }
+  });
+
+  it("every entry has a load function", () => {
+    for (const entry of PAGE_REGISTRY) {
+      expect(typeof entry.load, `${entry.id} missing load`).toBe("function");
+    }
+  });
+
+  it("ids are globally unique", () => {
+    const ids = PAGE_REGISTRY.map((e: PageEntry) => e.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("paths start with /components/, /examples/, or /dashboard", () => {
+    for (const entry of PAGE_REGISTRY) {
+      expect(
+        entry.path.startsWith("/components/") ||
+          entry.path.startsWith("/examples/") ||
+          entry.path === "/dashboard" ||
+          entry.path.startsWith("/dashboard/"),
+        `${entry.id} has invalid path: ${entry.path}`
+      ).toBe(true);
+    }
+  });
+});
+
+describe("PageRegistry — nav derivation", () => {
+  it("buildNavSections returns non-empty array", () => {
+    const sections = buildNavSections(PAGE_REGISTRY);
+    expect(sections.length).toBeGreaterThan(0);
+  });
+
+  it("every page in registry is listed in nav (by id)", () => {
+    const sections = buildNavSections(PAGE_REGISTRY);
+    const navIds = sections.flatMap((s) => s.items.map((i) => i.id));
+    for (const entry of PAGE_REGISTRY) {
+      expect(navIds, `${entry.id} not found in nav`).toContain(entry.id);
+    }
+  });
+
+  it("section labels are unique", () => {
+    const sections = buildNavSections(PAGE_REGISTRY);
+    const labels = sections.map((s) => s.label);
+    expect(new Set(labels).size).toBe(labels.length);
+  });
+
+  it("nav items use /components/{id} path pattern for component pages", () => {
+    const sections = buildNavSections(PAGE_REGISTRY);
+    const allItems = sections.flatMap((s) => s.items);
+    const componentItems = allItems.filter((item) => item.path.startsWith("/components/"));
+    for (const item of componentItems) {
+      expect(item.path).toBe(`/components/${item.id}`);
+    }
+  });
+});
+
+describe("PageRegistry — sitemap paths", () => {
+  it("buildSitemapPaths returns all page paths", () => {
+    const paths = buildSitemapPaths(PAGE_REGISTRY);
+    expect(paths.length).toBe(PAGE_REGISTRY.length);
+    for (const entry of PAGE_REGISTRY) {
+      expect(paths, `${entry.path} not in sitemap paths`).toContain(entry.path);
+    }
+  });
+});
+
+describe("PageRegistry — missing metadata guard", () => {
+  it("fails loudly when an entry lacks id", () => {
+    const badEntry = {
+      label: "Test",
+      category: "Forms",
+      path: "/components/test",
+      load: () => Promise.resolve({}),
+    } as unknown as PageEntry;
+    expect(() => buildNavSections([badEntry])).toThrow();
+  });
+
+  it("fails loudly when an entry lacks label", () => {
+    const badEntry = {
+      id: "test",
+      category: "Forms",
+      path: "/components/test",
+      load: () => Promise.resolve({}),
+    } as unknown as PageEntry;
+    expect(() => buildNavSections([badEntry])).toThrow();
+  });
+
+  it("fails loudly when an entry lacks category", () => {
+    const badEntry = {
+      id: "test",
+      label: "Test",
+      path: "/components/test",
+      load: () => Promise.resolve({}),
+    } as unknown as PageEntry;
+    expect(() => buildNavSections([badEntry])).toThrow();
+  });
+});

--- a/apps/rialto-web/src/data/page-registry.ts
+++ b/apps/rialto-web/src/data/page-registry.ts
@@ -1,0 +1,702 @@
+/**
+ * PageRegistry — single source of truth for all showcase pages.
+ *
+ * Nav sections, route definitions, and sitemap paths are all derived
+ * from this registry. Adding a new page means one edit here, not three.
+ *
+ * Each entry carries:
+ *   id       — kebab-case, unique. Component routes use /components/{id}.
+ *   label    — display name in the sidebar.
+ *   category — groups entries into nav sections (order of first appearance preserved).
+ *   path     — full route path (e.g. /components/button, /examples/dashboard).
+ *   comingSoon? — renders with a muted "coming soon" indicator in the nav.
+ *   load     — lazy dynamic import factory (preserves per-page code splitting).
+ */
+
+export interface PageEntry {
+  id: string;
+  label: string;
+  category: string;
+  path: string;
+  comingSoon?: boolean;
+  load: () => Promise<unknown>;
+}
+
+export interface NavItem {
+  id: string;
+  label: string;
+  path: string;
+  comingSoon?: boolean;
+}
+
+export interface NavSection {
+  label: string;
+  items: NavItem[];
+}
+
+// ---------------------------------------------------------------------------
+// Registry validation helper
+// ---------------------------------------------------------------------------
+
+function validateEntry(entry: PageEntry): void {
+  if (!entry.id) throw new Error(`PageRegistry: entry missing required field "id"`);
+  if (!entry.label)
+    throw new Error(`PageRegistry: entry "${entry.id}" missing required field "label"`);
+  if (!entry.category)
+    throw new Error(`PageRegistry: entry "${entry.id}" missing required field "category"`);
+}
+
+// ---------------------------------------------------------------------------
+// The registry
+// ---------------------------------------------------------------------------
+
+export const PAGE_REGISTRY: PageEntry[] = [
+  // ── Forms ──────────────────────────────────────────────────────────────
+  {
+    id: "button",
+    label: "Button",
+    category: "Forms",
+    path: "/components/button",
+    load: () => import("../pages/forms/ButtonPage").then((m) => ({ default: m.ButtonPage })),
+  },
+  {
+    id: "input",
+    label: "Input",
+    category: "Forms",
+    path: "/components/input",
+    load: () => import("../pages/forms/InputPage").then((m) => ({ default: m.InputPage })),
+  },
+  {
+    id: "textarea",
+    label: "TextArea",
+    category: "Forms",
+    path: "/components/textarea",
+    load: () => import("../pages/forms/TextAreaPage").then((m) => ({ default: m.TextAreaPage })),
+  },
+  {
+    id: "number-input",
+    label: "Number Input",
+    category: "Forms",
+    path: "/components/number-input",
+    load: () =>
+      import("../pages/forms/NumberInputPage").then((m) => ({ default: m.NumberInputPage })),
+  },
+  {
+    id: "checkbox-radio",
+    label: "Checkbox & Radio",
+    category: "Forms",
+    path: "/components/checkbox-radio",
+    load: () =>
+      import("../pages/forms/CheckboxRadioPage").then((m) => ({ default: m.CheckboxRadioPage })),
+  },
+  {
+    id: "toggle",
+    label: "Toggle",
+    category: "Forms",
+    path: "/components/toggle",
+    load: () => import("../pages/forms/TogglePage").then((m) => ({ default: m.TogglePage })),
+  },
+  {
+    id: "master-override",
+    label: "Master Override",
+    category: "Forms",
+    path: "/components/master-override",
+    load: () =>
+      import("../pages/forms/MasterOverridePage").then((m) => ({ default: m.MasterOverridePage })),
+  },
+  {
+    id: "slider",
+    label: "Slider",
+    category: "Forms",
+    path: "/components/slider",
+    load: () => import("../pages/forms/SliderPage").then((m) => ({ default: m.SliderPage })),
+  },
+  {
+    id: "select",
+    label: "Select",
+    category: "Forms",
+    path: "/components/select",
+    load: () => import("../pages/forms/SelectPage").then((m) => ({ default: m.SelectPage })),
+  },
+  {
+    id: "pin-input",
+    label: "Pin Input",
+    category: "Forms",
+    path: "/components/pin-input",
+    load: () => import("../pages/forms/PinInputPage").then((m) => ({ default: m.PinInputPage })),
+  },
+  {
+    id: "segmented-control",
+    label: "Segmented Control",
+    category: "Forms",
+    path: "/components/segmented-control",
+    load: () =>
+      import("../pages/forms/SegmentedControlPage").then((m) => ({
+        default: m.SegmentedControlPage,
+      })),
+  },
+  {
+    id: "autocomplete",
+    label: "Autocomplete",
+    category: "Forms",
+    path: "/components/autocomplete",
+    load: () =>
+      import("../pages/forms/AutocompletePage").then((m) => ({ default: m.AutocompletePage })),
+  },
+  {
+    id: "input-group",
+    label: "Input Group",
+    category: "Forms",
+    path: "/components/input-group",
+    load: () =>
+      import("../pages/forms/InputGroupPage").then((m) => ({ default: m.InputGroupPage })),
+  },
+  // ── Data Display ────────────────────────────────────────────────────────
+  {
+    id: "card",
+    label: "Card",
+    category: "Data Display",
+    path: "/components/card",
+    load: () => import("../pages/data/CardPage").then((m) => ({ default: m.CardPage })),
+  },
+  {
+    id: "table",
+    label: "Table",
+    category: "Data Display",
+    path: "/components/table",
+    load: () => import("../pages/data/TablePage").then((m) => ({ default: m.TablePage })),
+  },
+  {
+    id: "badge",
+    label: "Badge",
+    category: "Data Display",
+    path: "/components/badge",
+    load: () => import("../pages/data/BadgePage").then((m) => ({ default: m.BadgePage })),
+  },
+  {
+    id: "tag",
+    label: "Tag",
+    category: "Data Display",
+    path: "/components/tag",
+    load: () => import("../pages/data/TagPage").then((m) => ({ default: m.TagPage })),
+  },
+  {
+    id: "avatar",
+    label: "Avatar",
+    category: "Data Display",
+    path: "/components/avatar",
+    load: () => import("../pages/data/AvatarPage").then((m) => ({ default: m.AvatarPage })),
+  },
+  {
+    id: "stat",
+    label: "Stat",
+    category: "Data Display",
+    path: "/components/stat",
+    load: () => import("../pages/data/StatPage").then((m) => ({ default: m.StatPage })),
+  },
+  {
+    id: "data-list",
+    label: "Data List",
+    category: "Data Display",
+    path: "/components/data-list",
+    load: () => import("../pages/data/DataListPage").then((m) => ({ default: m.DataListPage })),
+  },
+  {
+    id: "meter",
+    label: "Meter",
+    category: "Data Display",
+    path: "/components/meter",
+    load: () => import("../pages/data/MeterPage").then((m) => ({ default: m.MeterPage })),
+  },
+  {
+    id: "kbd",
+    label: "Kbd",
+    category: "Data Display",
+    path: "/components/kbd",
+    load: () => import("../pages/data/KbdPage").then((m) => ({ default: m.KbdPage })),
+  },
+  {
+    id: "flip-dot",
+    label: "Flip Dot",
+    category: "Data Display",
+    path: "/components/flip-dot",
+    load: () => import("../pages/data/FlipDotPage").then((m) => ({ default: m.FlipDotPage })),
+  },
+  {
+    id: "split-flap",
+    label: "Split Flap",
+    category: "Data Display",
+    path: "/components/split-flap",
+    load: () => import("../pages/data/SplitFlapPage").then((m) => ({ default: m.SplitFlapPage })),
+  },
+  {
+    id: "chalkboard",
+    label: "Chalkboard",
+    category: "Data Display",
+    path: "/components/chalkboard",
+    load: () => import("../pages/data/ChalkboardPage").then((m) => ({ default: m.ChalkboardPage })),
+  },
+  {
+    id: "ferrofluid",
+    label: "Ferrofluid",
+    category: "Data Display",
+    path: "/components/ferrofluid",
+    load: () => import("../pages/data/FerrofluidPage").then((m) => ({ default: m.FerrofluidPage })),
+  },
+  {
+    id: "tape-chart",
+    label: "Tape Chart",
+    category: "Data Display",
+    path: "/components/tape-chart",
+    load: () => import("../pages/data/TapeChartPage").then((m) => ({ default: m.TapeChartPage })),
+  },
+  // ── Navigation ──────────────────────────────────────────────────────────
+  {
+    id: "tabs",
+    label: "Tabs",
+    category: "Navigation",
+    path: "/components/tabs",
+    load: () => import("../pages/navigation/TabsPage").then((m) => ({ default: m.TabsPage })),
+  },
+  {
+    id: "breadcrumb",
+    label: "Breadcrumb",
+    category: "Navigation",
+    path: "/components/breadcrumb",
+    load: () =>
+      import("../pages/navigation/BreadcrumbPage").then((m) => ({ default: m.BreadcrumbPage })),
+  },
+  {
+    id: "steps",
+    label: "Steps",
+    category: "Navigation",
+    path: "/components/steps",
+    load: () => import("../pages/navigation/StepsPage").then((m) => ({ default: m.StepsPage })),
+  },
+  {
+    id: "pagination",
+    label: "Pagination",
+    category: "Navigation",
+    path: "/components/pagination",
+    load: () =>
+      import("../pages/navigation/PaginationPage").then((m) => ({ default: m.PaginationPage })),
+  },
+  {
+    id: "navigation-menu",
+    label: "Navigation Menu",
+    category: "Navigation",
+    path: "/components/navigation-menu",
+    load: () =>
+      import("../pages/navigation/NavigationMenuPage").then((m) => ({
+        default: m.NavigationMenuPage,
+      })),
+  },
+  {
+    id: "tree",
+    label: "Tree",
+    category: "Navigation",
+    path: "/components/tree",
+    load: () => import("../pages/data/TreePage").then((m) => ({ default: m.TreePage })),
+  },
+  {
+    id: "sidebar",
+    label: "Sidebar",
+    category: "Navigation",
+    path: "/components/sidebar",
+    load: () => import("../pages/navigation/SidebarPage").then((m) => ({ default: m.SidebarPage })),
+  },
+  {
+    id: "navbar",
+    label: "Navbar",
+    category: "Navigation",
+    path: "/components/navbar",
+    load: () => import("../pages/navigation/NavbarPage").then((m) => ({ default: m.NavbarPage })),
+  },
+  // ── Feedback ────────────────────────────────────────────────────────────
+  {
+    id: "toast",
+    label: "Toast",
+    category: "Feedback",
+    path: "/components/toast",
+    load: () => import("../pages/feedback/ToastPage").then((m) => ({ default: m.ToastPage })),
+  },
+  {
+    id: "alert",
+    label: "Alert",
+    category: "Feedback",
+    path: "/components/alert",
+    load: () => import("../pages/feedback/AlertPage").then((m) => ({ default: m.AlertPage })),
+  },
+  {
+    id: "banner",
+    label: "Banner",
+    category: "Feedback",
+    path: "/components/banner",
+    load: () => import("../pages/feedback/BannerPage").then((m) => ({ default: m.BannerPage })),
+  },
+  {
+    id: "progress",
+    label: "Progress",
+    category: "Feedback",
+    path: "/components/progress",
+    load: () => import("../pages/feedback/ProgressPage").then((m) => ({ default: m.ProgressPage })),
+  },
+  {
+    id: "spinner",
+    label: "Spinner",
+    category: "Feedback",
+    path: "/components/spinner",
+    load: () => import("../pages/feedback/SpinnerPage").then((m) => ({ default: m.SpinnerPage })),
+  },
+  {
+    id: "skeleton",
+    label: "Skeleton",
+    category: "Feedback",
+    path: "/components/skeleton",
+    load: () => import("../pages/feedback/SkeletonPage").then((m) => ({ default: m.SkeletonPage })),
+  },
+  {
+    id: "empty-state",
+    label: "Empty State",
+    category: "Feedback",
+    path: "/components/empty-state",
+    load: () =>
+      import("../pages/feedback/EmptyStatePage").then((m) => ({ default: m.EmptyStatePage })),
+  },
+  // ── Overlays ────────────────────────────────────────────────────────────
+  {
+    id: "dialog",
+    label: "Dialog",
+    category: "Overlays",
+    path: "/components/dialog",
+    load: () => import("../pages/overlays/DialogPage").then((m) => ({ default: m.DialogPage })),
+  },
+  {
+    id: "confirm-dialog",
+    label: "Confirm Dialog",
+    category: "Overlays",
+    path: "/components/confirm-dialog",
+    load: () =>
+      import("../pages/overlays/ConfirmDialogPage").then((m) => ({
+        default: m.ConfirmDialogPage,
+      })),
+  },
+  {
+    id: "drawer",
+    label: "Drawer",
+    category: "Overlays",
+    path: "/components/drawer",
+    load: () => import("../pages/overlays/DrawerPage").then((m) => ({ default: m.DrawerPage })),
+  },
+  {
+    id: "command-palette",
+    label: "Command Palette",
+    category: "Overlays",
+    path: "/components/command-palette",
+    load: () =>
+      import("../pages/overlays/CommandPalettePage").then((m) => ({
+        default: m.CommandPalettePage,
+      })),
+  },
+  {
+    id: "tooltip",
+    label: "Tooltip",
+    category: "Overlays",
+    path: "/components/tooltip",
+    load: () => import("../pages/overlays/TooltipPage").then((m) => ({ default: m.TooltipPage })),
+  },
+  {
+    id: "popover",
+    label: "Popover",
+    category: "Overlays",
+    path: "/components/popover",
+    load: () => import("../pages/overlays/PopoverPage").then((m) => ({ default: m.PopoverPage })),
+  },
+  {
+    id: "hover-card",
+    label: "Hover Card",
+    category: "Overlays",
+    path: "/components/hover-card",
+    load: () =>
+      import("../pages/overlays/HoverCardPage").then((m) => ({ default: m.HoverCardPage })),
+  },
+  {
+    id: "dropdown-menu",
+    label: "Dropdown Menu",
+    category: "Overlays",
+    path: "/components/dropdown-menu",
+    load: () =>
+      import("../pages/overlays/DropdownMenuPage").then((m) => ({
+        default: m.DropdownMenuPage,
+      })),
+  },
+  {
+    id: "context-menu",
+    label: "Context Menu",
+    category: "Overlays",
+    path: "/components/context-menu",
+    load: () =>
+      import("../pages/overlays/ContextMenuPage").then((m) => ({
+        default: m.ContextMenuPage,
+      })),
+  },
+  {
+    id: "disabled-tooltip",
+    label: "Disabled Tooltip",
+    category: "Overlays",
+    path: "/components/disabled-tooltip",
+    load: () =>
+      import("../pages/overlays/DisabledTooltipPage").then((m) => ({
+        default: m.DisabledTooltipPage,
+      })),
+  },
+  // ── Layout ──────────────────────────────────────────────────────────────
+  {
+    id: "divider",
+    label: "Divider",
+    category: "Layout",
+    path: "/components/divider",
+    load: () => import("../pages/layout/DividerPage").then((m) => ({ default: m.DividerPage })),
+  },
+  {
+    id: "text",
+    label: "Text",
+    category: "Layout",
+    path: "/components/text",
+    load: () => import("../pages/layout/TextPage").then((m) => ({ default: m.TextPage })),
+  },
+  {
+    id: "stack",
+    label: "Stack",
+    category: "Layout",
+    path: "/components/stack",
+    load: () => import("../pages/layout/StackPage").then((m) => ({ default: m.StackPage })),
+  },
+  {
+    id: "collapsible",
+    label: "Collapsible",
+    category: "Layout",
+    path: "/components/collapsible",
+    load: () =>
+      import("../pages/layout/CollapsiblePage").then((m) => ({ default: m.CollapsiblePage })),
+  },
+  {
+    id: "accordion",
+    label: "Accordion",
+    category: "Layout",
+    path: "/components/accordion",
+    load: () => import("../pages/layout/AccordionPage").then((m) => ({ default: m.AccordionPage })),
+  },
+  {
+    id: "aspect-ratio",
+    label: "Aspect Ratio",
+    category: "Layout",
+    path: "/components/aspect-ratio",
+    load: () =>
+      import("../pages/layout/AspectRatioPage").then((m) => ({ default: m.AspectRatioPage })),
+  },
+  {
+    id: "split-screen-exit",
+    label: "Split Screen Exit",
+    category: "Layout",
+    path: "/components/split-screen-exit",
+    load: () =>
+      import("../pages/layout/SplitScreenExitPage").then((m) => ({
+        default: m.SplitScreenExitPage,
+      })),
+  },
+  {
+    id: "scroll-area",
+    label: "Scroll Area",
+    category: "Layout",
+    path: "/components/scroll-area",
+    load: () =>
+      import("../pages/layout/ScrollAreaPage").then((m) => ({ default: m.ScrollAreaPage })),
+  },
+  {
+    id: "timeline",
+    label: "Timeline",
+    category: "Layout",
+    path: "/components/timeline",
+    load: () => import("../pages/data/TimelinePage").then((m) => ({ default: m.TimelinePage })),
+  },
+  {
+    id: "hero",
+    label: "Hero",
+    category: "Layout",
+    path: "/components/hero",
+    load: () => import("../pages/layout/HeroPage").then((m) => ({ default: m.HeroPage })),
+  },
+  {
+    id: "footer",
+    label: "Footer",
+    category: "Layout",
+    path: "/components/footer",
+    load: () => import("../pages/layout/FooterPage").then((m) => ({ default: m.FooterPage })),
+  },
+  {
+    id: "page-header",
+    label: "Page Header",
+    category: "Layout",
+    path: "/components/page-header",
+    load: () =>
+      import("../pages/layout/PageHeaderPage").then((m) => ({ default: m.PageHeaderPage })),
+  },
+  // ── Tokens ──────────────────────────────────────────────────────────────
+  {
+    id: "motion",
+    label: "Motion",
+    category: "Tokens",
+    path: "/components/motion",
+    comingSoon: true,
+    load: () => Promise.resolve({}),
+  },
+  {
+    id: "typography",
+    label: "Typography",
+    category: "Tokens",
+    path: "/components/typography",
+    comingSoon: true,
+    load: () => Promise.resolve({}),
+  },
+  {
+    id: "color",
+    label: "Color",
+    category: "Tokens",
+    path: "/components/color",
+    comingSoon: true,
+    load: () => Promise.resolve({}),
+  },
+  {
+    id: "spacing",
+    label: "Spacing",
+    category: "Tokens",
+    path: "/components/spacing",
+    comingSoon: true,
+    load: () => Promise.resolve({}),
+  },
+  {
+    id: "radius",
+    label: "Radius",
+    category: "Tokens",
+    path: "/components/radius",
+    comingSoon: true,
+    load: () => Promise.resolve({}),
+  },
+  {
+    id: "shadows",
+    label: "Shadows",
+    category: "Tokens",
+    path: "/components/shadows",
+    comingSoon: true,
+    load: () => Promise.resolve({}),
+  },
+  {
+    id: "surfaces",
+    label: "Surfaces",
+    category: "Tokens",
+    path: "/components/surfaces",
+    comingSoon: true,
+    load: () => Promise.resolve({}),
+  },
+  {
+    id: "icon-vocabulary",
+    label: "Icon Vocabulary",
+    category: "Tokens",
+    path: "/components/icon-vocabulary",
+    comingSoon: true,
+    load: () => Promise.resolve({}),
+  },
+  // ── Dashboard ───────────────────────────────────────────────────────────
+  {
+    id: "acmm-dashboard",
+    label: "ACMM Dashboard",
+    category: "Dashboard",
+    path: "/dashboard",
+    load: () => import("../pages/dashboard/Dashboard").then((m) => ({ default: m.Dashboard })),
+  },
+  // ── Examples ────────────────────────────────────────────────────────────
+  {
+    id: "example-dashboard",
+    label: "Dashboard",
+    category: "Examples",
+    path: "/examples/dashboard",
+    load: () =>
+      import("../pages/examples/DashboardExamplePage").then((m) => ({
+        default: m.DashboardExamplePage,
+      })),
+  },
+  {
+    id: "example-settings",
+    label: "Settings",
+    category: "Examples",
+    path: "/examples/settings",
+    load: () =>
+      import("../pages/examples/SettingsExamplePage").then((m) => ({
+        default: m.SettingsExamplePage,
+      })),
+  },
+  {
+    id: "example-form",
+    label: "Form States",
+    category: "Examples",
+    path: "/examples/form",
+    load: () =>
+      import("../pages/examples/FormStatesExamplePage").then((m) => ({
+        default: m.FormStatesExamplePage,
+      })),
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Derived nav sections
+// ---------------------------------------------------------------------------
+
+/**
+ * Build nav sections from the registry, grouped by category.
+ * Category order is determined by first appearance in the registry.
+ * Throws if any entry is missing required fields.
+ */
+export function buildNavSections(entries: PageEntry[]): NavSection[] {
+  // Validate all entries first
+  for (const entry of entries) {
+    validateEntry(entry);
+  }
+
+  const sectionMap = new Map<string, NavItem[]>();
+
+  for (const entry of entries) {
+    if (!sectionMap.has(entry.category)) {
+      sectionMap.set(entry.category, []);
+    }
+    sectionMap.get(entry.category)!.push({
+      id: entry.id,
+      label: entry.label,
+      path: entry.path,
+      ...(entry.comingSoon ? { comingSoon: true } : {}),
+    });
+  }
+
+  return Array.from(sectionMap.entries()).map(([label, items]) => ({ label, items }));
+}
+
+// ---------------------------------------------------------------------------
+// Derived sitemap paths
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns all page paths for sitemap generation.
+ */
+export function buildSitemapPaths(entries: PageEntry[]): string[] {
+  return entries.map((e) => e.path);
+}
+
+// ---------------------------------------------------------------------------
+// Pre-built exports (derived from the registry at module load time)
+// ---------------------------------------------------------------------------
+
+/** Nav sections derived from PAGE_REGISTRY. Replaces the hand-written nav-sections list. */
+export const REGISTRY_NAV_SECTIONS: NavSection[] = buildNavSections(PAGE_REGISTRY);
+
+/** Sitemap paths derived from PAGE_REGISTRY. */
+export const REGISTRY_SITEMAP_PATHS: string[] = buildSitemapPaths(PAGE_REGISTRY);

--- a/apps/rialto-web/src/layouts/DemoLayout.test.tsx
+++ b/apps/rialto-web/src/layouts/DemoLayout.test.tsx
@@ -1,0 +1,336 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { DemoLayout, FloatingControls } from "./DemoLayout.js";
+
+vi.mock("@mattbutlerengineering/rialto", () => ({
+  GlobalNav: ({ onThemeToggle }: any) => (
+    <nav data-testid="global-nav">
+      <button onClick={onThemeToggle} data-testid="theme-toggle">
+        toggle
+      </button>
+    </nav>
+  ),
+  RialtoProvider: ({ children }: any) => <div data-testid="rialto-provider">{children}</div>,
+}));
+
+vi.mock("../components/CookieConsent/useCookieConsent.js", () => ({
+  useCookieConsent: () => ({
+    consented: null,
+    preferences: { analytics: false, marketing: false },
+    acceptAll: vi.fn(),
+    rejectAll: vi.fn(),
+    savePreferences: vi.fn(),
+  }),
+}));
+
+vi.mock("../components/CookieConsent/CookieConsent.js", () => ({
+  CookieBanner: ({ onAcceptAll, onRejectAll, onCustomize }: any) => (
+    <div data-testid="cookie-banner">
+      <button onClick={onAcceptAll}>Accept</button>
+      <button onClick={onRejectAll}>Reject</button>
+      <button onClick={onCustomize}>Customize</button>
+    </div>
+  ),
+  CookiePreferencesDialog: ({ open, onClose, onSave, onRejectAll }: any) =>
+    open ? (
+      <div data-testid="cookie-dialog">
+        <button onClick={onClose}>Close</button>
+        <button onClick={onSave}>Save</button>
+        <button onClick={onRejectAll}>Reject All</button>
+      </div>
+    ) : null,
+}));
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+function renderDemoLayout() {
+  return render(
+    <MemoryRouter>
+      <DemoLayout />
+    </MemoryRouter>
+  );
+}
+
+describe("DemoLayout", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it("renders the global nav", () => {
+    renderDemoLayout();
+    expect(screen.getByTestId("global-nav")).toBeInTheDocument();
+  });
+
+  it("renders the rialto provider", () => {
+    renderDemoLayout();
+    expect(screen.getByTestId("rialto-provider")).toBeInTheDocument();
+  });
+
+  it("renders the cookie banner", () => {
+    renderDemoLayout();
+    expect(screen.getByTestId("cookie-banner")).toBeInTheDocument();
+  });
+
+  it("does not show cookie preferences dialog initially", () => {
+    renderDemoLayout();
+    expect(screen.queryByTestId("cookie-dialog")).not.toBeInTheDocument();
+  });
+
+  it("opens cookie preferences dialog when Customize is clicked", () => {
+    renderDemoLayout();
+    fireEvent.click(screen.getByText("Customize"));
+    expect(screen.getByTestId("cookie-dialog")).toBeInTheDocument();
+  });
+
+  it("closes cookie preferences dialog when Close is clicked", () => {
+    renderDemoLayout();
+    fireEvent.click(screen.getByText("Customize"));
+    expect(screen.getByTestId("cookie-dialog")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Close"));
+    expect(screen.queryByTestId("cookie-dialog")).not.toBeInTheDocument();
+  });
+
+  it("re-mounts dialog (new key) when opened again after closing", () => {
+    renderDemoLayout();
+    fireEvent.click(screen.getByText("Customize"));
+    const dialog1 = screen.getByTestId("cookie-dialog");
+    fireEvent.click(screen.getByText("Close"));
+    fireEvent.click(screen.getByText("Customize"));
+    const dialog2 = screen.getByTestId("cookie-dialog");
+    // Both renders produced a dialog element
+    expect(dialog1).toBeTruthy();
+    expect(dialog2).toBeTruthy();
+  });
+
+  it("saves theme preference to localStorage when dark mode is toggled via GlobalNav", () => {
+    renderDemoLayout();
+    // GlobalNav onThemeToggle calls handleDarkModeChange(!darkMode)
+    // Initial state is light (matchMedia returns false). Toggling sets dark.
+    fireEvent.click(screen.getByTestId("theme-toggle"));
+    expect(localStorage.getItem("mbe-theme-preference")).toBe("dark");
+  });
+
+  it("saves 'light' to localStorage when toggled back from dark to light", () => {
+    // Start dark: simulate saved preference
+    localStorage.setItem("mbe-theme-preference", "dark");
+    renderDemoLayout();
+    // DemoLayout initialises darkMode=true from localStorage, toggles to light
+    fireEvent.click(screen.getByTestId("theme-toggle"));
+    expect(localStorage.getItem("mbe-theme-preference")).toBe("light");
+  });
+
+  it("reads initial dark mode state from localStorage", () => {
+    localStorage.setItem("mbe-theme-preference", "dark");
+    renderDemoLayout();
+    // No assertion on DOM (RialtoProvider is mocked) but should not throw
+    expect(screen.getByTestId("rialto-provider")).toBeInTheDocument();
+  });
+
+  it("falls back to system preference when localStorage has no theme", () => {
+    // matchMedia returns false (light), so dark mode is false by default
+    renderDemoLayout();
+    expect(screen.getByTestId("rialto-provider")).toBeInTheDocument();
+  });
+});
+
+describe("FloatingControls", () => {
+  it("renders dark mode toggle with correct aria-label in light mode", () => {
+    render(
+      <FloatingControls
+        darkMode={false}
+        onDarkModeChange={vi.fn()}
+        rtl={false}
+        onRtlChange={vi.fn()}
+        activeVibe="default"
+        onVibeChange={vi.fn()}
+      />
+    );
+    expect(screen.getByLabelText("Switch to dark mode")).toBeInTheDocument();
+  });
+
+  it("renders dark mode toggle with correct aria-label in dark mode", () => {
+    render(
+      <FloatingControls
+        darkMode={true}
+        onDarkModeChange={vi.fn()}
+        rtl={false}
+        onRtlChange={vi.fn()}
+        activeVibe="default"
+        onVibeChange={vi.fn()}
+      />
+    );
+    expect(screen.getByLabelText("Switch to light mode")).toBeInTheDocument();
+  });
+
+  it("calls onDarkModeChange(true) when toggling from light", () => {
+    const onDarkModeChange = vi.fn();
+    render(
+      <FloatingControls
+        darkMode={false}
+        onDarkModeChange={onDarkModeChange}
+        rtl={false}
+        onRtlChange={vi.fn()}
+        activeVibe="default"
+        onVibeChange={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByLabelText("Switch to dark mode"));
+    expect(onDarkModeChange).toHaveBeenCalledWith(true);
+  });
+
+  it("calls onDarkModeChange(false) when toggling from dark", () => {
+    const onDarkModeChange = vi.fn();
+    render(
+      <FloatingControls
+        darkMode={true}
+        onDarkModeChange={onDarkModeChange}
+        rtl={false}
+        onRtlChange={vi.fn()}
+        activeVibe="default"
+        onVibeChange={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByLabelText("Switch to light mode"));
+    expect(onDarkModeChange).toHaveBeenCalledWith(false);
+  });
+
+  it("renders RTL toggle with correct aria-label in LTR mode", () => {
+    render(
+      <FloatingControls
+        darkMode={false}
+        onDarkModeChange={vi.fn()}
+        rtl={false}
+        onRtlChange={vi.fn()}
+        activeVibe="default"
+        onVibeChange={vi.fn()}
+      />
+    );
+    expect(screen.getByLabelText("Switch to RTL")).toBeInTheDocument();
+  });
+
+  it("renders RTL toggle with correct aria-label in RTL mode", () => {
+    render(
+      <FloatingControls
+        darkMode={false}
+        onDarkModeChange={vi.fn()}
+        rtl={true}
+        onRtlChange={vi.fn()}
+        activeVibe="default"
+        onVibeChange={vi.fn()}
+      />
+    );
+    expect(screen.getByLabelText("Switch to LTR")).toBeInTheDocument();
+  });
+
+  it("calls onRtlChange(true) when toggling from LTR", () => {
+    const onRtlChange = vi.fn();
+    render(
+      <FloatingControls
+        darkMode={false}
+        onDarkModeChange={vi.fn()}
+        rtl={false}
+        onRtlChange={onRtlChange}
+        activeVibe="default"
+        onVibeChange={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByLabelText("Switch to RTL"));
+    expect(onRtlChange).toHaveBeenCalledWith(true);
+  });
+
+  it("calls onRtlChange(false) when toggling from RTL", () => {
+    const onRtlChange = vi.fn();
+    render(
+      <FloatingControls
+        darkMode={false}
+        onDarkModeChange={vi.fn()}
+        rtl={true}
+        onRtlChange={onRtlChange}
+        activeVibe="default"
+        onVibeChange={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByLabelText("Switch to LTR"));
+    expect(onRtlChange).toHaveBeenCalledWith(false);
+  });
+
+  it("renders vibe select with current activeVibe selected", () => {
+    render(
+      <FloatingControls
+        darkMode={false}
+        onDarkModeChange={vi.fn()}
+        rtl={false}
+        onRtlChange={vi.fn()}
+        activeVibe="transacting"
+        onVibeChange={vi.fn()}
+      />
+    );
+    const select = screen.getByLabelText("Select vibe") as HTMLSelectElement;
+    expect(select.value).toBe("transacting");
+  });
+
+  it("calls onVibeChange when vibe select changes", () => {
+    const onVibeChange = vi.fn();
+    render(
+      <FloatingControls
+        darkMode={false}
+        onDarkModeChange={vi.fn()}
+        rtl={false}
+        onRtlChange={vi.fn()}
+        activeVibe="default"
+        onVibeChange={onVibeChange}
+      />
+    );
+    fireEvent.change(screen.getByLabelText("Select vibe"), {
+      target: { value: "presenting" },
+    });
+    expect(onVibeChange).toHaveBeenCalledWith("presenting");
+  });
+
+  it("renders cookie preferences button when onOpenCookiePrefs is provided", () => {
+    const onOpenCookiePrefs = vi.fn();
+    render(
+      <FloatingControls
+        darkMode={false}
+        onDarkModeChange={vi.fn()}
+        rtl={false}
+        onRtlChange={vi.fn()}
+        activeVibe="default"
+        onVibeChange={vi.fn()}
+        onOpenCookiePrefs={onOpenCookiePrefs}
+      />
+    );
+    const cookieBtn = screen.getByLabelText("Cookie preferences");
+    expect(cookieBtn).toBeInTheDocument();
+    fireEvent.click(cookieBtn);
+    expect(onOpenCookiePrefs).toHaveBeenCalled();
+  });
+
+  it("does not render cookie preferences button when onOpenCookiePrefs is not provided", () => {
+    render(
+      <FloatingControls
+        darkMode={false}
+        onDarkModeChange={vi.fn()}
+        rtl={false}
+        onRtlChange={vi.fn()}
+        activeVibe="default"
+        onVibeChange={vi.fn()}
+      />
+    );
+    expect(screen.queryByLabelText("Cookie preferences")).toBeNull();
+  });
+});

--- a/apps/rialto-web/src/layouts/DemoLayout.test.tsx
+++ b/apps/rialto-web/src/layouts/DemoLayout.test.tsx
@@ -1,17 +1,20 @@
+import type { ReactNode } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { DemoLayout, FloatingControls } from "./DemoLayout.js";
 
 vi.mock("@mattbutlerengineering/rialto", () => ({
-  GlobalNav: ({ onThemeToggle }: any) => (
+  GlobalNav: ({ onThemeToggle }: { onThemeToggle?: () => void }) => (
     <nav data-testid="global-nav">
       <button onClick={onThemeToggle} data-testid="theme-toggle">
         toggle
       </button>
     </nav>
   ),
-  RialtoProvider: ({ children }: any) => <div data-testid="rialto-provider">{children}</div>,
+  RialtoProvider: ({ children }: { children?: ReactNode }) => (
+    <div data-testid="rialto-provider">{children}</div>
+  ),
 }));
 
 vi.mock("../components/CookieConsent/useCookieConsent.js", () => ({
@@ -25,14 +28,32 @@ vi.mock("../components/CookieConsent/useCookieConsent.js", () => ({
 }));
 
 vi.mock("../components/CookieConsent/CookieConsent.js", () => ({
-  CookieBanner: ({ onAcceptAll, onRejectAll, onCustomize }: any) => (
+  CookieBanner: ({
+    onAcceptAll,
+    onRejectAll,
+    onCustomize,
+  }: {
+    onAcceptAll?: () => void;
+    onRejectAll?: () => void;
+    onCustomize?: () => void;
+  }) => (
     <div data-testid="cookie-banner">
       <button onClick={onAcceptAll}>Accept</button>
       <button onClick={onRejectAll}>Reject</button>
       <button onClick={onCustomize}>Customize</button>
     </div>
   ),
-  CookiePreferencesDialog: ({ open, onClose, onSave, onRejectAll }: any) =>
+  CookiePreferencesDialog: ({
+    open,
+    onClose,
+    onSave,
+    onRejectAll,
+  }: {
+    open?: boolean;
+    onClose?: () => void;
+    onSave?: () => void;
+    onRejectAll?: () => void;
+  }) =>
     open ? (
       <div data-testid="cookie-dialog">
         <button onClick={onClose}>Close</button>

--- a/apps/rialto-web/src/routes.tsx
+++ b/apps/rialto-web/src/routes.tsx
@@ -5,8 +5,9 @@ import { Spinner, Text } from "@mattbutlerengineering/rialto";
 import { ShowcaseLayout } from "./layouts/ShowcaseLayout";
 import { OverviewPage } from "./pages/OverviewPage";
 import { PrivacyPage } from "./pages/PrivacyPage";
+import { PAGE_REGISTRY } from "./data/page-registry";
 
-/* ── Lazy-loaded demo pages ──────────────────── */
+/* ── Lazy-loaded demo pages ──────────────────────── */
 const SignIn = lazy(() => import("./pages/auth/SignIn").then((m) => ({ default: m.SignIn })));
 const SignUp = lazy(() => import("./pages/auth/SignUp").then((m) => ({ default: m.SignUp })));
 const Dashboard = lazy(() =>
@@ -38,212 +39,6 @@ const LayoutDemo = lazy(() =>
 );
 const DemoLayout = lazy(() =>
   import("./layouts/DemoLayout").then((m) => ({ default: m.DemoLayout }))
-);
-/* ── Forms ───────────────────────────────────── */
-const ButtonPage = lazy(() =>
-  import("./pages/forms/ButtonPage").then((m) => ({ default: m.ButtonPage }))
-);
-const InputPage = lazy(() =>
-  import("./pages/forms/InputPage").then((m) => ({ default: m.InputPage }))
-);
-const TextAreaPage = lazy(() =>
-  import("./pages/forms/TextAreaPage").then((m) => ({ default: m.TextAreaPage }))
-);
-const NumberInputPage = lazy(() =>
-  import("./pages/forms/NumberInputPage").then((m) => ({ default: m.NumberInputPage }))
-);
-const CheckboxRadioPage = lazy(() =>
-  import("./pages/forms/CheckboxRadioPage").then((m) => ({ default: m.CheckboxRadioPage }))
-);
-const TogglePage = lazy(() =>
-  import("./pages/forms/TogglePage").then((m) => ({ default: m.TogglePage }))
-);
-const MasterOverridePage = lazy(() =>
-  import("./pages/forms/MasterOverridePage").then((m) => ({ default: m.MasterOverridePage }))
-);
-const SliderPage = lazy(() =>
-  import("./pages/forms/SliderPage").then((m) => ({ default: m.SliderPage }))
-);
-const SelectPage = lazy(() =>
-  import("./pages/forms/SelectPage").then((m) => ({ default: m.SelectPage }))
-);
-const PinInputPage = lazy(() =>
-  import("./pages/forms/PinInputPage").then((m) => ({ default: m.PinInputPage }))
-);
-const SegmentedControlPage = lazy(() =>
-  import("./pages/forms/SegmentedControlPage").then((m) => ({ default: m.SegmentedControlPage }))
-);
-const AutocompletePage = lazy(() =>
-  import("./pages/forms/AutocompletePage").then((m) => ({ default: m.AutocompletePage }))
-);
-const InputGroupPage = lazy(() =>
-  import("./pages/forms/InputGroupPage").then((m) => ({ default: m.InputGroupPage }))
-);
-
-/* ── Data Display ────────────────────────────── */
-const CardPage = lazy(() => import("./pages/data/CardPage").then((m) => ({ default: m.CardPage })));
-const TablePage = lazy(() =>
-  import("./pages/data/TablePage").then((m) => ({ default: m.TablePage }))
-);
-const BadgePage = lazy(() =>
-  import("./pages/data/BadgePage").then((m) => ({ default: m.BadgePage }))
-);
-const TagPage = lazy(() => import("./pages/data/TagPage").then((m) => ({ default: m.TagPage })));
-const AvatarPage = lazy(() =>
-  import("./pages/data/AvatarPage").then((m) => ({ default: m.AvatarPage }))
-);
-const StatPage = lazy(() => import("./pages/data/StatPage").then((m) => ({ default: m.StatPage })));
-const DataListPage = lazy(() =>
-  import("./pages/data/DataListPage").then((m) => ({ default: m.DataListPage }))
-);
-const MeterPage = lazy(() =>
-  import("./pages/data/MeterPage").then((m) => ({ default: m.MeterPage }))
-);
-const KbdPage = lazy(() => import("./pages/data/KbdPage").then((m) => ({ default: m.KbdPage })));
-const FlipDotPage = lazy(() =>
-  import("./pages/data/FlipDotPage").then((m) => ({ default: m.FlipDotPage }))
-);
-const SplitFlapPage = lazy(() =>
-  import("./pages/data/SplitFlapPage").then((m) => ({ default: m.SplitFlapPage }))
-);
-const ChalkboardPage = lazy(() =>
-  import("./pages/data/ChalkboardPage").then((m) => ({ default: m.ChalkboardPage }))
-);
-const SplitScreenExitPage = lazy(() =>
-  import("./pages/layout/SplitScreenExitPage").then((m) => ({ default: m.SplitScreenExitPage }))
-);
-const FerrofluidPage = lazy(() =>
-  import("./pages/data/FerrofluidPage").then((m) => ({ default: m.FerrofluidPage }))
-);
-const TapeChartPage = lazy(() =>
-  import("./pages/data/TapeChartPage").then((m) => ({ default: m.TapeChartPage }))
-);
-
-/* ── Navigation ──────────────────────────────── */
-const TabsPage = lazy(() =>
-  import("./pages/navigation/TabsPage").then((m) => ({ default: m.TabsPage }))
-);
-const BreadcrumbPage = lazy(() =>
-  import("./pages/navigation/BreadcrumbPage").then((m) => ({ default: m.BreadcrumbPage }))
-);
-const StepsPage = lazy(() =>
-  import("./pages/navigation/StepsPage").then((m) => ({ default: m.StepsPage }))
-);
-const PaginationPage = lazy(() =>
-  import("./pages/navigation/PaginationPage").then((m) => ({ default: m.PaginationPage }))
-);
-const NavigationMenuPage = lazy(() =>
-  import("./pages/navigation/NavigationMenuPage").then((m) => ({ default: m.NavigationMenuPage }))
-);
-const TreePage = lazy(() => import("./pages/data/TreePage").then((m) => ({ default: m.TreePage })));
-const SidebarPage = lazy(() =>
-  import("./pages/navigation/SidebarPage").then((m) => ({ default: m.SidebarPage }))
-);
-const NavbarPage = lazy(() =>
-  import("./pages/navigation/NavbarPage").then((m) => ({ default: m.NavbarPage }))
-);
-
-/* ── Feedback ────────────────────────────────── */
-const ToastPage = lazy(() =>
-  import("./pages/feedback/ToastPage").then((m) => ({ default: m.ToastPage }))
-);
-const AlertPage = lazy(() =>
-  import("./pages/feedback/AlertPage").then((m) => ({ default: m.AlertPage }))
-);
-const BannerPage = lazy(() =>
-  import("./pages/feedback/BannerPage").then((m) => ({ default: m.BannerPage }))
-);
-const ProgressPage = lazy(() =>
-  import("./pages/feedback/ProgressPage").then((m) => ({ default: m.ProgressPage }))
-);
-const SpinnerPage = lazy(() =>
-  import("./pages/feedback/SpinnerPage").then((m) => ({ default: m.SpinnerPage }))
-);
-const SkeletonPage = lazy(() =>
-  import("./pages/feedback/SkeletonPage").then((m) => ({ default: m.SkeletonPage }))
-);
-const EmptyStatePage = lazy(() =>
-  import("./pages/feedback/EmptyStatePage").then((m) => ({ default: m.EmptyStatePage }))
-);
-
-/* ── Overlays ────────────────────────────────── */
-const DialogPage = lazy(() =>
-  import("./pages/overlays/DialogPage").then((m) => ({ default: m.DialogPage }))
-);
-const ConfirmDialogPage = lazy(() =>
-  import("./pages/overlays/ConfirmDialogPage").then((m) => ({ default: m.ConfirmDialogPage }))
-);
-const DrawerPage = lazy(() =>
-  import("./pages/overlays/DrawerPage").then((m) => ({ default: m.DrawerPage }))
-);
-const CommandPalettePage = lazy(() =>
-  import("./pages/overlays/CommandPalettePage").then((m) => ({ default: m.CommandPalettePage }))
-);
-const TooltipPage = lazy(() =>
-  import("./pages/overlays/TooltipPage").then((m) => ({ default: m.TooltipPage }))
-);
-const PopoverPage = lazy(() =>
-  import("./pages/overlays/PopoverPage").then((m) => ({ default: m.PopoverPage }))
-);
-const HoverCardPage = lazy(() =>
-  import("./pages/overlays/HoverCardPage").then((m) => ({ default: m.HoverCardPage }))
-);
-const DropdownMenuPage = lazy(() =>
-  import("./pages/overlays/DropdownMenuPage").then((m) => ({ default: m.DropdownMenuPage }))
-);
-const ContextMenuPage = lazy(() =>
-  import("./pages/overlays/ContextMenuPage").then((m) => ({ default: m.ContextMenuPage }))
-);
-const DisabledTooltipPage = lazy(() =>
-  import("./pages/overlays/DisabledTooltipPage").then((m) => ({ default: m.DisabledTooltipPage }))
-);
-
-/* ── Examples ────────────────────────────────── */
-const DashboardExamplePage = lazy(() =>
-  import("./pages/examples/DashboardExamplePage").then((m) => ({ default: m.DashboardExamplePage }))
-);
-const SettingsExamplePage = lazy(() =>
-  import("./pages/examples/SettingsExamplePage").then((m) => ({ default: m.SettingsExamplePage }))
-);
-const FormStatesExamplePage = lazy(() =>
-  import("./pages/examples/FormStatesExamplePage").then((m) => ({
-    default: m.FormStatesExamplePage,
-  }))
-);
-
-/* ── Layout ──────────────────────────────────── */
-const DividerPage = lazy(() =>
-  import("./pages/layout/DividerPage").then((m) => ({ default: m.DividerPage }))
-);
-const TextPage = lazy(() =>
-  import("./pages/layout/TextPage").then((m) => ({ default: m.TextPage }))
-);
-const StackPage = lazy(() =>
-  import("./pages/layout/StackPage").then((m) => ({ default: m.StackPage }))
-);
-const CollapsiblePage = lazy(() =>
-  import("./pages/layout/CollapsiblePage").then((m) => ({ default: m.CollapsiblePage }))
-);
-const AccordionPage = lazy(() =>
-  import("./pages/layout/AccordionPage").then((m) => ({ default: m.AccordionPage }))
-);
-const AspectRatioPage = lazy(() =>
-  import("./pages/layout/AspectRatioPage").then((m) => ({ default: m.AspectRatioPage }))
-);
-const ScrollAreaPage = lazy(() =>
-  import("./pages/layout/ScrollAreaPage").then((m) => ({ default: m.ScrollAreaPage }))
-);
-const TimelinePage = lazy(() =>
-  import("./pages/data/TimelinePage").then((m) => ({ default: m.TimelinePage }))
-);
-const HeroPage = lazy(() =>
-  import("./pages/layout/HeroPage").then((m) => ({ default: m.HeroPage }))
-);
-const FooterPage = lazy(() =>
-  import("./pages/layout/FooterPage").then((m) => ({ default: m.FooterPage }))
-);
-const PageHeaderPage = lazy(() =>
-  import("./pages/layout/PageHeaderPage").then((m) => ({ default: m.PageHeaderPage }))
 );
 
 /* ── Shared loading fallback ─────────────────── */
@@ -280,92 +75,37 @@ function tokenPlaceholder(name: string) {
   );
 }
 
-/* ── Component routes (inside ShowcaseLayout) ── */
-const componentRoutes: RouteObject[] = [
-  // Forms
-  { path: "components/button", element: suspended(ButtonPage) },
-  { path: "components/input", element: suspended(InputPage) },
-  { path: "components/textarea", element: suspended(TextAreaPage) },
-  { path: "components/number-input", element: suspended(NumberInputPage) },
-  { path: "components/checkbox-radio", element: suspended(CheckboxRadioPage) },
-  { path: "components/toggle", element: suspended(TogglePage) },
-  { path: "components/master-override", element: suspended(MasterOverridePage) },
-  { path: "components/slider", element: suspended(SliderPage) },
-  { path: "components/select", element: suspended(SelectPage) },
-  { path: "components/pin-input", element: suspended(PinInputPage) },
-  { path: "components/segmented-control", element: suspended(SegmentedControlPage) },
-  { path: "components/autocomplete", element: suspended(AutocompletePage) },
-  { path: "components/input-group", element: suspended(InputGroupPage) },
-  // Data Display
-  { path: "components/card", element: suspended(CardPage) },
-  { path: "components/table", element: suspended(TablePage) },
-  { path: "components/badge", element: suspended(BadgePage) },
-  { path: "components/tag", element: suspended(TagPage) },
-  { path: "components/avatar", element: suspended(AvatarPage) },
-  { path: "components/stat", element: suspended(StatPage) },
-  { path: "components/data-list", element: suspended(DataListPage) },
-  { path: "components/meter", element: suspended(MeterPage) },
-  { path: "components/kbd", element: suspended(KbdPage) },
-  { path: "components/flip-dot", element: suspended(FlipDotPage) },
-  { path: "components/split-flap", element: suspended(SplitFlapPage) },
-  { path: "components/chalkboard", element: suspended(ChalkboardPage) },
-  { path: "components/ferrofluid", element: suspended(FerrofluidPage) },
-  { path: "components/tape-chart", element: suspended(TapeChartPage) },
-  // Navigation
-  { path: "components/tabs", element: suspended(TabsPage) },
-  { path: "components/breadcrumb", element: suspended(BreadcrumbPage) },
-  { path: "components/steps", element: suspended(StepsPage) },
-  { path: "components/pagination", element: suspended(PaginationPage) },
-  { path: "components/navigation-menu", element: suspended(NavigationMenuPage) },
-  { path: "components/tree", element: suspended(TreePage) },
-  { path: "components/sidebar", element: suspended(SidebarPage) },
-  { path: "components/navbar", element: suspended(NavbarPage) },
-  // Feedback
-  { path: "components/toast", element: suspended(ToastPage) },
-  { path: "components/alert", element: suspended(AlertPage) },
-  { path: "components/banner", element: suspended(BannerPage) },
-  { path: "components/progress", element: suspended(ProgressPage) },
-  { path: "components/spinner", element: suspended(SpinnerPage) },
-  { path: "components/skeleton", element: suspended(SkeletonPage) },
-  { path: "components/empty-state", element: suspended(EmptyStatePage) },
-  // Overlays
-  { path: "components/dialog", element: suspended(DialogPage) },
-  { path: "components/confirm-dialog", element: suspended(ConfirmDialogPage) },
-  { path: "components/drawer", element: suspended(DrawerPage) },
-  { path: "components/command-palette", element: suspended(CommandPalettePage) },
-  { path: "components/tooltip", element: suspended(TooltipPage) },
-  { path: "components/popover", element: suspended(PopoverPage) },
-  { path: "components/hover-card", element: suspended(HoverCardPage) },
-  { path: "components/dropdown-menu", element: suspended(DropdownMenuPage) },
-  { path: "components/context-menu", element: suspended(ContextMenuPage) },
-  { path: "components/disabled-tooltip", element: suspended(DisabledTooltipPage) },
-  // Layout
-  { path: "components/divider", element: suspended(DividerPage) },
-  { path: "components/text", element: suspended(TextPage) },
-  { path: "components/stack", element: suspended(StackPage) },
-  { path: "components/collapsible", element: suspended(CollapsiblePage) },
-  { path: "components/accordion", element: suspended(AccordionPage) },
-  { path: "components/aspect-ratio", element: suspended(AspectRatioPage) },
-  { path: "components/split-screen-exit", element: suspended(SplitScreenExitPage) },
-  { path: "components/scroll-area", element: suspended(ScrollAreaPage) },
-  { path: "components/timeline", element: suspended(TimelinePage) },
-  { path: "components/hero", element: suspended(HeroPage) },
-  { path: "components/footer", element: suspended(FooterPage) },
-  { path: "components/page-header", element: suspended(PageHeaderPage) },
-  // Token pages
-  { path: "components/motion", element: tokenPlaceholder("Motion tokens") },
-  { path: "components/typography", element: tokenPlaceholder("Typography tokens") },
-  { path: "components/color", element: tokenPlaceholder("Color tokens") },
-  { path: "components/spacing", element: tokenPlaceholder("Spacing tokens") },
-  { path: "components/radius", element: tokenPlaceholder("Radius tokens") },
-  { path: "components/shadows", element: tokenPlaceholder("Shadow tokens") },
-  { path: "components/surfaces", element: tokenPlaceholder("Surface tokens") },
-  { path: "components/icon-vocabulary", element: tokenPlaceholder("Icon vocabulary") },
-  // Examples
-  { path: "examples/dashboard", element: suspended(DashboardExamplePage) },
-  { path: "examples/settings", element: suspended(SettingsExamplePage) },
-  { path: "examples/form", element: suspended(FormStatesExamplePage) },
-];
+/* ── Token placeholder labels — comingSoon entries have no component ── */
+const TOKEN_PLACEHOLDER_LABELS: Record<string, string> = {
+  motion: "Motion tokens",
+  typography: "Typography tokens",
+  color: "Color tokens",
+  spacing: "Spacing tokens",
+  radius: "Radius tokens",
+  shadows: "Shadow tokens",
+  surfaces: "Surface tokens",
+  "icon-vocabulary": "Icon vocabulary",
+};
+
+/* ── Component routes derived from PAGE_REGISTRY ── */
+const componentRoutes: RouteObject[] = PAGE_REGISTRY.map((entry) => {
+  // Strip the leading slash to get the relative path for React Router
+  const relativePath = entry.path.replace(/^\//, "");
+
+  if (entry.comingSoon && entry.id in TOKEN_PLACEHOLDER_LABELS) {
+    return {
+      path: relativePath,
+      element: tokenPlaceholder(TOKEN_PLACEHOLDER_LABELS[entry.id]!),
+    };
+  }
+
+  const LazyPage = lazy(entry.load as () => Promise<{ default: React.ComponentType }>);
+
+  return {
+    path: relativePath,
+    element: suspended(LazyPage),
+  };
+});
 
 /**
  * Route tree for createBrowserRouter.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14803,18 +14803,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2245,16 +2245,26 @@
     ];
   </file>
   <file path="apps/rialto-web/src/data/nav-sections.ts">
+    export const NAV_SECTIONS = REGISTRY_NAV_SECTIONS;
+    export const COMPONENT_COUNT = NAV_SECTIONS.reduce(
+      (total, section) => total + section.items.length,
+      0
+    );
+  </file>
+  <file path="apps/rialto-web/src/data/page-registry.ts">
+    export interface PageEntry {
+      id: string;
+      label: string;
+      category: string;
+      path: string;
+      comingSoon?: boolean;
+      load: () => Promise<unknown>;
+    }
     export interface NavItem {
       id: string;
       label: string;
       path: string;
-      /** When true, item is rendered in a muted style with a "coming soon" indicator. */
       comingSoon?: boolean;
-    }
-    export interface NavSection {
-      label: string;
-      items: NavItem[];
     }
   </file>
   <file path="apps/rialto-web/src/data/tapechart-fixtures.ts">
@@ -14793,7 +14803,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms.txt
+++ b/llms.txt
@@ -631,18 +631,29 @@
     </item>
   </file>
   <file path="apps/rialto-web/src/data/nav-sections.ts">
+    <item priority="high">
+      export const NAV_SECTIONS: unknown;
+    </item>
+    <item priority="high">
+      export const COMPONENT_COUNT: unknown;
+    </item>
+  </file>
+  <file path="apps/rialto-web/src/data/page-registry.ts">
+    <item priority="low">
+      interface PageEntry {
+        id: string;
+        label: string;
+        category: string;
+        path: string;
+        comingSoon?: boolean;
+      }
+    </item>
     <item priority="low">
       interface NavItem {
         id: string;
         label: string;
         path: string;
         comingSoon?: boolean;
-      }
-    </item>
-    <item priority="low">
-      interface NavSection {
-        label: string;
-        items: NavItem[];
       }
     </item>
   </file>


### PR DESCRIPTION
## Summary

- Add `page-registry.ts` as the single source of truth for all showcase pages — one place to add a new page instead of three
- `nav-sections.ts` now derives its `NAV_SECTIONS` from the registry (parallel hand-written list deleted)
- `routes.tsx` now derives all component routes from the registry (parallel hand-written `componentRoutes` array deleted)
- Sitemap paths are derivable via `buildSitemapPaths()` from the registry
- `buildNavSections()` throws loudly when an entry is missing `id`, `label`, or `category` — fails fast instead of silent drops
- Per-page code splitting preserved: each `PageEntry.load` is a `React.lazy()`-compatible factory
- 13 new tests covering registry structure, nav derivation, sitemap paths, and missing-metadata guard

## Gate results

- `pnpm lint`: 0 errors (pre-existing warnings only)
- `pnpm typecheck`: passes
- `pnpm test`: 113 passed / 10 test files (4 pre-existing failures from unbuilt rialto package in worktree, confirmed pre-existing)
- `pnpm build`: passes, per-page chunks generated (ButtonPage, CardPage, ToastPage, etc.)
- `check-adr` + `check-deps`: both pass
- `pnpm regen`: ran, artifacts staged

## Test plan

- [x] `pnpm test src/data/page-registry.test.ts` — 13 tests pass
- [x] `pnpm test src/data/nav-sections.test.ts` — 12 tests pass (backward compat)
- [x] Build output shows per-page code-split chunks
- [x] No new lint errors
- [x] Typecheck passes

Closes #2047