### PR TITLE
chore: weekly CLAUDE.md maintenance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,9 +128,7 @@ Managed at https://claude.ai/code/scheduled
 
 ## Dispatching Worktree Agents
 
-When spawning subagents with `isolation: "worktree"`, always include `pnpm install --frozen-lockfile` as the first step in the agent prompt. Worktrees are bare checkouts without `node_modules` — without this, every `vitest`/`pnpm test`/`pnpm build` call fails with `command not found`. The retry cost of a failed agent (wasted tokens + time) far exceeds the 15s install step.
-
-**Agents must run `pnpm typecheck` on affected packages before declaring done.** Vitest does not typecheck — tests can pass with completely wrong mock shapes (wrong property names, missing required fields). This has broken CI on main repeatedly. Always include typecheck verification in agent prompts.
+Worktrees are bare checkouts without `node_modules`. Always include `pnpm install --frozen-lockfile` as the first step in agent prompts, and run `pnpm typecheck` before declaring done. See [gotchas.md#build--pnpm--turbo](./.claude/rules/gotchas.md) for recurring agent failure patterns.
 
 ---
 


### PR DESCRIPTION
## Summary

Weekly CLAUDE.md maintenance completed.

### Changes Made

- **Consolidated duplicate guidance:** Removed verbose explanation of `pnpm install` and `pnpm typecheck` requirements from CLAUDE.md's "Dispatching Worktree Agents" section and pointed to `.claude/rules/gotchas.md` for authoritative details.
- **Line count reduction:** CLAUDE.md reduced from 258 to 256 lines (still above 200-line target, but content is critical for agent behavior).

### Audit Results

**Reflections review:** Checked all entries in `docs/reflections/*.md`:
- 2026-04-25-actionable-reports-beat-comprehensive-ones.md: findings already incorporated into `scripts/acmm/outputs/report.js`
- 2026-04-25-batch-when-honest-and-coherent.md: findings already incorporated into `docs/acmm.md`
- 2026-04-25-trust-live-audit-output.md: specific to ACMM workflow, not actionable for CLAUDE.md

**Deduplication check:** Found and consolidated one instance of duplicate guidance (worktree agent patterns). No contradictions or stale entries identified.

**Organization check:** 
- CLAUDE.md: 256 lines (status: ⚠️ still slightly over 200-line target, but minimal duplication removed)
- `.claude/rules/gotchas.md`: 69 lines (status: ✅ current and organized)
- No new sections added to CLAUDE.md; only consolidated existing content

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01AzdJjfkfw6Rik7Kmmsa968)_