### PR TITLE
docs: document scheduled cloud routines (+ weekly/monthly improvement triggers)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,15 +114,19 @@ mbe up                                           # Start dev servers
 
 Managed at https://claude.ai/code/scheduled
 
-| Trigger             | Schedule (PT)                                                     |
-| ------------------- | ----------------------------------------------------------------- |
-| `mbe-deep-audit`    | Mon 8:23am (weekly full site audit)                               |
-| `mbe-morning`       | Daily 9:03am (light audit + ACMM audit + issue-worker)            |
-| `mbe-midday`        | Daily 1:07pm (issue-worker + CI monitor)                          |
-| `mbe-evening`       | Daily 5:11pm (issue-worker + progress-tracker)                    |
-| `mbe-learning-loop` | Daily 11:00am (sensor report → verify fixes → triage regressions) |
+| Trigger                  | Schedule (PT)                                                                   |
+| ------------------------ | ------------------------------------------------------------------------------- |
+| `mbe-deep-audit`         | Mon 8:23am (weekly full site audit)                                             |
+| `mbe-morning`            | Daily 9:03am (light audit + ACMM audit + issue-worker)                          |
+| `mbe-midday`             | Daily 1:07pm (issue-worker + CI monitor)                                        |
+| `mbe-evening`            | Daily 5:11pm (issue-worker + progress-tracker)                                  |
+| `mbe-learning-loop`      | Daily 11:00am (sensor report → verify fixes → triage regressions)               |
+| `mbe-weekly-improve`     | Fri 7:00am (improve + improve-codebase-architecture → 1 PR + `ready` issues)    |
+| `mbe-monthly-meta-audit` | 1st of month 7:00am (claude-md-improver + claude-automation-recommender → 1 PR) |
 
-> **Max 5x plan**: 5 scheduled runs/day. The above fits exactly. `mbe-deep-audit` only fires Mon so Tue-Sun has 4 daily runs + headroom.
+> **Max 5x plan**: 5 scheduled runs/day. Daily baseline is 4 (`mbe-morning`/`midday`/`evening`/`learning-loop`). The weekly/occasional triggers add a 5th run on their day: `mbe-deep-audit` (Mon), `mbe-weekly-improve` (Fri). `mbe-monthly-meta-audit` adds one run on the 1st of each month and may briefly hit 6 runs if the 1st lands on a Mon/Fri — acceptable, or shift its date if throttled.
+
+> **Full catalog + prompts:** [docs/scheduled-tasks.md](./docs/scheduled-tasks.md).
 
 ---
 

--- a/docs/scheduled-tasks.md
+++ b/docs/scheduled-tasks.md
@@ -1,0 +1,78 @@
+# Scheduled Tasks (Cloud Routines)
+
+This repo is maintained partly by **scheduled cloud agents** — isolated Claude Code
+sessions that run on a cron schedule in Anthropic's cloud (CCR), each with its own
+git checkout. They are distinct from local `/loop` sessions: cloud routines keep
+running after you close your terminal, and they push to **PRs for review** rather
+than auto-merging.
+
+- **Manage / disable / inspect:** https://claude.ai/code/routines
+- **Create or edit from the CLI:** the `/schedule` skill (uses the `RemoteTrigger` tool).
+- Routines **cannot be deleted via the API** — disable them in the web UI.
+
+All times below are **America/Los_Angeles (PT)**; cron expressions are stored in UTC.
+
+## Routine catalog
+
+| Routine                  | Cadence (PT)        | Cron (UTC)   | Output                | Purpose                                                 |
+| ------------------------ | ------------------- | ------------ | --------------------- | ------------------------------------------------------- |
+| `mbe-deep-audit`         | Mon 8:23am          | —            | issues                | Weekly full site audit (Playwright + Lighthouse)        |
+| `mbe-morning`            | Daily 9:03am        | —            | issues / PRs          | Light site audit + ACMM audit + issue-worker            |
+| `mbe-learning-loop`      | Daily 11:00am       | —            | issues                | Sensor report → verify past fixes → triage regressions  |
+| `mbe-midday`             | Daily 1:07pm        | —            | PRs                   | issue-worker + CI monitor                               |
+| `mbe-evening`            | Daily 5:11pm        | —            | PRs / metrics         | issue-worker + progress-tracker                         |
+| `mbe-weekly-improve`     | Fri 7:00am          | `0 14 * * 5` | 1 PR + `ready` issues | Codebase improvement survey → implement the best change |
+| `mbe-monthly-meta-audit` | 1st of month 7:00am | `0 14 1 * *` | 1 PR + `ready` issues | Claude Code config + docs/automation health             |
+
+> The legacy `mbe-*` audit/worker triggers are managed in the claude.ai UI and
+> their exact prompts live there. The two improvement routines below were created
+> via `/schedule` and their prompts are reproduced here so they can be reviewed and
+> version-controlled.
+
+## `mbe-weekly-improve`
+
+- **When:** every Friday 7:00am PT (`0 14 * * 5` UTC). Friday is the documented
+  highest-token-headroom day.
+- **What it does:** runs the `improve` and `improve-codebase-architecture` skills (or
+  the equivalent analysis if the skills aren't present in the cloud checkout),
+  synthesizes a prioritized findings list, then:
+  1. Implements the **single most useful, reasonably-sized** change (Small/Medium,
+     low-risk, high-value) via TDD + full gates, and opens **one PR** targeting `main`.
+  2. Files the remaining strong findings as GitHub issues labeled `ready` (with
+     self-contained acceptance criteria) so `/implement-queue` can drain them.
+- **Does not merge.** Every change lands as a reviewable PR.
+
+## `mbe-monthly-meta-audit`
+
+- **When:** the 1st of each month 7:00am PT (`0 14 1 * *` UTC).
+  > "First Friday" was requested, but standard cron can't reliably express it
+  > (day-of-month + day-of-week is OR-semantics), so this uses the 1st of the month.
+  > Adjust in the web UI if a Friday cadence is preferred.
+- **What it does:** runs the `claude-md-improver` and `claude-automation-recommender`
+  skills (or the equivalent analysis), then opens **one PR** for the best doc/automation
+  improvement and files `ready` issues for the rest. Targets Claude Code config quality:
+  stale CLAUDE.md references, missing guidance, and worthwhile new hooks/agents/skills.
+- **Does not merge.**
+
+## Plan budget (Max 5x)
+
+The Max 5x plan allows ~5 scheduled runs/day. The **daily** baseline is 4 runs
+(`mbe-morning`, `mbe-midday`, `mbe-evening`, `mbe-learning-loop`). Weekly/occasional
+triggers add a 5th run on their day:
+
+- Mon: + `mbe-deep-audit` → 5
+- Fri: + `mbe-weekly-improve` → 5
+- 1st of month: + `mbe-monthly-meta-audit` → 5 (or briefly 6 if the 1st is a Mon/Fri)
+
+The rare 6-run overlap is acceptable; if it causes throttling, shift
+`mbe-monthly-meta-audit` to a mid-month date in the web UI.
+
+## Editing a routine
+
+```text
+/schedule          # then: "list routines", "update mbe-weekly-improve to ...", etc.
+```
+
+Or call the `RemoteTrigger` tool directly (`action: list|get|create|update|run`).
+Each routine's prompt is self-contained — the cloud agent starts with **zero context**,
+so any behavior change must be made in the prompt itself.


### PR DESCRIPTION
## What

Documents the repo's scheduled cloud routines and the two new improvement triggers I created via `/schedule`:

- **`mbe-weekly-improve`** — Fri 7am PT (`0 14 * * 5`): runs `improve` + `improve-codebase-architecture`, opens **1 PR** for the best reasonably-sized change, files `ready` issues for the rest.
- **`mbe-monthly-meta-audit`** — 1st of month 7am PT (`0 14 1 * *`): runs `claude-md-improver` + `claude-automation-recommender`, opens **1 PR** + `ready` issues.

## Changes

- New `docs/scheduled-tasks.md` — full routine catalog, the two new routines' self-contained prompts, plan-budget math, and how to edit routines.
- `CLAUDE.md` RemoteTriggers table + Max-5x note updated to include both new triggers.

## Notes

- Routines are live now (created via RemoteTrigger API). Manage at https://claude.ai/code/routines.
- "First Friday" for the monthly was switched to **1st of month** because standard cron can't reliably express first-Friday (DOM+DOW is OR-semantics). Documented + adjustable in the UI.

Docs-only; no code paths touched.