### PR TITLE
feat(eval): TaskScorer LLM-judge layer (reuse success-evaluator)

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2510,7 +2510,7 @@
       for (const task of selected) {
         try {
           const runResult = await opts.runTask(task);
-          scores.push(scoreTask(runResult));
+          scores.push(await scoreTask(runResult));
         } catch (err) {
           scores.push(failedScore(task, err));
         }
@@ -2563,7 +2563,7 @@
     }
   </file>
   <file path="packages/agent-core/src/eval/task-scorer.ts">
-    export function scoreTask(run: TaskRunResult): TaskScore {
+    export async function scoreTask(run: TaskRunResult, judge?: JudgeFunction): Promise<TaskScore> {
       const { task, session, checks } = run;
       const { rubric } = task;
     
@@ -2573,6 +2573,14 @@
       if (rubric.lintMustPass) signals.push(checks.lintPass);
       // Budget is always an applicable signal.
       signals.push(checks.withinBudget);
+    
+      // LLM-judge signals — only when criteria are specified and a judge is injected.
+      let judgeResult: TaskScore["judgeResult"];
+      if (rubric.judgeCriteria.length > 0 && judge !== undefined) {
+        const criteria = rubric.judgeCriteria.join("\n");
+        judgeResult = await judge(task.prompt, criteria);
+        signals.push(judgeResult.passed);
+      }
     
       const satisfied = signals.filter(Boolean).length;
       const score = signals.length === 0 ? 0 : satisfied / signals.length;
@@ -2584,6 +2592,7 @@
         passed,
         score,
         deterministic: checks,
+        judgeResult,
         selfEvaluation: session.evaluation,
         costUsd: session.costUsd,
         turns: session.numTurns,
@@ -14943,7 +14952,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14952,18 +14952,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms.txt
+++ b/llms.txt
@@ -771,7 +771,7 @@
   </file>
   <file path="packages/agent-core/src/eval/task-scorer.ts">
     <item priority="high">
-      export function scoreTask(run: TaskRunResult): TaskScore { /* ... */ }
+      export async function scoreTask(run: TaskRunResult, judge?: JudgeFunction): Promise<TaskScore> { /* ... */ }
     </item>
   </file>
   <file path="packages/agent-core/src/eval/types.ts">

--- a/packages/agent-core/llms-full.txt
+++ b/packages/agent-core/llms-full.txt
@@ -376,7 +376,7 @@
       for (const task of selected) {
         try {
           const runResult = await opts.runTask(task);
-          scores.push(scoreTask(runResult));
+          scores.push(await scoreTask(runResult));
         } catch (err) {
           scores.push(failedScore(task, err));
         }
@@ -429,7 +429,7 @@
     }
   </file>
   <file path="src/eval/task-scorer.ts">
-    export function scoreTask(run: TaskRunResult): TaskScore {
+    export async function scoreTask(run: TaskRunResult, judge?: JudgeFunction): Promise<TaskScore> {
       const { task, session, checks } = run;
       const { rubric } = task;
     
@@ -439,6 +439,14 @@
       if (rubric.lintMustPass) signals.push(checks.lintPass);
       // Budget is always an applicable signal.
       signals.push(checks.withinBudget);
+    
+      // LLM-judge signals — only when criteria are specified and a judge is injected.
+      let judgeResult: TaskScore["judgeResult"];
+      if (rubric.judgeCriteria.length > 0 && judge !== undefined) {
+        const criteria = rubric.judgeCriteria.join("\n");
+        judgeResult = await judge(task.prompt, criteria);
+        signals.push(judgeResult.passed);
+      }
     
       const satisfied = signals.filter(Boolean).length;
       const score = signals.length === 0 ? 0 : satisfied / signals.length;
@@ -450,6 +458,7 @@
         passed,
         score,
         deterministic: checks,
+        judgeResult,
         selfEvaluation: session.evaluation,
         costUsd: session.costUsd,
         turns: session.numTurns,

--- a/packages/agent-core/llms.txt
+++ b/packages/agent-core/llms.txt
@@ -76,7 +76,7 @@
   </file>
   <file path="src/eval/task-scorer.ts">
     <item priority="high">
-      export function scoreTask(run: TaskRunResult): TaskScore { /* ... */ }
+      export async function scoreTask(run: TaskRunResult, judge?: JudgeFunction): Promise<TaskScore> { /* ... */ }
     </item>
   </file>
   <file path="src/eval/types.ts">

--- a/packages/agent-core/src/eval/eval-harness.ts
+++ b/packages/agent-core/src/eval/eval-harness.ts
@@ -26,7 +26,7 @@ export async function runEvalSuite(
   for (const task of selected) {
     try {
       const runResult = await opts.runTask(task);
-      scores.push(scoreTask(runResult));
+      scores.push(await scoreTask(runResult));
     } catch (err) {
       scores.push(failedScore(task, err));
     }

--- a/packages/agent-core/src/eval/task-scorer.test.ts
+++ b/packages/agent-core/src/eval/task-scorer.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { scoreTask } from "./task-scorer.js";
-import type { DeterministicChecks, Task, TaskRunResult } from "./types.js";
+import type { DeterministicChecks, JudgeFunction, Task, TaskRunResult } from "./types.js";
 import type { SessionResult } from "../types.js";
 
 function makeTask(overrides: Partial<Task> = {}): Task {
@@ -51,27 +51,27 @@ const ALL_PASS: DeterministicChecks = {
   withinBudget: true,
 };
 
-describe("scoreTask", () => {
-  it("passes and scores 1 when all applicable signals hold", () => {
-    const score = scoreTask(makeRun(ALL_PASS));
+describe("scoreTask — deterministic only (no judgeCriteria)", () => {
+  it("passes and scores 1 when all applicable signals hold", async () => {
+    const score = await scoreTask(makeRun(ALL_PASS));
     expect(score.passed).toBe(true);
     expect(score.score).toBe(1);
   });
 
-  it("fails when a required signal (tests) is false", () => {
-    const score = scoreTask(makeRun({ ...ALL_PASS, testsPass: false }));
+  it("fails when a required signal (tests) is false", async () => {
+    const score = await scoreTask(makeRun({ ...ALL_PASS, testsPass: false }));
     expect(score.passed).toBe(false);
     expect(score.score).toBeLessThan(1);
   });
 
-  it("ignores lint when rubric.lintMustPass is false", () => {
+  it("ignores lint when rubric.lintMustPass is false", async () => {
     // lint failing but not required → still passes (tests, typecheck, budget hold)
-    const score = scoreTask(makeRun({ ...ALL_PASS, lintPass: false }));
+    const score = await scoreTask(makeRun({ ...ALL_PASS, lintPass: false }));
     expect(score.passed).toBe(true);
     expect(score.score).toBe(1);
   });
 
-  it("counts lint when rubric.lintMustPass is true", () => {
+  it("counts lint when rubric.lintMustPass is true", async () => {
     const task = makeTask({
       rubric: {
         testsMustPass: true,
@@ -80,26 +80,153 @@ describe("scoreTask", () => {
         judgeCriteria: [],
       },
     });
-    const score = scoreTask(makeRun({ ...ALL_PASS, lintPass: false }, task));
+    const score = await scoreTask(makeRun({ ...ALL_PASS, lintPass: false }, task));
     expect(score.passed).toBe(false);
     // 3 of 4 applicable signals satisfied (tests, typecheck, budget) — lint failed
     expect(score.score).toBeCloseTo(3 / 4);
   });
 
-  it("budget is always an applicable signal", () => {
-    const score = scoreTask(makeRun({ ...ALL_PASS, withinBudget: false }));
+  it("budget is always an applicable signal", async () => {
+    const score = await scoreTask(makeRun({ ...ALL_PASS, withinBudget: false }));
     expect(score.passed).toBe(false);
   });
 
-  it("carries cost, turns, and self-evaluation through for calibration", () => {
+  it("carries cost, turns, and self-evaluation through for calibration", async () => {
     const session = makeSession({
       costUsd: 0.5,
       numTurns: 12,
       evaluation: { passed: true, confidence: 0.9, reasoning: "looks good" },
     });
-    const score = scoreTask(makeRun(ALL_PASS, makeTask(), session));
+    const score = await scoreTask(makeRun(ALL_PASS, makeTask(), session));
     expect(score.costUsd).toBe(0.5);
     expect(score.turns).toBe(12);
     expect(score.selfEvaluation?.confidence).toBe(0.9);
+  });
+});
+
+describe("scoreTask — LLM judge (stubbed via JudgeFunction seam)", () => {
+  const passingJudge: JudgeFunction = vi.fn().mockResolvedValue({
+    passed: true,
+    confidence: 0.9,
+    reasoning: "change solves the task",
+    issues: [],
+  });
+
+  const failingJudge: JudgeFunction = vi.fn().mockResolvedValue({
+    passed: false,
+    confidence: 0.85,
+    reasoning: "change does not address the task",
+    issues: ["Missing implementation"],
+  });
+
+  it("does NOT invoke judge when judgeCriteria is empty", async () => {
+    const judge = vi.fn();
+    await scoreTask(makeRun(ALL_PASS), judge);
+    expect(judge).not.toHaveBeenCalled();
+  });
+
+  it("invokes judge when rubric has judgeCriteria", async () => {
+    const task = makeTask({
+      rubric: {
+        testsMustPass: true,
+        typecheckMustPass: true,
+        lintMustPass: false,
+        judgeCriteria: ["change actually fixes the reported bug"],
+      },
+    });
+    const judge: JudgeFunction = vi.fn().mockResolvedValue({
+      passed: true,
+      confidence: 0.9,
+      reasoning: "ok",
+      issues: [],
+    });
+    await scoreTask(makeRun(ALL_PASS, task), judge);
+    expect(judge).toHaveBeenCalledOnce();
+    expect(judge).toHaveBeenCalledWith(
+      task.prompt,
+      expect.stringContaining("change actually fixes the reported bug")
+    );
+  });
+
+  it("combines passing judge with passing deterministic → score 1, passed true", async () => {
+    const task = makeTask({
+      rubric: {
+        testsMustPass: true,
+        typecheckMustPass: true,
+        lintMustPass: false,
+        judgeCriteria: ["fix is correct"],
+      },
+    });
+    const score = await scoreTask(makeRun(ALL_PASS, task), passingJudge);
+    expect(score.passed).toBe(true);
+    expect(score.score).toBe(1);
+    expect(score.judgeResult?.passed).toBe(true);
+  });
+
+  it("combines failing judge with passing deterministic → passed false", async () => {
+    const task = makeTask({
+      rubric: {
+        testsMustPass: true,
+        typecheckMustPass: true,
+        lintMustPass: false,
+        judgeCriteria: ["fix is correct"],
+      },
+    });
+    const score = await scoreTask(makeRun(ALL_PASS, task), failingJudge);
+    expect(score.passed).toBe(false);
+    // 3 deterministic pass + 1 judge fails → 3/4
+    expect(score.score).toBeCloseTo(3 / 4);
+    expect(score.judgeResult?.passed).toBe(false);
+    expect(score.judgeResult?.reasoning).toMatch(/does not address/);
+  });
+
+  it("combines passing judge with failing deterministic → passed false", async () => {
+    const task = makeTask({
+      rubric: {
+        testsMustPass: true,
+        typecheckMustPass: true,
+        lintMustPass: false,
+        judgeCriteria: ["fix is correct"],
+      },
+    });
+    const score = await scoreTask(makeRun({ ...ALL_PASS, testsPass: false }, task), passingJudge);
+    expect(score.passed).toBe(false);
+    // tests fail (1/4 deterministic applicable), judge passes → 3/4
+    expect(score.score).toBeCloseTo(3 / 4);
+  });
+
+  it("attaches judgeResult to TaskScore when judge runs", async () => {
+    const task = makeTask({
+      rubric: {
+        testsMustPass: true,
+        typecheckMustPass: true,
+        lintMustPass: false,
+        judgeCriteria: ["fix is correct"],
+      },
+    });
+    const score = await scoreTask(makeRun(ALL_PASS, task), passingJudge);
+    expect(score.judgeResult).toBeDefined();
+    expect(score.judgeResult?.confidence).toBe(0.9);
+  });
+
+  it("does NOT attach judgeResult when no judgeCriteria", async () => {
+    const score = await scoreTask(makeRun(ALL_PASS));
+    expect(score.judgeResult).toBeUndefined();
+  });
+
+  it("treats judge as passed when no judge function provided but judgeCriteria present", async () => {
+    // No judge passed — should default to passing (don't block deterministic tasks)
+    const task = makeTask({
+      rubric: {
+        testsMustPass: true,
+        typecheckMustPass: true,
+        lintMustPass: false,
+        judgeCriteria: ["fix is correct"],
+      },
+    });
+    const score = await scoreTask(makeRun(ALL_PASS, task));
+    // judge not provided, criteria ignored → pure deterministic scoring
+    expect(score.passed).toBe(true);
+    expect(score.judgeResult).toBeUndefined();
   });
 });

--- a/packages/agent-core/src/eval/task-scorer.ts
+++ b/packages/agent-core/src/eval/task-scorer.ts
@@ -1,15 +1,18 @@
-import type { TaskRunResult, TaskScore } from "./types.js";
+import type { JudgeFunction, TaskRunResult, TaskScore } from "./types.js";
 
 /**
- * Scores a single task run against its rubric using deterministic signals only.
+ * Scores a single task run against its rubric.
  *
- * (The LLM-judge half — for rubric `judgeCriteria` a deterministic check can't
- * express — is added in a later slice and folded into `score`/`passed` here.)
+ * Deterministic signals (tests, typecheck, lint, budget) are always applied.
+ * When the rubric has `judgeCriteria` AND a `judge` function is provided, the
+ * LLM judge is invoked and its pass/fail outcome is added as one additional
+ * signal — keeping the judge isolated behind an injectable seam so tests
+ * can stub it without live LLM calls.
  *
- * `score` is the fraction of *applicable* rubric signals that were satisfied;
+ * `score` is the fraction of *applicable* signals that were satisfied;
  * `passed` requires every applicable signal to hold.
  */
-export function scoreTask(run: TaskRunResult): TaskScore {
+export async function scoreTask(run: TaskRunResult, judge?: JudgeFunction): Promise<TaskScore> {
   const { task, session, checks } = run;
   const { rubric } = task;
 
@@ -19,6 +22,14 @@ export function scoreTask(run: TaskRunResult): TaskScore {
   if (rubric.lintMustPass) signals.push(checks.lintPass);
   // Budget is always an applicable signal.
   signals.push(checks.withinBudget);
+
+  // LLM-judge signals — only when criteria are specified and a judge is injected.
+  let judgeResult: TaskScore["judgeResult"];
+  if (rubric.judgeCriteria.length > 0 && judge !== undefined) {
+    const criteria = rubric.judgeCriteria.join("\n");
+    judgeResult = await judge(task.prompt, criteria);
+    signals.push(judgeResult.passed);
+  }
 
   const satisfied = signals.filter(Boolean).length;
   const score = signals.length === 0 ? 0 : satisfied / signals.length;
@@ -30,6 +41,7 @@ export function scoreTask(run: TaskRunResult): TaskScore {
     passed,
     score,
     deterministic: checks,
+    judgeResult,
     selfEvaluation: session.evaluation,
     costUsd: session.costUsd,
     turns: session.numTurns,

--- a/packages/agent-core/src/eval/types.ts
+++ b/packages/agent-core/src/eval/types.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { SessionResult } from "../types.js";
+import type { EvaluationResult } from "../success-evaluator.js";
 
 /**
  * Golden-task eval harness types.
@@ -84,6 +85,8 @@ export interface TaskScore {
   readonly deterministic: DeterministicChecks;
   /** Self-reported agent evaluation, when present — used for calibration. */
   readonly selfEvaluation?: SessionResult["evaluation"];
+  /** LLM-judge result, present when `rubric.judgeCriteria` is non-empty and a judge was provided. */
+  readonly judgeResult?: EvaluationResult;
   readonly costUsd: number;
   readonly turns: number;
   /** Set when the task crashed mid-run rather than completing. */
@@ -107,3 +110,15 @@ export interface EvalReport {
 
 /** Injected agent-invocation seam. Real impl runs `runSession` + checks; tests stub it. */
 export type TaskRunner = (task: Task) => Promise<TaskRunResult>;
+
+/**
+ * Injectable LLM-judge seam for `scoreTask`.
+ *
+ * Receives the task prompt and a concatenated string of all rubric
+ * `judgeCriteria`; returns an {@link EvaluationResult}.  Tests stub this
+ * instead of making live LLM calls.
+ *
+ * Production implementations delegate to {@link evaluateSuccess} from
+ * `success-evaluator.ts`.
+ */
+export type JudgeFunction = (taskPrompt: string, criteria: string) => Promise<EvaluationResult>;

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -338,6 +338,7 @@ export type {
   TaskRunResult,
   TaskScore,
   TaskRunner,
+  JudgeFunction,
   EvalAggregate,
   EvalReport,
 } from "./eval/types.js";

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,18 +337,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,7 +337,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),


### PR DESCRIPTION
## Summary

- Adds `JudgeFunction` injectable seam to `scoreTask` — isolates LLM judge behind an interface so tests stub it with no live LLM calls
- Reuses `EvaluationResult` from `success-evaluator.ts` as the judge return type — no second grader built
- `scoreTask` is now async and folds judge pass/fail as one additional signal into the combined `score` and `passed` on `TaskScore`
- `judgeResult?: EvaluationResult` is added to `TaskScore` for observability/calibration
- Judge is only invoked when `rubric.judgeCriteria` is non-empty AND a `judge` function is passed — zero overhead for deterministic-only tasks
- `eval-harness.ts` updated to `await scoreTask()`
- `JudgeFunction` exported from `index.ts`

## Test plan

- [x] 14 unit tests in `task-scorer.test.ts` (all GREEN): covers judged+deterministic combinations, stub verification, no-judge fallback, judgeResult attachment
- [x] `pnpm --dir packages/agent-core lint` — clean
- [x] `pnpm --dir packages/agent-core typecheck` — clean
- [x] `pnpm --dir packages/agent-core test` — 1243 tests passed
- [x] `pnpm --filter @mbe/cli start check-adr` — no violations
- [x] `pnpm --filter @mbe/cli start check-deps` — clean
- [x] `pnpm regen` — llms.txt artifacts regenerated and staged
- [x] `node scripts/detect-instruction-rot.mjs` — no rot detected

Closes #1945