### PR TITLE
refactor(agent-core): typed per-phase input/output contracts with injected deps

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -376,6 +376,73 @@
     }
   </file>
   </section>
+  <section priority="medium" role="__tests__">
+  <file path="packages/agent-core/src/__tests__/fake-phase-deps.ts">
+    export function makeFakePhaseDeps(): PhaseDeps {
+      return {
+        worktreeManager: {
+          createWorktree: vi.fn().mockResolvedValue({
+            path: "/repo/.agent-worktrees/agent-fix-bug-abc123",
+            branchName: "agent/fix-bug-abc123",
+            mode: "full",
+          }),
+          hasChanges: vi.fn().mockResolvedValue(false),
+          commitChanges: vi.fn().mockResolvedValue("abc123"),
+          pushBranch: vi.fn().mockResolvedValue(undefined),
+          removeWorktree: vi.fn().mockResolvedValue(undefined),
+        },
+        promptBuilder: {
+          buildSystemPrompt: vi.fn().mockResolvedValue("system prompt"),
+          loadSourceFiles: vi.fn().mockResolvedValue([]),
+          loadProjectContext: vi.fn().mockResolvedValue(null),
+        },
+        failureMemory: {
+          loadMemory: vi.fn().mockResolvedValue({ records: [] }),
+          queryPastFailures: vi.fn().mockReturnValue([]),
+          buildFailureContext: vi.fn().mockReturnValue(""),
+        },
+        queryRunner: {
+          runHardenedQuery: vi.fn().mockResolvedValue({
+            resultMessage: null,
+            stuckReason: null,
+            rawTurnMetrics: [],
+            rawToolCallMetrics: [],
+            errorMessage: null,
+            contextMetrics: null,
+          }),
+        },
+        successEvaluator: {
+          getGitDiff: vi.fn().mockResolvedValue("diff --git a/file.ts\n+change"),
+        },
+        gateway: {
+          runPostCommitGateway: vi.fn().mockResolvedValue({
+            outcome: "create-pr",
+            passed: true,
+            gateFailures: [],
+            errors: [],
+          }),
+        },
+        prCreator: {
+          createPullRequest: vi.fn().mockResolvedValue({
+            url: "https://github.com/repo/pull/1",
+            number: 1,
+          }),
+          buildPrTitle: vi.fn().mockReturnValue("feat: test"),
+          buildPrBody: vi.fn().mockReturnValue("body"),
+          buildFailurePrBody: vi.fn().mockReturnValue("failure body"),
+          mergeDirectly: vi.fn().mockResolvedValue("https://github.com/repo/pull/merged"),
+        },
+        feedbackLoop: {
+          runFeedbackLoop: vi.fn().mockResolvedValue({
+            resolved: false,
+            retriesUsed: 0,
+            lastFingerprint: null,
+          }),
+        },
+      };
+    }
+  </file>
+  </section>
   <section priority="medium" role="adapters">
   <file path="packages/agent-core/src/adapters/claude-adapter.ts">
     function deriveHasChanges(result: SessionResult): boolean {
@@ -3477,17 +3544,59 @@
   </file>
   </section>
   <section priority="medium" role="phases">
+  <file path="packages/agent-core/src/phases/default-deps.ts">
+    export function createDefaultPhaseDeps(): PhaseDeps {
+      return {
+        worktreeManager: {
+          createWorktree,
+          hasChanges,
+          commitChanges,
+          pushBranch,
+          removeWorktree,
+        },
+        promptBuilder: {
+          buildSystemPrompt,
+          loadSourceFiles,
+          loadProjectContext,
+        },
+        failureMemory: {
+          loadMemory,
+          queryPastFailures,
+          buildFailureContext,
+        },
+        queryRunner: {
+          runHardenedQuery,
+        },
+        successEvaluator: {
+          getGitDiff,
+        },
+        gateway: {
+          runPostCommitGateway,
+        },
+        prCreator: {
+          createPullRequest,
+          buildPrTitle,
+          buildPrBody,
+          buildFailurePrBody,
+          mergeDirectly,
+        },
+        feedbackLoop: {
+          runFeedbackLoop,
+        },
+      };
+    }
+  </file>
   <file path="packages/agent-core/src/phases/feedback-phase.ts">
-    export class FeedbackPhase implements PipelinePhase {
+    export class FeedbackPhase implements Phase<FeedbackPhaseInput, void> {
       readonly name = "feedback" as const;
     
-      async run(ctx: PipelineContext): Promise<{ result: PhaseResult; ctx: PipelineContext }> {
-        const { config, onEvent, worktree, resultMessage, prNumber } = ctx;
+      async run(input: FeedbackPhaseInput, deps: PhaseDeps): Promise<PhaseExecution<void>> {
+        const { config, onEvent, worktree, resultMessage, prNumber, prUrl } = input;
     
-        if (!config.feedbackLoop?.enabled || !prNumber || !ctx.prUrl || !worktree) {
+        if (!config.feedbackLoop?.enabled || !prNumber || !prUrl) {
           return {
             result: { phase: this.name, status: "skipped", errors: [] },
-            ctx,
+            output: null,
           };
         }
     
@@ -3498,7 +3607,7 @@
         const fbSpan = tracer.startSpan("agent_core.feedback_loop");
         let feedbackResult;
         try {
-          feedbackResult = await runFeedbackLoop(
+          feedbackResult = await deps.feedbackLoop.runFeedbackLoop(
             {
               prNumber,
               branchName: worktree.branchName,
@@ -3524,50 +3633,56 @@
     
         return {
           result: { phase: this.name, status: "success", errors: [] },
-          ctx,
+          output: undefined,
         };
       }
     }
   </file>
   <file path="packages/agent-core/src/phases/pipeline-types.ts">
-    export type PhaseStatus = "success" | "failed" | "skipped";
-    export interface PhaseResult {
-      readonly phase: string;
-      readonly status: PhaseStatus;
-      readonly errors: readonly string[];
+    export interface MergeDirectlyOptions {
+      readonly branchName: string;
+      readonly baseBranch: string;
+      readonly repoPath: string;
+      readonly commitTitle: string;
     }
+    export type PhaseStatus = "success" | "failed" | "skipped";
   </file>
   <file path="packages/agent-core/src/phases/publish-phase.ts">
-    export class PublishPhase implements PipelinePhase {
+    export class PublishPhase implements Phase<PublishPhaseInput, PublishPhaseOutput> {
       readonly name = "publish" as const;
     
-      async run(ctx: PipelineContext): Promise<{ result: PhaseResult; ctx: PipelineContext }> {
-        const { config, worktree } = ctx;
+      async run(
+        input: PublishPhaseInput,
+        deps: PhaseDeps
+      ): Promise<PhaseExecution<PublishPhaseOutput>> {
+        const { config, worktree, hasChanges } = input;
     
-        if (!config.createPr || !ctx.hasChanges || !worktree) {
+        if (!config.createPr || !hasChanges) {
           return {
             result: { phase: this.name, status: "skipped", errors: [] },
-            ctx,
+            output: null,
           };
         }
     
-        const { prUrl, prNumber } = await this.createOrMergePr(ctx, worktree);
+        const { prUrl, prNumber } = await this.createOrMergePr(input, worktree, deps);
     
         return {
           result: { phase: this.name, status: "success", errors: [] },
-          ctx: { ...ctx, prUrl, prNumber },
+          output: { prUrl, prNumber },
         };
       }
     
       private async createOrMergePr(
-        ctx: PipelineContext,
-        worktree: WorktreeInfo
+        input: PublishPhaseInput,
+        worktree: WorktreeInfo,
+        deps: PhaseDeps
       ): Promise<{ prUrl: string | null; prNumber?: number }> {
-        const { config, onEvent, resultMessage, stuckReason, gatewayVerdict } = ctx;
+        const { config, onEvent, resultMessage, stuckReason, gatewayVerdict } = input;
+        const { prCreator } = deps;
     
         if (gatewayVerdict?.outcome === "merge-direct") {
-          const commitTitle = buildPrTitle(config.taskDescription);
-          const mergedUrl = await mergeDirectly({
+          const commitTitle = prCreator.buildPrTitle(config.taskDescription);
+          const mergedUrl = await prCreator.mergeDirectly({
             branchName: worktree.branchName,
             baseBranch: config.baseBranch,
             repoPath: worktree.path,
@@ -3580,21 +3695,25 @@
         }
     
         if (!gatewayVerdict || gatewayVerdict.outcome === "create-pr") {
-          const title = buildPrTitle(config.taskDescription);
+          const title = prCreator.buildPrTitle(config.taskDescription);
           const body = resultMessage
-            ? buildPrBody(
+            ? prCreator.buildPrBody(
                 config.taskDescription,
                 resultMessage.session_id,
                 resultMessage.total_cost_usd,
                 resultMessage.num_turns
               )
-            : buildFailurePrBody(config.taskDescription, [...ctx.errors], stuckReason?.type);
+            : prCreator.buildFailurePrBody(
+                config.taskDescription,
+                [...input.errors],
+                stuckReason?.type
+              );
     
           const prSpan = tracer.startSpan("agent_core.create_pr");
           try {
             const { value: pr } = await withRetry(
               () =>
-                createPullRequest({
+                prCreator.createPullRequest({
                   title,
                   body,
                   baseBranch: config.baseBranch,
@@ -3619,11 +3738,15 @@
     
         // verdict.outcome === "create-draft-pr" — quality gates failed
         const title = `wip: ${config.taskDescription.slice(0, 57)}`;
-        const body = buildFailurePrBody(config.taskDescription, [...ctx.errors], stuckReason?.type);
+        const body = prCreator.buildFailurePrBody(
+          config.taskDescription,
+          [...input.errors],
+          stuckReason?.type
+        );
     
         const { value: pr } = await withRetry(
           () =>
-            createPullRequest({
+            prCreator.createPullRequest({
               title,
               body,
               baseBranch: config.baseBranch,
@@ -3642,19 +3765,11 @@
     }
   </file>
   <file path="packages/agent-core/src/phases/query-phase.ts">
-    export class QueryPhase implements PipelinePhase {
+    export class QueryPhase implements Phase<QueryPhaseInput, QueryPhaseOutput> {
       readonly name = "query" as const;
     
-      async run(ctx: PipelineContext): Promise<{ result: PhaseResult; ctx: PipelineContext }> {
-        const { config, onEvent, worktree, systemPrompt } = ctx;
-    
-        if (!worktree || !systemPrompt) {
-          const msg = "QueryPhase requires worktree and systemPrompt in context";
-          return {
-            result: { phase: this.name, status: "failed", errors: [msg] },
-            ctx: { ...ctx, errors: [...ctx.errors, msg] },
-          };
-        }
+      async run(input: QueryPhaseInput, deps: PhaseDeps): Promise<PhaseExecution<QueryPhaseOutput>> {
+        const { config, onEvent, worktree, systemPrompt } = input;
     
         // Fail fast if the circuit breaker is open
         if (apiCircuitBreaker.getState() === CircuitState.Open) {
@@ -3663,7 +3778,7 @@
           emitEvent(onEvent, "session:error", { message: circuitMsg });
           return {
             result: { phase: this.name, status: "failed", errors: [circuitMsg] },
-            ctx: { ...ctx, errors: [...ctx.errors, circuitMsg] },
+            output: null,
           };
         }
     
@@ -3674,7 +3789,7 @@
           rawToolCallMetrics,
           errorMessage,
           contextMetrics,
-        } = await runHardenedQuery(
+        } = await deps.queryRunner.runHardenedQuery(
           {
             prompt: config.taskDescription,
             cwd: worktree.path,
@@ -3692,7 +3807,7 @@
         if (errorMessage) {
           return {
             result: { phase: this.name, status: "failed", errors: [errorMessage] },
-            ctx: { ...ctx, errors: [...ctx.errors, errorMessage] },
+            output: null,
           };
         }
     
@@ -3700,8 +3815,7 @@
     
         return {
           result: { phase: this.name, status: "success", errors: [] },
-          ctx: {
-            ...ctx,
+          output: {
             resultMessage: resultMessage ?? undefined,
             stuckReason: stuckReason ?? undefined,
             turnMetrics: buildTurnMetricsList(rawTurnMetrics),
@@ -3713,20 +3827,17 @@
     }
   </file>
   <file path="packages/agent-core/src/phases/verification-phase.ts">
-    export class VerificationPhase implements PipelinePhase {
+    export class VerificationPhase implements Phase<VerificationPhaseInput, VerificationPhaseOutput> {
       readonly name = "verification" as const;
     
-      async run(ctx: PipelineContext): Promise<{ result: PhaseResult; ctx: PipelineContext }> {
-        const { config, onEvent, worktree, resultMessage, stuckReason } = ctx;
+      async run(
+        input: VerificationPhaseInput,
+        deps: PhaseDeps
+      ): Promise<PhaseExecution<VerificationPhaseOutput>> {
+        const { config, onEvent, worktree, resultMessage, stuckReason } = input;
+        const { worktreeManager, successEvaluator, gateway } = deps;
     
-        if (!worktree) {
-          return {
-            result: { phase: this.name, status: "skipped", errors: [] },
-            ctx,
-          };
-        }
-    
-        const changed = await hasChanges(worktree.path);
+        const changed = await worktreeManager.hasChanges(worktree.path);
     
         if (!changed) {
           emitEvent(onEvent, "session:result", {
@@ -3734,7 +3845,7 @@
           });
           return {
             result: { phase: this.name, status: "success", errors: [] },
-            ctx: { ...ctx, hasChanges: false },
+            output: { hasChanges: false },
           };
         }
     
@@ -3742,20 +3853,22 @@
         const isSuccess = resultMessage?.subtype === "success" && !stuckReason;
         const prefix = isSuccess ? "feat" : "wip";
         const commitMsg = `${prefix}: ${sanitizeForCommitMessage(config.taskDescription)}`;
-        await commitChanges(worktree.path, commitMsg);
+        await worktreeManager.commitChanges(worktree.path, commitMsg);
     
         // Push with retry for transient network failures
-        await withRetry(() => pushBranch(worktree.path, worktree.branchName), { maxRetries: 3 });
+        await withRetry(() => worktreeManager.pushBranch(worktree.path, worktree.branchName), {
+          maxRetries: 3,
+        });
     
         // Run post-commit gateway (verification + quality gates) only on success
         const errors: string[] = [];
-        let gatewayVerdict;
-        let gatewayEvaluation;
+        let gatewayVerdict: GatewayVerdict | undefined;
+        let gatewayEvaluation: EvaluationResult | undefined;
         let cachedDiff: string | undefined;
     
         if (isSuccess) {
-          cachedDiff = await getGitDiff(worktree.path);
-          gatewayVerdict = await runPostCommitGateway(
+          cachedDiff = await successEvaluator.getGitDiff(worktree.path);
+          gatewayVerdict = await gateway.runPostCommitGateway(
             {
               worktreePath: worktree.path,
               diff: cachedDiff,
@@ -3775,25 +3888,27 @@
     
         return {
           result: { phase: this.name, status: "success", errors },
-          ctx: {
-            ...ctx,
+          output: {
             hasChanges: true,
             commitMsg,
             cachedDiff,
             gatewayVerdict,
             gatewayEvaluation,
-            errors: [...ctx.errors, ...errors],
           },
         };
       }
     }
   </file>
   <file path="packages/agent-core/src/phases/worktree-phase.ts">
-    export class WorktreePhase implements PipelinePhase {
+    export class WorktreePhase implements Phase<WorktreePhaseInput, WorktreePhaseOutput> {
       readonly name = "worktree" as const;
     
-      async run(ctx: PipelineContext): Promise<{ result: PhaseResult; ctx: PipelineContext }> {
-        const { config, onEvent } = ctx;
+      async run(
+        input: WorktreePhaseInput,
+        deps: PhaseDeps
+      ): Promise<PhaseExecution<WorktreePhaseOutput>> {
+        const { config, onEvent } = input;
+        const { worktreeManager, promptBuilder, failureMemory } = deps;
     
         // Classify the task once so downstream consumers reuse the result instead
         // of re-scanning the description.
@@ -3805,7 +3920,12 @@
         try {
           // 1. Create isolated worktree (with retry for transient git failures)
           const { value: worktree } = await withRetry(
-            () => createWorktree(config.repoPath, config.baseBranch, config.taskDescription),
+            () =>
+              worktreeManager.createWorktree(
+                config.repoPath,
+                config.baseBranch,
+                config.taskDescription
+              ),
             { maxRetries: 2 }
           );
           wtSpan.setAttribute("worktree.branch", worktree.branchName);
@@ -3813,9 +3933,9 @@
           wtSpan.end();
     
           // 2. Build system prompt with failure context, source files, and PR examples
-          const failureMemory = await loadMemory(config.repoPath);
-          const pastFailures = queryPastFailures(failureMemory, config.taskDescription);
-          const failureContext = buildFailureContext(pastFailures);
+          const memory = await failureMemory.loadMemory(config.repoPath);
+          const pastFailures = failureMemory.queryPastFailures(memory, config.taskDescription);
+          const failureContext = failureMemory.buildFailureContext(pastFailures);
     
           // Auto-resolve source files from task description if none provided
           const resolvedSourcePaths =
@@ -3824,11 +3944,12 @@
               const { resolveSourceFiles } = await import("../source-resolver.js");
               return resolveSourceFiles(config.taskDescription);
             })();
-    
           const finalSourcePaths = await resolvedSourcePaths;
     
           const sourceFileEntries =
-            finalSourcePaths.length > 0 ? await loadSourceFiles(finalSourcePaths) : undefined;
+            finalSourcePaths.length > 0
+              ? await promptBuilder.loadSourceFiles(finalSourcePaths)
+              : undefined;
     
           // Fetch recent successful PRs as examples (non-blocking)
           const { fetchRecentPrExamples, formatPrExamples } = await import("../budget-calculator.js");
@@ -3836,13 +3957,15 @@
           const prExamplesSection = formatPrExamples(prExamples);
     
           // Load project CLAUDE.md for coding conventions (non-blocking)
-          const projectContext = await loadProjectContext(worktree.path).catch(() => null);
+          const projectContext = await promptBuilder
+            .loadProjectContext(worktree.path)
+            .catch(() => null);
           const projectSection = projectContext
             ? `\n\n## Project Conventions (from CLAUDE.md)\n\n${projectContext}`
             : "";
     
           const systemPrompt =
-            (await buildSystemPrompt(config.taskDescription, {
+            (await promptBuilder.buildSystemPrompt(config.taskDescription, {
               sourceFileEntries,
               prExamplesSection,
               failureContext,
@@ -3854,14 +3977,14 @@
     
           return {
             result: { phase: this.name, status: "success", errors: [] },
-            ctx: { ...ctx, worktree, systemPrompt, taskSignals },
+            output: { worktree, systemPrompt, taskSignals },
           };
         } catch (error) {
           wtSpan.end();
           const errorMessage = error instanceof Error ? error.message : String(error);
           return {
             result: { phase: this.name, status: "failed", errors: [errorMessage] },
-            ctx: { ...ctx, errors: [...ctx.errors, errorMessage] },
+            output: null,
           };
         }
       }
@@ -12869,9 +12992,27 @@
     }
   </file>
   <file path="packages/agent-core/src/session-runner.ts">
+    interface SessionState {
+      worktree?: WorktreeInfo;
+      systemPrompt?: string;
+      resultMessage?: SDKResultMessage;
+      stuckReason?: StuckPattern;
+      turnMetrics: readonly TurnMetrics[];
+      toolCallMetrics: readonly ToolCallMetrics[];
+      contextMetrics?: ContextMetrics;
+      hasChanges: boolean;
+      commitMsg?: string;
+      cachedDiff?: string;
+      gatewayVerdict?: GatewayVerdict;
+      gatewayEvaluation?: EvaluationResult;
+      prUrl: string | null;
+      prNumber?: number;
+      errors: string[];
+    }
     export async function runSession(
       config: SessionConfig,
-      onEvent?: SessionEventCallback
+      onEvent?: SessionEventCallback,
+      deps: PhaseDeps = createDefaultPhaseDeps()
     ): Promise<SessionResult> {
       return startActiveObservation(
         "agent-session",
@@ -12887,76 +13028,26 @@
               },
             },
             async (): Promise<SessionResult> => {
-              // Apply QA tuning defaults from .github/auto-qa-tuning.json
-              const tuning = loadQaTuning(config.repoPath);
-              const tuningOverrides = tuning
-                ? applyTuningDefaults(
-                    {
-                      maxBudgetUsd: config.maxBudgetUsd,
-                      stuckDetectorConfig: config.stuckDetectorConfig,
-                    },
-                    tuning,
-                    DEFAULT_SESSION_CONFIG.maxBudgetUsd
-                  )
-                : null;
-    
-              const effectiveConfig = tuningOverrides
-                ? {
-                    ...config,
-                    maxBudgetUsd: tuningOverrides.maxBudgetUsd,
-                    stuckDetectorConfig: {
-                      ...config.stuckDetectorConfig,
-                      ...tuningOverrides.stuckDetectorConfig,
-                    },
-                  }
-                : config;
+              const effectiveConfig = applyEffectiveConfig(config);
     
               const rootSpan = tracer.startSpan("agent_core.run_session", {
-                attributes: {
-                  "session.task": effectiveConfig.taskDescription.slice(0, 200),
-                  "session.model": effectiveConfig.model,
-                  "session.max_turns": effectiveConfig.maxTurns,
-                  "session.max_budget_usd": effectiveConfig.maxBudgetUsd,
-                  "session.base_branch": effectiveConfig.baseBranch,
-                  ...(tuning ? { "session.qa_tuning_applied": true } : {}),
-                  ...(effectiveConfig.modelRoutingReason
-                    ? { "session.model_routing_reason": effectiveConfig.modelRoutingReason }
-                    : {}),
-                  ...(effectiveConfig.modelRoutingTier
-                    ? { "session.model_routing_tier": effectiveConfig.modelRoutingTier }
-                    : {}),
-                },
+                attributes: buildRootSpanAttributes(effectiveConfig, loadQaTuning(config.repoPath)),
               });
     
               const cleanupErrors: string[] = [];
-              let ctx: PipelineContext = {
-                config: effectiveConfig,
-                onEvent,
+              const state: SessionState = {
+                turnMetrics: [],
+                toolCallMetrics: [],
+                hasChanges: false,
+                prUrl: null,
                 errors: [],
               };
     
               let pendingResult: SessionResult | undefined;
     
               try {
-                // Run pipeline phases sequentially
-                for (const phase of phases) {
-                  const { result, ctx: nextCtx } = await phase.run(ctx);
-                  ctx = nextCtx;
-    
-                  if (result.status === "failed") {
-                    // Phase failure — attempt partial work push then abort
-                    if (ctx.worktree && effectiveConfig.createPr) {
-                      const errorMsg = result.errors[0] ?? "Phase failed";
-                      const prUrl = await pushPartialWork(ctx, errorMsg);
-                      if (prUrl) {
-                        ctx = { ...ctx, prUrl };
-                      }
-                    }
-                    break;
-                  }
-                }
-    
-                pendingResult = buildFinalResult(ctx, rootSpan);
+                await runPipeline(effectiveConfig, onEvent, deps, state);
+                pendingResult = buildFinalResult(effectiveConfig, state, rootSpan, onEvent);
               } catch (error) {
                 const errorMessage = error instanceof Error ? error.message : String(error);
                 emitEvent(onEvent, "session:error", { message: errorMessage });
@@ -12964,13 +13055,19 @@
                 rootSpan.setStatus({ code: SpanStatusCode.ERROR, message: errorMessage });
     
                 // Attempt to push partial work from failed sessions
-                const prUrl = await pushPartialWork(ctx, errorMessage);
+                const prUrl = await pushPartialWork(
+                  effectiveConfig,
+                  state,
+                  deps,
+                  errorMessage,
+                  onEvent
+                );
     
                 rootSpan.setAttribute("session.status", "failed");
                 pendingResult = {
                   sessionId: "",
                   status: "failed",
-                  branchName: ctx.worktree?.branchName ?? "",
+                  branchName: state.worktree?.branchName ?? "",
                   prUrl,
                   costUsd: 0,
                   tokenUsage: { inputTokens: 0, outputTokens: 0 },
@@ -12978,18 +13075,20 @@
                   numTurns: 0,
                   resultText: "",
                   errors: [errorMessage],
-                  stuckPattern: ctx.stuckReason?.type,
+                  stuckPattern: state.stuckReason?.type,
                 };
               } finally {
-                // Clean up worktree when PR was created (branch is pushed)
-                // Keep worktree when --no-pr so user can inspect
-                if (ctx.worktree && effectiveConfig.createPr) {
+                // Clean up worktree when PR was created (branch is pushed).
+                // Keep worktree when --no-pr so user can inspect.
+                if (state.worktree && effectiveConfig.createPr) {
                   try {
-                    await removeWorktree(effectiveConfig.repoPath, ctx.worktree.path);
+                    await deps.worktreeManager.removeWorktree(
+                      effectiveConfig.repoPath,
+                      state.worktree.path
+                    );
                   } catch (cleanupErr) {
                     const cleanupMsg =
                       cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr);
-                    // Record the error in the result (unchanged behavior)
                     cleanupErrors.push(cleanupMsg);
                     console.warn(`Worktree cleanup failed: ${cleanupMsg}`);
                     emitEvent(onEvent, "session:cleanup_warning", {
@@ -13000,8 +13099,8 @@
                     // level (never silent) and is not treated as a session failure.
                     await scheduleWorktreeReap({
                       repoPath: effectiveConfig.repoPath,
-                      worktreePath: ctx.worktree.path,
-                      mode: ctx.worktree.mode,
+                      worktreePath: state.worktree.path,
+                      mode: state.worktree.mode,
                     });
                   }
                 }
@@ -13014,144 +13113,6 @@
           );
         }
       );
-    }
-    function buildFinalResult(
-      ctx: PipelineContext,
-      rootSpan: ReturnType<ReturnType<typeof trace.getTracer>["startSpan"]>
-    ): SessionResult {
-      const {
-        resultMessage,
-        stuckReason,
-        gatewayEvaluation,
-        turnMetrics,
-        toolCallMetrics,
-        contextMetrics,
-      } = ctx;
-      const errors = [...ctx.errors];
-    
-      if (stuckReason) {
-        // Deduplicate — stuck error may already be in ctx.errors
-        const stuckMsg = `Stuck: ${stuckReason.description}`;
-        if (!errors.includes(stuckMsg)) {
-          errors.push(stuckMsg);
-        }
-      }
-      if (!resultMessage) {
-        const noResultMsg = "No result message received from agent";
-        if (!errors.includes(noResultMsg)) {
-          errors.push(noResultMsg);
-        }
-      }
-    
-      const evalSummary = gatewayEvaluation
-        ? {
-            passed: gatewayEvaluation.passed,
-            confidence: gatewayEvaluation.confidence,
-            reasoning: gatewayEvaluation.reasoning,
-          }
-        : undefined;
-    
-      const collectedTurnMetrics = turnMetrics ?? [];
-      const collectedToolCallMetrics = toolCallMetrics ?? [];
-    
-      if (resultMessage) {
-        const sessionResult = buildSessionResult(
-          resultMessage,
-          ctx.worktree?.branchName ?? "",
-          ctx.prUrl ?? null
-        );
-    
-        const isFailed = sessionResult.status === "failed" || !!stuckReason;
-        const failureCategory = isFailed ? categorizeFailure(errors, stuckReason?.type) : undefined;
-    
-        const finalResult: SessionResult = {
-          ...sessionResult,
-          ...(stuckReason ? { status: "failed" as const, stuckPattern: stuckReason.type } : {}),
-          ...(evalSummary ? { evaluation: evalSummary } : {}),
-          ...(failureCategory ? { failureCategory } : {}),
-          turnMetrics: collectedTurnMetrics,
-          toolCallMetrics: collectedToolCallMetrics,
-        };
-    
-        // Record failure for future context
-        if (finalResult.status === "failed") {
-          recordFailure(ctx.config.repoPath, {
-            taskDescription: ctx.config.taskDescription,
-            timestamp: new Date().toISOString(),
-            stuckPattern: stuckReason?.type,
-            errors,
-            approach: finalResult.resultText || "Unknown approach",
-          }).catch(() => {});
-        }
-    
-        // Set final span attributes
-        rootSpan.setAttribute("session.status", finalResult.status);
-        rootSpan.setAttribute("session.cost_usd", finalResult.costUsd);
-        rootSpan.setAttribute("session.num_turns", finalResult.numTurns);
-        rootSpan.setAttribute("session.branch", finalResult.branchName);
-        if (finalResult.prUrl) rootSpan.setAttribute("session.pr_url", finalResult.prUrl);
-        if (finalResult.stuckPattern)
-          rootSpan.setAttribute("session.stuck_pattern", finalResult.stuckPattern);
-        if (failureCategory) rootSpan.setAttribute("session.failure_category", failureCategory);
-        rootSpan.setAttribute("session.turn_count", collectedTurnMetrics.length);
-        rootSpan.setAttribute("session.tool_call_count", collectedToolCallMetrics.length);
-        if (contextMetrics) {
-          rootSpan.setAttribute("session.context_percent_at_exit", contextMetrics.contextPercentAtExit);
-          rootSpan.setAttribute("session.peak_context_percent", contextMetrics.peakContextPercent);
-          rootSpan.setAttribute("session.context_compaction_count", contextMetrics.compactionCount);
-        }
-    
-        emitEvent(ctx.onEvent, "session:result", {
-          message: `Session completed: ${finalResult.status}`,
-        });
-    
-        // Attach session metrics to the Langfuse trace
-        updateActiveObservation({
-          metadata: {
-            success: String(finalResult.status === "succeeded" ? 1 : 0),
-            cost_usd: String(finalResult.costUsd),
-            num_turns: String(finalResult.numTurns),
-            stuck: String(stuckReason ? 1 : 0),
-            ...(evalSummary
-              ? {
-                  evaluation_confidence: String(evalSummary.confidence),
-                  evaluation_reasoning: evalSummary.reasoning,
-                }
-              : {}),
-            ...(contextMetrics
-              ? {
-                  context_percent_at_exit: String(contextMetrics.contextPercentAtExit),
-                  peak_context_percent: String(contextMetrics.peakContextPercent),
-                  context_compaction_count: String(contextMetrics.compactionCount),
-                }
-              : {}),
-          },
-        });
-    
-        return finalResult;
-      }
-    
-      // No result message — build a failure result
-      const failureCategoryNoResult = categorizeFailure(errors, stuckReason?.type);
-      rootSpan.setAttribute("session.status", "failed");
-    
-      return {
-        sessionId: "",
-        status: "failed",
-        branchName: ctx.worktree?.branchName ?? "",
-        prUrl: ctx.prUrl ?? null,
-        costUsd: 0,
-        tokenUsage: { inputTokens: 0, outputTokens: 0 },
-        durationMs: 0,
-        numTurns: 0,
-        resultText: "",
-        errors,
-        stuckPattern: stuckReason?.type,
-        evaluation: evalSummary,
-        ...(failureCategoryNoResult ? { failureCategory: failureCategoryNoResult } : {}),
-        turnMetrics: collectedTurnMetrics,
-        toolCallMetrics: collectedToolCallMetrics,
-      };
     }
   </file>
   <file path="packages/agent-core/src/source-resolver.ts">
@@ -14793,7 +14754,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14865,18 +14865,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms.txt
+++ b/llms.txt
@@ -179,6 +179,13 @@
     </item>
   </file>
   </section>
+  <section priority="medium" role="__tests__">
+  <file path="packages/agent-core/src/__tests__/fake-phase-deps.ts">
+    <item priority="high">
+      export function makeFakePhaseDeps(): PhaseDeps { /* ... */ }
+    </item>
+  </file>
+  </section>
   <section priority="medium" role="adapters">
   <file path="packages/agent-core/src/adapters/claude-adapter.ts">
     <item priority="medium">
@@ -1223,6 +1230,11 @@
   </file>
   </section>
   <section priority="medium" role="phases">
+  <file path="packages/agent-core/src/phases/default-deps.ts">
+    <item priority="high">
+      export function createDefaultPhaseDeps(): PhaseDeps { /* ... */ }
+    </item>
+  </file>
   <file path="packages/agent-core/src/phases/feedback-phase.ts">
     <item priority="high">
       class FeedbackPhase {
@@ -1233,14 +1245,15 @@
   </file>
   <file path="packages/agent-core/src/phases/pipeline-types.ts">
     <item priority="low">
-      type PhaseStatus = "success" | "failed" | "skipped";
+      interface MergeDirectlyOptions {
+        branchName: string;
+        baseBranch: string;
+        repoPath: string;
+        commitTitle: string;
+      }
     </item>
     <item priority="low">
-      interface PhaseResult {
-        phase: string;
-        status: PhaseStatus;
-        errors: readonly string[];
-      }
+      type PhaseStatus = "success" | "failed" | "skipped";
     </item>
   </file>
   <file path="packages/agent-core/src/phases/publish-phase.ts">
@@ -3008,16 +3021,20 @@
   </file>
   <file path="packages/agent-core/src/session-runner.ts">
     <item priority="high">
+      interface SessionState {
+        worktree?: WorktreeInfo;
+        systemPrompt?: string;
+        resultMessage?: SDKResultMessage;
+        stuckReason?: StuckPattern;
+        turnMetrics: readonly TurnMetrics[];
+      }
+    </item>
+    <item priority="high">
       export async function runSession(
         config: SessionConfig,
-        onEvent?: SessionEventCallback
+        onEvent?: SessionEventCallback,
+        deps: PhaseDeps = createDefaultPhaseDeps()
       ): Promise<SessionResult> { /* ... */ }
-    </item>
-    <item priority="medium">
-      function buildFinalResult(
-        ctx: PipelineContext,
-        rootSpan: ReturnType<ReturnType<typeof trace.getTracer>["startSpan"]>
-      ): SessionResult { /* ... */ }
     </item>
   </file>
   <file path="packages/agent-core/src/source-resolver.ts">

--- a/packages/agent-core/llms-full.txt
+++ b/packages/agent-core/llms-full.txt
@@ -1,4 +1,71 @@
 <codebase path="packages/agent-core">
+  <section priority="medium" role="__tests__">
+  <file path="src/__tests__/fake-phase-deps.ts">
+    export function makeFakePhaseDeps(): PhaseDeps {
+      return {
+        worktreeManager: {
+          createWorktree: vi.fn().mockResolvedValue({
+            path: "/repo/.agent-worktrees/agent-fix-bug-abc123",
+            branchName: "agent/fix-bug-abc123",
+            mode: "full",
+          }),
+          hasChanges: vi.fn().mockResolvedValue(false),
+          commitChanges: vi.fn().mockResolvedValue("abc123"),
+          pushBranch: vi.fn().mockResolvedValue(undefined),
+          removeWorktree: vi.fn().mockResolvedValue(undefined),
+        },
+        promptBuilder: {
+          buildSystemPrompt: vi.fn().mockResolvedValue("system prompt"),
+          loadSourceFiles: vi.fn().mockResolvedValue([]),
+          loadProjectContext: vi.fn().mockResolvedValue(null),
+        },
+        failureMemory: {
+          loadMemory: vi.fn().mockResolvedValue({ records: [] }),
+          queryPastFailures: vi.fn().mockReturnValue([]),
+          buildFailureContext: vi.fn().mockReturnValue(""),
+        },
+        queryRunner: {
+          runHardenedQuery: vi.fn().mockResolvedValue({
+            resultMessage: null,
+            stuckReason: null,
+            rawTurnMetrics: [],
+            rawToolCallMetrics: [],
+            errorMessage: null,
+            contextMetrics: null,
+          }),
+        },
+        successEvaluator: {
+          getGitDiff: vi.fn().mockResolvedValue("diff --git a/file.ts\n+change"),
+        },
+        gateway: {
+          runPostCommitGateway: vi.fn().mockResolvedValue({
+            outcome: "create-pr",
+            passed: true,
+            gateFailures: [],
+            errors: [],
+          }),
+        },
+        prCreator: {
+          createPullRequest: vi.fn().mockResolvedValue({
+            url: "https://github.com/repo/pull/1",
+            number: 1,
+          }),
+          buildPrTitle: vi.fn().mockReturnValue("feat: test"),
+          buildPrBody: vi.fn().mockReturnValue("body"),
+          buildFailurePrBody: vi.fn().mockReturnValue("failure body"),
+          mergeDirectly: vi.fn().mockResolvedValue("https://github.com/repo/pull/merged"),
+        },
+        feedbackLoop: {
+          runFeedbackLoop: vi.fn().mockResolvedValue({
+            resolved: false,
+            retriesUsed: 0,
+            lastFingerprint: null,
+          }),
+        },
+      };
+    }
+  </file>
+  </section>
   <section priority="medium" role="adapters">
   <file path="src/adapters/claude-adapter.ts">
     function deriveHasChanges(result: SessionResult): boolean {
@@ -528,17 +595,59 @@
   </file>
   </section>
   <section priority="medium" role="phases">
+  <file path="src/phases/default-deps.ts">
+    export function createDefaultPhaseDeps(): PhaseDeps {
+      return {
+        worktreeManager: {
+          createWorktree,
+          hasChanges,
+          commitChanges,
+          pushBranch,
+          removeWorktree,
+        },
+        promptBuilder: {
+          buildSystemPrompt,
+          loadSourceFiles,
+          loadProjectContext,
+        },
+        failureMemory: {
+          loadMemory,
+          queryPastFailures,
+          buildFailureContext,
+        },
+        queryRunner: {
+          runHardenedQuery,
+        },
+        successEvaluator: {
+          getGitDiff,
+        },
+        gateway: {
+          runPostCommitGateway,
+        },
+        prCreator: {
+          createPullRequest,
+          buildPrTitle,
+          buildPrBody,
+          buildFailurePrBody,
+          mergeDirectly,
+        },
+        feedbackLoop: {
+          runFeedbackLoop,
+        },
+      };
+    }
+  </file>
   <file path="src/phases/feedback-phase.ts">
-    export class FeedbackPhase implements PipelinePhase {
+    export class FeedbackPhase implements Phase<FeedbackPhaseInput, void> {
       readonly name = "feedback" as const;
     
-      async run(ctx: PipelineContext): Promise<{ result: PhaseResult; ctx: PipelineContext }> {
-        const { config, onEvent, worktree, resultMessage, prNumber } = ctx;
+      async run(input: FeedbackPhaseInput, deps: PhaseDeps): Promise<PhaseExecution<void>> {
+        const { config, onEvent, worktree, resultMessage, prNumber, prUrl } = input;
     
-        if (!config.feedbackLoop?.enabled || !prNumber || !ctx.prUrl || !worktree) {
+        if (!config.feedbackLoop?.enabled || !prNumber || !prUrl) {
           return {
             result: { phase: this.name, status: "skipped", errors: [] },
-            ctx,
+            output: null,
           };
         }
     
@@ -549,7 +658,7 @@
         const fbSpan = tracer.startSpan("agent_core.feedback_loop");
         let feedbackResult;
         try {
-          feedbackResult = await runFeedbackLoop(
+          feedbackResult = await deps.feedbackLoop.runFeedbackLoop(
             {
               prNumber,
               branchName: worktree.branchName,
@@ -575,50 +684,56 @@
     
         return {
           result: { phase: this.name, status: "success", errors: [] },
-          ctx,
+          output: undefined,
         };
       }
     }
   </file>
   <file path="src/phases/pipeline-types.ts">
-    export type PhaseStatus = "success" | "failed" | "skipped";
-    export interface PhaseResult {
-      readonly phase: string;
-      readonly status: PhaseStatus;
-      readonly errors: readonly string[];
+    export interface MergeDirectlyOptions {
+      readonly branchName: string;
+      readonly baseBranch: string;
+      readonly repoPath: string;
+      readonly commitTitle: string;
     }
+    export type PhaseStatus = "success" | "failed" | "skipped";
   </file>
   <file path="src/phases/publish-phase.ts">
-    export class PublishPhase implements PipelinePhase {
+    export class PublishPhase implements Phase<PublishPhaseInput, PublishPhaseOutput> {
       readonly name = "publish" as const;
     
-      async run(ctx: PipelineContext): Promise<{ result: PhaseResult; ctx: PipelineContext }> {
-        const { config, worktree } = ctx;
+      async run(
+        input: PublishPhaseInput,
+        deps: PhaseDeps
+      ): Promise<PhaseExecution<PublishPhaseOutput>> {
+        const { config, worktree, hasChanges } = input;
     
-        if (!config.createPr || !ctx.hasChanges || !worktree) {
+        if (!config.createPr || !hasChanges) {
           return {
             result: { phase: this.name, status: "skipped", errors: [] },
-            ctx,
+            output: null,
           };
         }
     
-        const { prUrl, prNumber } = await this.createOrMergePr(ctx, worktree);
+        const { prUrl, prNumber } = await this.createOrMergePr(input, worktree, deps);
     
         return {
           result: { phase: this.name, status: "success", errors: [] },
-          ctx: { ...ctx, prUrl, prNumber },
+          output: { prUrl, prNumber },
         };
       }
     
       private async createOrMergePr(
-        ctx: PipelineContext,
-        worktree: WorktreeInfo
+        input: PublishPhaseInput,
+        worktree: WorktreeInfo,
+        deps: PhaseDeps
       ): Promise<{ prUrl: string | null; prNumber?: number }> {
-        const { config, onEvent, resultMessage, stuckReason, gatewayVerdict } = ctx;
+        const { config, onEvent, resultMessage, stuckReason, gatewayVerdict } = input;
+        const { prCreator } = deps;
     
         if (gatewayVerdict?.outcome === "merge-direct") {
-          const commitTitle = buildPrTitle(config.taskDescription);
-          const mergedUrl = await mergeDirectly({
+          const commitTitle = prCreator.buildPrTitle(config.taskDescription);
+          const mergedUrl = await prCreator.mergeDirectly({
             branchName: worktree.branchName,
             baseBranch: config.baseBranch,
             repoPath: worktree.path,
@@ -631,21 +746,25 @@
         }
     
         if (!gatewayVerdict || gatewayVerdict.outcome === "create-pr") {
-          const title = buildPrTitle(config.taskDescription);
+          const title = prCreator.buildPrTitle(config.taskDescription);
           const body = resultMessage
-            ? buildPrBody(
+            ? prCreator.buildPrBody(
                 config.taskDescription,
                 resultMessage.session_id,
                 resultMessage.total_cost_usd,
                 resultMessage.num_turns
               )
-            : buildFailurePrBody(config.taskDescription, [...ctx.errors], stuckReason?.type);
+            : prCreator.buildFailurePrBody(
+                config.taskDescription,
+                [...input.errors],
+                stuckReason?.type
+              );
     
           const prSpan = tracer.startSpan("agent_core.create_pr");
           try {
             const { value: pr } = await withRetry(
               () =>
-                createPullRequest({
+                prCreator.createPullRequest({
                   title,
                   body,
                   baseBranch: config.baseBranch,
@@ -670,11 +789,15 @@
     
         // verdict.outcome === "create-draft-pr" — quality gates failed
         const title = `wip: ${config.taskDescription.slice(0, 57)}`;
-        const body = buildFailurePrBody(config.taskDescription, [...ctx.errors], stuckReason?.type);
+        const body = prCreator.buildFailurePrBody(
+          config.taskDescription,
+          [...input.errors],
+          stuckReason?.type
+        );
     
         const { value: pr } = await withRetry(
           () =>
-            createPullRequest({
+            prCreator.createPullRequest({
               title,
               body,
               baseBranch: config.baseBranch,
@@ -693,19 +816,11 @@
     }
   </file>
   <file path="src/phases/query-phase.ts">
-    export class QueryPhase implements PipelinePhase {
+    export class QueryPhase implements Phase<QueryPhaseInput, QueryPhaseOutput> {
       readonly name = "query" as const;
     
-      async run(ctx: PipelineContext): Promise<{ result: PhaseResult; ctx: PipelineContext }> {
-        const { config, onEvent, worktree, systemPrompt } = ctx;
-    
-        if (!worktree || !systemPrompt) {
-          const msg = "QueryPhase requires worktree and systemPrompt in context";
-          return {
-            result: { phase: this.name, status: "failed", errors: [msg] },
-            ctx: { ...ctx, errors: [...ctx.errors, msg] },
-          };
-        }
+      async run(input: QueryPhaseInput, deps: PhaseDeps): Promise<PhaseExecution<QueryPhaseOutput>> {
+        const { config, onEvent, worktree, systemPrompt } = input;
     
         // Fail fast if the circuit breaker is open
         if (apiCircuitBreaker.getState() === CircuitState.Open) {
@@ -714,7 +829,7 @@
           emitEvent(onEvent, "session:error", { message: circuitMsg });
           return {
             result: { phase: this.name, status: "failed", errors: [circuitMsg] },
-            ctx: { ...ctx, errors: [...ctx.errors, circuitMsg] },
+            output: null,
           };
         }
     
@@ -725,7 +840,7 @@
           rawToolCallMetrics,
           errorMessage,
           contextMetrics,
-        } = await runHardenedQuery(
+        } = await deps.queryRunner.runHardenedQuery(
           {
             prompt: config.taskDescription,
             cwd: worktree.path,
@@ -743,7 +858,7 @@
         if (errorMessage) {
           return {
             result: { phase: this.name, status: "failed", errors: [errorMessage] },
-            ctx: { ...ctx, errors: [...ctx.errors, errorMessage] },
+            output: null,
           };
         }
     
@@ -751,8 +866,7 @@
     
         return {
           result: { phase: this.name, status: "success", errors: [] },
-          ctx: {
-            ...ctx,
+          output: {
             resultMessage: resultMessage ?? undefined,
             stuckReason: stuckReason ?? undefined,
             turnMetrics: buildTurnMetricsList(rawTurnMetrics),
@@ -764,20 +878,17 @@
     }
   </file>
   <file path="src/phases/verification-phase.ts">
-    export class VerificationPhase implements PipelinePhase {
+    export class VerificationPhase implements Phase<VerificationPhaseInput, VerificationPhaseOutput> {
       readonly name = "verification" as const;
     
-      async run(ctx: PipelineContext): Promise<{ result: PhaseResult; ctx: PipelineContext }> {
-        const { config, onEvent, worktree, resultMessage, stuckReason } = ctx;
+      async run(
+        input: VerificationPhaseInput,
+        deps: PhaseDeps
+      ): Promise<PhaseExecution<VerificationPhaseOutput>> {
+        const { config, onEvent, worktree, resultMessage, stuckReason } = input;
+        const { worktreeManager, successEvaluator, gateway } = deps;
     
-        if (!worktree) {
-          return {
-            result: { phase: this.name, status: "skipped", errors: [] },
-            ctx,
-          };
-        }
-    
-        const changed = await hasChanges(worktree.path);
+        const changed = await worktreeManager.hasChanges(worktree.path);
     
         if (!changed) {
           emitEvent(onEvent, "session:result", {
@@ -785,7 +896,7 @@
           });
           return {
             result: { phase: this.name, status: "success", errors: [] },
-            ctx: { ...ctx, hasChanges: false },
+            output: { hasChanges: false },
           };
         }
     
@@ -793,20 +904,22 @@
         const isSuccess = resultMessage?.subtype === "success" && !stuckReason;
         const prefix = isSuccess ? "feat" : "wip";
         const commitMsg = `${prefix}: ${sanitizeForCommitMessage(config.taskDescription)}`;
-        await commitChanges(worktree.path, commitMsg);
+        await worktreeManager.commitChanges(worktree.path, commitMsg);
     
         // Push with retry for transient network failures
-        await withRetry(() => pushBranch(worktree.path, worktree.branchName), { maxRetries: 3 });
+        await withRetry(() => worktreeManager.pushBranch(worktree.path, worktree.branchName), {
+          maxRetries: 3,
+        });
     
         // Run post-commit gateway (verification + quality gates) only on success
         const errors: string[] = [];
-        let gatewayVerdict;
-        let gatewayEvaluation;
+        let gatewayVerdict: GatewayVerdict | undefined;
+        let gatewayEvaluation: EvaluationResult | undefined;
         let cachedDiff: string | undefined;
     
         if (isSuccess) {
-          cachedDiff = await getGitDiff(worktree.path);
-          gatewayVerdict = await runPostCommitGateway(
+          cachedDiff = await successEvaluator.getGitDiff(worktree.path);
+          gatewayVerdict = await gateway.runPostCommitGateway(
             {
               worktreePath: worktree.path,
               diff: cachedDiff,
@@ -826,25 +939,27 @@
     
         return {
           result: { phase: this.name, status: "success", errors },
-          ctx: {
-            ...ctx,
+          output: {
             hasChanges: true,
             commitMsg,
             cachedDiff,
             gatewayVerdict,
             gatewayEvaluation,
-            errors: [...ctx.errors, ...errors],
           },
         };
       }
     }
   </file>
   <file path="src/phases/worktree-phase.ts">
-    export class WorktreePhase implements PipelinePhase {
+    export class WorktreePhase implements Phase<WorktreePhaseInput, WorktreePhaseOutput> {
       readonly name = "worktree" as const;
     
-      async run(ctx: PipelineContext): Promise<{ result: PhaseResult; ctx: PipelineContext }> {
-        const { config, onEvent } = ctx;
+      async run(
+        input: WorktreePhaseInput,
+        deps: PhaseDeps
+      ): Promise<PhaseExecution<WorktreePhaseOutput>> {
+        const { config, onEvent } = input;
+        const { worktreeManager, promptBuilder, failureMemory } = deps;
     
         // Classify the task once so downstream consumers reuse the result instead
         // of re-scanning the description.
@@ -856,7 +971,12 @@
         try {
           // 1. Create isolated worktree (with retry for transient git failures)
           const { value: worktree } = await withRetry(
-            () => createWorktree(config.repoPath, config.baseBranch, config.taskDescription),
+            () =>
+              worktreeManager.createWorktree(
+                config.repoPath,
+                config.baseBranch,
+                config.taskDescription
+              ),
             { maxRetries: 2 }
           );
           wtSpan.setAttribute("worktree.branch", worktree.branchName);
@@ -864,9 +984,9 @@
           wtSpan.end();
     
           // 2. Build system prompt with failure context, source files, and PR examples
-          const failureMemory = await loadMemory(config.repoPath);
-          const pastFailures = queryPastFailures(failureMemory, config.taskDescription);
-          const failureContext = buildFailureContext(pastFailures);
+          const memory = await failureMemory.loadMemory(config.repoPath);
+          const pastFailures = failureMemory.queryPastFailures(memory, config.taskDescription);
+          const failureContext = failureMemory.buildFailureContext(pastFailures);
     
           // Auto-resolve source files from task description if none provided
           const resolvedSourcePaths =
@@ -875,11 +995,12 @@
               const { resolveSourceFiles } = await import("../source-resolver.js");
               return resolveSourceFiles(config.taskDescription);
             })();
-    
           const finalSourcePaths = await resolvedSourcePaths;
     
           const sourceFileEntries =
-            finalSourcePaths.length > 0 ? await loadSourceFiles(finalSourcePaths) : undefined;
+            finalSourcePaths.length > 0
+              ? await promptBuilder.loadSourceFiles(finalSourcePaths)
+              : undefined;
     
           // Fetch recent successful PRs as examples (non-blocking)
           const { fetchRecentPrExamples, formatPrExamples } = await import("../budget-calculator.js");
@@ -887,13 +1008,15 @@
           const prExamplesSection = formatPrExamples(prExamples);
     
           // Load project CLAUDE.md for coding conventions (non-blocking)
-          const projectContext = await loadProjectContext(worktree.path).catch(() => null);
+          const projectContext = await promptBuilder
+            .loadProjectContext(worktree.path)
+            .catch(() => null);
           const projectSection = projectContext
             ? `\n\n## Project Conventions (from CLAUDE.md)\n\n${projectContext}`
             : "";
     
           const systemPrompt =
-            (await buildSystemPrompt(config.taskDescription, {
+            (await promptBuilder.buildSystemPrompt(config.taskDescription, {
               sourceFileEntries,
               prExamplesSection,
               failureContext,
@@ -905,14 +1028,14 @@
     
           return {
             result: { phase: this.name, status: "success", errors: [] },
-            ctx: { ...ctx, worktree, systemPrompt, taskSignals },
+            output: { worktree, systemPrompt, taskSignals },
           };
         } catch (error) {
           wtSpan.end();
           const errorMessage = error instanceof Error ? error.message : String(error);
           return {
             result: { phase: this.name, status: "failed", errors: [errorMessage] },
-            ctx: { ...ctx, errors: [...ctx.errors, errorMessage] },
+            output: null,
           };
         }
       }
@@ -1856,9 +1979,27 @@
     }
   </file>
   <file path="src/session-runner.ts">
+    interface SessionState {
+      worktree?: WorktreeInfo;
+      systemPrompt?: string;
+      resultMessage?: SDKResultMessage;
+      stuckReason?: StuckPattern;
+      turnMetrics: readonly TurnMetrics[];
+      toolCallMetrics: readonly ToolCallMetrics[];
+      contextMetrics?: ContextMetrics;
+      hasChanges: boolean;
+      commitMsg?: string;
+      cachedDiff?: string;
+      gatewayVerdict?: GatewayVerdict;
+      gatewayEvaluation?: EvaluationResult;
+      prUrl: string | null;
+      prNumber?: number;
+      errors: string[];
+    }
     export async function runSession(
       config: SessionConfig,
-      onEvent?: SessionEventCallback
+      onEvent?: SessionEventCallback,
+      deps: PhaseDeps = createDefaultPhaseDeps()
     ): Promise<SessionResult> {
       return startActiveObservation(
         "agent-session",
@@ -1874,76 +2015,26 @@
               },
             },
             async (): Promise<SessionResult> => {
-              // Apply QA tuning defaults from .github/auto-qa-tuning.json
-              const tuning = loadQaTuning(config.repoPath);
-              const tuningOverrides = tuning
-                ? applyTuningDefaults(
-                    {
-                      maxBudgetUsd: config.maxBudgetUsd,
-                      stuckDetectorConfig: config.stuckDetectorConfig,
-                    },
-                    tuning,
-                    DEFAULT_SESSION_CONFIG.maxBudgetUsd
-                  )
-                : null;
-    
-              const effectiveConfig = tuningOverrides
-                ? {
-                    ...config,
-                    maxBudgetUsd: tuningOverrides.maxBudgetUsd,
-                    stuckDetectorConfig: {
-                      ...config.stuckDetectorConfig,
-                      ...tuningOverrides.stuckDetectorConfig,
-                    },
-                  }
-                : config;
+              const effectiveConfig = applyEffectiveConfig(config);
     
               const rootSpan = tracer.startSpan("agent_core.run_session", {
-                attributes: {
-                  "session.task": effectiveConfig.taskDescription.slice(0, 200),
-                  "session.model": effectiveConfig.model,
-                  "session.max_turns": effectiveConfig.maxTurns,
-                  "session.max_budget_usd": effectiveConfig.maxBudgetUsd,
-                  "session.base_branch": effectiveConfig.baseBranch,
-                  ...(tuning ? { "session.qa_tuning_applied": true } : {}),
-                  ...(effectiveConfig.modelRoutingReason
-                    ? { "session.model_routing_reason": effectiveConfig.modelRoutingReason }
-                    : {}),
-                  ...(effectiveConfig.modelRoutingTier
-                    ? { "session.model_routing_tier": effectiveConfig.modelRoutingTier }
-                    : {}),
-                },
+                attributes: buildRootSpanAttributes(effectiveConfig, loadQaTuning(config.repoPath)),
               });
     
               const cleanupErrors: string[] = [];
-              let ctx: PipelineContext = {
-                config: effectiveConfig,
-                onEvent,
+              const state: SessionState = {
+                turnMetrics: [],
+                toolCallMetrics: [],
+                hasChanges: false,
+                prUrl: null,
                 errors: [],
               };
     
               let pendingResult: SessionResult | undefined;
     
               try {
-                // Run pipeline phases sequentially
-                for (const phase of phases) {
-                  const { result, ctx: nextCtx } = await phase.run(ctx);
-                  ctx = nextCtx;
-    
-                  if (result.status === "failed") {
-                    // Phase failure — attempt partial work push then abort
-                    if (ctx.worktree && effectiveConfig.createPr) {
-                      const errorMsg = result.errors[0] ?? "Phase failed";
-                      const prUrl = await pushPartialWork(ctx, errorMsg);
-                      if (prUrl) {
-                        ctx = { ...ctx, prUrl };
-                      }
-                    }
-                    break;
-                  }
-                }
-    
-                pendingResult = buildFinalResult(ctx, rootSpan);
+                await runPipeline(effectiveConfig, onEvent, deps, state);
+                pendingResult = buildFinalResult(effectiveConfig, state, rootSpan, onEvent);
               } catch (error) {
                 const errorMessage = error instanceof Error ? error.message : String(error);
                 emitEvent(onEvent, "session:error", { message: errorMessage });
@@ -1951,13 +2042,19 @@
                 rootSpan.setStatus({ code: SpanStatusCode.ERROR, message: errorMessage });
     
                 // Attempt to push partial work from failed sessions
-                const prUrl = await pushPartialWork(ctx, errorMessage);
+                const prUrl = await pushPartialWork(
+                  effectiveConfig,
+                  state,
+                  deps,
+                  errorMessage,
+                  onEvent
+                );
     
                 rootSpan.setAttribute("session.status", "failed");
                 pendingResult = {
                   sessionId: "",
                   status: "failed",
-                  branchName: ctx.worktree?.branchName ?? "",
+                  branchName: state.worktree?.branchName ?? "",
                   prUrl,
                   costUsd: 0,
                   tokenUsage: { inputTokens: 0, outputTokens: 0 },
@@ -1965,18 +2062,20 @@
                   numTurns: 0,
                   resultText: "",
                   errors: [errorMessage],
-                  stuckPattern: ctx.stuckReason?.type,
+                  stuckPattern: state.stuckReason?.type,
                 };
               } finally {
-                // Clean up worktree when PR was created (branch is pushed)
-                // Keep worktree when --no-pr so user can inspect
-                if (ctx.worktree && effectiveConfig.createPr) {
+                // Clean up worktree when PR was created (branch is pushed).
+                // Keep worktree when --no-pr so user can inspect.
+                if (state.worktree && effectiveConfig.createPr) {
                   try {
-                    await removeWorktree(effectiveConfig.repoPath, ctx.worktree.path);
+                    await deps.worktreeManager.removeWorktree(
+                      effectiveConfig.repoPath,
+                      state.worktree.path
+                    );
                   } catch (cleanupErr) {
                     const cleanupMsg =
                       cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr);
-                    // Record the error in the result (unchanged behavior)
                     cleanupErrors.push(cleanupMsg);
                     console.warn(`Worktree cleanup failed: ${cleanupMsg}`);
                     emitEvent(onEvent, "session:cleanup_warning", {
@@ -1987,8 +2086,8 @@
                     // level (never silent) and is not treated as a session failure.
                     await scheduleWorktreeReap({
                       repoPath: effectiveConfig.repoPath,
-                      worktreePath: ctx.worktree.path,
-                      mode: ctx.worktree.mode,
+                      worktreePath: state.worktree.path,
+                      mode: state.worktree.mode,
                     });
                   }
                 }
@@ -2001,144 +2100,6 @@
           );
         }
       );
-    }
-    function buildFinalResult(
-      ctx: PipelineContext,
-      rootSpan: ReturnType<ReturnType<typeof trace.getTracer>["startSpan"]>
-    ): SessionResult {
-      const {
-        resultMessage,
-        stuckReason,
-        gatewayEvaluation,
-        turnMetrics,
-        toolCallMetrics,
-        contextMetrics,
-      } = ctx;
-      const errors = [...ctx.errors];
-    
-      if (stuckReason) {
-        // Deduplicate — stuck error may already be in ctx.errors
-        const stuckMsg = `Stuck: ${stuckReason.description}`;
-        if (!errors.includes(stuckMsg)) {
-          errors.push(stuckMsg);
-        }
-      }
-      if (!resultMessage) {
-        const noResultMsg = "No result message received from agent";
-        if (!errors.includes(noResultMsg)) {
-          errors.push(noResultMsg);
-        }
-      }
-    
-      const evalSummary = gatewayEvaluation
-        ? {
-            passed: gatewayEvaluation.passed,
-            confidence: gatewayEvaluation.confidence,
-            reasoning: gatewayEvaluation.reasoning,
-          }
-        : undefined;
-    
-      const collectedTurnMetrics = turnMetrics ?? [];
-      const collectedToolCallMetrics = toolCallMetrics ?? [];
-    
-      if (resultMessage) {
-        const sessionResult = buildSessionResult(
-          resultMessage,
-          ctx.worktree?.branchName ?? "",
-          ctx.prUrl ?? null
-        );
-    
-        const isFailed = sessionResult.status === "failed" || !!stuckReason;
-        const failureCategory = isFailed ? categorizeFailure(errors, stuckReason?.type) : undefined;
-    
-        const finalResult: SessionResult = {
-          ...sessionResult,
-          ...(stuckReason ? { status: "failed" as const, stuckPattern: stuckReason.type } : {}),
-          ...(evalSummary ? { evaluation: evalSummary } : {}),
-          ...(failureCategory ? { failureCategory } : {}),
-          turnMetrics: collectedTurnMetrics,
-          toolCallMetrics: collectedToolCallMetrics,
-        };
-    
-        // Record failure for future context
-        if (finalResult.status === "failed") {
-          recordFailure(ctx.config.repoPath, {
-            taskDescription: ctx.config.taskDescription,
-            timestamp: new Date().toISOString(),
-            stuckPattern: stuckReason?.type,
-            errors,
-            approach: finalResult.resultText || "Unknown approach",
-          }).catch(() => {});
-        }
-    
-        // Set final span attributes
-        rootSpan.setAttribute("session.status", finalResult.status);
-        rootSpan.setAttribute("session.cost_usd", finalResult.costUsd);
-        rootSpan.setAttribute("session.num_turns", finalResult.numTurns);
-        rootSpan.setAttribute("session.branch", finalResult.branchName);
-        if (finalResult.prUrl) rootSpan.setAttribute("session.pr_url", finalResult.prUrl);
-        if (finalResult.stuckPattern)
-          rootSpan.setAttribute("session.stuck_pattern", finalResult.stuckPattern);
-        if (failureCategory) rootSpan.setAttribute("session.failure_category", failureCategory);
-        rootSpan.setAttribute("session.turn_count", collectedTurnMetrics.length);
-        rootSpan.setAttribute("session.tool_call_count", collectedToolCallMetrics.length);
-        if (contextMetrics) {
-          rootSpan.setAttribute("session.context_percent_at_exit", contextMetrics.contextPercentAtExit);
-          rootSpan.setAttribute("session.peak_context_percent", contextMetrics.peakContextPercent);
-          rootSpan.setAttribute("session.context_compaction_count", contextMetrics.compactionCount);
-        }
-    
-        emitEvent(ctx.onEvent, "session:result", {
-          message: `Session completed: ${finalResult.status}`,
-        });
-    
-        // Attach session metrics to the Langfuse trace
-        updateActiveObservation({
-          metadata: {
-            success: String(finalResult.status === "succeeded" ? 1 : 0),
-            cost_usd: String(finalResult.costUsd),
-            num_turns: String(finalResult.numTurns),
-            stuck: String(stuckReason ? 1 : 0),
-            ...(evalSummary
-              ? {
-                  evaluation_confidence: String(evalSummary.confidence),
-                  evaluation_reasoning: evalSummary.reasoning,
-                }
-              : {}),
-            ...(contextMetrics
-              ? {
-                  context_percent_at_exit: String(contextMetrics.contextPercentAtExit),
-                  peak_context_percent: String(contextMetrics.peakContextPercent),
-                  context_compaction_count: String(contextMetrics.compactionCount),
-                }
-              : {}),
-          },
-        });
-    
-        return finalResult;
-      }
-    
-      // No result message — build a failure result
-      const failureCategoryNoResult = categorizeFailure(errors, stuckReason?.type);
-      rootSpan.setAttribute("session.status", "failed");
-    
-      return {
-        sessionId: "",
-        status: "failed",
-        branchName: ctx.worktree?.branchName ?? "",
-        prUrl: ctx.prUrl ?? null,
-        costUsd: 0,
-        tokenUsage: { inputTokens: 0, outputTokens: 0 },
-        durationMs: 0,
-        numTurns: 0,
-        resultText: "",
-        errors,
-        stuckPattern: stuckReason?.type,
-        evaluation: evalSummary,
-        ...(failureCategoryNoResult ? { failureCategory: failureCategoryNoResult } : {}),
-        turnMetrics: collectedTurnMetrics,
-        toolCallMetrics: collectedToolCallMetrics,
-      };
     }
   </file>
   <file path="src/source-resolver.ts">

--- a/packages/agent-core/llms.txt
+++ b/packages/agent-core/llms.txt
@@ -1,4 +1,11 @@
 <codebase path="packages/agent-core">
+  <section priority="medium" role="__tests__">
+  <file path="src/__tests__/fake-phase-deps.ts">
+    <item priority="high">
+      export function makeFakePhaseDeps(): PhaseDeps { /* ... */ }
+    </item>
+  </file>
+  </section>
   <section priority="medium" role="adapters">
   <file path="src/adapters/claude-adapter.ts">
     <item priority="medium">
@@ -111,6 +118,11 @@
   </file>
   </section>
   <section priority="medium" role="phases">
+  <file path="src/phases/default-deps.ts">
+    <item priority="high">
+      export function createDefaultPhaseDeps(): PhaseDeps { /* ... */ }
+    </item>
+  </file>
   <file path="src/phases/feedback-phase.ts">
     <item priority="high">
       class FeedbackPhase {
@@ -121,14 +133,15 @@
   </file>
   <file path="src/phases/pipeline-types.ts">
     <item priority="low">
-      type PhaseStatus = "success" | "failed" | "skipped";
+      interface MergeDirectlyOptions {
+        branchName: string;
+        baseBranch: string;
+        repoPath: string;
+        commitTitle: string;
+      }
     </item>
     <item priority="low">
-      interface PhaseResult {
-        phase: string;
-        status: PhaseStatus;
-        errors: readonly string[];
-      }
+      type PhaseStatus = "success" | "failed" | "skipped";
     </item>
   </file>
   <file path="src/phases/publish-phase.ts">
@@ -681,16 +694,20 @@
   </file>
   <file path="src/session-runner.ts">
     <item priority="high">
+      interface SessionState {
+        worktree?: WorktreeInfo;
+        systemPrompt?: string;
+        resultMessage?: SDKResultMessage;
+        stuckReason?: StuckPattern;
+        turnMetrics: readonly TurnMetrics[];
+      }
+    </item>
+    <item priority="high">
       export async function runSession(
         config: SessionConfig,
-        onEvent?: SessionEventCallback
+        onEvent?: SessionEventCallback,
+        deps: PhaseDeps = createDefaultPhaseDeps()
       ): Promise<SessionResult> { /* ... */ }
-    </item>
-    <item priority="medium">
-      function buildFinalResult(
-        ctx: PipelineContext,
-        rootSpan: ReturnType<ReturnType<typeof trace.getTracer>["startSpan"]>
-      ): SessionResult { /* ... */ }
     </item>
   </file>
   <file path="src/source-resolver.ts">

--- a/packages/agent-core/src/__tests__/default-deps.test.ts
+++ b/packages/agent-core/src/__tests__/default-deps.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { createDefaultPhaseDeps } from "../phases/index.js";
+
+describe("createDefaultPhaseDeps", () => {
+  it("wires every collaborator group with real module functions", () => {
+    const deps = createDefaultPhaseDeps();
+
+    expect(typeof deps.worktreeManager.createWorktree).toBe("function");
+    expect(typeof deps.worktreeManager.hasChanges).toBe("function");
+    expect(typeof deps.worktreeManager.commitChanges).toBe("function");
+    expect(typeof deps.worktreeManager.pushBranch).toBe("function");
+    expect(typeof deps.worktreeManager.removeWorktree).toBe("function");
+
+    expect(typeof deps.promptBuilder.buildSystemPrompt).toBe("function");
+    expect(typeof deps.promptBuilder.loadSourceFiles).toBe("function");
+    expect(typeof deps.promptBuilder.loadProjectContext).toBe("function");
+
+    expect(typeof deps.failureMemory.loadMemory).toBe("function");
+    expect(typeof deps.failureMemory.queryPastFailures).toBe("function");
+    expect(typeof deps.failureMemory.buildFailureContext).toBe("function");
+
+    expect(typeof deps.queryRunner.runHardenedQuery).toBe("function");
+    expect(typeof deps.successEvaluator.getGitDiff).toBe("function");
+    expect(typeof deps.gateway.runPostCommitGateway).toBe("function");
+
+    expect(typeof deps.prCreator.createPullRequest).toBe("function");
+    expect(typeof deps.prCreator.buildPrTitle).toBe("function");
+    expect(typeof deps.prCreator.buildPrBody).toBe("function");
+    expect(typeof deps.prCreator.buildFailurePrBody).toBe("function");
+    expect(typeof deps.prCreator.mergeDirectly).toBe("function");
+
+    expect(typeof deps.feedbackLoop.runFeedbackLoop).toBe("function");
+  });
+});

--- a/packages/agent-core/src/__tests__/fake-phase-deps.ts
+++ b/packages/agent-core/src/__tests__/fake-phase-deps.ts
@@ -1,0 +1,72 @@
+import { vi } from "vitest";
+import type { PhaseDeps } from "../phases/index.js";
+
+/**
+ * Builds a `PhaseDeps` bundle whose every collaborator is a `vi.fn()` stub
+ * with safe defaults. Phase and session-runner tests inject this (and
+ * override the handful of methods they exercise) instead of `vi.mock`-ing
+ * a dozen modules.
+ */
+export function makeFakePhaseDeps(): PhaseDeps {
+  return {
+    worktreeManager: {
+      createWorktree: vi.fn().mockResolvedValue({
+        path: "/repo/.agent-worktrees/agent-fix-bug-abc123",
+        branchName: "agent/fix-bug-abc123",
+        mode: "full",
+      }),
+      hasChanges: vi.fn().mockResolvedValue(false),
+      commitChanges: vi.fn().mockResolvedValue("abc123"),
+      pushBranch: vi.fn().mockResolvedValue(undefined),
+      removeWorktree: vi.fn().mockResolvedValue(undefined),
+    },
+    promptBuilder: {
+      buildSystemPrompt: vi.fn().mockResolvedValue("system prompt"),
+      loadSourceFiles: vi.fn().mockResolvedValue([]),
+      loadProjectContext: vi.fn().mockResolvedValue(null),
+    },
+    failureMemory: {
+      loadMemory: vi.fn().mockResolvedValue({ records: [] }),
+      queryPastFailures: vi.fn().mockReturnValue([]),
+      buildFailureContext: vi.fn().mockReturnValue(""),
+    },
+    queryRunner: {
+      runHardenedQuery: vi.fn().mockResolvedValue({
+        resultMessage: null,
+        stuckReason: null,
+        rawTurnMetrics: [],
+        rawToolCallMetrics: [],
+        errorMessage: null,
+        contextMetrics: null,
+      }),
+    },
+    successEvaluator: {
+      getGitDiff: vi.fn().mockResolvedValue("diff --git a/file.ts\n+change"),
+    },
+    gateway: {
+      runPostCommitGateway: vi.fn().mockResolvedValue({
+        outcome: "create-pr",
+        passed: true,
+        gateFailures: [],
+        errors: [],
+      }),
+    },
+    prCreator: {
+      createPullRequest: vi.fn().mockResolvedValue({
+        url: "https://github.com/repo/pull/1",
+        number: 1,
+      }),
+      buildPrTitle: vi.fn().mockReturnValue("feat: test"),
+      buildPrBody: vi.fn().mockReturnValue("body"),
+      buildFailurePrBody: vi.fn().mockReturnValue("failure body"),
+      mergeDirectly: vi.fn().mockResolvedValue("https://github.com/repo/pull/merged"),
+    },
+    feedbackLoop: {
+      runFeedbackLoop: vi.fn().mockResolvedValue({
+        resolved: false,
+        retriesUsed: 0,
+        lastFingerprint: null,
+      }),
+    },
+  };
+}

--- a/packages/agent-core/src/__tests__/feedback-phase.test.ts
+++ b/packages/agent-core/src/__tests__/feedback-phase.test.ts
@@ -1,35 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { SessionConfig, SessionEvent } from "../types.js";
-import type { PipelineContext } from "../phases/pipeline-types.js";
+import type { PhaseDeps, FeedbackPhaseInput } from "../phases/index.js";
+import { makeFakePhaseDeps } from "./fake-phase-deps.js";
 
 // ── Mocks ───────────────────────────────────────────────────────────
-
-vi.mock("../feedback-loop.js", () => ({
-  runFeedbackLoop: vi.fn(),
-}));
+//
+// model-router resolves the feedback model; the feedback loop itself is
+// injected via `PhaseDeps`.
 
 vi.mock("../model-router.js", () => ({
   getFeedbackLoopModel: vi.fn().mockReturnValue("claude-haiku-4-5"),
   resolveModelId: vi.fn().mockReturnValue("claude-sonnet-4-6"),
 }));
 
-vi.mock("@opentelemetry/api", () => ({
-  trace: {
-    getTracer: () => ({
-      startSpan: () => ({
-        setAttribute: vi.fn(),
-        end: vi.fn(),
-        recordException: vi.fn(),
-        setStatus: vi.fn(),
-      }),
-    }),
-  },
-  SpanStatusCode: { ERROR: 2 },
-}));
-
 // ── Imports (after mocks) ───────────────────────────────────────────
 
-import { runFeedbackLoop } from "../feedback-loop.js";
 import { FeedbackPhase } from "../phases/feedback-phase.js";
 
 // ── Helpers ─────────────────────────────────────────────────────────
@@ -75,18 +60,15 @@ function createMockResultMessage() {
   };
 }
 
-function makeCtx(overrides?: Partial<PipelineContext>): PipelineContext {
+function makeInput(overrides?: Partial<FeedbackPhaseInput>): FeedbackPhaseInput {
   return {
     config: BASE_CONFIG,
-    errors: [],
     worktree: {
       path: "/repo/.agent-worktrees/agent-fix-bug-abc123",
       branchName: "agent/fix-bug-abc123",
       mode: "full",
     },
-    systemPrompt: "system prompt",
-    resultMessage: createMockResultMessage() as PipelineContext["resultMessage"],
-    hasChanges: true,
+    resultMessage: createMockResultMessage() as FeedbackPhaseInput["resultMessage"],
     prUrl: "https://github.com/repo/pull/1",
     prNumber: 1,
     ...overrides,
@@ -97,10 +79,16 @@ function makeCtx(overrides?: Partial<PipelineContext>): PipelineContext {
 
 describe("FeedbackPhase", () => {
   const phase = new FeedbackPhase();
+  let deps: PhaseDeps;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(runFeedbackLoop).mockResolvedValue({ resolved: true, retriesUsed: 1 });
+    deps = makeFakePhaseDeps();
+    vi.mocked(deps.feedbackLoop.runFeedbackLoop).mockResolvedValue({
+      resolved: true,
+      retriesUsed: 1,
+      lastFingerprint: null,
+    });
   });
 
   it("has name 'feedback'", () => {
@@ -108,24 +96,25 @@ describe("FeedbackPhase", () => {
   });
 
   it("runs feedback loop when enabled and PR exists", async () => {
-    const { result } = await phase.run(makeCtx());
+    const { result } = await phase.run(makeInput(), deps);
 
     expect(result.status).toBe("success");
-    expect(runFeedbackLoop).toHaveBeenCalled();
+    expect(deps.feedbackLoop.runFeedbackLoop).toHaveBeenCalled();
   });
 
   it("skips when feedbackLoop is not enabled", async () => {
     const { result } = await phase.run(
-      makeCtx({ config: { ...BASE_CONFIG, feedbackLoop: undefined } })
+      makeInput({ config: { ...BASE_CONFIG, feedbackLoop: undefined } }),
+      deps
     );
 
     expect(result.status).toBe("skipped");
-    expect(runFeedbackLoop).not.toHaveBeenCalled();
+    expect(deps.feedbackLoop.runFeedbackLoop).not.toHaveBeenCalled();
   });
 
   it("skips when feedbackLoop.enabled is false", async () => {
     const { result } = await phase.run(
-      makeCtx({
+      makeInput({
         config: {
           ...BASE_CONFIG,
           feedbackLoop: {
@@ -135,24 +124,25 @@ describe("FeedbackPhase", () => {
             pollTimeoutMs: 300_000,
           },
         },
-      })
+      }),
+      deps
     );
 
     expect(result.status).toBe("skipped");
-    expect(runFeedbackLoop).not.toHaveBeenCalled();
+    expect(deps.feedbackLoop.runFeedbackLoop).not.toHaveBeenCalled();
   });
 
   it("skips when no PR was created", async () => {
-    const { result } = await phase.run(makeCtx({ prUrl: null, prNumber: undefined }));
+    const { result } = await phase.run(makeInput({ prUrl: null, prNumber: undefined }), deps);
 
     expect(result.status).toBe("skipped");
-    expect(runFeedbackLoop).not.toHaveBeenCalled();
+    expect(deps.feedbackLoop.runFeedbackLoop).not.toHaveBeenCalled();
   });
 
   it("uses remaining budget (total - session cost)", async () => {
-    await phase.run(makeCtx());
+    await phase.run(makeInput(), deps);
 
-    const fbCall = vi.mocked(runFeedbackLoop).mock.calls[0][0];
+    const fbCall = vi.mocked(deps.feedbackLoop.runFeedbackLoop).mock.calls[0][0];
     // maxBudgetUsd = 1.0, resultMessage.total_cost_usd = 0.25 → remaining = 0.75
     expect(fbCall.maxBudgetUsd).toBeCloseTo(0.75);
   });
@@ -161,7 +151,7 @@ describe("FeedbackPhase", () => {
     const events: SessionEvent[] = [];
     const onEvent = (event: SessionEvent) => events.push(event);
 
-    await phase.run(makeCtx({ onEvent }));
+    await phase.run(makeInput({ onEvent }), deps);
 
     const resultEvents = events.filter((e) => e.type === "session:result");
     expect(resultEvents.length).toBeGreaterThan(0);

--- a/packages/agent-core/src/__tests__/publish-phase.test.ts
+++ b/packages/agent-core/src/__tests__/publish-phase.test.ts
@@ -1,19 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { SessionConfig, SessionEvent } from "../types.js";
-import type { PipelineContext } from "../phases/pipeline-types.js";
+import type { PhaseDeps, PublishPhaseInput } from "../phases/index.js";
+import { makeFakePhaseDeps } from "./fake-phase-deps.js";
 
 // ── Mocks ───────────────────────────────────────────────────────────
-
-vi.mock("../pr-creator.js", () => ({
-  createPullRequest: vi.fn(),
-  buildPrTitle: vi.fn(),
-  buildPrBody: vi.fn(),
-  buildFailurePrBody: vi.fn(),
-}));
-
-vi.mock("../dep-bump-merger.js", () => ({
-  mergeDirectly: vi.fn(),
-}));
+//
+// Only retry (skip delays) is module-mocked; pr-creator / dep-bump-merger
+// collaborators are injected via `PhaseDeps`.
 
 vi.mock("../retry.js", async () => {
   const actual = (await vi.importActual("../retry.js")) as Record<string, unknown>;
@@ -26,24 +19,8 @@ vi.mock("../retry.js", async () => {
   };
 });
 
-vi.mock("@opentelemetry/api", () => ({
-  trace: {
-    getTracer: () => ({
-      startSpan: () => ({
-        setAttribute: vi.fn(),
-        end: vi.fn(),
-        recordException: vi.fn(),
-        setStatus: vi.fn(),
-      }),
-    }),
-  },
-  SpanStatusCode: { ERROR: 2 },
-}));
-
 // ── Imports (after mocks) ───────────────────────────────────────────
 
-import { createPullRequest, buildPrTitle, buildPrBody, buildFailurePrBody } from "../pr-creator.js";
-import { mergeDirectly } from "../dep-bump-merger.js";
 import { PublishPhase } from "../phases/publish-phase.js";
 
 // ── Helpers ─────────────────────────────────────────────────────────
@@ -83,18 +60,17 @@ function createMockResultMessage() {
   };
 }
 
-function makeCtx(overrides?: Partial<PipelineContext>): PipelineContext {
+function makeInput(overrides?: Partial<PublishPhaseInput>): PublishPhaseInput {
   return {
     config: BASE_CONFIG,
-    errors: [],
     worktree: {
       path: "/repo/.agent-worktrees/agent-fix-bug-abc123",
       branchName: "agent/fix-bug-abc123",
       mode: "full",
     },
-    systemPrompt: "system prompt",
-    resultMessage: createMockResultMessage() as PipelineContext["resultMessage"],
+    resultMessage: createMockResultMessage() as PublishPhaseInput["resultMessage"],
     hasChanges: true,
+    errors: [],
     gatewayVerdict: {
       outcome: "create-pr",
       passed: true,
@@ -109,13 +85,14 @@ function makeCtx(overrides?: Partial<PipelineContext>): PipelineContext {
 
 describe("PublishPhase", () => {
   const phase = new PublishPhase();
+  let deps: PhaseDeps;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(buildPrTitle).mockReturnValue("feat: Fix the login bug");
-    vi.mocked(buildPrBody).mockReturnValue("PR body");
-    vi.mocked(buildFailurePrBody).mockReturnValue("Failure body");
-    vi.mocked(createPullRequest).mockResolvedValue({
+    deps = makeFakePhaseDeps();
+    vi.mocked(deps.prCreator.buildPrTitle).mockReturnValue("feat: Fix the login bug");
+    vi.mocked(deps.prCreator.buildPrBody).mockReturnValue("PR body");
+    vi.mocked(deps.prCreator.createPullRequest).mockResolvedValue({
       url: "https://github.com/repo/pull/1",
       number: 1,
     });
@@ -126,73 +103,80 @@ describe("PublishPhase", () => {
   });
 
   it("creates PR when gates pass", async () => {
-    const { result, ctx } = await phase.run(makeCtx());
+    const { result, output } = await phase.run(makeInput(), deps);
 
     expect(result.status).toBe("success");
-    expect(ctx.prUrl).toBe("https://github.com/repo/pull/1");
-    expect(ctx.prNumber).toBe(1);
-    expect(createPullRequest).toHaveBeenCalledWith(expect.objectContaining({ draft: false }));
+    expect(output?.prUrl).toBe("https://github.com/repo/pull/1");
+    expect(output?.prNumber).toBe(1);
+    expect(deps.prCreator.createPullRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ draft: false })
+    );
   });
 
   it("skips when createPr is false", async () => {
-    const { result, ctx } = await phase.run(
-      makeCtx({ config: { ...BASE_CONFIG, createPr: false } })
+    const { result, output } = await phase.run(
+      makeInput({ config: { ...BASE_CONFIG, createPr: false } }),
+      deps
     );
 
     expect(result.status).toBe("skipped");
-    expect(ctx.prUrl).toBeUndefined();
-    expect(createPullRequest).not.toHaveBeenCalled();
+    expect(output).toBeNull();
+    expect(deps.prCreator.createPullRequest).not.toHaveBeenCalled();
   });
 
   it("skips when no changes", async () => {
-    const { result } = await phase.run(makeCtx({ hasChanges: false }));
+    const { result } = await phase.run(makeInput({ hasChanges: false }), deps);
 
     expect(result.status).toBe("skipped");
-    expect(createPullRequest).not.toHaveBeenCalled();
+    expect(deps.prCreator.createPullRequest).not.toHaveBeenCalled();
   });
 
   it("creates draft PR when gates fail", async () => {
-    const { result, ctx } = await phase.run(
-      makeCtx({
+    const { result, output } = await phase.run(
+      makeInput({
         gatewayVerdict: {
           outcome: "create-draft-pr",
           passed: false,
           gateFailures: ["verification"],
           errors: ["typecheck failed"],
         },
-      })
+      }),
+      deps
     );
 
     expect(result.status).toBe("success");
-    expect(ctx.prUrl).toBe("https://github.com/repo/pull/1");
-    expect(createPullRequest).toHaveBeenCalledWith(expect.objectContaining({ draft: true }));
+    expect(output?.prUrl).toBe("https://github.com/repo/pull/1");
+    expect(deps.prCreator.createPullRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ draft: true })
+    );
   });
 
   it("direct-merges trivial dep bumps", async () => {
-    vi.mocked(mergeDirectly).mockResolvedValue("https://github.com/repo/pull/2");
+    vi.mocked(deps.prCreator.mergeDirectly).mockResolvedValue("https://github.com/repo/pull/2");
 
-    const { result, ctx } = await phase.run(
-      makeCtx({
+    const { result, output } = await phase.run(
+      makeInput({
         gatewayVerdict: {
           outcome: "merge-direct",
           passed: true,
           gateFailures: [],
           errors: [],
         },
-      })
+      }),
+      deps
     );
 
     expect(result.status).toBe("success");
-    expect(ctx.prUrl).toBe("https://github.com/repo/pull/2");
-    expect(mergeDirectly).toHaveBeenCalled();
-    expect(createPullRequest).not.toHaveBeenCalled();
+    expect(output?.prUrl).toBe("https://github.com/repo/pull/2");
+    expect(deps.prCreator.mergeDirectly).toHaveBeenCalled();
+    expect(deps.prCreator.createPullRequest).not.toHaveBeenCalled();
   });
 
   it("emits session:result events", async () => {
     const events: SessionEvent[] = [];
     const onEvent = (event: SessionEvent) => events.push(event);
 
-    await phase.run(makeCtx({ onEvent }));
+    await phase.run(makeInput({ onEvent }), deps);
 
     const resultEvents = events.filter((e) => e.type === "session:result");
     expect(resultEvents.length).toBeGreaterThan(0);
@@ -200,10 +184,12 @@ describe("PublishPhase", () => {
   });
 
   it("creates PR without gateway verdict (failed session with changes)", async () => {
-    const { result, ctx } = await phase.run(makeCtx({ gatewayVerdict: undefined }));
+    const { result, output } = await phase.run(makeInput({ gatewayVerdict: undefined }), deps);
 
     expect(result.status).toBe("success");
-    expect(ctx.prUrl).toBe("https://github.com/repo/pull/1");
-    expect(createPullRequest).toHaveBeenCalledWith(expect.objectContaining({ draft: false }));
+    expect(output?.prUrl).toBe("https://github.com/repo/pull/1");
+    expect(deps.prCreator.createPullRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ draft: false })
+    );
   });
 });

--- a/packages/agent-core/src/__tests__/query-phase.test.ts
+++ b/packages/agent-core/src/__tests__/query-phase.test.ts
@@ -1,61 +1,25 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { SessionConfig, SessionEvent } from "../types.js";
-import type { PipelineContext } from "../phases/pipeline-types.js";
+import type { SessionConfig } from "../types.js";
+import type { PhaseDeps, QueryPhaseInput } from "../phases/index.js";
+import type { HardenedQueryResult } from "../run-hardened-query.js";
+import { makeFakePhaseDeps } from "./fake-phase-deps.js";
 
 // ── Mocks ───────────────────────────────────────────────────────────
+//
+// The circuit-breaker gate is read directly from `run-hardened-query`; the
+// query loop itself is injected via `deps.queryRunner`.
 
-vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
-  query: vi.fn(),
+vi.mock("../circuit-breaker.js", () => ({
+  CircuitState: { Open: "OPEN", Closed: "CLOSED", HalfOpen: "HALF_OPEN" },
 }));
 
-vi.mock("../tool-permissions.js", () => ({
-  createToolPermissionHandler: vi.fn(),
+vi.mock("../run-hardened-query.js", () => ({
+  apiCircuitBreaker: { getState: vi.fn().mockReturnValue("CLOSED") },
 }));
-
-vi.mock("../event-mapper.js", () => ({
-  mapSdkMessage: vi.fn().mockReturnValue([]),
-}));
-
-vi.mock("../sanitize-output.js", () => ({
-  sanitizeStreamChunk: vi.fn((s: string) => s),
-}));
-
-vi.mock("@opentelemetry/api", () => ({
-  trace: {
-    getTracer: () => ({
-      startSpan: () => ({
-        setAttribute: vi.fn(),
-        end: vi.fn(),
-        recordException: vi.fn(),
-        setStatus: vi.fn(),
-      }),
-    }),
-  },
-  SpanStatusCode: { ERROR: 2 },
-}));
-
-vi.mock("@langfuse/tracing", () => ({
-  startObservation: vi.fn().mockReturnValue({
-    update: vi.fn().mockReturnThis(),
-    end: vi.fn(),
-  }),
-}));
-
-vi.mock("../circuit-breaker.js", () => {
-  class MockCircuitBreaker {
-    wrap = vi.fn().mockImplementation(async (fn: () => Promise<unknown>) => fn());
-    getState = vi.fn().mockReturnValue("CLOSED");
-  }
-  return {
-    CircuitBreaker: MockCircuitBreaker,
-    CircuitState: { Open: "OPEN", Closed: "CLOSED", HalfOpen: "HALF_OPEN" },
-  };
-});
 
 // ── Imports (after mocks) ───────────────────────────────────────────
 
-import { query } from "@anthropic-ai/claude-agent-sdk";
-import { createToolPermissionHandler } from "../tool-permissions.js";
+import { apiCircuitBreaker } from "../run-hardened-query.js";
 import { QueryPhase } from "../phases/query-phase.js";
 
 // ── Helpers ─────────────────────────────────────────────────────────
@@ -71,10 +35,9 @@ const BASE_CONFIG: SessionConfig = {
   createPr: true,
 };
 
-function makeCtx(overrides?: Partial<PipelineContext>): PipelineContext {
+function makeInput(overrides?: Partial<QueryPhaseInput>): QueryPhaseInput {
   return {
     config: BASE_CONFIG,
-    errors: [],
     worktree: {
       path: "/repo/.agent-worktrees/agent-fix-bug-abc123",
       branchName: "agent/fix-bug-abc123",
@@ -109,125 +72,103 @@ function createMockResultMessage() {
   };
 }
 
-async function* mockQueryGenerator(messages: unknown[]) {
-  for (const msg of messages) {
-    yield msg;
-  }
+function hardenedResult(overrides?: Partial<HardenedQueryResult>): HardenedQueryResult {
+  return {
+    resultMessage: null,
+    stuckReason: null,
+    rawTurnMetrics: [],
+    rawToolCallMetrics: [],
+    errorMessage: null,
+    contextMetrics: null,
+    ...overrides,
+  };
 }
 
 // ── Tests ───────────────────────────────────────────────────────────
 
 describe("QueryPhase", () => {
   const phase = new QueryPhase();
+  let deps: PhaseDeps;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(createToolPermissionHandler).mockReturnValue(
-      vi.fn().mockResolvedValue({ behavior: "allow" })
-    );
+    deps = makeFakePhaseDeps();
+    vi.mocked(apiCircuitBreaker.getState).mockReturnValue("CLOSED" as never);
   });
 
   it("has name 'query'", () => {
     expect(phase.name).toBe("query");
   });
 
-  it("returns resultMessage on successful SDK query", async () => {
+  it("returns resultMessage on successful query", async () => {
     const mockResult = createMockResultMessage();
-    vi.mocked(query).mockReturnValue(mockQueryGenerator([mockResult]) as ReturnType<typeof query>);
+    vi.mocked(deps.queryRunner.runHardenedQuery).mockResolvedValue(
+      hardenedResult({ resultMessage: mockResult as never })
+    );
 
-    const { result, ctx } = await phase.run(makeCtx());
+    const { result, output } = await phase.run(makeInput(), deps);
 
     expect(result.status).toBe("success");
     expect(result.phase).toBe("query");
-    expect(ctx.resultMessage).toBeDefined();
-    expect(ctx.resultMessage?.session_id).toBe("session-123");
-    expect(ctx.stuckReason).toBeUndefined();
+    expect(output?.resultMessage).toBeDefined();
+    expect(output?.resultMessage?.session_id).toBe("session-123");
+    expect(output?.stuckReason).toBeUndefined();
   });
 
-  it("returns failed when no worktree in context", async () => {
-    const { result } = await phase.run(makeCtx({ worktree: undefined }));
+  it("forwards the system prompt and config to the query runner", async () => {
+    vi.mocked(deps.queryRunner.runHardenedQuery).mockResolvedValue(hardenedResult());
+
+    await phase.run(makeInput(), deps);
+
+    expect(deps.queryRunner.runHardenedQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: "Fix the login bug",
+        cwd: "/repo/.agent-worktrees/agent-fix-bug-abc123",
+        systemPromptAppend: "system prompt",
+        model: "claude-sonnet-4-6",
+      }),
+      undefined
+    );
+  });
+
+  it("fails fast when the circuit breaker is OPEN", async () => {
+    vi.mocked(apiCircuitBreaker.getState).mockReturnValue("OPEN" as never);
+
+    const { result, output } = await phase.run(makeInput(), deps);
 
     expect(result.status).toBe("failed");
-    expect(result.errors[0]).toContain("requires worktree");
+    expect(result.errors[0]).toContain("Circuit breaker is OPEN");
+    expect(output).toBeNull();
+    expect(deps.queryRunner.runHardenedQuery).not.toHaveBeenCalled();
   });
 
-  it("detects context exhaustion from compaction events", async () => {
-    const compactMessages = Array.from({ length: 5 }, () => ({
-      type: "system",
-      subtype: "compact_boundary",
-    }));
-    const mockResult = createMockResultMessage();
-    vi.mocked(query).mockReturnValue(
-      mockQueryGenerator([...compactMessages, mockResult]) as ReturnType<typeof query>
+  it("surfaces stuck reason as output metadata while the phase succeeds", async () => {
+    vi.mocked(deps.queryRunner.runHardenedQuery).mockResolvedValue(
+      hardenedResult({
+        resultMessage: createMockResultMessage() as never,
+        stuckReason: {
+          type: "context_window_loop",
+          description: "context window exhausted",
+          severity: "error",
+        } as never,
+      })
     );
 
-    const { result, ctx } = await phase.run(makeCtx());
+    const { result, output } = await phase.run(makeInput(), deps);
 
-    expect(result.status).toBe("success"); // phase itself succeeds, stuck is metadata
-    expect(ctx.stuckReason).toBeDefined();
-    expect(ctx.stuckReason?.type).toBe("context_window_loop");
+    expect(result.status).toBe("success");
+    expect(output?.stuckReason?.type).toBe("context_window_loop");
   });
 
-  it("emits session:stuck events on compaction exhaustion", async () => {
-    const compactMessages = Array.from({ length: 5 }, () => ({
-      type: "system",
-      subtype: "compact_boundary",
-    }));
-    const mockResult = createMockResultMessage();
-    vi.mocked(query).mockReturnValue(
-      mockQueryGenerator([...compactMessages, mockResult]) as ReturnType<typeof query>
+  it("returns failed with null output when the query runner reports an error", async () => {
+    vi.mocked(deps.queryRunner.runHardenedQuery).mockResolvedValue(
+      hardenedResult({ errorMessage: "SDK connection failed" })
     );
 
-    const events: SessionEvent[] = [];
-    const onEvent = (event: SessionEvent) => events.push(event);
-
-    await phase.run(makeCtx({ onEvent }));
-
-    const stuckEvents = events.filter((e) => e.type === "session:stuck");
-    expect(stuckEvents.length).toBeGreaterThan(0);
-  });
-
-  it("records turn metrics for assistant messages", async () => {
-    vi.mocked((await import("../event-mapper.js")).mapSdkMessage).mockReturnValue([
-      {
-        type: "session:turn_metrics",
-        turnIndex: 1,
-        inputTokens: 100,
-        outputTokens: 50,
-        thinkingTokens: 0,
-        costUsd: 0,
-        modelId: "claude-sonnet-4-6",
-      },
-    ]);
-
-    const assistantMsg = {
-      type: "assistant" as const,
-      message: {
-        role: "assistant",
-        content: [{ type: "text", text: "I'll fix the bug" }],
-        usage: { input_tokens: 100, output_tokens: 50 },
-      },
-    };
-    const mockResult = createMockResultMessage();
-    vi.mocked(query).mockReturnValue(
-      mockQueryGenerator([assistantMsg, mockResult]) as ReturnType<typeof query>
-    );
-
-    const { ctx } = await phase.run(makeCtx());
-
-    expect(ctx.turnMetrics).toBeDefined();
-    expect(ctx.turnMetrics!.length).toBeGreaterThan(0);
-  });
-
-  it("handles SDK errors gracefully", async () => {
-    vi.mocked(query).mockImplementation(() => {
-      throw new Error("SDK connection failed");
-    });
-
-    const { result, ctx } = await phase.run(makeCtx());
+    const { result, output } = await phase.run(makeInput(), deps);
 
     expect(result.status).toBe("failed");
     expect(result.errors).toContain("SDK connection failed");
-    expect(ctx.errors).toContain("SDK connection failed");
+    expect(output).toBeNull();
   });
 });

--- a/packages/agent-core/src/__tests__/session-runner.test.ts
+++ b/packages/agent-core/src/__tests__/session-runner.test.ts
@@ -1,54 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { SessionConfig, SessionEvent } from "../types.js";
+import type { PhaseDeps } from "../phases/index.js";
+import type { HardenedQueryResult } from "../run-hardened-query.js";
+import { makeFakePhaseDeps } from "./fake-phase-deps.js";
 
-// Mock all dependencies
-vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
-  query: vi.fn(),
-}));
-
-vi.mock("../worktree-manager.js", () => ({
-  createWorktree: vi.fn(),
-  commitChanges: vi.fn(),
-  pushBranch: vi.fn(),
-  hasChanges: vi.fn(),
-  removeWorktree: vi.fn(),
-}));
-
-vi.mock("../pr-creator.js", () => ({
-  createPullRequest: vi.fn(),
-  buildPrTitle: vi.fn(),
-  buildPrBody: vi.fn(),
-  buildFailurePrBody: vi.fn(),
-}));
-
-vi.mock("../success-evaluator.js", () => ({
-  getGitDiff: vi.fn(),
-}));
-
-vi.mock("../post-commit-gateway.js", () => ({
-  runPostCommitGateway: vi.fn(),
-}));
-
-vi.mock("../feedback-loop.js", () => ({
-  runFeedbackLoop: vi.fn(),
-}));
-
-vi.mock("../failure-memory.js", () => ({
-  loadMemory: vi.fn(),
-  queryPastFailures: vi.fn(),
-  buildFailureContext: vi.fn(),
-  recordFailure: vi.fn(),
-}));
-
-vi.mock("../prompt-builder.js", () => ({
-  buildSystemPrompt: vi.fn(),
-  loadSourceFiles: vi.fn().mockResolvedValue([]),
-  loadProjectContext: vi.fn().mockResolvedValue(null),
-}));
-
-vi.mock("../tool-permissions.js", () => ({
-  createToolPermissionHandler: vi.fn(),
-}));
+// ── Mocks ───────────────────────────────────────────────────────────
+//
+// Phase collaborators are injected through `PhaseDeps` (no `vi.mock`).
+// Only the three pieces of session-runner *infrastructure* are mocked:
+// Langfuse tracing, the worktree reaper, and retry (to skip backoff
+// delays and assert retry wrapping).
 
 vi.mock("@langfuse/tracing", () => ({
   startActiveObservation: vi
@@ -93,26 +54,10 @@ vi.mock("../retry.js", async () => {
   };
 });
 
-import { query } from "@anthropic-ai/claude-agent-sdk";
-import {
-  createWorktree,
-  commitChanges,
-  pushBranch,
-  hasChanges,
-  removeWorktree,
-} from "../worktree-manager.js";
-import { createPullRequest, buildPrTitle, buildPrBody } from "../pr-creator.js";
-import { getGitDiff } from "../success-evaluator.js";
-import { runPostCommitGateway } from "../post-commit-gateway.js";
-import { runFeedbackLoop } from "../feedback-loop.js";
-import { loadMemory, queryPastFailures, buildFailureContext } from "../failure-memory.js";
-import { buildSystemPrompt } from "../prompt-builder.js";
-import { createToolPermissionHandler } from "../tool-permissions.js";
 import { withRetry } from "../retry.js";
 import { scheduleWorktreeReap } from "../worktree-reaper.js";
 import {
   startActiveObservation,
-  startObservation,
   propagateAttributes,
   updateActiveObservation,
 } from "@langfuse/tracing";
@@ -129,7 +74,7 @@ const BASE_CONFIG: SessionConfig = {
   createPr: true,
 };
 
-function createMockResultMessage() {
+function createMockResultMessage(overrides?: Record<string, unknown>) {
   return {
     type: "result" as const,
     subtype: "success" as const,
@@ -150,204 +95,172 @@ function createMockResultMessage() {
     },
     modelUsage: {},
     permission_denials: [],
+    ...overrides,
   };
 }
 
-// Helper to create an async generator from an array of messages
-async function* mockQueryGenerator(messages: unknown[]) {
-  for (const msg of messages) {
-    yield msg;
-  }
+function hardenedResult(overrides?: Partial<HardenedQueryResult>): HardenedQueryResult {
+  return {
+    resultMessage: null,
+    stuckReason: null,
+    rawTurnMetrics: [],
+    rawToolCallMetrics: [],
+    errorMessage: null,
+    contextMetrics: null,
+    ...overrides,
+  };
+}
+
+/** Configures `deps` so the query runner resolves with `resultMessage`. */
+function withResult(deps: PhaseDeps, resultMessage: unknown): void {
+  vi.mocked(deps.queryRunner.runHardenedQuery).mockResolvedValue(
+    hardenedResult({ resultMessage: resultMessage as never })
+  );
 }
 
 describe("runSession", () => {
+  let deps: PhaseDeps;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    deps = makeFakePhaseDeps();
 
-    // Reset withRetry to default pass-through
     vi.mocked(withRetry).mockImplementation(async (fn) => {
       const value = await fn();
       return { value, attempts: 1 };
     });
 
-    // Reset reaper to default success
     vi.mocked(scheduleWorktreeReap).mockResolvedValue({ succeeded: true, attempts: 2 });
 
-    vi.mocked(createWorktree).mockResolvedValue({
+    vi.mocked(deps.worktreeManager.createWorktree).mockResolvedValue({
       path: "/repo/.agent-worktrees/agent-fix-bug-abc123",
       branchName: "agent/fix-bug-abc123",
+      mode: "full",
     });
-
-    vi.mocked(buildSystemPrompt).mockReturnValue("system prompt");
-    vi.mocked(createToolPermissionHandler).mockReturnValue(
-      vi.fn().mockResolvedValue({ behavior: "allow" })
-    );
-
-    vi.mocked(loadMemory).mockResolvedValue({ records: [] });
-    vi.mocked(queryPastFailures).mockReturnValue([]);
-    vi.mocked(buildFailureContext).mockReturnValue("");
-
-    vi.mocked(runPostCommitGateway).mockResolvedValue({
-      outcome: "create-pr",
-      passed: true,
-      gateFailures: [],
-      errors: [],
-    });
-
-    vi.mocked(runFeedbackLoop).mockResolvedValue({ resolved: false, retriesUsed: 0 });
-
-    vi.mocked(getGitDiff).mockResolvedValue("diff --git a/file.ts\n+change");
   });
 
   it("runs a successful session with PR creation", async () => {
-    const mockResult = createMockResultMessage();
-
-    vi.mocked(query).mockReturnValue(mockQueryGenerator([mockResult]) as ReturnType<typeof query>);
-    vi.mocked(hasChanges).mockResolvedValue(true);
-    vi.mocked(commitChanges).mockResolvedValue("abc123");
-    vi.mocked(pushBranch).mockResolvedValue(undefined);
-    vi.mocked(buildPrTitle).mockReturnValue("feat: Fix the login bug");
-    vi.mocked(buildPrBody).mockReturnValue("PR body");
-    vi.mocked(createPullRequest).mockResolvedValue({
+    withResult(deps, createMockResultMessage());
+    vi.mocked(deps.worktreeManager.hasChanges).mockResolvedValue(true);
+    vi.mocked(deps.prCreator.buildPrTitle).mockReturnValue("feat: Fix the login bug");
+    vi.mocked(deps.prCreator.buildPrBody).mockReturnValue("PR body");
+    vi.mocked(deps.prCreator.createPullRequest).mockResolvedValue({
       url: "https://github.com/repo/pull/1",
       number: 1,
     });
 
-    const result = await runSession(BASE_CONFIG);
+    const result = await runSession(BASE_CONFIG, undefined, deps);
 
     expect(result.status).toBe("succeeded");
     expect(result.prUrl).toBe("https://github.com/repo/pull/1");
     expect(result.branchName).toBe("agent/fix-bug-abc123");
     expect(result.costUsd).toBe(0.25);
     expect(result.numTurns).toBe(5);
-    expect(commitChanges).toHaveBeenCalled();
+    expect(deps.worktreeManager.commitChanges).toHaveBeenCalled();
   });
 
   it("skips PR creation when no changes are made", async () => {
-    const mockResult = createMockResultMessage();
+    withResult(deps, createMockResultMessage());
+    vi.mocked(deps.worktreeManager.hasChanges).mockResolvedValue(false);
 
-    vi.mocked(query).mockReturnValue(mockQueryGenerator([mockResult]) as ReturnType<typeof query>);
-    vi.mocked(hasChanges).mockResolvedValue(false);
-
-    const result = await runSession(BASE_CONFIG);
+    const result = await runSession(BASE_CONFIG, undefined, deps);
 
     expect(result.status).toBe("succeeded");
     expect(result.prUrl).toBeNull();
-    expect(commitChanges).not.toHaveBeenCalled();
-    expect(pushBranch).not.toHaveBeenCalled();
-    expect(createPullRequest).not.toHaveBeenCalled();
+    expect(deps.worktreeManager.commitChanges).not.toHaveBeenCalled();
+    expect(deps.worktreeManager.pushBranch).not.toHaveBeenCalled();
+    expect(deps.prCreator.createPullRequest).not.toHaveBeenCalled();
   });
 
   it("skips PR when createPr is false", async () => {
-    const mockResult = createMockResultMessage();
-
-    vi.mocked(query).mockReturnValue(mockQueryGenerator([mockResult]) as ReturnType<typeof query>);
-    vi.mocked(hasChanges).mockResolvedValue(true);
-    vi.mocked(commitChanges).mockResolvedValue("abc123");
-    vi.mocked(pushBranch).mockResolvedValue(undefined);
+    withResult(deps, createMockResultMessage());
+    vi.mocked(deps.worktreeManager.hasChanges).mockResolvedValue(true);
 
     const config = { ...BASE_CONFIG, createPr: false };
-    const result = await runSession(config);
+    const result = await runSession(config, undefined, deps);
 
     expect(result.status).toBe("succeeded");
     expect(result.prUrl).toBeNull();
-    expect(createPullRequest).not.toHaveBeenCalled();
+    expect(deps.prCreator.createPullRequest).not.toHaveBeenCalled();
   });
 
   it("returns failed result when no result message is received", async () => {
-    vi.mocked(query).mockReturnValue(
-      mockQueryGenerator([{ type: "system", subtype: "init" }]) as ReturnType<typeof query>
-    );
-    vi.mocked(hasChanges).mockResolvedValue(false);
+    withResult(deps, null);
+    vi.mocked(deps.worktreeManager.hasChanges).mockResolvedValue(false);
 
-    const result = await runSession(BASE_CONFIG);
+    const result = await runSession(BASE_CONFIG, undefined, deps);
 
     expect(result.status).toBe("failed");
     expect(result.errors).toContain("No result message received from agent");
   });
 
   it("handles errors and returns failed result", async () => {
-    vi.mocked(query).mockImplementation(() => {
-      throw new Error("SDK connection failed");
-    });
+    vi.mocked(deps.queryRunner.runHardenedQuery).mockRejectedValue(
+      new Error("SDK connection failed")
+    );
 
-    const result = await runSession(BASE_CONFIG);
+    const result = await runSession(BASE_CONFIG, undefined, deps);
 
     expect(result.status).toBe("failed");
     expect(result.errors).toContain("SDK connection failed");
   });
 
   it("emits events when callback is provided", async () => {
-    const mockResult = createMockResultMessage();
-
-    vi.mocked(query).mockReturnValue(mockQueryGenerator([mockResult]) as ReturnType<typeof query>);
-    vi.mocked(hasChanges).mockResolvedValue(false);
+    withResult(deps, createMockResultMessage());
+    vi.mocked(deps.worktreeManager.hasChanges).mockResolvedValue(false);
 
     const events: SessionEvent[] = [];
-    await runSession(BASE_CONFIG, (event) => events.push(event));
+    await runSession(BASE_CONFIG, (event) => events.push(event), deps);
 
     expect(events.length).toBeGreaterThan(0);
     expect(events[0].type).toBe("session:start");
   });
 
   it("cleans up worktree after successful PR creation", async () => {
-    const mockResult = createMockResultMessage();
-
-    vi.mocked(query).mockReturnValue(mockQueryGenerator([mockResult]) as ReturnType<typeof query>);
-    vi.mocked(hasChanges).mockResolvedValue(true);
-    vi.mocked(commitChanges).mockResolvedValue("abc123");
-    vi.mocked(pushBranch).mockResolvedValue(undefined);
-    vi.mocked(buildPrTitle).mockReturnValue("feat: test");
-    vi.mocked(buildPrBody).mockReturnValue("body");
-    vi.mocked(createPullRequest).mockResolvedValue({
+    withResult(deps, createMockResultMessage());
+    vi.mocked(deps.worktreeManager.hasChanges).mockResolvedValue(true);
+    vi.mocked(deps.prCreator.buildPrTitle).mockReturnValue("feat: test");
+    vi.mocked(deps.prCreator.buildPrBody).mockReturnValue("body");
+    vi.mocked(deps.prCreator.createPullRequest).mockResolvedValue({
       url: "https://github.com/repo/pull/1",
       number: 1,
     });
 
-    await runSession(BASE_CONFIG);
+    await runSession(BASE_CONFIG, undefined, deps);
 
-    expect(removeWorktree).toHaveBeenCalledWith(
+    expect(deps.worktreeManager.removeWorktree).toHaveBeenCalledWith(
       "/repo",
       "/repo/.agent-worktrees/agent-fix-bug-abc123"
     );
   });
 
   it("preserves worktree when createPr is false (--no-pr)", async () => {
-    const mockResult = createMockResultMessage();
+    withResult(deps, createMockResultMessage());
+    vi.mocked(deps.worktreeManager.hasChanges).mockResolvedValue(true);
 
-    vi.mocked(query).mockReturnValue(mockQueryGenerator([mockResult]) as ReturnType<typeof query>);
-    vi.mocked(hasChanges).mockResolvedValue(true);
-    vi.mocked(commitChanges).mockResolvedValue("abc123");
-    vi.mocked(pushBranch).mockResolvedValue(undefined);
+    await runSession({ ...BASE_CONFIG, createPr: false }, undefined, deps);
 
-    await runSession({ ...BASE_CONFIG, createPr: false });
-
-    expect(removeWorktree).not.toHaveBeenCalled();
+    expect(deps.worktreeManager.removeWorktree).not.toHaveBeenCalled();
   });
 
   it("surfaces cleanup errors in cleanupErrors when removeWorktree fails", async () => {
-    const mockResult = createMockResultMessage();
-
-    vi.mocked(query).mockReturnValue(mockQueryGenerator([mockResult]) as ReturnType<typeof query>);
-    vi.mocked(hasChanges).mockResolvedValue(true);
-    vi.mocked(commitChanges).mockResolvedValue("abc123");
-    vi.mocked(pushBranch).mockResolvedValue(undefined);
-    vi.mocked(buildPrTitle).mockReturnValue("feat: test");
-    vi.mocked(buildPrBody).mockReturnValue("body");
-    vi.mocked(createPullRequest).mockResolvedValue({
+    withResult(deps, createMockResultMessage());
+    vi.mocked(deps.worktreeManager.hasChanges).mockResolvedValue(true);
+    vi.mocked(deps.prCreator.buildPrTitle).mockReturnValue("feat: test");
+    vi.mocked(deps.prCreator.buildPrBody).mockReturnValue("body");
+    vi.mocked(deps.prCreator.createPullRequest).mockResolvedValue({
       url: "https://github.com/repo/pull/1",
       number: 1,
     });
-    vi.mocked(removeWorktree).mockRejectedValue(new Error("fatal: worktree is locked"));
+    vi.mocked(deps.worktreeManager.removeWorktree).mockRejectedValue(
+      new Error("fatal: worktree is locked")
+    );
 
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const result = await runSession(BASE_CONFIG);
+    const result = await runSession(BASE_CONFIG, undefined, deps);
 
-    // Session itself should still succeed
     expect(result.status).toBe("succeeded");
     expect(result.prUrl).toBe("https://github.com/repo/pull/1");
-
-    // Cleanup error should be surfaced
     expect(result.cleanupErrors).toEqual(["fatal: worktree is locked"]);
     expect(warnSpy).toHaveBeenCalledWith("Worktree cleanup failed: fatal: worktree is locked");
 
@@ -355,23 +268,21 @@ describe("runSession", () => {
   });
 
   it("emits session:cleanup_warning event when removeWorktree fails", async () => {
-    const mockResult = createMockResultMessage();
-
-    vi.mocked(query).mockReturnValue(mockQueryGenerator([mockResult]) as ReturnType<typeof query>);
-    vi.mocked(hasChanges).mockResolvedValue(true);
-    vi.mocked(commitChanges).mockResolvedValue("abc123");
-    vi.mocked(pushBranch).mockResolvedValue(undefined);
-    vi.mocked(buildPrTitle).mockReturnValue("feat: test");
-    vi.mocked(buildPrBody).mockReturnValue("body");
-    vi.mocked(createPullRequest).mockResolvedValue({
+    withResult(deps, createMockResultMessage());
+    vi.mocked(deps.worktreeManager.hasChanges).mockResolvedValue(true);
+    vi.mocked(deps.prCreator.buildPrTitle).mockReturnValue("feat: test");
+    vi.mocked(deps.prCreator.buildPrBody).mockReturnValue("body");
+    vi.mocked(deps.prCreator.createPullRequest).mockResolvedValue({
       url: "https://github.com/repo/pull/1",
       number: 1,
     });
-    vi.mocked(removeWorktree).mockRejectedValue(new Error("fatal: worktree is locked"));
+    vi.mocked(deps.worktreeManager.removeWorktree).mockRejectedValue(
+      new Error("fatal: worktree is locked")
+    );
 
     vi.spyOn(console, "warn").mockImplementation(() => {});
     const events: SessionEvent[] = [];
-    await runSession(BASE_CONFIG, (event) => events.push(event));
+    await runSession(BASE_CONFIG, (event) => events.push(event), deps);
 
     const cleanupEvents = events.filter((e) => e.type === "session:cleanup_warning");
     expect(cleanupEvents).toHaveLength(1);
@@ -383,47 +294,39 @@ describe("runSession", () => {
   });
 
   it("omits cleanupErrors when removeWorktree succeeds", async () => {
-    const mockResult = createMockResultMessage();
-
-    vi.mocked(query).mockReturnValue(mockQueryGenerator([mockResult]) as ReturnType<typeof query>);
-    vi.mocked(hasChanges).mockResolvedValue(true);
-    vi.mocked(commitChanges).mockResolvedValue("abc123");
-    vi.mocked(pushBranch).mockResolvedValue(undefined);
-    vi.mocked(buildPrTitle).mockReturnValue("feat: test");
-    vi.mocked(buildPrBody).mockReturnValue("body");
-    vi.mocked(createPullRequest).mockResolvedValue({
+    withResult(deps, createMockResultMessage());
+    vi.mocked(deps.worktreeManager.hasChanges).mockResolvedValue(true);
+    vi.mocked(deps.prCreator.buildPrTitle).mockReturnValue("feat: test");
+    vi.mocked(deps.prCreator.buildPrBody).mockReturnValue("body");
+    vi.mocked(deps.prCreator.createPullRequest).mockResolvedValue({
       url: "https://github.com/repo/pull/1",
       number: 1,
     });
-    vi.mocked(removeWorktree).mockResolvedValue(undefined);
+    vi.mocked(deps.worktreeManager.removeWorktree).mockResolvedValue(undefined);
 
-    const result = await runSession(BASE_CONFIG);
+    const result = await runSession(BASE_CONFIG, undefined, deps);
 
     expect(result.status).toBe("succeeded");
     expect(result.cleanupErrors).toBeUndefined();
   });
 
   it("schedules a worktree reap retry when removeWorktree fails", async () => {
-    const mockResult = createMockResultMessage();
-
-    vi.mocked(query).mockReturnValue(mockQueryGenerator([mockResult]) as ReturnType<typeof query>);
-    vi.mocked(hasChanges).mockResolvedValue(true);
-    vi.mocked(commitChanges).mockResolvedValue("abc123");
-    vi.mocked(pushBranch).mockResolvedValue(undefined);
-    vi.mocked(buildPrTitle).mockReturnValue("feat: test");
-    vi.mocked(buildPrBody).mockReturnValue("body");
-    vi.mocked(createPullRequest).mockResolvedValue({
+    withResult(deps, createMockResultMessage());
+    vi.mocked(deps.worktreeManager.hasChanges).mockResolvedValue(true);
+    vi.mocked(deps.prCreator.buildPrTitle).mockReturnValue("feat: test");
+    vi.mocked(deps.prCreator.buildPrBody).mockReturnValue("body");
+    vi.mocked(deps.prCreator.createPullRequest).mockResolvedValue({
       url: "https://github.com/repo/pull/1",
       number: 1,
     });
-    vi.mocked(removeWorktree).mockRejectedValue(new Error("fatal: worktree is locked"));
+    vi.mocked(deps.worktreeManager.removeWorktree).mockRejectedValue(
+      new Error("fatal: worktree is locked")
+    );
 
     vi.spyOn(console, "warn").mockImplementation(() => {});
-    const result = await runSession(BASE_CONFIG);
+    const result = await runSession(BASE_CONFIG, undefined, deps);
 
-    // Error is still recorded in the result (unchanged behavior)
     expect(result.cleanupErrors).toEqual(["fatal: worktree is locked"]);
-    // And a follow-up reap retry is scheduled for the same worktree
     expect(scheduleWorktreeReap).toHaveBeenCalledWith(
       expect.objectContaining({
         repoPath: "/repo",
@@ -435,30 +338,28 @@ describe("runSession", () => {
   });
 
   it("does not schedule a reap when removeWorktree succeeds first try", async () => {
-    const mockResult = createMockResultMessage();
-
-    vi.mocked(query).mockReturnValue(mockQueryGenerator([mockResult]) as ReturnType<typeof query>);
-    vi.mocked(hasChanges).mockResolvedValue(true);
-    vi.mocked(commitChanges).mockResolvedValue("abc123");
-    vi.mocked(pushBranch).mockResolvedValue(undefined);
-    vi.mocked(buildPrTitle).mockReturnValue("feat: test");
-    vi.mocked(buildPrBody).mockReturnValue("body");
-    vi.mocked(createPullRequest).mockResolvedValue({
+    withResult(deps, createMockResultMessage());
+    vi.mocked(deps.worktreeManager.hasChanges).mockResolvedValue(true);
+    vi.mocked(deps.prCreator.buildPrTitle).mockReturnValue("feat: test");
+    vi.mocked(deps.prCreator.buildPrBody).mockReturnValue("body");
+    vi.mocked(deps.prCreator.createPullRequest).mockResolvedValue({
       url: "https://github.com/repo/pull/1",
       number: 1,
     });
-    vi.mocked(removeWorktree).mockResolvedValue(undefined);
+    vi.mocked(deps.worktreeManager.removeWorktree).mockResolvedValue(undefined);
 
-    const result = await runSession(BASE_CONFIG);
+    const result = await runSession(BASE_CONFIG, undefined, deps);
 
     expect(result.status).toBe("succeeded");
     expect(scheduleWorktreeReap).not.toHaveBeenCalled();
   });
 
   it("handles createWorktree failure gracefully", async () => {
-    vi.mocked(createWorktree).mockRejectedValue(new Error("git worktree add failed"));
+    vi.mocked(deps.worktreeManager.createWorktree).mockRejectedValue(
+      new Error("git worktree add failed")
+    );
 
-    const result = await runSession(BASE_CONFIG);
+    const result = await runSession(BASE_CONFIG, undefined, deps);
 
     expect(result.status).toBe("failed");
     expect(result.errors).toContain("git worktree add failed");
@@ -466,122 +367,102 @@ describe("runSession", () => {
   });
 
   it("creates draft PR when verification fails", async () => {
-    const mockResult = createMockResultMessage();
-    vi.mocked(query).mockReturnValue(mockQueryGenerator([mockResult]) as ReturnType<typeof query>);
-    vi.mocked(hasChanges).mockResolvedValue(true);
-    vi.mocked(commitChanges).mockResolvedValue("abc123");
-    vi.mocked(pushBranch).mockResolvedValue(undefined);
-    vi.mocked(runPostCommitGateway).mockResolvedValue({
+    withResult(deps, createMockResultMessage());
+    vi.mocked(deps.worktreeManager.hasChanges).mockResolvedValue(true);
+    vi.mocked(deps.gateway.runPostCommitGateway).mockResolvedValue({
       outcome: "create-draft-pr",
       passed: false,
       gateFailures: ["verification"],
       errors: ["Verification failed: typecheck errors"],
     });
-    vi.mocked(buildPrTitle).mockReturnValue("wip: Fix the login bug");
-    vi.mocked(buildPrBody).mockReturnValue("body");
-    vi.mocked(createPullRequest).mockResolvedValue({
+    vi.mocked(deps.prCreator.buildPrTitle).mockReturnValue("wip: Fix the login bug");
+    vi.mocked(deps.prCreator.buildPrBody).mockReturnValue("body");
+    vi.mocked(deps.prCreator.createPullRequest).mockResolvedValue({
       url: "https://github.com/repo/pull/2",
       number: 2,
     });
 
-    const result = await runSession(BASE_CONFIG);
+    const result = await runSession(BASE_CONFIG, undefined, deps);
 
-    // Should still produce a PR URL even when verification fails
     expect(result.prUrl).toBe("https://github.com/repo/pull/2");
-    expect(createPullRequest).toHaveBeenCalledWith(expect.objectContaining({ draft: true }));
+    expect(deps.prCreator.createPullRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ draft: true })
+    );
   });
 
   it("attempts to push partial work when session throws mid-execution", async () => {
-    // Simulate worktree creation succeeding then query throwing
-    vi.mocked(query).mockImplementation(() => {
-      throw new Error("Unexpected API error");
-    });
-    vi.mocked(hasChanges).mockResolvedValue(true);
-    vi.mocked(commitChanges).mockResolvedValue("partial-commit");
-    vi.mocked(pushBranch).mockResolvedValue(undefined);
-    vi.mocked(createPullRequest).mockResolvedValue({
+    vi.mocked(deps.queryRunner.runHardenedQuery).mockRejectedValue(
+      new Error("Unexpected API error")
+    );
+    vi.mocked(deps.worktreeManager.hasChanges).mockResolvedValue(true);
+    vi.mocked(deps.prCreator.createPullRequest).mockResolvedValue({
       url: "https://github.com/repo/pull/3",
       number: 3,
     });
 
     const events: SessionEvent[] = [];
-    const result = await runSession(BASE_CONFIG, (event) => events.push(event));
+    const result = await runSession(BASE_CONFIG, (event) => events.push(event), deps);
 
     expect(result.status).toBe("failed");
     expect(result.errors).toContain("Unexpected API error");
-    // Partial work should be pushed and a draft PR created
     expect(result.prUrl).toBe("https://github.com/repo/pull/3");
   });
 
   it("handles partial work push failure gracefully (best-effort)", async () => {
-    vi.mocked(query).mockImplementation(() => {
-      throw new Error("Unexpected API error");
-    });
-    // hasChanges returns true but pushBranch fails
-    vi.mocked(hasChanges).mockResolvedValue(true);
-    vi.mocked(commitChanges).mockResolvedValue("partial-commit");
-    vi.mocked(pushBranch).mockRejectedValue(new Error("git push failed"));
+    vi.mocked(deps.queryRunner.runHardenedQuery).mockRejectedValue(
+      new Error("Unexpected API error")
+    );
+    vi.mocked(deps.worktreeManager.hasChanges).mockResolvedValue(true);
+    vi.mocked(deps.worktreeManager.pushBranch).mockRejectedValue(new Error("git push failed"));
 
-    const result = await runSession(BASE_CONFIG);
+    const result = await runSession(BASE_CONFIG, undefined, deps);
 
-    // Should still return failed with original error, not the push error
     expect(result.status).toBe("failed");
     expect(result.errors).toContain("Unexpected API error");
     expect(result.prUrl).toBeNull();
   });
 
   it("handles partial work when no changes exist after crash", async () => {
-    vi.mocked(query).mockImplementation(() => {
-      throw new Error("Unexpected API error");
-    });
-    vi.mocked(hasChanges).mockResolvedValue(false);
+    vi.mocked(deps.queryRunner.runHardenedQuery).mockRejectedValue(
+      new Error("Unexpected API error")
+    );
+    vi.mocked(deps.worktreeManager.hasChanges).mockResolvedValue(false);
 
-    const result = await runSession(BASE_CONFIG);
+    const result = await runSession(BASE_CONFIG, undefined, deps);
 
     expect(result.status).toBe("failed");
     expect(result.errors).toContain("Unexpected API error");
     expect(result.prUrl).toBeNull();
-    // commitChanges should not be called since there are no changes
-    expect(commitChanges).not.toHaveBeenCalled();
+    expect(deps.worktreeManager.commitChanges).not.toHaveBeenCalled();
   });
 
   // ── Retry logic tests ──────────────────────────────────────────────
 
   it("uses withRetry for createWorktree", async () => {
-    const mockResult = createMockResultMessage();
-    vi.mocked(query).mockReturnValue(mockQueryGenerator([mockResult]) as ReturnType<typeof query>);
-    vi.mocked(hasChanges).mockResolvedValue(false);
+    withResult(deps, createMockResultMessage());
+    vi.mocked(deps.worktreeManager.hasChanges).mockResolvedValue(false);
 
-    await runSession(BASE_CONFIG);
+    await runSession(BASE_CONFIG, undefined, deps);
 
-    // withRetry should have been called for createWorktree
     expect(withRetry).toHaveBeenCalled();
-    const calls = vi.mocked(withRetry).mock.calls;
-    // First call is for createWorktree
-    expect(calls.length).toBeGreaterThanOrEqual(1);
+    expect(vi.mocked(withRetry).mock.calls.length).toBeGreaterThanOrEqual(1);
   });
 
   it("uses withRetry for pushBranch with 3 retries", async () => {
-    const mockResult = createMockResultMessage();
-    vi.mocked(query).mockReturnValue(mockQueryGenerator([mockResult]) as ReturnType<typeof query>);
-    vi.mocked(hasChanges).mockResolvedValue(true);
-    vi.mocked(commitChanges).mockResolvedValue("abc123");
-    vi.mocked(pushBranch).mockResolvedValue(undefined);
-    vi.mocked(buildPrTitle).mockReturnValue("feat: test");
-    vi.mocked(buildPrBody).mockReturnValue("body");
-    vi.mocked(createPullRequest).mockResolvedValue({
+    withResult(deps, createMockResultMessage());
+    vi.mocked(deps.worktreeManager.hasChanges).mockResolvedValue(true);
+    vi.mocked(deps.prCreator.buildPrTitle).mockReturnValue("feat: test");
+    vi.mocked(deps.prCreator.buildPrBody).mockReturnValue("body");
+    vi.mocked(deps.prCreator.createPullRequest).mockResolvedValue({
       url: "https://github.com/repo/pull/1",
       number: 1,
     });
 
-    await runSession(BASE_CONFIG);
+    await runSession(BASE_CONFIG, undefined, deps);
 
-    // withRetry should be called for push and PR creation
     const retryCalls = vi.mocked(withRetry).mock.calls;
-    // At least: createWorktree, pushBranch, createPullRequest
     expect(retryCalls.length).toBeGreaterThanOrEqual(3);
 
-    // Verify push retry has maxRetries: 3
     const pushRetryCall = retryCalls.find(
       (call) => call[1] && (call[1] as { maxRetries?: number }).maxRetries === 3
     );
@@ -589,68 +470,46 @@ describe("runSession", () => {
   });
 
   it("uses withRetry for createPullRequest", async () => {
-    const mockResult = createMockResultMessage();
-    vi.mocked(query).mockReturnValue(mockQueryGenerator([mockResult]) as ReturnType<typeof query>);
-    vi.mocked(hasChanges).mockResolvedValue(true);
-    vi.mocked(commitChanges).mockResolvedValue("abc123");
-    vi.mocked(pushBranch).mockResolvedValue(undefined);
-    vi.mocked(buildPrTitle).mockReturnValue("feat: test");
-    vi.mocked(buildPrBody).mockReturnValue("body");
-    vi.mocked(createPullRequest).mockResolvedValue({
+    withResult(deps, createMockResultMessage());
+    vi.mocked(deps.worktreeManager.hasChanges).mockResolvedValue(true);
+    vi.mocked(deps.prCreator.buildPrTitle).mockReturnValue("feat: test");
+    vi.mocked(deps.prCreator.buildPrBody).mockReturnValue("body");
+    vi.mocked(deps.prCreator.createPullRequest).mockResolvedValue({
       url: "https://github.com/repo/pull/1",
       number: 1,
     });
 
-    await runSession(BASE_CONFIG);
+    await runSession(BASE_CONFIG, undefined, deps);
 
-    // Verify createPullRequest was called through withRetry
-    expect(createPullRequest).toHaveBeenCalled();
+    expect(deps.prCreator.createPullRequest).toHaveBeenCalled();
   });
 
   // ── Context window exhaustion detection tests ──────────────────────
 
-  it("detects context exhaustion when compaction threshold exceeded", async () => {
-    // Create 5 compact_boundary messages followed by a result
-    const compactMessages = Array.from({ length: 5 }, () => ({
-      type: "system",
-      subtype: "compact_boundary",
-    }));
-    const mockResult = createMockResultMessage();
-
-    vi.mocked(query).mockReturnValue(
-      mockQueryGenerator([...compactMessages, mockResult]) as ReturnType<typeof query>
+  it("detects context exhaustion when stuck reason is context_window_loop", async () => {
+    vi.mocked(deps.queryRunner.runHardenedQuery).mockResolvedValue(
+      hardenedResult({
+        resultMessage: createMockResultMessage() as never,
+        stuckReason: {
+          type: "context_window_loop",
+          description: "Context window exhaustion detected",
+          severity: "error",
+        } as never,
+      })
     );
-    vi.mocked(hasChanges).mockResolvedValue(false);
+    vi.mocked(deps.worktreeManager.hasChanges).mockResolvedValue(false);
 
-    const events: SessionEvent[] = [];
-    const result = await runSession(BASE_CONFIG, (event) => events.push(event));
+    const result = await runSession(BASE_CONFIG, undefined, deps);
 
     expect(result.status).toBe("failed");
     expect(result.stuckPattern).toBe("context_window_loop");
-
-    // Verify context exhaustion stuck event was emitted
-    const stuckEvents = events.filter((e) => e.type === "session:stuck");
-    expect(stuckEvents.length).toBeGreaterThan(0);
-    const exhaustionEvent = stuckEvents.find((e) =>
-      (e.data as { message: string }).message.includes("Context window exhaustion")
-    );
-    expect(exhaustionEvent).toBeDefined();
   });
 
-  it("does not abort when compaction count is below threshold", async () => {
-    // 3 compactions (below threshold of 5)
-    const compactMessages = Array.from({ length: 3 }, () => ({
-      type: "system",
-      subtype: "compact_boundary",
-    }));
-    const mockResult = createMockResultMessage();
+  it("does not abort when no stuck reason is reported", async () => {
+    withResult(deps, createMockResultMessage());
+    vi.mocked(deps.worktreeManager.hasChanges).mockResolvedValue(false);
 
-    vi.mocked(query).mockReturnValue(
-      mockQueryGenerator([...compactMessages, mockResult]) as ReturnType<typeof query>
-    );
-    vi.mocked(hasChanges).mockResolvedValue(false);
-
-    const result = await runSession(BASE_CONFIG);
+    const result = await runSession(BASE_CONFIG, undefined, deps);
 
     expect(result.status).toBe("succeeded");
     expect(result.stuckPattern).toBeUndefined();
@@ -659,18 +518,19 @@ describe("runSession", () => {
   // ── Feedback loop budget tests ─────────────────────────────────────
 
   it("uses remaining budget for feedback loop instead of fixed 50%", async () => {
-    const mockResult = createMockResultMessage(); // cost: 0.25
-    vi.mocked(query).mockReturnValue(mockQueryGenerator([mockResult]) as ReturnType<typeof query>);
-    vi.mocked(hasChanges).mockResolvedValue(true);
-    vi.mocked(commitChanges).mockResolvedValue("abc123");
-    vi.mocked(pushBranch).mockResolvedValue(undefined);
-    vi.mocked(buildPrTitle).mockReturnValue("feat: test");
-    vi.mocked(buildPrBody).mockReturnValue("body");
-    vi.mocked(createPullRequest).mockResolvedValue({
+    withResult(deps, createMockResultMessage()); // cost: 0.25
+    vi.mocked(deps.worktreeManager.hasChanges).mockResolvedValue(true);
+    vi.mocked(deps.prCreator.buildPrTitle).mockReturnValue("feat: test");
+    vi.mocked(deps.prCreator.buildPrBody).mockReturnValue("body");
+    vi.mocked(deps.prCreator.createPullRequest).mockResolvedValue({
       url: "https://github.com/repo/pull/1",
       number: 1,
     });
-    vi.mocked(runFeedbackLoop).mockResolvedValue({ resolved: true, retriesUsed: 1 });
+    vi.mocked(deps.feedbackLoop.runFeedbackLoop).mockResolvedValue({
+      resolved: true,
+      retriesUsed: 1,
+      lastFingerprint: null,
+    });
 
     const config = {
       ...BASE_CONFIG,
@@ -683,10 +543,10 @@ describe("runSession", () => {
       },
     };
 
-    await runSession(config);
+    await runSession(config, undefined, deps);
 
-    expect(runFeedbackLoop).toHaveBeenCalled();
-    const fbCall = vi.mocked(runFeedbackLoop).mock.calls[0][0];
+    expect(deps.feedbackLoop.runFeedbackLoop).toHaveBeenCalled();
+    const fbCall = vi.mocked(deps.feedbackLoop.runFeedbackLoop).mock.calls[0][0];
     // Remaining budget: 1.0 - 0.25 = 0.75 (not 0.50 from fixed ratio)
     expect(fbCall.maxBudgetUsd).toBeCloseTo(0.75);
   });
@@ -694,67 +554,47 @@ describe("runSession", () => {
   // ── Cached git diff tests ─────────────────────────────────────────
 
   it("caches git diff across evaluation, static analysis, and security review", async () => {
-    const mockResult = createMockResultMessage();
-    vi.mocked(query).mockReturnValue(mockQueryGenerator([mockResult]) as ReturnType<typeof query>);
-    vi.mocked(hasChanges).mockResolvedValue(true);
-    vi.mocked(commitChanges).mockResolvedValue("abc123");
-    vi.mocked(pushBranch).mockResolvedValue(undefined);
-    vi.mocked(buildPrTitle).mockReturnValue("feat: test");
-    vi.mocked(buildPrBody).mockReturnValue("body");
-    vi.mocked(createPullRequest).mockResolvedValue({
+    withResult(deps, createMockResultMessage());
+    vi.mocked(deps.worktreeManager.hasChanges).mockResolvedValue(true);
+    vi.mocked(deps.prCreator.buildPrTitle).mockReturnValue("feat: test");
+    vi.mocked(deps.prCreator.buildPrBody).mockReturnValue("body");
+    vi.mocked(deps.prCreator.createPullRequest).mockResolvedValue({
       url: "https://github.com/repo/pull/1",
       number: 1,
     });
 
-    await runSession(BASE_CONFIG);
+    await runSession(BASE_CONFIG, undefined, deps);
 
     // getGitDiff should only be called once despite multiple stages using it
-    // (evaluation, static analysis, security review, dep-bump check)
-    expect(getGitDiff).toHaveBeenCalledTimes(1);
+    expect(deps.successEvaluator.getGitDiff).toHaveBeenCalledTimes(1);
   });
 });
 
 describe("Langfuse tracing", () => {
-  it("wraps session with startActiveObservation", async () => {
-    vi.mocked(createWorktree).mockResolvedValue({
+  let deps: PhaseDeps;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    deps = makeFakePhaseDeps();
+    vi.mocked(withRetry).mockImplementation(async (fn) => {
+      const value = await fn();
+      return { value, attempts: 1 };
+    });
+    vi.mocked(deps.worktreeManager.createWorktree).mockResolvedValue({
       path: "/worktree",
       branchName: "agent/fix-login",
       mode: "full",
     });
-    vi.mocked(loadMemory).mockResolvedValue({ failures: [] });
-    vi.mocked(queryPastFailures).mockReturnValue([]);
-    vi.mocked(buildFailureContext).mockReturnValue("");
-    vi.mocked(buildSystemPrompt).mockReturnValue("system prompt");
-    vi.mocked(createToolPermissionHandler).mockReturnValue(async () => true);
-    vi.mocked(hasChanges).mockResolvedValue(false);
+    vi.mocked(deps.worktreeManager.hasChanges).mockResolvedValue(false);
+  });
 
-    const resultMessage = {
-      type: "result" as const,
-      subtype: "success" as const,
-      uuid: "test-uuid",
-      session_id: "sess-1",
-      result: "Done",
-      total_cost_usd: 0.05,
-      duration_ms: 1000,
-      duration_api_ms: 800,
-      is_error: false,
-      num_turns: 3,
-      stop_reason: "end_turn",
-      usage: {
-        input_tokens: 100,
-        output_tokens: 50,
-        cache_creation_input_tokens: 0,
-        cache_read_input_tokens: 0,
-      },
-    };
-
-    vi.mocked(query).mockReturnValue(
-      (async function* () {
-        yield resultMessage;
-      })() as ReturnType<typeof query>
+  it("wraps session with startActiveObservation", async () => {
+    withResult(
+      deps,
+      createMockResultMessage({ session_id: "sess-1", total_cost_usd: 0.05, num_turns: 3 })
     );
 
-    await runSession(BASE_CONFIG);
+    await runSession(BASE_CONFIG, undefined, deps);
 
     expect(startActiveObservation).toHaveBeenCalledWith("agent-session", expect.any(Function));
     expect(propagateAttributes).toHaveBeenCalledWith(
@@ -769,104 +609,13 @@ describe("Langfuse tracing", () => {
     );
   });
 
-  it("creates generation observations for assistant messages", async () => {
-    vi.mocked(createWorktree).mockResolvedValue({
-      path: "/worktree",
-      branchName: "agent/fix-login",
-      mode: "full",
-    });
-    vi.mocked(loadMemory).mockResolvedValue({ failures: [] });
-    vi.mocked(queryPastFailures).mockReturnValue([]);
-    vi.mocked(buildFailureContext).mockReturnValue("");
-    vi.mocked(buildSystemPrompt).mockReturnValue("system prompt");
-    vi.mocked(createToolPermissionHandler).mockReturnValue(async () => true);
-    vi.mocked(hasChanges).mockResolvedValue(false);
-
-    const assistantMessage = {
-      type: "assistant" as const,
-      message: {
-        role: "assistant",
-        content: [{ type: "text", text: "I'll fix the bug" }],
-        usage: { input_tokens: 50, output_tokens: 25 },
-      },
-    };
-
-    const resultMessage = {
-      type: "result" as const,
-      subtype: "success" as const,
-      uuid: "test-uuid",
-      session_id: "sess-1",
-      result: "Done",
-      total_cost_usd: 0.05,
-      duration_ms: 1000,
-      duration_api_ms: 800,
-      is_error: false,
-      num_turns: 3,
-      stop_reason: "end_turn",
-      usage: {
-        input_tokens: 100,
-        output_tokens: 50,
-        cache_creation_input_tokens: 0,
-        cache_read_input_tokens: 0,
-      },
-    };
-
-    vi.mocked(query).mockReturnValue(
-      (async function* () {
-        yield assistantMessage;
-        yield resultMessage;
-      })() as ReturnType<typeof query>
-    );
-
-    await runSession(BASE_CONFIG);
-
-    expect(startObservation).toHaveBeenCalledWith(
-      "llm-turn-1",
-      expect.objectContaining({ model: BASE_CONFIG.model }),
-      { asType: "generation" }
-    );
-  });
-
   it("attaches session metrics to the Langfuse trace", async () => {
-    vi.mocked(createWorktree).mockResolvedValue({
-      path: "/worktree",
-      branchName: "agent/fix-login",
-      mode: "full",
-    });
-    vi.mocked(loadMemory).mockResolvedValue({ failures: [] });
-    vi.mocked(queryPastFailures).mockReturnValue([]);
-    vi.mocked(buildFailureContext).mockReturnValue("");
-    vi.mocked(buildSystemPrompt).mockReturnValue("system prompt");
-    vi.mocked(createToolPermissionHandler).mockReturnValue(async () => true);
-    vi.mocked(hasChanges).mockResolvedValue(false);
-
-    const resultMessage = {
-      type: "result" as const,
-      subtype: "success" as const,
-      uuid: "test-uuid",
-      session_id: "sess-1",
-      result: "Done",
-      total_cost_usd: 0.05,
-      duration_ms: 1000,
-      duration_api_ms: 800,
-      is_error: false,
-      num_turns: 3,
-      stop_reason: "end_turn",
-      usage: {
-        input_tokens: 100,
-        output_tokens: 50,
-        cache_creation_input_tokens: 0,
-        cache_read_input_tokens: 0,
-      },
-    };
-
-    vi.mocked(query).mockReturnValue(
-      (async function* () {
-        yield resultMessage;
-      })() as ReturnType<typeof query>
+    withResult(
+      deps,
+      createMockResultMessage({ session_id: "sess-1", total_cost_usd: 0.05, num_turns: 3 })
     );
 
-    await runSession(BASE_CONFIG);
+    await runSession(BASE_CONFIG, undefined, deps);
 
     expect(updateActiveObservation).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/agent-core/src/__tests__/verification-phase.test.ts
+++ b/packages/agent-core/src/__tests__/verification-phase.test.ts
@@ -1,24 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { SessionConfig, SessionEvent } from "../types.js";
-import type { PipelineContext } from "../phases/pipeline-types.js";
+import type { PhaseDeps, VerificationPhaseInput } from "../phases/index.js";
+import { makeFakePhaseDeps } from "./fake-phase-deps.js";
 
 // ── Mocks ───────────────────────────────────────────────────────────
-
-vi.mock("../worktree-manager.js", () => ({
-  createWorktree: vi.fn(),
-  commitChanges: vi.fn(),
-  pushBranch: vi.fn(),
-  hasChanges: vi.fn(),
-  removeWorktree: vi.fn(),
-}));
-
-vi.mock("../success-evaluator.js", () => ({
-  getGitDiff: vi.fn(),
-}));
-
-vi.mock("../post-commit-gateway.js", () => ({
-  runPostCommitGateway: vi.fn(),
-}));
+//
+// Only retry (skip delays) is module-mocked; all collaborators are
+// injected via `PhaseDeps`.
 
 vi.mock("../retry.js", async () => {
   const actual = (await vi.importActual("../retry.js")) as Record<string, unknown>;
@@ -31,25 +19,8 @@ vi.mock("../retry.js", async () => {
   };
 });
 
-vi.mock("@opentelemetry/api", () => ({
-  trace: {
-    getTracer: () => ({
-      startSpan: () => ({
-        setAttribute: vi.fn(),
-        end: vi.fn(),
-        recordException: vi.fn(),
-        setStatus: vi.fn(),
-      }),
-    }),
-  },
-  SpanStatusCode: { ERROR: 2 },
-}));
-
 // ── Imports (after mocks) ───────────────────────────────────────────
 
-import { commitChanges, pushBranch, hasChanges } from "../worktree-manager.js";
-import { getGitDiff } from "../success-evaluator.js";
-import { runPostCommitGateway } from "../post-commit-gateway.js";
 import { VerificationPhase } from "../phases/verification-phase.js";
 
 // ── Helpers ─────────────────────────────────────────────────────────
@@ -89,17 +60,15 @@ function createMockResultMessage() {
   };
 }
 
-function makeCtx(overrides?: Partial<PipelineContext>): PipelineContext {
+function makeInput(overrides?: Partial<VerificationPhaseInput>): VerificationPhaseInput {
   return {
     config: BASE_CONFIG,
-    errors: [],
     worktree: {
       path: "/repo/.agent-worktrees/agent-fix-bug-abc123",
       branchName: "agent/fix-bug-abc123",
       mode: "full",
     },
-    systemPrompt: "system prompt",
-    resultMessage: createMockResultMessage() as PipelineContext["resultMessage"],
+    resultMessage: createMockResultMessage() as VerificationPhaseInput["resultMessage"],
     ...overrides,
   };
 }
@@ -108,19 +77,12 @@ function makeCtx(overrides?: Partial<PipelineContext>): PipelineContext {
 
 describe("VerificationPhase", () => {
   const phase = new VerificationPhase();
+  let deps: PhaseDeps;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(hasChanges).mockResolvedValue(true);
-    vi.mocked(commitChanges).mockResolvedValue("abc123");
-    vi.mocked(pushBranch).mockResolvedValue(undefined);
-    vi.mocked(getGitDiff).mockResolvedValue("diff --git a/file.ts\n+change");
-    vi.mocked(runPostCommitGateway).mockResolvedValue({
-      outcome: "create-pr",
-      passed: true,
-      gateFailures: [],
-      errors: [],
-    });
+    deps = makeFakePhaseDeps();
+    vi.mocked(deps.worktreeManager.hasChanges).mockResolvedValue(true);
   });
 
   it("has name 'verification'", () => {
@@ -128,79 +90,74 @@ describe("VerificationPhase", () => {
   });
 
   it("commits, pushes, and runs gateway when changes exist", async () => {
-    const { result, ctx } = await phase.run(makeCtx());
+    const { result, output } = await phase.run(makeInput(), deps);
 
     expect(result.status).toBe("success");
-    expect(commitChanges).toHaveBeenCalled();
-    expect(pushBranch).toHaveBeenCalled();
-    expect(ctx.hasChanges).toBe(true);
-    expect(ctx.gatewayVerdict).toBeDefined();
-    expect(ctx.gatewayVerdict?.outcome).toBe("create-pr");
+    expect(deps.worktreeManager.commitChanges).toHaveBeenCalled();
+    expect(deps.worktreeManager.pushBranch).toHaveBeenCalled();
+    expect(output?.hasChanges).toBe(true);
+    expect(output?.gatewayVerdict).toBeDefined();
+    expect(output?.gatewayVerdict?.outcome).toBe("create-pr");
   });
 
   it("skips commit/push when no changes", async () => {
-    vi.mocked(hasChanges).mockResolvedValue(false);
+    vi.mocked(deps.worktreeManager.hasChanges).mockResolvedValue(false);
 
-    const { result, ctx } = await phase.run(makeCtx());
+    const { result, output } = await phase.run(makeInput(), deps);
 
     expect(result.status).toBe("success");
-    expect(ctx.hasChanges).toBe(false);
-    expect(commitChanges).not.toHaveBeenCalled();
-    expect(pushBranch).not.toHaveBeenCalled();
-  });
-
-  it("skips when no worktree in context", async () => {
-    const { result } = await phase.run(makeCtx({ worktree: undefined }));
-
-    expect(result.status).toBe("skipped");
+    expect(output?.hasChanges).toBe(false);
+    expect(deps.worktreeManager.commitChanges).not.toHaveBeenCalled();
+    expect(deps.worktreeManager.pushBranch).not.toHaveBeenCalled();
   });
 
   it("runs gateway only when session succeeded (no stuck)", async () => {
-    const { ctx } = await phase.run(
-      makeCtx({
+    const { output } = await phase.run(
+      makeInput({
         stuckReason: {
           type: "repeated_action_observation",
           count: 4,
           threshold: 4,
           description: "stuck",
           severity: "error",
-        },
-      })
+        } as VerificationPhaseInput["stuckReason"],
+      }),
+      deps
     );
 
     // Should still commit/push, but not run gateway
-    expect(commitChanges).toHaveBeenCalled();
-    expect(runPostCommitGateway).not.toHaveBeenCalled();
-    expect(ctx.gatewayVerdict).toBeUndefined();
+    expect(deps.worktreeManager.commitChanges).toHaveBeenCalled();
+    expect(deps.gateway.runPostCommitGateway).not.toHaveBeenCalled();
+    expect(output?.gatewayVerdict).toBeUndefined();
   });
 
-  it("collects errors from gateway failures", async () => {
-    vi.mocked(runPostCommitGateway).mockResolvedValue({
+  it("collects gateway errors into the phase result", async () => {
+    vi.mocked(deps.gateway.runPostCommitGateway).mockResolvedValue({
       outcome: "create-draft-pr",
       passed: false,
       gateFailures: ["verification"],
       errors: ["Verification failed: typecheck errors"],
     });
 
-    const { ctx } = await phase.run(makeCtx());
+    const { result, output } = await phase.run(makeInput(), deps);
 
-    expect(ctx.errors).toContain("Verification failed: typecheck errors");
-    expect(ctx.gatewayVerdict?.outcome).toBe("create-draft-pr");
+    expect(result.errors).toContain("Verification failed: typecheck errors");
+    expect(output?.gatewayVerdict?.outcome).toBe("create-draft-pr");
   });
 
   it("caches git diff (only calls getGitDiff once)", async () => {
-    await phase.run(makeCtx());
+    await phase.run(makeInput(), deps);
 
-    expect(getGitDiff).toHaveBeenCalledTimes(1);
+    expect(deps.successEvaluator.getGitDiff).toHaveBeenCalledTimes(1);
   });
 
   it("emits 'no changes' event when nothing changed", async () => {
-    vi.mocked(hasChanges).mockResolvedValue(false);
+    vi.mocked(deps.worktreeManager.hasChanges).mockResolvedValue(false);
 
     const events: SessionEvent[] = [];
     const onEvent = (event: SessionEvent) => events.push(event);
 
-    await phase.run(makeCtx({ onEvent }));
+    await phase.run(makeInput({ onEvent }), deps);
 
     const resultEvents = events.filter((e) => e.type === "session:result");
     expect(resultEvents.length).toBeGreaterThan(0);

--- a/packages/agent-core/src/__tests__/worktree-phase.test.ts
+++ b/packages/agent-core/src/__tests__/worktree-phase.test.ts
@@ -1,29 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { SessionConfig, SessionEvent } from "../types.js";
-import type { PipelineContext } from "../phases/pipeline-types.js";
+import type { PhaseDeps, WorktreePhaseInput } from "../phases/index.js";
+import { makeFakePhaseDeps } from "./fake-phase-deps.js";
 
 // ── Mocks ───────────────────────────────────────────────────────────
-
-vi.mock("../worktree-manager.js", () => ({
-  createWorktree: vi.fn(),
-  commitChanges: vi.fn(),
-  pushBranch: vi.fn(),
-  hasChanges: vi.fn(),
-  removeWorktree: vi.fn(),
-}));
-
-vi.mock("../prompt-builder.js", () => ({
-  buildSystemPrompt: vi.fn(),
-  loadSourceFiles: vi.fn().mockResolvedValue([]),
-  loadProjectContext: vi.fn().mockResolvedValue(null),
-}));
-
-vi.mock("../failure-memory.js", () => ({
-  loadMemory: vi.fn(),
-  queryPastFailures: vi.fn(),
-  buildFailureContext: vi.fn(),
-  recordFailure: vi.fn(),
-}));
+//
+// WorktreePhase reaches into a couple of small auxiliary modules via
+// dynamic import (source resolution, PR-example fetching, retry, tracing).
+// Everything else is injected through `PhaseDeps`.
 
 vi.mock("../retry.js", async () => {
   const actual = (await vi.importActual("../retry.js")) as Record<string, unknown>;
@@ -52,9 +36,6 @@ vi.mock("@opentelemetry/api", () => ({
 
 // ── Imports (after mocks) ───────────────────────────────────────────
 
-import { createWorktree } from "../worktree-manager.js";
-import { buildSystemPrompt, loadProjectContext } from "../prompt-builder.js";
-import { loadMemory, queryPastFailures, buildFailureContext } from "../failure-memory.js";
 import { WorktreePhase } from "../phases/worktree-phase.js";
 
 // ── Helpers ─────────────────────────────────────────────────────────
@@ -68,34 +49,29 @@ const BASE_CONFIG: SessionConfig = {
   maxBudgetUsd: 1.0,
   allowedTools: ["Read", "Write", "Edit", "Bash"],
   createPr: true,
+  // Provide sourceFiles so the phase skips the source-resolver dynamic import.
+  sourceFiles: [],
 };
 
-function makeCtx(overrides?: Partial<PipelineContext>): PipelineContext {
-  return {
-    config: BASE_CONFIG,
-    errors: [],
-    ...overrides,
-  };
+function makeInput(overrides?: Partial<WorktreePhaseInput>): WorktreePhaseInput {
+  return { config: BASE_CONFIG, ...overrides };
 }
 
 // ── Tests ───────────────────────────────────────────────────────────
 
 describe("WorktreePhase", () => {
   const phase = new WorktreePhase();
+  let deps: PhaseDeps;
 
   beforeEach(() => {
     vi.clearAllMocks();
-
-    vi.mocked(createWorktree).mockResolvedValue({
+    deps = makeFakePhaseDeps();
+    vi.mocked(deps.worktreeManager.createWorktree).mockResolvedValue({
       path: "/repo/.agent-worktrees/agent-fix-bug-abc123",
       branchName: "agent/fix-bug-abc123",
       mode: "full",
     });
-    vi.mocked(buildSystemPrompt).mockReturnValue("system prompt");
-    vi.mocked(loadProjectContext).mockResolvedValue(null);
-    vi.mocked(loadMemory).mockResolvedValue({ records: [] });
-    vi.mocked(queryPastFailures).mockReturnValue([]);
-    vi.mocked(buildFailureContext).mockReturnValue("");
+    vi.mocked(deps.promptBuilder.buildSystemPrompt).mockResolvedValue("system prompt");
   });
 
   it("has name 'worktree'", () => {
@@ -103,54 +79,60 @@ describe("WorktreePhase", () => {
   });
 
   it("creates worktree and builds system prompt", async () => {
-    const { result, ctx } = await phase.run(makeCtx());
+    const { result, output } = await phase.run(makeInput(), deps);
 
     expect(result.status).toBe("success");
     expect(result.phase).toBe("worktree");
-    expect(ctx.worktree).toEqual({
+    expect(output?.worktree).toEqual({
       path: "/repo/.agent-worktrees/agent-fix-bug-abc123",
       branchName: "agent/fix-bug-abc123",
       mode: "full",
     });
-    expect(ctx.systemPrompt).toBe("system prompt");
-    expect(createWorktree).toHaveBeenCalledWith("/repo", "main", "Fix the login bug");
+    expect(output?.systemPrompt).toBe("system prompt");
+    expect(deps.worktreeManager.createWorktree).toHaveBeenCalledWith(
+      "/repo",
+      "main",
+      "Fix the login bug"
+    );
   });
 
-  it("returns failed result when createWorktree throws", async () => {
-    vi.mocked(createWorktree).mockRejectedValue(new Error("git worktree add failed"));
+  it("returns failed result with null output when createWorktree throws", async () => {
+    vi.mocked(deps.worktreeManager.createWorktree).mockRejectedValue(
+      new Error("git worktree add failed")
+    );
 
-    const { result, ctx } = await phase.run(makeCtx());
+    const { result, output } = await phase.run(makeInput(), deps);
 
     expect(result.status).toBe("failed");
     expect(result.errors).toContain("git worktree add failed");
-    expect(ctx.worktree).toBeUndefined();
+    expect(output).toBeNull();
   });
 
   it("loads failure memory for context", async () => {
-    await phase.run(makeCtx());
+    await phase.run(makeInput(), deps);
 
-    expect(loadMemory).toHaveBeenCalledWith("/repo");
-    expect(queryPastFailures).toHaveBeenCalled();
-    expect(buildFailureContext).toHaveBeenCalled();
+    expect(deps.failureMemory.loadMemory).toHaveBeenCalledWith("/repo");
+    expect(deps.failureMemory.queryPastFailures).toHaveBeenCalled();
+    expect(deps.failureMemory.buildFailureContext).toHaveBeenCalled();
   });
 
   it("emits session:start events", async () => {
     const events: SessionEvent[] = [];
     const onEvent = (event: SessionEvent) => events.push(event);
 
-    await phase.run(makeCtx({ onEvent }));
+    await phase.run(makeInput({ onEvent }), deps);
 
     expect(events.length).toBeGreaterThan(0);
     expect(events[0].type).toBe("session:start");
   });
 
   it("appends project context to system prompt when available", async () => {
-    vi.mocked(loadProjectContext).mockResolvedValue("## Conventions\nUse TDD");
-    vi.mocked(buildSystemPrompt).mockReturnValue("base prompt");
+    vi.mocked(deps.promptBuilder.loadProjectContext).mockResolvedValue("## Conventions\nUse TDD");
+    vi.mocked(deps.promptBuilder.buildSystemPrompt).mockResolvedValue("base prompt");
 
-    const { ctx } = await phase.run(makeCtx());
+    const { output } = await phase.run(makeInput(), deps);
 
-    expect(ctx.systemPrompt).toContain("base prompt");
-    expect(ctx.systemPrompt).toContain("## Conventions\nUse TDD");
+    expect(output?.systemPrompt).toContain("base prompt");
+    expect(output?.systemPrompt).toContain("## Conventions\nUse TDD");
   });
 });

--- a/packages/agent-core/src/phases/default-deps.ts
+++ b/packages/agent-core/src/phases/default-deps.ts
@@ -1,0 +1,62 @@
+import {
+  createWorktree,
+  hasChanges,
+  commitChanges,
+  pushBranch,
+  removeWorktree,
+} from "../worktree-manager.js";
+import { buildSystemPrompt, loadSourceFiles, loadProjectContext } from "../prompt-builder.js";
+import { loadMemory, queryPastFailures, buildFailureContext } from "../failure-memory.js";
+import { runHardenedQuery } from "../run-hardened-query.js";
+import { getGitDiff } from "../success-evaluator.js";
+import { runPostCommitGateway } from "../post-commit-gateway.js";
+import { createPullRequest, buildPrTitle, buildPrBody, buildFailurePrBody } from "../pr-creator.js";
+import { mergeDirectly } from "../dep-bump-merger.js";
+import { runFeedbackLoop } from "../feedback-loop.js";
+import type { PhaseDeps } from "./pipeline-types.js";
+
+/**
+ * Wires the real agent-core module implementations into the injectable
+ * `PhaseDeps` bundle. `runSession()` uses this by default; tests pass a
+ * partial fake instead of `vi.mock`-ing each module.
+ */
+export function createDefaultPhaseDeps(): PhaseDeps {
+  return {
+    worktreeManager: {
+      createWorktree,
+      hasChanges,
+      commitChanges,
+      pushBranch,
+      removeWorktree,
+    },
+    promptBuilder: {
+      buildSystemPrompt,
+      loadSourceFiles,
+      loadProjectContext,
+    },
+    failureMemory: {
+      loadMemory,
+      queryPastFailures,
+      buildFailureContext,
+    },
+    queryRunner: {
+      runHardenedQuery,
+    },
+    successEvaluator: {
+      getGitDiff,
+    },
+    gateway: {
+      runPostCommitGateway,
+    },
+    prCreator: {
+      createPullRequest,
+      buildPrTitle,
+      buildPrBody,
+      buildFailurePrBody,
+      mergeDirectly,
+    },
+    feedbackLoop: {
+      runFeedbackLoop,
+    },
+  };
+}

--- a/packages/agent-core/src/phases/feedback-phase.ts
+++ b/packages/agent-core/src/phases/feedback-phase.ts
@@ -1,21 +1,20 @@
 import { trace } from "@opentelemetry/api";
-import { runFeedbackLoop } from "../feedback-loop.js";
 import { getFeedbackLoopModel } from "../model-router.js";
 import { emitEvent } from "../utils.js";
-import type { PipelineContext, PipelinePhase, PhaseResult } from "./pipeline-types.js";
+import type { Phase, PhaseDeps, PhaseExecution, FeedbackPhaseInput } from "./pipeline-types.js";
 
 const tracer = trace.getTracer("@mbe/agent-core");
 
-export class FeedbackPhase implements PipelinePhase {
+export class FeedbackPhase implements Phase<FeedbackPhaseInput, void> {
   readonly name = "feedback" as const;
 
-  async run(ctx: PipelineContext): Promise<{ result: PhaseResult; ctx: PipelineContext }> {
-    const { config, onEvent, worktree, resultMessage, prNumber } = ctx;
+  async run(input: FeedbackPhaseInput, deps: PhaseDeps): Promise<PhaseExecution<void>> {
+    const { config, onEvent, worktree, resultMessage, prNumber, prUrl } = input;
 
-    if (!config.feedbackLoop?.enabled || !prNumber || !ctx.prUrl || !worktree) {
+    if (!config.feedbackLoop?.enabled || !prNumber || !prUrl) {
       return {
         result: { phase: this.name, status: "skipped", errors: [] },
-        ctx,
+        output: null,
       };
     }
 
@@ -26,7 +25,7 @@ export class FeedbackPhase implements PipelinePhase {
     const fbSpan = tracer.startSpan("agent_core.feedback_loop");
     let feedbackResult;
     try {
-      feedbackResult = await runFeedbackLoop(
+      feedbackResult = await deps.feedbackLoop.runFeedbackLoop(
         {
           prNumber,
           branchName: worktree.branchName,
@@ -52,7 +51,7 @@ export class FeedbackPhase implements PipelinePhase {
 
     return {
       result: { phase: this.name, status: "success", errors: [] },
-      ctx,
+      output: undefined,
     };
   }
 }

--- a/packages/agent-core/src/phases/index.ts
+++ b/packages/agent-core/src/phases/index.ts
@@ -1,4 +1,29 @@
-export type { PhaseStatus, PhaseResult, PipelineContext, PipelinePhase } from "./pipeline-types.js";
+export type {
+  PhaseStatus,
+  PhaseResult,
+  PhaseExecution,
+  Phase,
+  PhaseDeps,
+  WorktreeManagerDeps,
+  PromptBuilderDeps,
+  FailureMemoryDeps,
+  QueryRunnerDeps,
+  SuccessEvaluatorDeps,
+  GatewayDeps,
+  PrCreatorDeps,
+  FeedbackLoopDeps,
+  WorktreePhaseInput,
+  WorktreePhaseOutput,
+  QueryPhaseInput,
+  QueryPhaseOutput,
+  VerificationPhaseInput,
+  VerificationPhaseOutput,
+  PublishPhaseInput,
+  PublishPhaseOutput,
+  FeedbackPhaseInput,
+} from "./pipeline-types.js";
+
+export { createDefaultPhaseDeps } from "./default-deps.js";
 
 export { WorktreePhase } from "./worktree-phase.js";
 export { QueryPhase } from "./query-phase.js";

--- a/packages/agent-core/src/phases/pipeline-types.ts
+++ b/packages/agent-core/src/phases/pipeline-types.ts
@@ -5,12 +5,26 @@ import type {
   WorktreeInfo,
   TurnMetrics,
   ToolCallMetrics,
+  PrOptions,
+  PrResult,
 } from "../types.js";
 import type { StuckPattern } from "../stuck-detector.js";
 import type { ContextMetrics } from "../context-budget.js";
 import type { EvaluationResult } from "../success-evaluator.js";
-import type { GatewayVerdict } from "../post-commit-gateway.js";
+import type { GatewayVerdict, PostCommitGatewayInput } from "../post-commit-gateway.js";
 import type { TaskSignals } from "../task-signal-registry.js";
+import type { HardenedQueryConfig, HardenedQueryResult } from "../run-hardened-query.js";
+import type { FeedbackLoopParams, FeedbackLoopResult } from "../feedback-loop.js";
+import type { SourceFileEntry, PromptBuilderConfig } from "../prompt-builder.js";
+import type { FailureMemory, FailureRecord } from "../failure-memory.js";
+
+/** Options accepted by `mergeDirectly` (dep-bump fast path). */
+export interface MergeDirectlyOptions {
+  readonly branchName: string;
+  readonly baseBranch: string;
+  readonly repoPath: string;
+  readonly commitTitle: string;
+}
 
 // ── Phase result ────────────────────────────────────────────────────
 
@@ -22,58 +36,186 @@ export interface PhaseResult {
   readonly errors: readonly string[];
 }
 
-// ── Immutable pipeline context ──────────────────────────────────────
+// ── Injected phase dependencies ─────────────────────────────────────
 //
-// Each phase receives the context and returns a new context (spread)
-// with its additions. No mutation.
+// Phases collaborate with the rest of agent-core through these injected
+// interfaces instead of importing module functions directly. This lets
+// tests substitute lightweight fakes for one `PhaseDeps` object rather
+// than `vi.mock`-ing a dozen modules.
 
-export interface PipelineContext {
-  /** Effective config after QA tuning overrides. */
-  readonly config: SessionConfig;
-  /** Event callback for streaming. */
-  readonly onEvent?: SessionEventCallback;
+export interface WorktreeManagerDeps {
+  createWorktree(
+    repoPath: string,
+    baseBranch: string,
+    taskDescription: string
+  ): Promise<WorktreeInfo>;
+  hasChanges(worktreePath: string): Promise<boolean>;
+  commitChanges(worktreePath: string, message: string): Promise<string>;
+  pushBranch(worktreePath: string, branchName: string): Promise<void>;
+  removeWorktree(repoPath: string, worktreePath: string): Promise<void>;
+}
 
-  // WorktreePhase outputs
-  readonly worktree?: WorktreeInfo;
-  readonly systemPrompt?: string;
-  /**
-   * Task signals (tier/domains/context bundles) classified once from the task
-   * description by the shared TaskSignalRegistry, so downstream consumers do
-   * not re-scan the description.
-   */
-  readonly taskSignals?: TaskSignals;
+export interface PromptBuilderDeps {
+  buildSystemPrompt(taskDescription: string, config?: PromptBuilderConfig): Promise<string>;
+  loadSourceFiles(paths: readonly string[]): Promise<readonly SourceFileEntry[]>;
+  loadProjectContext(repoPath: string): Promise<string | null>;
+}
 
-  // QueryPhase outputs
-  readonly resultMessage?: SDKResultMessage;
-  readonly stuckReason?: StuckPattern;
-  readonly turnMetrics?: readonly TurnMetrics[];
-  readonly toolCallMetrics?: readonly ToolCallMetrics[];
-  readonly contextMetrics?: ContextMetrics;
+export interface FailureMemoryDeps {
+  loadMemory(repoPath: string): Promise<FailureMemory>;
+  queryPastFailures(memory: FailureMemory, taskDescription: string): readonly FailureRecord[];
+  buildFailureContext(failures: readonly FailureRecord[]): string;
+}
 
-  // VerificationPhase outputs
-  readonly hasChanges?: boolean;
-  readonly gatewayVerdict?: GatewayVerdict;
-  readonly gatewayEvaluation?: EvaluationResult;
-  readonly cachedDiff?: string;
-  readonly commitMsg?: string;
+export interface QueryRunnerDeps {
+  runHardenedQuery(
+    config: HardenedQueryConfig,
+    onEvent?: SessionEventCallback
+  ): Promise<HardenedQueryResult>;
+}
 
-  // PublishPhase outputs
-  readonly prUrl?: string | null;
-  readonly prNumber?: number;
+export interface SuccessEvaluatorDeps {
+  getGitDiff(worktreePath: string): Promise<string>;
+}
 
-  // Accumulated errors from all phases
-  readonly errors: readonly string[];
+export interface GatewayDeps {
+  runPostCommitGateway(
+    input: PostCommitGatewayInput,
+    onEvent?: SessionEventCallback
+  ): Promise<GatewayVerdict>;
+}
+
+export interface PrCreatorDeps {
+  createPullRequest(options: PrOptions): Promise<PrResult>;
+  buildPrTitle(taskDescription: string): string;
+  buildPrBody(
+    taskDescription: string,
+    sessionId: string,
+    costUsd: number,
+    numTurns: number
+  ): string;
+  buildFailurePrBody(
+    taskDescription: string,
+    errors: readonly string[],
+    stuckPattern?: string
+  ): string;
+  mergeDirectly(options: MergeDirectlyOptions): Promise<string>;
+}
+
+export interface FeedbackLoopDeps {
+  runFeedbackLoop(
+    config: FeedbackLoopParams,
+    onEvent?: SessionEventCallback
+  ): Promise<FeedbackLoopResult>;
 }
 
 /**
- * A pipeline phase: receives immutable context, returns a result and
- * an updated context. The caller spreads the returned context into the
- * next phase invocation.
+ * The full bundle of collaborators injected into the phase pipeline.
+ * `createDefaultPhaseDeps()` wires the real module implementations;
+ * tests pass lightweight fakes.
  */
-export interface PipelinePhase {
+export interface PhaseDeps {
+  readonly worktreeManager: WorktreeManagerDeps;
+  readonly promptBuilder: PromptBuilderDeps;
+  readonly failureMemory: FailureMemoryDeps;
+  readonly queryRunner: QueryRunnerDeps;
+  readonly successEvaluator: SuccessEvaluatorDeps;
+  readonly gateway: GatewayDeps;
+  readonly prCreator: PrCreatorDeps;
+  readonly feedbackLoop: FeedbackLoopDeps;
+}
+
+// ── Per-phase input / output contracts ──────────────────────────────
+//
+// Each phase declares exactly the fields it reads (input) and produces
+// (output). session-runner composes them explicitly, threading one
+// phase's output into the next phase's input — no amorphous shared bag.
+
+export interface WorktreePhaseInput {
+  readonly config: SessionConfig;
+  readonly onEvent?: SessionEventCallback;
+}
+
+export interface WorktreePhaseOutput {
+  readonly worktree: WorktreeInfo;
+  readonly systemPrompt: string;
+  readonly taskSignals: TaskSignals;
+}
+
+export interface QueryPhaseInput {
+  readonly config: SessionConfig;
+  readonly onEvent?: SessionEventCallback;
+  readonly worktree: WorktreeInfo;
+  readonly systemPrompt: string;
+}
+
+export interface QueryPhaseOutput {
+  readonly resultMessage?: SDKResultMessage;
+  readonly stuckReason?: StuckPattern;
+  readonly turnMetrics: readonly TurnMetrics[];
+  readonly toolCallMetrics: readonly ToolCallMetrics[];
+  readonly contextMetrics?: ContextMetrics;
+}
+
+export interface VerificationPhaseInput {
+  readonly config: SessionConfig;
+  readonly onEvent?: SessionEventCallback;
+  readonly worktree: WorktreeInfo;
+  readonly resultMessage?: SDKResultMessage;
+  readonly stuckReason?: StuckPattern;
+}
+
+export interface VerificationPhaseOutput {
+  readonly hasChanges: boolean;
+  readonly commitMsg?: string;
+  readonly cachedDiff?: string;
+  readonly gatewayVerdict?: GatewayVerdict;
+  readonly gatewayEvaluation?: EvaluationResult;
+}
+
+export interface PublishPhaseInput {
+  readonly config: SessionConfig;
+  readonly onEvent?: SessionEventCallback;
+  readonly worktree: WorktreeInfo;
+  readonly hasChanges: boolean;
+  readonly resultMessage?: SDKResultMessage;
+  readonly stuckReason?: StuckPattern;
+  readonly gatewayVerdict?: GatewayVerdict;
+  /** Accumulated errors from prior phases — included in failure PR bodies. */
+  readonly errors: readonly string[];
+}
+
+export interface PublishPhaseOutput {
+  readonly prUrl: string | null;
+  readonly prNumber?: number;
+}
+
+export interface FeedbackPhaseInput {
+  readonly config: SessionConfig;
+  readonly onEvent?: SessionEventCallback;
+  readonly worktree: WorktreeInfo;
+  readonly resultMessage?: SDKResultMessage;
+  readonly prUrl: string | null;
+  readonly prNumber?: number;
+}
+
+/**
+ * The outcome of running a phase: a `PhaseResult` plus the phase's typed
+ * output. `output` is `null` when the phase failed or was skipped (it has
+ * nothing valid to contribute), so the caller composes forward only the
+ * outputs of phases that succeeded.
+ */
+export interface PhaseExecution<TOutput> {
+  readonly result: PhaseResult;
+  readonly output: TOutput | null;
+}
+
+/**
+ * A pipeline phase: receives a typed input plus injected deps, returns a
+ * `PhaseResult` and a typed output. The caller composes the output into
+ * the next phase's input.
+ */
+export interface Phase<TInput, TOutput> {
   readonly name: string;
-  run(ctx: PipelineContext): Promise<{
-    readonly result: PhaseResult;
-    readonly ctx: PipelineContext;
-  }>;
+  run(input: TInput, deps: PhaseDeps): Promise<PhaseExecution<TOutput>>;
 }

--- a/packages/agent-core/src/phases/publish-phase.ts
+++ b/packages/agent-core/src/phases/publish-phase.ts
@@ -1,43 +1,52 @@
 import { trace } from "@opentelemetry/api";
-import { createPullRequest, buildPrTitle, buildPrBody, buildFailurePrBody } from "../pr-creator.js";
-import { mergeDirectly } from "../dep-bump-merger.js";
 import { withRetry } from "../retry.js";
 import { emitEvent } from "../utils.js";
 import type { WorktreeInfo } from "../types.js";
-import type { PipelineContext, PipelinePhase, PhaseResult } from "./pipeline-types.js";
+import type {
+  Phase,
+  PhaseDeps,
+  PhaseExecution,
+  PublishPhaseInput,
+  PublishPhaseOutput,
+} from "./pipeline-types.js";
 
 const tracer = trace.getTracer("@mbe/agent-core");
 
-export class PublishPhase implements PipelinePhase {
+export class PublishPhase implements Phase<PublishPhaseInput, PublishPhaseOutput> {
   readonly name = "publish" as const;
 
-  async run(ctx: PipelineContext): Promise<{ result: PhaseResult; ctx: PipelineContext }> {
-    const { config, worktree } = ctx;
+  async run(
+    input: PublishPhaseInput,
+    deps: PhaseDeps
+  ): Promise<PhaseExecution<PublishPhaseOutput>> {
+    const { config, worktree, hasChanges } = input;
 
-    if (!config.createPr || !ctx.hasChanges || !worktree) {
+    if (!config.createPr || !hasChanges) {
       return {
         result: { phase: this.name, status: "skipped", errors: [] },
-        ctx,
+        output: null,
       };
     }
 
-    const { prUrl, prNumber } = await this.createOrMergePr(ctx, worktree);
+    const { prUrl, prNumber } = await this.createOrMergePr(input, worktree, deps);
 
     return {
       result: { phase: this.name, status: "success", errors: [] },
-      ctx: { ...ctx, prUrl, prNumber },
+      output: { prUrl, prNumber },
     };
   }
 
   private async createOrMergePr(
-    ctx: PipelineContext,
-    worktree: WorktreeInfo
+    input: PublishPhaseInput,
+    worktree: WorktreeInfo,
+    deps: PhaseDeps
   ): Promise<{ prUrl: string | null; prNumber?: number }> {
-    const { config, onEvent, resultMessage, stuckReason, gatewayVerdict } = ctx;
+    const { config, onEvent, resultMessage, stuckReason, gatewayVerdict } = input;
+    const { prCreator } = deps;
 
     if (gatewayVerdict?.outcome === "merge-direct") {
-      const commitTitle = buildPrTitle(config.taskDescription);
-      const mergedUrl = await mergeDirectly({
+      const commitTitle = prCreator.buildPrTitle(config.taskDescription);
+      const mergedUrl = await prCreator.mergeDirectly({
         branchName: worktree.branchName,
         baseBranch: config.baseBranch,
         repoPath: worktree.path,
@@ -50,21 +59,25 @@ export class PublishPhase implements PipelinePhase {
     }
 
     if (!gatewayVerdict || gatewayVerdict.outcome === "create-pr") {
-      const title = buildPrTitle(config.taskDescription);
+      const title = prCreator.buildPrTitle(config.taskDescription);
       const body = resultMessage
-        ? buildPrBody(
+        ? prCreator.buildPrBody(
             config.taskDescription,
             resultMessage.session_id,
             resultMessage.total_cost_usd,
             resultMessage.num_turns
           )
-        : buildFailurePrBody(config.taskDescription, [...ctx.errors], stuckReason?.type);
+        : prCreator.buildFailurePrBody(
+            config.taskDescription,
+            [...input.errors],
+            stuckReason?.type
+          );
 
       const prSpan = tracer.startSpan("agent_core.create_pr");
       try {
         const { value: pr } = await withRetry(
           () =>
-            createPullRequest({
+            prCreator.createPullRequest({
               title,
               body,
               baseBranch: config.baseBranch,
@@ -89,11 +102,15 @@ export class PublishPhase implements PipelinePhase {
 
     // verdict.outcome === "create-draft-pr" — quality gates failed
     const title = `wip: ${config.taskDescription.slice(0, 57)}`;
-    const body = buildFailurePrBody(config.taskDescription, [...ctx.errors], stuckReason?.type);
+    const body = prCreator.buildFailurePrBody(
+      config.taskDescription,
+      [...input.errors],
+      stuckReason?.type
+    );
 
     const { value: pr } = await withRetry(
       () =>
-        createPullRequest({
+        prCreator.createPullRequest({
           title,
           body,
           baseBranch: config.baseBranch,

--- a/packages/agent-core/src/phases/query-phase.ts
+++ b/packages/agent-core/src/phases/query-phase.ts
@@ -1,21 +1,19 @@
 import { CircuitState } from "../circuit-breaker.js";
-import { apiCircuitBreaker, runHardenedQuery } from "../run-hardened-query.js";
+import { apiCircuitBreaker } from "../run-hardened-query.js";
 import { emitEvent } from "../utils.js";
-import type { PipelineContext, PipelinePhase, PhaseResult } from "./pipeline-types.js";
+import type {
+  Phase,
+  PhaseDeps,
+  PhaseExecution,
+  QueryPhaseInput,
+  QueryPhaseOutput,
+} from "./pipeline-types.js";
 
-export class QueryPhase implements PipelinePhase {
+export class QueryPhase implements Phase<QueryPhaseInput, QueryPhaseOutput> {
   readonly name = "query" as const;
 
-  async run(ctx: PipelineContext): Promise<{ result: PhaseResult; ctx: PipelineContext }> {
-    const { config, onEvent, worktree, systemPrompt } = ctx;
-
-    if (!worktree || !systemPrompt) {
-      const msg = "QueryPhase requires worktree and systemPrompt in context";
-      return {
-        result: { phase: this.name, status: "failed", errors: [msg] },
-        ctx: { ...ctx, errors: [...ctx.errors, msg] },
-      };
-    }
+  async run(input: QueryPhaseInput, deps: PhaseDeps): Promise<PhaseExecution<QueryPhaseOutput>> {
+    const { config, onEvent, worktree, systemPrompt } = input;
 
     // Fail fast if the circuit breaker is open
     if (apiCircuitBreaker.getState() === CircuitState.Open) {
@@ -24,7 +22,7 @@ export class QueryPhase implements PipelinePhase {
       emitEvent(onEvent, "session:error", { message: circuitMsg });
       return {
         result: { phase: this.name, status: "failed", errors: [circuitMsg] },
-        ctx: { ...ctx, errors: [...ctx.errors, circuitMsg] },
+        output: null,
       };
     }
 
@@ -35,7 +33,7 @@ export class QueryPhase implements PipelinePhase {
       rawToolCallMetrics,
       errorMessage,
       contextMetrics,
-    } = await runHardenedQuery(
+    } = await deps.queryRunner.runHardenedQuery(
       {
         prompt: config.taskDescription,
         cwd: worktree.path,
@@ -53,7 +51,7 @@ export class QueryPhase implements PipelinePhase {
     if (errorMessage) {
       return {
         result: { phase: this.name, status: "failed", errors: [errorMessage] },
-        ctx: { ...ctx, errors: [...ctx.errors, errorMessage] },
+        output: null,
       };
     }
 
@@ -61,8 +59,7 @@ export class QueryPhase implements PipelinePhase {
 
     return {
       result: { phase: this.name, status: "success", errors: [] },
-      ctx: {
-        ...ctx,
+      output: {
         resultMessage: resultMessage ?? undefined,
         stuckReason: stuckReason ?? undefined,
         turnMetrics: buildTurnMetricsList(rawTurnMetrics),

--- a/packages/agent-core/src/phases/verification-phase.ts
+++ b/packages/agent-core/src/phases/verification-phase.ts
@@ -1,24 +1,26 @@
-import { hasChanges, commitChanges, pushBranch } from "../worktree-manager.js";
-import { getGitDiff } from "../success-evaluator.js";
-import { runPostCommitGateway } from "../post-commit-gateway.js";
 import { withRetry } from "../retry.js";
 import { emitEvent, sanitizeForCommitMessage } from "../utils.js";
-import type { PipelineContext, PipelinePhase, PhaseResult } from "./pipeline-types.js";
+import type { GatewayVerdict } from "../post-commit-gateway.js";
+import type { EvaluationResult } from "../success-evaluator.js";
+import type {
+  Phase,
+  PhaseDeps,
+  PhaseExecution,
+  VerificationPhaseInput,
+  VerificationPhaseOutput,
+} from "./pipeline-types.js";
 
-export class VerificationPhase implements PipelinePhase {
+export class VerificationPhase implements Phase<VerificationPhaseInput, VerificationPhaseOutput> {
   readonly name = "verification" as const;
 
-  async run(ctx: PipelineContext): Promise<{ result: PhaseResult; ctx: PipelineContext }> {
-    const { config, onEvent, worktree, resultMessage, stuckReason } = ctx;
+  async run(
+    input: VerificationPhaseInput,
+    deps: PhaseDeps
+  ): Promise<PhaseExecution<VerificationPhaseOutput>> {
+    const { config, onEvent, worktree, resultMessage, stuckReason } = input;
+    const { worktreeManager, successEvaluator, gateway } = deps;
 
-    if (!worktree) {
-      return {
-        result: { phase: this.name, status: "skipped", errors: [] },
-        ctx,
-      };
-    }
-
-    const changed = await hasChanges(worktree.path);
+    const changed = await worktreeManager.hasChanges(worktree.path);
 
     if (!changed) {
       emitEvent(onEvent, "session:result", {
@@ -26,7 +28,7 @@ export class VerificationPhase implements PipelinePhase {
       });
       return {
         result: { phase: this.name, status: "success", errors: [] },
-        ctx: { ...ctx, hasChanges: false },
+        output: { hasChanges: false },
       };
     }
 
@@ -34,20 +36,22 @@ export class VerificationPhase implements PipelinePhase {
     const isSuccess = resultMessage?.subtype === "success" && !stuckReason;
     const prefix = isSuccess ? "feat" : "wip";
     const commitMsg = `${prefix}: ${sanitizeForCommitMessage(config.taskDescription)}`;
-    await commitChanges(worktree.path, commitMsg);
+    await worktreeManager.commitChanges(worktree.path, commitMsg);
 
     // Push with retry for transient network failures
-    await withRetry(() => pushBranch(worktree.path, worktree.branchName), { maxRetries: 3 });
+    await withRetry(() => worktreeManager.pushBranch(worktree.path, worktree.branchName), {
+      maxRetries: 3,
+    });
 
     // Run post-commit gateway (verification + quality gates) only on success
     const errors: string[] = [];
-    let gatewayVerdict;
-    let gatewayEvaluation;
+    let gatewayVerdict: GatewayVerdict | undefined;
+    let gatewayEvaluation: EvaluationResult | undefined;
     let cachedDiff: string | undefined;
 
     if (isSuccess) {
-      cachedDiff = await getGitDiff(worktree.path);
-      gatewayVerdict = await runPostCommitGateway(
+      cachedDiff = await successEvaluator.getGitDiff(worktree.path);
+      gatewayVerdict = await gateway.runPostCommitGateway(
         {
           worktreePath: worktree.path,
           diff: cachedDiff,
@@ -67,14 +71,12 @@ export class VerificationPhase implements PipelinePhase {
 
     return {
       result: { phase: this.name, status: "success", errors },
-      ctx: {
-        ...ctx,
+      output: {
         hasChanges: true,
         commitMsg,
         cachedDiff,
         gatewayVerdict,
         gatewayEvaluation,
-        errors: [...ctx.errors, ...errors],
       },
     };
   }

--- a/packages/agent-core/src/phases/worktree-phase.ts
+++ b/packages/agent-core/src/phases/worktree-phase.ts
@@ -1,19 +1,26 @@
 import { trace } from "@opentelemetry/api";
-import { createWorktree } from "../worktree-manager.js";
-import { buildSystemPrompt, loadSourceFiles, loadProjectContext } from "../prompt-builder.js";
-import { loadMemory, queryPastFailures, buildFailureContext } from "../failure-memory.js";
 import { withRetry } from "../retry.js";
 import { emitEvent } from "../utils.js";
 import { classifyTask } from "../task-signal-registry.js";
-import type { PipelineContext, PipelinePhase, PhaseResult } from "./pipeline-types.js";
+import type {
+  Phase,
+  PhaseDeps,
+  PhaseExecution,
+  WorktreePhaseInput,
+  WorktreePhaseOutput,
+} from "./pipeline-types.js";
 
 const tracer = trace.getTracer("@mbe/agent-core");
 
-export class WorktreePhase implements PipelinePhase {
+export class WorktreePhase implements Phase<WorktreePhaseInput, WorktreePhaseOutput> {
   readonly name = "worktree" as const;
 
-  async run(ctx: PipelineContext): Promise<{ result: PhaseResult; ctx: PipelineContext }> {
-    const { config, onEvent } = ctx;
+  async run(
+    input: WorktreePhaseInput,
+    deps: PhaseDeps
+  ): Promise<PhaseExecution<WorktreePhaseOutput>> {
+    const { config, onEvent } = input;
+    const { worktreeManager, promptBuilder, failureMemory } = deps;
 
     // Classify the task once so downstream consumers reuse the result instead
     // of re-scanning the description.
@@ -25,7 +32,12 @@ export class WorktreePhase implements PipelinePhase {
     try {
       // 1. Create isolated worktree (with retry for transient git failures)
       const { value: worktree } = await withRetry(
-        () => createWorktree(config.repoPath, config.baseBranch, config.taskDescription),
+        () =>
+          worktreeManager.createWorktree(
+            config.repoPath,
+            config.baseBranch,
+            config.taskDescription
+          ),
         { maxRetries: 2 }
       );
       wtSpan.setAttribute("worktree.branch", worktree.branchName);
@@ -33,9 +45,9 @@ export class WorktreePhase implements PipelinePhase {
       wtSpan.end();
 
       // 2. Build system prompt with failure context, source files, and PR examples
-      const failureMemory = await loadMemory(config.repoPath);
-      const pastFailures = queryPastFailures(failureMemory, config.taskDescription);
-      const failureContext = buildFailureContext(pastFailures);
+      const memory = await failureMemory.loadMemory(config.repoPath);
+      const pastFailures = failureMemory.queryPastFailures(memory, config.taskDescription);
+      const failureContext = failureMemory.buildFailureContext(pastFailures);
 
       // Auto-resolve source files from task description if none provided
       const resolvedSourcePaths =
@@ -44,11 +56,12 @@ export class WorktreePhase implements PipelinePhase {
           const { resolveSourceFiles } = await import("../source-resolver.js");
           return resolveSourceFiles(config.taskDescription);
         })();
-
       const finalSourcePaths = await resolvedSourcePaths;
 
       const sourceFileEntries =
-        finalSourcePaths.length > 0 ? await loadSourceFiles(finalSourcePaths) : undefined;
+        finalSourcePaths.length > 0
+          ? await promptBuilder.loadSourceFiles(finalSourcePaths)
+          : undefined;
 
       // Fetch recent successful PRs as examples (non-blocking)
       const { fetchRecentPrExamples, formatPrExamples } = await import("../budget-calculator.js");
@@ -56,13 +69,15 @@ export class WorktreePhase implements PipelinePhase {
       const prExamplesSection = formatPrExamples(prExamples);
 
       // Load project CLAUDE.md for coding conventions (non-blocking)
-      const projectContext = await loadProjectContext(worktree.path).catch(() => null);
+      const projectContext = await promptBuilder
+        .loadProjectContext(worktree.path)
+        .catch(() => null);
       const projectSection = projectContext
         ? `\n\n## Project Conventions (from CLAUDE.md)\n\n${projectContext}`
         : "";
 
       const systemPrompt =
-        (await buildSystemPrompt(config.taskDescription, {
+        (await promptBuilder.buildSystemPrompt(config.taskDescription, {
           sourceFileEntries,
           prExamplesSection,
           failureContext,
@@ -74,14 +89,14 @@ export class WorktreePhase implements PipelinePhase {
 
       return {
         result: { phase: this.name, status: "success", errors: [] },
-        ctx: { ...ctx, worktree, systemPrompt, taskSignals },
+        output: { worktree, systemPrompt, taskSignals },
       };
     } catch (error) {
       wtSpan.end();
       const errorMessage = error instanceof Error ? error.message : String(error);
       return {
         result: { phase: this.name, status: "failed", errors: [errorMessage] },
-        ctx: { ...ctx, errors: [...ctx.errors, errorMessage] },
+        output: null,
       };
     }
   }

--- a/packages/agent-core/src/session-runner.ts
+++ b/packages/agent-core/src/session-runner.ts
@@ -1,9 +1,19 @@
 import { trace, SpanStatusCode } from "@opentelemetry/api";
-import type { SessionConfig, SessionResult, SessionEventCallback } from "./types.js";
+import type { SDKResultMessage } from "@anthropic-ai/claude-agent-sdk";
+import type {
+  SessionConfig,
+  SessionResult,
+  SessionEventCallback,
+  WorktreeInfo,
+  TurnMetrics,
+  ToolCallMetrics,
+} from "./types.js";
+import type { StuckPattern } from "./stuck-detector.js";
+import type { ContextMetrics } from "./context-budget.js";
+import type { EvaluationResult } from "./success-evaluator.js";
+import type { GatewayVerdict } from "./post-commit-gateway.js";
 import { buildSessionResult } from "./cost-tracker.js";
-import { hasChanges, commitChanges, pushBranch, removeWorktree } from "./worktree-manager.js";
 import { scheduleWorktreeReap } from "./worktree-reaper.js";
-import { createPullRequest, buildFailurePrBody } from "./pr-creator.js";
 import { recordFailure } from "./failure-memory.js";
 import { withRetry } from "./retry.js";
 import { emitEvent, sanitizeForCommitMessage } from "./utils.js";
@@ -16,8 +26,9 @@ import {
   updateActiveObservation,
 } from "@langfuse/tracing";
 
-import type { PipelineContext } from "./phases/pipeline-types.js";
+import type { PhaseDeps } from "./phases/index.js";
 import {
+  createDefaultPhaseDeps,
   WorktreePhase,
   QueryPhase,
   VerificationPhase,
@@ -29,19 +40,41 @@ const tracer = trace.getTracer("@mbe/agent-core");
 
 // ── Pipeline phases (stateless singletons) ──────────────────────────
 
-const phases = [
-  new WorktreePhase(),
-  new QueryPhase(),
-  new VerificationPhase(),
-  new PublishPhase(),
-  new FeedbackPhase(),
-] as const;
+const worktreePhase = new WorktreePhase();
+const queryPhase = new QueryPhase();
+const verificationPhase = new VerificationPhase();
+const publishPhase = new PublishPhase();
+const feedbackPhase = new FeedbackPhase();
+
+/**
+ * Mutable accumulator threaded across phases. Each phase reads the fields
+ * it needs and the session-runner composes the next phase's typed input
+ * from these values. Replaces the former amorphous `PipelineContext` bag.
+ */
+interface SessionState {
+  worktree?: WorktreeInfo;
+  systemPrompt?: string;
+  resultMessage?: SDKResultMessage;
+  stuckReason?: StuckPattern;
+  turnMetrics: readonly TurnMetrics[];
+  toolCallMetrics: readonly ToolCallMetrics[];
+  contextMetrics?: ContextMetrics;
+  hasChanges: boolean;
+  commitMsg?: string;
+  cachedDiff?: string;
+  gatewayVerdict?: GatewayVerdict;
+  gatewayEvaluation?: EvaluationResult;
+  prUrl: string | null;
+  prNumber?: number;
+  errors: string[];
+}
 
 // ── Public API ──────────────────────────────────────────────────────
 
 export async function runSession(
   config: SessionConfig,
-  onEvent?: SessionEventCallback
+  onEvent?: SessionEventCallback,
+  deps: PhaseDeps = createDefaultPhaseDeps()
 ): Promise<SessionResult> {
   return startActiveObservation(
     "agent-session",
@@ -57,76 +90,26 @@ export async function runSession(
           },
         },
         async (): Promise<SessionResult> => {
-          // Apply QA tuning defaults from .github/auto-qa-tuning.json
-          const tuning = loadQaTuning(config.repoPath);
-          const tuningOverrides = tuning
-            ? applyTuningDefaults(
-                {
-                  maxBudgetUsd: config.maxBudgetUsd,
-                  stuckDetectorConfig: config.stuckDetectorConfig,
-                },
-                tuning,
-                DEFAULT_SESSION_CONFIG.maxBudgetUsd
-              )
-            : null;
-
-          const effectiveConfig = tuningOverrides
-            ? {
-                ...config,
-                maxBudgetUsd: tuningOverrides.maxBudgetUsd,
-                stuckDetectorConfig: {
-                  ...config.stuckDetectorConfig,
-                  ...tuningOverrides.stuckDetectorConfig,
-                },
-              }
-            : config;
+          const effectiveConfig = applyEffectiveConfig(config);
 
           const rootSpan = tracer.startSpan("agent_core.run_session", {
-            attributes: {
-              "session.task": effectiveConfig.taskDescription.slice(0, 200),
-              "session.model": effectiveConfig.model,
-              "session.max_turns": effectiveConfig.maxTurns,
-              "session.max_budget_usd": effectiveConfig.maxBudgetUsd,
-              "session.base_branch": effectiveConfig.baseBranch,
-              ...(tuning ? { "session.qa_tuning_applied": true } : {}),
-              ...(effectiveConfig.modelRoutingReason
-                ? { "session.model_routing_reason": effectiveConfig.modelRoutingReason }
-                : {}),
-              ...(effectiveConfig.modelRoutingTier
-                ? { "session.model_routing_tier": effectiveConfig.modelRoutingTier }
-                : {}),
-            },
+            attributes: buildRootSpanAttributes(effectiveConfig, loadQaTuning(config.repoPath)),
           });
 
           const cleanupErrors: string[] = [];
-          let ctx: PipelineContext = {
-            config: effectiveConfig,
-            onEvent,
+          const state: SessionState = {
+            turnMetrics: [],
+            toolCallMetrics: [],
+            hasChanges: false,
+            prUrl: null,
             errors: [],
           };
 
           let pendingResult: SessionResult | undefined;
 
           try {
-            // Run pipeline phases sequentially
-            for (const phase of phases) {
-              const { result, ctx: nextCtx } = await phase.run(ctx);
-              ctx = nextCtx;
-
-              if (result.status === "failed") {
-                // Phase failure — attempt partial work push then abort
-                if (ctx.worktree && effectiveConfig.createPr) {
-                  const errorMsg = result.errors[0] ?? "Phase failed";
-                  const prUrl = await pushPartialWork(ctx, errorMsg);
-                  if (prUrl) {
-                    ctx = { ...ctx, prUrl };
-                  }
-                }
-                break;
-              }
-            }
-
-            pendingResult = buildFinalResult(ctx, rootSpan);
+            await runPipeline(effectiveConfig, onEvent, deps, state);
+            pendingResult = buildFinalResult(effectiveConfig, state, rootSpan, onEvent);
           } catch (error) {
             const errorMessage = error instanceof Error ? error.message : String(error);
             emitEvent(onEvent, "session:error", { message: errorMessage });
@@ -134,13 +117,19 @@ export async function runSession(
             rootSpan.setStatus({ code: SpanStatusCode.ERROR, message: errorMessage });
 
             // Attempt to push partial work from failed sessions
-            const prUrl = await pushPartialWork(ctx, errorMessage);
+            const prUrl = await pushPartialWork(
+              effectiveConfig,
+              state,
+              deps,
+              errorMessage,
+              onEvent
+            );
 
             rootSpan.setAttribute("session.status", "failed");
             pendingResult = {
               sessionId: "",
               status: "failed",
-              branchName: ctx.worktree?.branchName ?? "",
+              branchName: state.worktree?.branchName ?? "",
               prUrl,
               costUsd: 0,
               tokenUsage: { inputTokens: 0, outputTokens: 0 },
@@ -148,18 +137,20 @@ export async function runSession(
               numTurns: 0,
               resultText: "",
               errors: [errorMessage],
-              stuckPattern: ctx.stuckReason?.type,
+              stuckPattern: state.stuckReason?.type,
             };
           } finally {
-            // Clean up worktree when PR was created (branch is pushed)
-            // Keep worktree when --no-pr so user can inspect
-            if (ctx.worktree && effectiveConfig.createPr) {
+            // Clean up worktree when PR was created (branch is pushed).
+            // Keep worktree when --no-pr so user can inspect.
+            if (state.worktree && effectiveConfig.createPr) {
               try {
-                await removeWorktree(effectiveConfig.repoPath, ctx.worktree.path);
+                await deps.worktreeManager.removeWorktree(
+                  effectiveConfig.repoPath,
+                  state.worktree.path
+                );
               } catch (cleanupErr) {
                 const cleanupMsg =
                   cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr);
-                // Record the error in the result (unchanged behavior)
                 cleanupErrors.push(cleanupMsg);
                 console.warn(`Worktree cleanup failed: ${cleanupMsg}`);
                 emitEvent(onEvent, "session:cleanup_warning", {
@@ -170,8 +161,8 @@ export async function runSession(
                 // level (never silent) and is not treated as a session failure.
                 await scheduleWorktreeReap({
                   repoPath: effectiveConfig.repoPath,
-                  worktreePath: ctx.worktree.path,
-                  mode: ctx.worktree.mode,
+                  worktreePath: state.worktree.path,
+                  mode: state.worktree.mode,
                 });
               }
             }
@@ -186,11 +177,180 @@ export async function runSession(
   );
 }
 
+// ── Pipeline composition ────────────────────────────────────────────
+//
+// Each phase receives a typed input composed from prior phase outputs.
+// A failed phase short-circuits the pipeline (after a best-effort
+// partial-work push), mirroring the prior break-on-failure behaviour.
+
+async function runPipeline(
+  config: SessionConfig,
+  onEvent: SessionEventCallback | undefined,
+  deps: PhaseDeps,
+  state: SessionState
+): Promise<void> {
+  // WorktreePhase
+  const worktreeExec = await worktreePhase.run({ config, onEvent }, deps);
+  if (worktreeExec.output) {
+    state.worktree = worktreeExec.output.worktree;
+    state.systemPrompt = worktreeExec.output.systemPrompt;
+  }
+  if (await abortOnFailure(worktreeExec.result, config, state, deps, onEvent)) return;
+
+  // QueryPhase
+  const queryExec = await queryPhase.run(
+    { config, onEvent, worktree: state.worktree!, systemPrompt: state.systemPrompt! },
+    deps
+  );
+  if (queryExec.output) {
+    state.resultMessage = queryExec.output.resultMessage;
+    state.stuckReason = queryExec.output.stuckReason;
+    state.turnMetrics = queryExec.output.turnMetrics;
+    state.toolCallMetrics = queryExec.output.toolCallMetrics;
+    state.contextMetrics = queryExec.output.contextMetrics;
+  }
+  if (await abortOnFailure(queryExec.result, config, state, deps, onEvent)) return;
+
+  // VerificationPhase
+  const verifyExec = await verificationPhase.run(
+    {
+      config,
+      onEvent,
+      worktree: state.worktree!,
+      resultMessage: state.resultMessage,
+      stuckReason: state.stuckReason,
+    },
+    deps
+  );
+  if (verifyExec.output) {
+    state.hasChanges = verifyExec.output.hasChanges;
+    state.commitMsg = verifyExec.output.commitMsg;
+    state.cachedDiff = verifyExec.output.cachedDiff;
+    state.gatewayVerdict = verifyExec.output.gatewayVerdict;
+    state.gatewayEvaluation = verifyExec.output.gatewayEvaluation;
+  }
+  // VerificationPhase always succeeds; its gateway errors flow into the
+  // final result via state.errors (e.g. a draft PR with failing gates).
+  state.errors.push(...verifyExec.result.errors);
+  if (await abortOnFailure(verifyExec.result, config, state, deps, onEvent)) return;
+
+  // PublishPhase
+  const publishExec = await publishPhase.run(
+    {
+      config,
+      onEvent,
+      worktree: state.worktree!,
+      hasChanges: state.hasChanges,
+      resultMessage: state.resultMessage,
+      stuckReason: state.stuckReason,
+      gatewayVerdict: state.gatewayVerdict,
+      errors: state.errors,
+    },
+    deps
+  );
+  if (publishExec.output) {
+    state.prUrl = publishExec.output.prUrl;
+    state.prNumber = publishExec.output.prNumber;
+  }
+  if (await abortOnFailure(publishExec.result, config, state, deps, onEvent)) return;
+
+  // FeedbackPhase
+  const feedbackExec = await feedbackPhase.run(
+    {
+      config,
+      onEvent,
+      worktree: state.worktree!,
+      resultMessage: state.resultMessage,
+      prUrl: state.prUrl,
+      prNumber: state.prNumber,
+    },
+    deps
+  );
+  await abortOnFailure(feedbackExec.result, config, state, deps, onEvent);
+}
+
+/**
+ * On phase failure: record the phase errors, push partial work (when a
+ * worktree exists and PRs are enabled), and signal the caller to abort.
+ * Returns `true` when the pipeline should stop.
+ *
+ * No-op for non-failing phases. VerificationPhase always succeeds and
+ * pushes its gateway errors into `state.errors` directly, so this never
+ * double-counts.
+ */
+async function abortOnFailure(
+  result: { status: string; errors: readonly string[] },
+  config: SessionConfig,
+  state: SessionState,
+  deps: PhaseDeps,
+  onEvent: SessionEventCallback | undefined
+): Promise<boolean> {
+  if (result.status !== "failed") return false;
+
+  state.errors.push(...result.errors);
+
+  if (state.worktree && config.createPr) {
+    const errorMsg = result.errors[0] ?? "Phase failed";
+    const prUrl = await pushPartialWork(config, state, deps, errorMsg, onEvent);
+    if (prUrl) {
+      state.prUrl = prUrl;
+    }
+  }
+  return true;
+}
+
+// ── Config helpers ──────────────────────────────────────────────────
+
+function applyEffectiveConfig(config: SessionConfig): SessionConfig {
+  const tuning = loadQaTuning(config.repoPath);
+  const tuningOverrides = tuning
+    ? applyTuningDefaults(
+        {
+          maxBudgetUsd: config.maxBudgetUsd,
+          stuckDetectorConfig: config.stuckDetectorConfig,
+        },
+        tuning,
+        DEFAULT_SESSION_CONFIG.maxBudgetUsd
+      )
+    : null;
+
+  return tuningOverrides
+    ? {
+        ...config,
+        maxBudgetUsd: tuningOverrides.maxBudgetUsd,
+        stuckDetectorConfig: {
+          ...config.stuckDetectorConfig,
+          ...tuningOverrides.stuckDetectorConfig,
+        },
+      }
+    : config;
+}
+
+function buildRootSpanAttributes(
+  config: SessionConfig,
+  tuning: ReturnType<typeof loadQaTuning>
+): Record<string, string | number | boolean> {
+  return {
+    "session.task": config.taskDescription.slice(0, 200),
+    "session.model": config.model,
+    "session.max_turns": config.maxTurns,
+    "session.max_budget_usd": config.maxBudgetUsd,
+    "session.base_branch": config.baseBranch,
+    ...(tuning ? { "session.qa_tuning_applied": true } : {}),
+    ...(config.modelRoutingReason
+      ? { "session.model_routing_reason": config.modelRoutingReason }
+      : {}),
+    ...(config.modelRoutingTier ? { "session.model_routing_tier": config.modelRoutingTier } : {}),
+  };
+}
+
 // ── Result builder ──────────────────────────────────────────────────
 
 function buildFinalResult(
-  ctx: PipelineContext,
-  rootSpan: ReturnType<ReturnType<typeof trace.getTracer>["startSpan"]>
+  config: SessionConfig,
+  state: SessionState,
+  rootSpan: ReturnType<ReturnType<typeof trace.getTracer>["startSpan"]>,
+  onEvent: SessionEventCallback | undefined
 ): SessionResult {
   const {
     resultMessage,
@@ -199,11 +359,11 @@ function buildFinalResult(
     turnMetrics,
     toolCallMetrics,
     contextMetrics,
-  } = ctx;
-  const errors = [...ctx.errors];
+  } = state;
+  const errors = [...state.errors];
 
   if (stuckReason) {
-    // Deduplicate — stuck error may already be in ctx.errors
+    // Deduplicate — stuck error may already be in state.errors
     const stuckMsg = `Stuck: ${stuckReason.description}`;
     if (!errors.includes(stuckMsg)) {
       errors.push(stuckMsg);
@@ -230,8 +390,8 @@ function buildFinalResult(
   if (resultMessage) {
     const sessionResult = buildSessionResult(
       resultMessage,
-      ctx.worktree?.branchName ?? "",
-      ctx.prUrl ?? null
+      state.worktree?.branchName ?? "",
+      state.prUrl ?? null
     );
 
     const isFailed = sessionResult.status === "failed" || !!stuckReason;
@@ -248,8 +408,8 @@ function buildFinalResult(
 
     // Record failure for future context
     if (finalResult.status === "failed") {
-      recordFailure(ctx.config.repoPath, {
-        taskDescription: ctx.config.taskDescription,
+      recordFailure(config.repoPath, {
+        taskDescription: config.taskDescription,
         timestamp: new Date().toISOString(),
         stuckPattern: stuckReason?.type,
         errors,
@@ -274,7 +434,7 @@ function buildFinalResult(
       rootSpan.setAttribute("session.context_compaction_count", contextMetrics.compactionCount);
     }
 
-    emitEvent(ctx.onEvent, "session:result", {
+    emitEvent(onEvent, "session:result", {
       message: `Session completed: ${finalResult.status}`,
     });
 
@@ -311,8 +471,8 @@ function buildFinalResult(
   return {
     sessionId: "",
     status: "failed",
-    branchName: ctx.worktree?.branchName ?? "",
-    prUrl: ctx.prUrl ?? null,
+    branchName: state.worktree?.branchName ?? "",
+    prUrl: state.prUrl ?? null,
     costUsd: 0,
     tokenUsage: { inputTokens: 0, outputTokens: 0 },
     durationMs: 0,
@@ -329,26 +489,37 @@ function buildFinalResult(
 
 // ── Error recovery ──────────────────────────────────────────────────
 
-async function pushPartialWork(ctx: PipelineContext, errorMessage: string): Promise<string | null> {
-  const { config, worktree, stuckReason, onEvent } = ctx;
+async function pushPartialWork(
+  config: SessionConfig,
+  state: SessionState,
+  deps: PhaseDeps,
+  errorMessage: string,
+  onEvent: SessionEventCallback | undefined
+): Promise<string | null> {
+  const { worktree, stuckReason } = state;
+  const { worktreeManager, prCreator } = deps;
 
   if (!worktree || !config.createPr) return null;
 
   try {
-    const changed = await hasChanges(worktree.path);
+    const changed = await worktreeManager.hasChanges(worktree.path);
     if (!changed) return null;
 
     const commitMsg = `wip: ${sanitizeForCommitMessage(config.taskDescription)}`;
-    await commitChanges(worktree.path, commitMsg);
-    await withRetry(() => pushBranch(worktree.path, worktree.branchName), {
+    await worktreeManager.commitChanges(worktree.path, commitMsg);
+    await withRetry(() => worktreeManager.pushBranch(worktree.path, worktree.branchName), {
       maxRetries: 2,
     });
 
     const { value: pr } = await withRetry(
       () =>
-        createPullRequest({
+        prCreator.createPullRequest({
           title: `wip: ${config.taskDescription.slice(0, 57)}`,
-          body: buildFailurePrBody(config.taskDescription, [errorMessage], stuckReason?.type),
+          body: prCreator.buildFailurePrBody(
+            config.taskDescription,
+            [errorMessage],
+            stuckReason?.type
+          ),
           baseBranch: config.baseBranch,
           branchName: worktree.branchName,
           repoPath: worktree.path,


### PR DESCRIPTION
Closes #1992

## What changed

Replaces the amorphous all-optional `PipelineContext` bag with **explicit per-phase input/output contracts** and **injected phase dependencies**. This is a seam-tightening refactor — `runSession()` behaviour is identical, observable only in types and tests.

### Typed per-phase contracts
Each phase now declares exactly what it reads and produces:
- `WorktreePhaseInput` → `WorktreePhaseOutput`
- `QueryPhaseInput` → `QueryPhaseOutput`
- `VerificationPhaseInput` → `VerificationPhaseOutput`
- `PublishPhaseInput` → `PublishPhaseOutput`
- `FeedbackPhaseInput` → `void`

`session-runner` composes them explicitly, threading one phase's typed output into the next phase's input via a small internal `SessionState` accumulator — no shared spread-the-union bag. A failed/skipped phase returns `output: null` (it has nothing valid to contribute), so only successful phases compose forward.

### Injected dependencies
Phases collaborate through a `PhaseDeps` interface bundle (worktree manager, prompt builder, failure memory, query runner, success evaluator, gateway, PR creator, feedback loop) instead of importing module functions directly. `createDefaultPhaseDeps()` wires the real modules; `runSession(config, onEvent, deps?)` takes an optional injected bundle (defaulted), so existing callers are unaffected.

### Test impact (the point of the refactor)
- `session-runner.test.ts` `vi.mock` count drops **12 → 3** (only langfuse / worktree-reaper / retry session-infra remain). It injects one `makeFakePhaseDeps()` bundle instead of mocking a dozen modules.
- Phase tests now mock the injected `PhaseDeps` interface, not module internals.

## Gates (all green)

| Gate | agent-core | services/agent |
|------|-----------|----------------|
| `pnpm lint` | ✅ | ✅ |
| `pnpm typecheck` | ✅ | ✅ |
| `pnpm test` | ✅ 66 files / 1241 | ✅ 26 files / 285 |

Also verified: `check-adr` ✅, `check-deps` ✅, `pnpm regen --check` clean (agent-core + root `llms.txt`/`llms-full.txt` regenerated and committed), instruction-rot ✅, pre-push `turbo test` across all 30 tasks ✅ (under pinned Node 22).

No behaviour change in `runSession()`. No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)