### PR TITLE
refactor(agent-core): remove uncalled with*Span observability wrappers

### DIFF
--- a/packages/agent-core/src/__tests__/observability.test.ts
+++ b/packages/agent-core/src/__tests__/observability.test.ts
@@ -3,11 +3,8 @@ import {
   categorizeFailure,
   buildTurnMetricsList,
   buildToolCallMetricsList,
-  withModelSelectionSpan,
-  withToolPermissionSpan,
-  withStuckDetectionSpan,
-  withSuccessEvaluationSpan,
 } from "../observability.js";
+import * as publicApi from "../index.js";
 import type { StuckPatternType } from "../stuck-detector.js";
 
 // ── categorizeFailure ────────────────────────────────────────────────
@@ -199,168 +196,28 @@ describe("buildToolCallMetricsList", () => {
   });
 });
 
-// ── withModelSelectionSpan ───────────────────────────────────────────
+// ── public API: uncalled span wrappers must not be exported ──────────
+//
+// The four `with*Span` higher-order wrappers had no production caller —
+// phases create spans inline (e.g. LlmEvaluationGate emits the
+// success-evaluation span directly). They were removed from the public
+// API rather than wired in: model selection happens in the CLI layer
+// (outside agent-core), and the tool-permission / stuck-detection call
+// sites are per-call/per-message hot paths where a span would be a
+// perf regression. This guards against re-introducing dead public API.
 
-describe("withModelSelectionSpan", () => {
-  it("returns the result of the wrapped function", () => {
-    const result = withModelSelectionSpan(() => ({
-      tier: "sonnet",
-      modelId: "claude-sonnet-4-6",
-      reason: "default routing",
-    }));
-
-    expect(result.tier).toBe("sonnet");
-    expect(result.modelId).toBe("claude-sonnet-4-6");
-    expect(result.reason).toBe("default routing");
+describe("public observability API", () => {
+  it("does not export the uncalled span wrappers", () => {
+    expect(publicApi).not.toHaveProperty("withModelSelectionSpan");
+    expect(publicApi).not.toHaveProperty("withToolPermissionSpan");
+    expect(publicApi).not.toHaveProperty("withStuckDetectionSpan");
+    expect(publicApi).not.toHaveProperty("withSuccessEvaluationSpan");
   });
 
-  it("propagates errors from the wrapped function", () => {
-    expect(() =>
-      withModelSelectionSpan(() => {
-        throw new Error("model selection failed");
-      })
-    ).toThrow("model selection failed");
-  });
-
-  it("returns result with different model tiers", () => {
-    const opus = withModelSelectionSpan(() => ({
-      tier: "opus",
-      modelId: "claude-opus-4-6",
-      reason: "complexity keywords: migration, schema change",
-    }));
-    expect(opus.tier).toBe("opus");
-
-    const haiku = withModelSelectionSpan(() => ({
-      tier: "haiku",
-      modelId: "claude-haiku-4-5",
-      reason: "dep bump pattern",
-    }));
-    expect(haiku.tier).toBe("haiku");
-  });
-});
-
-// ── withToolPermissionSpan ───────────────────────────────────────────
-
-describe("withToolPermissionSpan", () => {
-  it("returns the result when tool is allowed", async () => {
-    const result = await withToolPermissionSpan("Read", async () => ({
-      behavior: "allow",
-    }));
-
-    expect(result.behavior).toBe("allow");
-  });
-
-  it("returns the result when tool is denied", async () => {
-    const result = await withToolPermissionSpan("WebSearch", async () => ({
-      behavior: "deny",
-    }));
-
-    expect(result.behavior).toBe("deny");
-  });
-
-  it("propagates errors from the wrapped function", async () => {
-    await expect(
-      withToolPermissionSpan("Bash", async () => {
-        throw new Error("permission check failed");
-      })
-    ).rejects.toThrow("permission check failed");
-  });
-
-  it("records tool name for span attributes", async () => {
-    const result = await withToolPermissionSpan("Edit", async () => ({
-      behavior: "allow",
-    }));
-
-    expect(result.behavior).toBe("allow");
-  });
-});
-
-// ── withStuckDetectionSpan ──────────────────────────────────────────
-
-describe("withStuckDetectionSpan", () => {
-  it("returns null when no stuck pattern detected", () => {
-    const result = withStuckDetectionSpan(() => null);
-    expect(result).toBeNull();
-  });
-
-  it("returns the stuck pattern when detected", () => {
-    const pattern = {
-      type: "repeated_action_observation",
-      description: "4 identical action+observation pairs",
-    };
-
-    const result = withStuckDetectionSpan(() => pattern);
-
-    expect(result).toEqual(pattern);
-    expect(result!.type).toBe("repeated_action_observation");
-    expect(result!.description).toBe("4 identical action+observation pairs");
-  });
-
-  it("propagates errors from the wrapped function", () => {
-    expect(() =>
-      withStuckDetectionSpan(() => {
-        throw new Error("stuck detection error");
-      })
-    ).toThrow("stuck detection error");
-  });
-
-  it("handles different stuck pattern types", () => {
-    const zeroProgress = withStuckDetectionSpan(() => ({
-      type: "zero_progress",
-      description: "5 turns with no tool use",
-    }));
-    expect(zeroProgress!.type).toBe("zero_progress");
-
-    const selfLoop = withStuckDetectionSpan(() => ({
-      type: "self_message_loop",
-      description: "3 identical text messages",
-    }));
-    expect(selfLoop!.type).toBe("self_message_loop");
-  });
-});
-
-// ── withSuccessEvaluationSpan ───────────────────────────────────────
-
-describe("withSuccessEvaluationSpan", () => {
-  it("returns the result when evaluation passes", async () => {
-    const result = await withSuccessEvaluationSpan(async () => ({
-      passed: true,
-      confidence: 0.95,
-    }));
-
-    expect(result.passed).toBe(true);
-    expect(result.confidence).toBe(0.95);
-  });
-
-  it("returns the result when evaluation fails", async () => {
-    const result = await withSuccessEvaluationSpan(async () => ({
-      passed: false,
-      confidence: 0.3,
-    }));
-
-    expect(result.passed).toBe(false);
-    expect(result.confidence).toBe(0.3);
-  });
-
-  it("propagates errors from the wrapped function", async () => {
-    await expect(
-      withSuccessEvaluationSpan(async () => {
-        throw new Error("evaluation crashed");
-      })
-    ).rejects.toThrow("evaluation crashed");
-  });
-
-  it("handles edge case confidence values", async () => {
-    const zero = await withSuccessEvaluationSpan(async () => ({
-      passed: false,
-      confidence: 0,
-    }));
-    expect(zero.confidence).toBe(0);
-
-    const one = await withSuccessEvaluationSpan(async () => ({
-      passed: true,
-      confidence: 1.0,
-    }));
-    expect(one.confidence).toBe(1.0);
+  it("still exports the observability helpers that have real callers", () => {
+    expect(publicApi).toHaveProperty("categorizeFailure");
+    expect(publicApi).toHaveProperty("buildTurnMetricsList");
+    expect(publicApi).toHaveProperty("buildToolCallMetricsList");
+    expect(publicApi).toHaveProperty("observabilityTracer");
   });
 });

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -165,15 +165,11 @@ export type {
   TurnMetricsEvent,
 } from "./event-mapper.js";
 
-// Observability — failure categorization, OTel spans, metrics builders
+// Observability — failure categorization, metrics builders, OTel tracer
 export {
   categorizeFailure,
   buildTurnMetricsList,
   buildToolCallMetricsList,
-  withModelSelectionSpan,
-  withToolPermissionSpan,
-  withStuckDetectionSpan,
-  withSuccessEvaluationSpan,
   observabilityTracer,
 } from "./observability.js";
 

--- a/packages/agent-core/src/observability.ts
+++ b/packages/agent-core/src/observability.ts
@@ -1,5 +1,5 @@
-import { trace, SpanStatusCode } from "@opentelemetry/api";
-import type { Span, Tracer } from "@opentelemetry/api";
+import { trace } from "@opentelemetry/api";
+import type { Tracer } from "@opentelemetry/api";
 import type { FailureCategory, TurnMetrics, ToolCallMetrics } from "./types.js";
 import type { StuckPatternType } from "./stuck-detector.js";
 
@@ -96,101 +96,6 @@ export function categorizeFailure(
   }
 
   return undefined;
-}
-
-// ── OTel decision-point spans ─────────────────────────────────────────
-
-/**
- * Wrap a model-selection call in an OTel span.
- * The span records the resolved tier, model ID, and reason.
- */
-export function withModelSelectionSpan<T extends { tier: string; modelId: string; reason: string }>(
-  fn: () => T
-): T {
-  const span: Span = observabilityTracer.startSpan("agent_core.model_selection");
-  try {
-    const result = fn();
-    span.setAttribute("model.tier", result.tier);
-    span.setAttribute("model.id", result.modelId);
-    span.setAttribute("model.selection_reason", result.reason);
-    return result;
-  } catch (err) {
-    span.recordException(err as Error);
-    span.setStatus({ code: SpanStatusCode.ERROR });
-    throw err;
-  } finally {
-    span.end();
-  }
-}
-
-/**
- * Wrap a tool-permission check in an OTel span.
- * The span records the tool name and whether it was allowed or denied.
- */
-export async function withToolPermissionSpan<T extends { behavior: string }>(
-  toolName: string,
-  fn: () => Promise<T>
-): Promise<T> {
-  const span: Span = observabilityTracer.startSpan("agent_core.tool_permission_check");
-  span.setAttribute("tool.name", toolName);
-  try {
-    const result = await fn();
-    span.setAttribute("tool.allowed", result.behavior === "allow");
-    return result;
-  } catch (err) {
-    span.recordException(err as Error);
-    span.setStatus({ code: SpanStatusCode.ERROR });
-    throw err;
-  } finally {
-    span.end();
-  }
-}
-
-/**
- * Wrap a stuck-detection ingestion step in an OTel span.
- * The span records whether a stuck pattern was detected and its type.
- */
-export function withStuckDetectionSpan<T extends { type: string; description: string } | null>(
-  fn: () => T
-): T {
-  const span: Span = observabilityTracer.startSpan("agent_core.stuck_detection");
-  try {
-    const result = fn();
-    span.setAttribute("stuck.detected", result !== null);
-    if (result !== null) {
-      span.setAttribute("stuck.pattern_type", result.type);
-      span.setAttribute("stuck.description", result.description);
-    }
-    return result;
-  } catch (err) {
-    span.recordException(err as Error);
-    span.setStatus({ code: SpanStatusCode.ERROR });
-    throw err;
-  } finally {
-    span.end();
-  }
-}
-
-/**
- * Wrap a success-evaluation call in an OTel span.
- * The span records whether the evaluation passed and its confidence.
- */
-export async function withSuccessEvaluationSpan<T extends { passed: boolean; confidence: number }>(
-  fn: () => Promise<T>
-): Promise<T> {
-  const span: Span = observabilityTracer.startSpan("agent_core.success_evaluation");
-  try {
-    const result = await fn();
-    span.setAttribute("evaluation.passed", result.passed);
-    span.setAttribute("evaluation.confidence", result.confidence);
-    return result;
-  } catch (err) {
-    span.recordException(err as Error);
-    span.setStatus({ code: SpanStatusCode.ERROR });
-    throw err;
-  } finally {
-    span.end();
-  }
 }
 
 // ── Per-turn metrics aggregation ─────────────────────────────────────


### PR DESCRIPTION
Closes #1782

## Option chosen: B (with A proven infeasible)

The four higher-order span wrappers in `packages/agent-core/src/observability.ts` — `withModelSelectionSpan`, `withToolPermissionSpan`, `withStuckDetectionSpan`, `withSuccessEvaluationSpan` — were re-exported as public API but had **zero production callers**. This PR removes them from the public API and deletes their orphaned tests.

### Why Option A (wire wrappers into phases) is infeasible

The issue's preferred option was to call the wrappers inside the pipeline phases. Analysis of the actual call sites shows there is no inline span whose attribute contract a wrapper would replace without harm:

- **`withModelSelectionSpan`** — model selection (`routeModelWithReason`) happens entirely in the **CLI layer** (`tools/cli/src/resolve-issue-model.ts`, `commands/agent.ts`), *outside* agent-core. By the time agent-core runs, the model is already resolved and recorded as attributes on the existing `agent_core.run_session` root span (`session-runner.ts:88-98`). There is no model-selection decision point inside the package to wrap.
- **`withToolPermissionSpan`** — its natural call site is the `canUseTool` handler (`run-hardened-query.ts:172`), invoked **per tool call** (a hot path). There is deliberately no span there; wrapping it would emit hundreds of spans per session — a perf regression.
- **`withStuckDetectionSpan`** — its natural call site is `detector.ingest(message)` (`run-hardened-query.ts:361`), invoked **per message** (also a hot path). Same span-explosion concern.
- **`withSuccessEvaluationSpan`** — this one *does* have a real match: `LlmEvaluationGate.evaluate` (`gates/llm-evaluation-gate.ts`) already creates an equivalent span (`agent_core.llm_evaluation_gate`) with identical `evaluation.passed` / `evaluation.confidence` attributes, inline.

The acceptance criteria are all-or-nothing ("every wrapper has a real caller, OR remove them all — no middle state"). Since 3 of 4 wrappers have no feasible non-regressive caller inside agent-core, full Option A is infeasible, so Option B is correct. No observability is lost — the single genuine decision point (`LlmEvaluationGate`) already implements its span inline.

## TDD

Added a public-API regression test (`__tests__/observability.test.ts`) that imports the package namespace and asserts the four wrappers are **not** exported, while the real helpers (`categorizeFailure`, `buildTurnMetricsList`, `buildToolCallMetricsList`, `observabilityTracer`) still are. Confirmed RED before removal, GREEN after.

## Files changed
- `packages/agent-core/src/observability.ts` — removed the four wrapper functions and the now-unused `SpanStatusCode` / `Span` imports
- `packages/agent-core/src/index.ts` — dropped the four exports from the observability re-export block
- `packages/agent-core/src/__tests__/observability.test.ts` — deleted the four wrapper `describe` blocks; added the public-API regression test

## Gate results (`packages/agent-core`)
- `pnpm lint` — clean
- `pnpm typecheck` — clean
- `pnpm test` — 66 files, 1237 tests passing
- `check-adr` / `check-deps` — pass
- `pnpm regen` — no agent-core artifact drift (wrappers were never in the packed llms output)
- Repo-wide grep — no external consumers of the removed wrappers

🤖 Generated with [Claude Code](https://claude.com/claude-code)