### PR TITLE
refactor(agent): SessionConcurrency module — one owner for the max-concurrent gate

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5139,14 +5139,13 @@
           });
     
           if (!result.accepted) {
-            const maxConcurrent = parseInt(process.env.MAX_CONCURRENT_SESSIONS ?? "5", 10);
             return reply
               .code(429)
               .send(
                 createProblemDetails(
                   429,
                   "Too Many Requests",
-                  `Maximum concurrent sessions (${maxConcurrent}) reached. Try again later.`
+                  `Maximum concurrent sessions (${defaultConcurrency.limit}) reached. Try again later.`
                 )
               );
           }
@@ -10655,6 +10654,46 @@
         .join("\n");
     }
   </file>
+  <file path="services/agent/src/services/session-concurrency.ts">
+    export interface SessionConcurrency {
+      /** The configured maximum number of concurrent sessions. */
+      readonly limit: number;
+      /** True when a new session could be admitted right now (no reservation). */
+      canStart(): boolean;
+      /**
+       * Atomically reserve a slot for `sessionId`. Returns true if the slot was
+       * granted (or already held by this id), false if at capacity. Idempotent for
+       * an id that already holds a slot — never consumes a second slot.
+       */
+      acquire(sessionId: string): boolean;
+      /** Release the slot held by `sessionId`. No-op if it holds none. */
+      release(sessionId: string): void;
+      /** Number of currently reserved slots. */
+      activeCount(): number;
+    }
+    export function createSessionConcurrency(limit: number): SessionConcurrency {
+      const active = new Set<string>();
+    
+      return {
+        limit,
+        canStart() {
+          return active.size < limit;
+        },
+        acquire(sessionId: string) {
+          if (active.has(sessionId)) return true;
+          if (active.size >= limit) return false;
+          active.add(sessionId);
+          return true;
+        },
+        release(sessionId: string) {
+          active.delete(sessionId);
+        },
+        activeCount() {
+          return active.size;
+        },
+      };
+    }
+  </file>
   <file path="services/agent/src/services/session-event-emitter.ts">
     export type SessionEventListener = (event: AgentSessionEvent) => void;
     export interface SessionEventEmitter {
@@ -10669,7 +10708,8 @@
   </file>
   <file path="services/agent/src/services/session-executor.ts">
     export interface SessionExecutorConfig {
-      maxConcurrent: number;
+      /** The single gate that owns the max-concurrent-sessions policy. */
+      concurrency: SessionConcurrency;
       sessionService: typeof SessionServiceType;
     }
     export interface SessionExecutor {

--- a/llms.txt
+++ b/llms.txt
@@ -1962,6 +1962,16 @@
       function extractText(content: unknown): string { /* ... */ }
     </item>
   </file>
+  <file path="services/agent/src/services/session-concurrency.ts">
+    <item priority="low">
+      interface SessionConcurrency {
+        limit: number;
+      }
+    </item>
+    <item priority="high">
+      export function createSessionConcurrency(limit: number): SessionConcurrency { /* ... */ }
+    </item>
+  </file>
   <file path="services/agent/src/services/session-event-emitter.ts">
     <item priority="low">
       type SessionEventListener = (event: AgentSessionEvent) => void;
@@ -1975,7 +1985,7 @@
   <file path="services/agent/src/services/session-executor.ts">
     <item priority="low">
       interface SessionExecutorConfig {
-        maxConcurrent: number;
+        concurrency: SessionConcurrency;
         sessionService: typeof SessionServiceType;
       }
     </item>

--- a/services/agent/llms-full.txt
+++ b/services/agent/llms-full.txt
@@ -1077,14 +1077,13 @@
           });
     
           if (!result.accepted) {
-            const maxConcurrent = parseInt(process.env.MAX_CONCURRENT_SESSIONS ?? "5", 10);
             return reply
               .code(429)
               .send(
                 createProblemDetails(
                   429,
                   "Too Many Requests",
-                  `Maximum concurrent sessions (${maxConcurrent}) reached. Try again later.`
+                  `Maximum concurrent sessions (${defaultConcurrency.limit}) reached. Try again later.`
                 )
               );
           }
@@ -1341,6 +1340,46 @@
         .join("\n");
     }
   </file>
+  <file path="src/services/session-concurrency.ts">
+    export interface SessionConcurrency {
+      /** The configured maximum number of concurrent sessions. */
+      readonly limit: number;
+      /** True when a new session could be admitted right now (no reservation). */
+      canStart(): boolean;
+      /**
+       * Atomically reserve a slot for `sessionId`. Returns true if the slot was
+       * granted (or already held by this id), false if at capacity. Idempotent for
+       * an id that already holds a slot — never consumes a second slot.
+       */
+      acquire(sessionId: string): boolean;
+      /** Release the slot held by `sessionId`. No-op if it holds none. */
+      release(sessionId: string): void;
+      /** Number of currently reserved slots. */
+      activeCount(): number;
+    }
+    export function createSessionConcurrency(limit: number): SessionConcurrency {
+      const active = new Set<string>();
+    
+      return {
+        limit,
+        canStart() {
+          return active.size < limit;
+        },
+        acquire(sessionId: string) {
+          if (active.has(sessionId)) return true;
+          if (active.size >= limit) return false;
+          active.add(sessionId);
+          return true;
+        },
+        release(sessionId: string) {
+          active.delete(sessionId);
+        },
+        activeCount() {
+          return active.size;
+        },
+      };
+    }
+  </file>
   <file path="src/services/session-event-emitter.ts">
     export type SessionEventListener = (event: AgentSessionEvent) => void;
     export interface SessionEventEmitter {
@@ -1355,7 +1394,8 @@
   </file>
   <file path="src/services/session-executor.ts">
     export interface SessionExecutorConfig {
-      maxConcurrent: number;
+      /** The single gate that owns the max-concurrent-sessions policy. */
+      concurrency: SessionConcurrency;
       sessionService: typeof SessionServiceType;
     }
     export interface SessionExecutor {

--- a/services/agent/llms.txt
+++ b/services/agent/llms.txt
@@ -205,6 +205,16 @@
       function extractText(content: unknown): string { /* ... */ }
     </item>
   </file>
+  <file path="src/services/session-concurrency.ts">
+    <item priority="low">
+      interface SessionConcurrency {
+        limit: number;
+      }
+    </item>
+    <item priority="high">
+      export function createSessionConcurrency(limit: number): SessionConcurrency { /* ... */ }
+    </item>
+  </file>
   <file path="src/services/session-event-emitter.ts">
     <item priority="low">
       type SessionEventListener = (event: AgentSessionEvent) => void;
@@ -218,7 +228,7 @@
   <file path="src/services/session-executor.ts">
     <item priority="low">
       interface SessionExecutorConfig {
-        maxConcurrent: number;
+        concurrency: SessionConcurrency;
         sessionService: typeof SessionServiceType;
       }
     </item>

--- a/services/agent/src/routes/sessions.ts
+++ b/services/agent/src/routes/sessions.ts
@@ -12,6 +12,7 @@ import { requireAuth } from "@mbe/auth/fastify";
 import { parseListQuery } from "@mbe/database";
 import { sessionService } from "../services/session.js";
 import { cancelSession } from "../services/session-executor.js";
+import { defaultConcurrency } from "../services/session-concurrency.js";
 
 export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
   // POST /v1/sessions — Create + start a new session
@@ -49,14 +50,13 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
       });
 
       if (!result.accepted) {
-        const maxConcurrent = parseInt(process.env.MAX_CONCURRENT_SESSIONS ?? "5", 10);
         return reply
           .code(429)
           .send(
             createProblemDetails(
               429,
               "Too Many Requests",
-              `Maximum concurrent sessions (${maxConcurrent}) reached. Try again later.`
+              `Maximum concurrent sessions (${defaultConcurrency.limit}) reached. Try again later.`
             )
           );
       }

--- a/services/agent/src/services/session-concurrency.test.ts
+++ b/services/agent/src/services/session-concurrency.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { createSessionConcurrency } from "./session-concurrency.js";
+
+describe("session-concurrency", () => {
+  it("admits up to the injected limit", () => {
+    const gate = createSessionConcurrency(2);
+
+    expect(gate.canStart()).toBe(true);
+    expect(gate.acquire("a")).toBe(true);
+    expect(gate.acquire("b")).toBe(true);
+    expect(gate.activeCount()).toBe(2);
+  });
+
+  it("rejects once at capacity", () => {
+    const gate = createSessionConcurrency(2);
+
+    gate.acquire("a");
+    gate.acquire("b");
+
+    expect(gate.canStart()).toBe(false);
+    expect(gate.acquire("c")).toBe(false);
+    expect(gate.activeCount()).toBe(2);
+  });
+
+  it("re-admits after a release frees a slot", () => {
+    const gate = createSessionConcurrency(2);
+
+    gate.acquire("a");
+    gate.acquire("b");
+    expect(gate.acquire("c")).toBe(false);
+
+    gate.release("a");
+
+    expect(gate.canStart()).toBe(true);
+    expect(gate.acquire("c")).toBe(true);
+    expect(gate.activeCount()).toBe(2);
+  });
+
+  it("exposes the configured limit for messaging", () => {
+    const gate = createSessionConcurrency(7);
+    expect(gate.limit).toBe(7);
+  });
+
+  it("acquire is idempotent for an already-held id (no double-count)", () => {
+    const gate = createSessionConcurrency(2);
+
+    expect(gate.acquire("a")).toBe(true);
+    // Re-acquiring the same id must not consume a second slot.
+    expect(gate.acquire("a")).toBe(true);
+    expect(gate.activeCount()).toBe(1);
+  });
+
+  it("release of an unknown id is a no-op", () => {
+    const gate = createSessionConcurrency(2);
+    gate.acquire("a");
+
+    gate.release("never-acquired");
+
+    expect(gate.activeCount()).toBe(1);
+  });
+
+  it("monitor-cancels-then-route-admits goes through the same atomic count (no over-subscription)", () => {
+    // Single shared gate is the only owner of the count. The monitor frees a
+    // slot via release(); the route then admits via the same gate's acquire().
+    // Both paths read+mutate one count, so a freed slot can be re-used exactly
+    // once — never double-spent.
+    const gate = createSessionConcurrency(2);
+
+    gate.acquire("running-1");
+    gate.acquire("running-2");
+    expect(gate.canStart()).toBe(false);
+
+    // Liveness monitor cancels a stale session — releases its slot.
+    gate.release("running-1");
+
+    // Exactly one slot is now free: the first admit wins, the second is rejected.
+    expect(gate.acquire("incoming-1")).toBe(true);
+    expect(gate.acquire("incoming-2")).toBe(false);
+    expect(gate.activeCount()).toBe(2);
+  });
+});

--- a/services/agent/src/services/session-concurrency.ts
+++ b/services/agent/src/services/session-concurrency.ts
@@ -1,0 +1,67 @@
+/**
+ * SessionConcurrency — the single owner of the max-concurrent-sessions policy.
+ *
+ * Before this module the limit was parsed from `MAX_CONCURRENT_SESSIONS` in
+ * three places (the create route, the session service's `triggerSession`, and
+ * the session executor) and the active count was tracked separately in the
+ * executor's controller map. Three modules co-owned one policy, so the
+ * route-admit and monitor-release paths could read stale counts and
+ * over-subscribe.
+ *
+ * This module owns BOTH the limit and the set of active session ids. `acquire`
+ * is the only check-and-reserve operation; it runs synchronously, so a slot
+ * freed by `release` (e.g. the liveness monitor cancelling a stale session) can
+ * be re-used exactly once — never double-spent.
+ */
+export interface SessionConcurrency {
+  /** The configured maximum number of concurrent sessions. */
+  readonly limit: number;
+  /** True when a new session could be admitted right now (no reservation). */
+  canStart(): boolean;
+  /**
+   * Atomically reserve a slot for `sessionId`. Returns true if the slot was
+   * granted (or already held by this id), false if at capacity. Idempotent for
+   * an id that already holds a slot — never consumes a second slot.
+   */
+  acquire(sessionId: string): boolean;
+  /** Release the slot held by `sessionId`. No-op if it holds none. */
+  release(sessionId: string): void;
+  /** Number of currently reserved slots. */
+  activeCount(): number;
+}
+
+export function createSessionConcurrency(limit: number): SessionConcurrency {
+  const active = new Set<string>();
+
+  return {
+    limit,
+    canStart() {
+      return active.size < limit;
+    },
+    acquire(sessionId: string) {
+      if (active.has(sessionId)) return true;
+      if (active.size >= limit) return false;
+      active.add(sessionId);
+      return true;
+    },
+    release(sessionId: string) {
+      active.delete(sessionId);
+    },
+    activeCount() {
+      return active.size;
+    },
+  };
+}
+
+/** Parse the concurrency limit from the environment. Single parse site. */
+export function resolveConcurrencyLimit(): number {
+  return parseInt(process.env.MAX_CONCURRENT_SESSIONS ?? "5", 10);
+}
+
+/**
+ * The process-wide default gate. Built once from the environment at module
+ * load. The route, the session service, and the session executor all share
+ * THIS instance so the count is single-owned. The limit is parsed exactly here.
+ */
+export const defaultConcurrency: SessionConcurrency =
+  createSessionConcurrency(resolveConcurrencyLimit());

--- a/services/agent/src/services/session-executor.test.ts
+++ b/services/agent/src/services/session-executor.test.ts
@@ -28,6 +28,7 @@ import {
   getActiveSessionCount,
   createSessionExecutor,
 } from "./session-executor.js";
+import { createSessionConcurrency } from "./session-concurrency.js";
 import type { AgentSession } from "@mbe/types";
 
 const makeSession = (overrides: Partial<AgentSession> = {}): AgentSession => ({
@@ -352,7 +353,10 @@ describe("session-executor", () => {
     });
 
     it("returns an object with executeSession, cancelSession, getActiveSessionCount", () => {
-      const executor = createSessionExecutor({ maxConcurrent: 2, sessionService });
+      const executor = createSessionExecutor({
+        concurrency: createSessionConcurrency(2),
+        sessionService,
+      });
       expect(typeof executor.executeSession).toBe("function");
       expect(typeof executor.cancelSession).toBe("function");
       expect(typeof executor.getActiveSessionCount).toBe("function");
@@ -367,8 +371,14 @@ describe("session-executor", () => {
         return makeSuccessResult();
       });
 
-      const instanceA = createSessionExecutor({ maxConcurrent: 5, sessionService });
-      const instanceB = createSessionExecutor({ maxConcurrent: 5, sessionService });
+      const instanceA = createSessionExecutor({
+        concurrency: createSessionConcurrency(5),
+        sessionService,
+      });
+      const instanceB = createSessionExecutor({
+        concurrency: createSessionConcurrency(5),
+        sessionService,
+      });
 
       const sessionA = makeSession({ id: "iso-a" });
       const promiseA = instanceA.executeSession(sessionA);
@@ -385,7 +395,7 @@ describe("session-executor", () => {
       await promiseA;
     });
 
-    it("respects its own maxConcurrent config independent of other instances", async () => {
+    it("respects its own concurrency gate independent of other instances", async () => {
       const resolvers: (() => void)[] = [];
       vi.mocked(runSession).mockImplementation(async () => {
         await new Promise<void>((resolve) => {
@@ -395,7 +405,10 @@ describe("session-executor", () => {
       });
 
       // Instance with cap of 1
-      const tightExecutor = createSessionExecutor({ maxConcurrent: 1, sessionService });
+      const tightExecutor = createSessionExecutor({
+        concurrency: createSessionConcurrency(1),
+        sessionService,
+      });
 
       const first = makeSession({ id: "tight-0" });
       const firstPromise = tightExecutor.executeSession(first);
@@ -431,8 +444,14 @@ describe("session-executor", () => {
         return makeSuccessResult();
       });
 
-      const instanceA = createSessionExecutor({ maxConcurrent: 5, sessionService });
-      const instanceB = createSessionExecutor({ maxConcurrent: 5, sessionService });
+      const instanceA = createSessionExecutor({
+        concurrency: createSessionConcurrency(5),
+        sessionService,
+      });
+      const instanceB = createSessionExecutor({
+        concurrency: createSessionConcurrency(5),
+        sessionService,
+      });
 
       const sessionA = makeSession({ id: "cross-cancel" });
       const promiseA = instanceA.executeSession(sessionA);

--- a/services/agent/src/services/session-executor.ts
+++ b/services/agent/src/services/session-executor.ts
@@ -7,12 +7,14 @@ import {
 } from "@mbe/agent-core";
 import type { AgentSession } from "@mbe/types";
 import type { sessionService as SessionServiceType } from "./session.js";
+import type { SessionConcurrency } from "./session-concurrency.js";
 import { mapSdkEvent } from "./sdk-event-mapper.js";
 
 // ── Types ─────────────────────────────────────────────────────────────
 
 export interface SessionExecutorConfig {
-  maxConcurrent: number;
+  /** The single gate that owns the max-concurrent-sessions policy. */
+  concurrency: SessionConcurrency;
   sessionService: typeof SessionServiceType;
 }
 
@@ -25,7 +27,9 @@ export interface SessionExecutor {
 // ── Factory ───────────────────────────────────────────────────────────
 
 export function createSessionExecutor(config: SessionExecutorConfig): SessionExecutor {
-  const { maxConcurrent, sessionService } = config;
+  const { concurrency, sessionService } = config;
+  // AbortControllers keyed by session id, used purely for cancellation handles.
+  // The active-slot COUNT is owned by the injected `concurrency` gate, not here.
   const activeControllers = new Map<string, AbortController>();
 
   function getRepoPath(): string {
@@ -33,13 +37,16 @@ export function createSessionExecutor(config: SessionExecutorConfig): SessionExe
   }
 
   function getActiveSessionCount(): number {
-    return activeControllers.size;
+    return concurrency.activeCount();
   }
 
   async function executeSession(session: AgentSession): Promise<void> {
-    if (activeControllers.size >= maxConcurrent) {
+    // Atomic check-and-reserve through the single gate. A slot freed elsewhere
+    // (e.g. the liveness monitor cancelling a stale session) can be claimed
+    // here exactly once — no over-subscription.
+    if (!concurrency.acquire(session.id)) {
       await sessionService.updateStatus(session.id, "FAILED", {
-        errors: [`Max concurrent sessions (${maxConcurrent}) reached`],
+        errors: [`Max concurrent sessions (${concurrency.limit}) reached`],
       });
       return;
     }
@@ -107,6 +114,7 @@ export function createSessionExecutor(config: SessionExecutorConfig): SessionExe
       });
     } finally {
       activeControllers.delete(session.id);
+      concurrency.release(session.id);
     }
   }
 
@@ -118,6 +126,7 @@ export function createSessionExecutor(config: SessionExecutorConfig): SessionExe
 
     controller.abort();
     activeControllers.delete(sessionId);
+    concurrency.release(sessionId);
 
     await sessionService.updateStatus(sessionId, "CANCELLED", {
       errors: ["Cancelled by user"],
@@ -136,9 +145,10 @@ export function createSessionExecutor(config: SessionExecutorConfig): SessionExe
 // ── Default instance (backward-compat module-level exports) ───────────
 
 import { sessionService } from "./session.js";
+import { defaultConcurrency } from "./session-concurrency.js";
 
 const _defaultExecutor = createSessionExecutor({
-  maxConcurrent: parseInt(process.env.MAX_CONCURRENT_SESSIONS ?? "5", 10),
+  concurrency: defaultConcurrency,
   sessionService,
 });
 

--- a/services/agent/src/services/session.test.ts
+++ b/services/agent/src/services/session.test.ts
@@ -25,9 +25,16 @@ vi.mock("./session-executor.js", () => ({
   getActiveSessionCount: vi.fn().mockReturnValue(0),
 }));
 
+vi.mock("./session-concurrency.js", () => ({
+  defaultConcurrency: {
+    canStart: vi.fn().mockReturnValue(true),
+  },
+}));
+
 import { prisma } from "./database.js";
 import { sessionService } from "./session.js";
-import { executeSession, getActiveSessionCount } from "./session-executor.js";
+import { executeSession } from "./session-executor.js";
+import { defaultConcurrency } from "./session-concurrency.js";
 
 const baseDate = new Date("2026-03-01T12:00:00Z");
 
@@ -253,7 +260,7 @@ describe("sessionService", () => {
 
   describe("triggerSession", () => {
     beforeEach(() => {
-      vi.mocked(getActiveSessionCount).mockReturnValue(0);
+      vi.mocked(defaultConcurrency.canStart).mockReturnValue(true);
     });
 
     it("creates session, dispatches execution, returns accepted=true", async () => {
@@ -284,7 +291,7 @@ describe("sessionService", () => {
     });
 
     it("returns accepted=false when concurrency cap is hit", async () => {
-      vi.mocked(getActiveSessionCount).mockReturnValue(5);
+      vi.mocked(defaultConcurrency.canStart).mockReturnValue(false);
 
       const result = await sessionService.triggerSession({
         taskDescription: "Another task",

--- a/services/agent/src/services/session.ts
+++ b/services/agent/src/services/session.ts
@@ -3,6 +3,7 @@ import type { AgentSession, AgentSessionEvent, Pagination } from "@mbe/types";
 import { paginate, toPaginationMeta, isPrismaNotFound } from "@mbe/database";
 import { prisma } from "./database.js";
 import { getSessionEventEmitter } from "./session-event-emitter.js";
+import { defaultConcurrency } from "./session-concurrency.js";
 
 function mapPrismaSession(session: Session): AgentSession {
   return {
@@ -65,8 +66,6 @@ export interface TriggerSessionResult {
   accepted: boolean;
 }
 
-const MAX_CONCURRENT = parseInt(process.env.MAX_CONCURRENT_SESSIONS ?? "5", 10);
-
 export const sessionService = {
   async list(options: ListOptions): Promise<{ data: AgentSession[]; pagination: Pagination }> {
     const { page, limit, status } = options;
@@ -118,9 +117,12 @@ export const sessionService = {
   },
 
   async triggerSession(opts: TriggerSessionOptions): Promise<TriggerSessionResult> {
-    const { executeSession, getActiveSessionCount } = await import("./session-executor.js");
+    const { executeSession } = await import("./session-executor.js");
 
-    if (getActiveSessionCount() >= MAX_CONCURRENT) {
+    // Early-reject through the single concurrency gate so we never create a DB
+    // row for a session that can't start. The executor performs the atomic
+    // acquire(); this check just avoids the wasted write on an obvious reject.
+    if (!defaultConcurrency.canStart()) {
       return { session: null, accepted: false };
     }
 


### PR DESCRIPTION
Closes #2079

## What changed

`MAX_CONCURRENT_SESSIONS` was parsed from env in **three** places (the create route, `triggerSession` in the session service, and the session executor), with the active count tracked separately in the executor's `activeControllers` map — three modules co-owning one policy, none owning it.

This introduces a single **`SessionConcurrency`** module (`services/agent/src/services/session-concurrency.ts`) that owns both the limit and the set of active session ids, exposing an atomic `canStart` / `acquire` / `release` interface.

### Seam design
- **One parse site.** `resolveConcurrencyLimit()` reads the env exactly once, frozen into a shared `defaultConcurrency` instance at module load. No env parsing remains in routes/services.
- **Executor delegates the gate.** `executeSession` now calls `concurrency.acquire(id)` (atomic check-and-reserve) and `release()` on completion/cancel. `activeControllers` holds only abort handles now, not the count; `getActiveSessionCount()` reads `concurrency.activeCount()`.
- **Route + triggerSession delegate too.** `triggerSession` early-rejects via `canStart()` (avoids a wasted DB write); the 429 route reports the limit from the same gate.
- **Monitor shares the count.** The liveness monitor frees slots through `cancelSession → concurrency.release`, so monitor-cancel and route-admit go through one atomic count.

## How the race is tested
`session-concurrency.test.ts` injects `limit = 2` and proves: admit up to limit, reject at capacity, re-admit after release. The over-subscription test models the monitor-cancels-then-route-admits path: with 2 slots full, a `release()` frees exactly one slot, the first `acquire()` wins, the second is rejected — the freed slot is re-used exactly once, never double-spent. `acquire` is also idempotent per id (no double-count).

## Gate results (agent service)
- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` ✅ 292 passed (27 files)
- `check-adr` ✅ / `check-deps` ✅
- `pnpm regen` ✅ (root + services/agent llms artifacts staged; no other drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)