### PR TITLE
feat(eval): EvaluatorCalibration — self-grade vs ground-truth bucketed accuracy

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1122,6 +1122,7 @@
       .option("-m, --model <model>", "Model to run the agent with", DEFAULT_SESSION_CONFIG.model)
       .option("--json", "Emit the EvalReport as JSON", false)
       .option("--threshold <pct>", "Exit non-zero if suite pass rate is below this percent")
+      .option("--calibrate", "Print self-grade vs ground-truth calibration summary", false)
       .action(
         async (options: {
           suite: string;
@@ -1129,6 +1130,7 @@
           model: string;
           json: boolean;
           threshold?: string;
+          calibrate: boolean;
         }) => {
           const repoPath = resolve(process.cwd());
           const suiteDir = resolve(repoPath, options.suite);
@@ -1155,6 +1157,10 @@
             console.log(JSON.stringify(report, null, 2));
           } else {
             printReport(report);
+          }
+    
+          if (options.calibrate) {
+            printCalibration(calibrate(report));
           }
     
           if (options.threshold !== undefined) {
@@ -2491,6 +2497,23 @@
   </file>
   </section>
   <section priority="medium" role="eval">
+  <file path="packages/agent-core/src/eval/calibrate.ts">
+    export interface CalibrationBucket {
+      /** Number of tasks in this confidence bucket (with self-evaluation). */
+      readonly count: number;
+      /** Fraction of tasks in this bucket that actually passed (ground-truth). 0 when count is 0. */
+      readonly passRate: number;
+    }
+    export interface CalibrationSummary {
+      readonly high: CalibrationBucket;
+      readonly medium: CalibrationBucket;
+      readonly low: CalibrationBucket;
+      /** Tasks that had a selfEvaluation field. */
+      readonly totalWithSelfEval: number;
+      /** Tasks that had no selfEvaluation field (not counted in any bucket). */
+      readonly totalWithoutSelfEval: number;
+    }
+  </file>
   <file path="packages/agent-core/src/eval/eval-harness.ts">
     export interface RunEvalSuiteOptions {
       /** Agent-invocation seam. Real impl runs `runSession`; tests stub it. */
@@ -14952,7 +14975,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14975,18 +14975,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms.txt
+++ b/llms.txt
@@ -746,6 +746,23 @@
   </file>
   </section>
   <section priority="medium" role="eval">
+  <file path="packages/agent-core/src/eval/calibrate.ts">
+    <item priority="low">
+      interface CalibrationBucket {
+        count: number;
+        passRate: number;
+      }
+    </item>
+    <item priority="low">
+      interface CalibrationSummary {
+        high: CalibrationBucket;
+        medium: CalibrationBucket;
+        low: CalibrationBucket;
+        totalWithSelfEval: number;
+        totalWithoutSelfEval: number;
+      }
+    </item>
+  </file>
   <file path="packages/agent-core/src/eval/eval-harness.ts">
     <item priority="low">
       interface RunEvalSuiteOptions {

--- a/metrics/ai-antipattern-baselines.json
+++ b/metrics/ai-antipattern-baselines.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-20T14:32:44.917Z",
+  "generatedAt": "2026-06-20T15:47:02.925Z",
   "patterns": {
     "magicTimeouts": {
       "count": 32,
@@ -22,7 +22,7 @@
       "description": "TypeScript `as any` casts or `: any` type annotations"
     },
     "consoleLogs": {
-      "count": 751,
+      "count": 758,
       "description": "console.log() calls in production (non-test) source files"
     },
     "unusedParams": {

--- a/packages/agent-core/llms-full.txt
+++ b/packages/agent-core/llms-full.txt
@@ -357,6 +357,23 @@
   </file>
   </section>
   <section priority="medium" role="eval">
+  <file path="src/eval/calibrate.ts">
+    export interface CalibrationBucket {
+      /** Number of tasks in this confidence bucket (with self-evaluation). */
+      readonly count: number;
+      /** Fraction of tasks in this bucket that actually passed (ground-truth). 0 when count is 0. */
+      readonly passRate: number;
+    }
+    export interface CalibrationSummary {
+      readonly high: CalibrationBucket;
+      readonly medium: CalibrationBucket;
+      readonly low: CalibrationBucket;
+      /** Tasks that had a selfEvaluation field. */
+      readonly totalWithSelfEval: number;
+      /** Tasks that had no selfEvaluation field (not counted in any bucket). */
+      readonly totalWithoutSelfEval: number;
+    }
+  </file>
   <file path="src/eval/eval-harness.ts">
     export interface RunEvalSuiteOptions {
       /** Agent-invocation seam. Real impl runs `runSession`; tests stub it. */

--- a/packages/agent-core/llms.txt
+++ b/packages/agent-core/llms.txt
@@ -51,6 +51,23 @@
   </file>
   </section>
   <section priority="medium" role="eval">
+  <file path="src/eval/calibrate.ts">
+    <item priority="low">
+      interface CalibrationBucket {
+        count: number;
+        passRate: number;
+      }
+    </item>
+    <item priority="low">
+      interface CalibrationSummary {
+        high: CalibrationBucket;
+        medium: CalibrationBucket;
+        low: CalibrationBucket;
+        totalWithSelfEval: number;
+        totalWithoutSelfEval: number;
+      }
+    </item>
+  </file>
   <file path="src/eval/eval-harness.ts">
     <item priority="low">
       interface RunEvalSuiteOptions {

--- a/packages/agent-core/src/eval/calibrate.test.ts
+++ b/packages/agent-core/src/eval/calibrate.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+import { calibrate } from "./calibrate.js";
+import type { EvalReport, TaskScore } from "./types.js";
+
+function makeScore(
+  taskId: string,
+  opts: {
+    passed: boolean;
+    confidence?: number;
+  }
+): TaskScore {
+  return {
+    taskId,
+    category: "bugfix",
+    passed: opts.passed,
+    score: opts.passed ? 1 : 0,
+    deterministic: {
+      testsPass: opts.passed,
+      typecheckPass: true,
+      lintPass: true,
+      withinBudget: true,
+    },
+    selfEvaluation:
+      opts.confidence !== undefined
+        ? { passed: opts.confidence >= 0.7, confidence: opts.confidence, reasoning: "auto" }
+        : undefined,
+    costUsd: 0.1,
+    turns: 5,
+  };
+}
+
+function makeReport(scores: TaskScore[]): EvalReport {
+  const total = scores.length;
+  const passed = scores.filter((s) => s.passed).length;
+  return {
+    runId: "test-run",
+    tasks: scores,
+    aggregate: {
+      total,
+      passRate: total === 0 ? 0 : passed / total,
+      meanScore: total === 0 ? 0 : scores.reduce((a, s) => a + s.score, 0) / total,
+      meanCostUsd: 0.1,
+      meanTurns: 5,
+      stuckCount: 0,
+    },
+  };
+}
+
+describe("calibrate", () => {
+  it("returns correct bucketed accuracy for mixed high/med/low confidence", () => {
+    const report = makeReport([
+      makeScore("t1", { passed: true, confidence: 0.9 }), // high, passed
+      makeScore("t2", { passed: true, confidence: 0.85 }), // high, passed
+      makeScore("t3", { passed: false, confidence: 0.8 }), // high, failed
+      makeScore("t4", { passed: true, confidence: 0.6 }), // med, passed
+      makeScore("t5", { passed: false, confidence: 0.5 }), // med, failed
+      makeScore("t6", { passed: false, confidence: 0.3 }), // low, failed
+    ]);
+
+    const summary = calibrate(report);
+
+    expect(summary.high.count).toBe(3);
+    expect(summary.high.passRate).toBeCloseTo(2 / 3);
+
+    expect(summary.medium.count).toBe(2);
+    expect(summary.medium.passRate).toBeCloseTo(1 / 2);
+
+    expect(summary.low.count).toBe(1);
+    expect(summary.low.passRate).toBe(0);
+
+    expect(summary.totalWithSelfEval).toBe(6);
+    expect(summary.totalWithoutSelfEval).toBe(0);
+  });
+
+  it("returns zero-counts for an empty report", () => {
+    const summary = calibrate(makeReport([]));
+    expect(summary.high.count).toBe(0);
+    expect(summary.medium.count).toBe(0);
+    expect(summary.low.count).toBe(0);
+    expect(summary.totalWithSelfEval).toBe(0);
+    expect(summary.totalWithoutSelfEval).toBe(0);
+  });
+
+  it("tracks tasks without self-evaluation separately", () => {
+    const report = makeReport([
+      makeScore("t1", { passed: true, confidence: 0.9 }),
+      makeScore("t2", { passed: true }), // no selfEvaluation
+    ]);
+
+    const summary = calibrate(report);
+
+    expect(summary.totalWithSelfEval).toBe(1);
+    expect(summary.totalWithoutSelfEval).toBe(1);
+    expect(summary.high.count).toBe(1);
+  });
+
+  it("handles all-pass report with high confidence correctly", () => {
+    const report = makeReport([
+      makeScore("t1", { passed: true, confidence: 0.9 }),
+      makeScore("t2", { passed: true, confidence: 0.95 }),
+    ]);
+
+    const summary = calibrate(report);
+
+    expect(summary.high.count).toBe(2);
+    expect(summary.high.passRate).toBe(1);
+    expect(summary.medium.count).toBe(0);
+    expect(summary.low.count).toBe(0);
+  });
+
+  it("handles all-fail report with low confidence correctly", () => {
+    const report = makeReport([
+      makeScore("t1", { passed: false, confidence: 0.2 }),
+      makeScore("t2", { passed: false, confidence: 0.3 }),
+    ]);
+
+    const summary = calibrate(report);
+
+    expect(summary.low.count).toBe(2);
+    expect(summary.low.passRate).toBe(0);
+    expect(summary.high.count).toBe(0);
+    expect(summary.medium.count).toBe(0);
+  });
+
+  it("boundary: confidence exactly 0.7 is high, exactly 0.4 is medium", () => {
+    const report = makeReport([
+      makeScore("boundary-high", { passed: true, confidence: 0.7 }),
+      makeScore("boundary-med", { passed: false, confidence: 0.4 }),
+    ]);
+
+    const summary = calibrate(report);
+
+    expect(summary.high.count).toBe(1);
+    expect(summary.medium.count).toBe(1);
+    expect(summary.low.count).toBe(0);
+  });
+
+  it("is a pure function — does not mutate the input report", () => {
+    const scores = [makeScore("t1", { passed: true, confidence: 0.9 })];
+    const report = makeReport(scores);
+    const tasksBefore = report.tasks;
+
+    calibrate(report);
+
+    expect(report.tasks).toBe(tasksBefore);
+  });
+});

--- a/packages/agent-core/src/eval/calibrate.ts
+++ b/packages/agent-core/src/eval/calibrate.ts
@@ -1,0 +1,84 @@
+import type { EvalReport } from "./types.js";
+
+/** Confidence thresholds for bucketing self-evaluation confidence scores. */
+const HIGH_THRESHOLD = 0.7;
+const MEDIUM_THRESHOLD = 0.4;
+
+/** Per-bucket calibration data: how many tasks fell in this bucket and their actual pass rate. */
+export interface CalibrationBucket {
+  /** Number of tasks in this confidence bucket (with self-evaluation). */
+  readonly count: number;
+  /** Fraction of tasks in this bucket that actually passed (ground-truth). 0 when count is 0. */
+  readonly passRate: number;
+}
+
+/**
+ * Calibration summary: bucketed accuracy of the agent's self-reported confidence
+ * vs the harness ground-truth pass/fail outcome.
+ *
+ * Buckets:
+ *   high:   confidence >= 0.7
+ *   medium: 0.4 <= confidence < 0.7
+ *   low:    confidence < 0.4
+ */
+export interface CalibrationSummary {
+  readonly high: CalibrationBucket;
+  readonly medium: CalibrationBucket;
+  readonly low: CalibrationBucket;
+  /** Tasks that had a selfEvaluation field. */
+  readonly totalWithSelfEval: number;
+  /** Tasks that had no selfEvaluation field (not counted in any bucket). */
+  readonly totalWithoutSelfEval: number;
+}
+
+function bucket(count: number, passed: number): CalibrationBucket {
+  return { count, passRate: count === 0 ? 0 : passed / count };
+}
+
+/**
+ * Pure function — no I/O.
+ *
+ * Pairs each task's agent self-reported confidence with the harness ground-truth
+ * pass/fail, and returns bucketed accuracy: how often high/med/low confidence
+ * coincided with an actual pass.
+ */
+export function calibrate(report: EvalReport): CalibrationSummary {
+  let highCount = 0;
+  let highPassed = 0;
+  let medCount = 0;
+  let medPassed = 0;
+  let lowCount = 0;
+  let lowPassed = 0;
+  let withSelfEval = 0;
+  let withoutSelfEval = 0;
+
+  for (const task of report.tasks) {
+    if (task.selfEvaluation === undefined) {
+      withoutSelfEval += 1;
+      continue;
+    }
+
+    withSelfEval += 1;
+    const { confidence } = task.selfEvaluation;
+    const passed = task.passed ? 1 : 0;
+
+    if (confidence >= HIGH_THRESHOLD) {
+      highCount += 1;
+      highPassed += passed;
+    } else if (confidence >= MEDIUM_THRESHOLD) {
+      medCount += 1;
+      medPassed += passed;
+    } else {
+      lowCount += 1;
+      lowPassed += passed;
+    }
+  }
+
+  return {
+    high: bucket(highCount, highPassed),
+    medium: bucket(medCount, medPassed),
+    low: bucket(lowCount, lowPassed),
+    totalWithSelfEval: withSelfEval,
+    totalWithoutSelfEval: withoutSelfEval,
+  };
+}

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -342,6 +342,8 @@ export type {
   EvalAggregate,
   EvalReport,
 } from "./eval/types.js";
+export { calibrate } from "./eval/calibrate.js";
+export type { CalibrationBucket, CalibrationSummary } from "./eval/calibrate.js";
 
 // Reviewer contract (multi-agent quality gates)
 export type {

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,18 +337,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,7 +337,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/tools/cli/src/commands/agent-eval.test.ts
+++ b/tools/cli/src/commands/agent-eval.test.ts
@@ -152,4 +152,34 @@ describe("agent eval command", () => {
     expect(mockMkdirSync).toHaveBeenCalledWith(expect.any(String), { recursive: true });
     expect(mockAppendFileSync).toHaveBeenCalledOnce();
   });
+
+  it("prints calibration summary with --calibrate", async () => {
+    mockLoadSuite.mockResolvedValue([task]);
+    // costUsd 0.2, maxCostUsd 1 → withinBudget true → task passes
+    mockRunSession.mockResolvedValue(
+      fakeSession({ evaluation: { passed: true, confidence: 0.9, reasoning: "ok" } })
+    );
+
+    await agentEvalCommand.parseAsync(["--calibrate"], { from: "user" });
+
+    const out = logSpy.mock.calls.flat().join("\n");
+    expect(out).toContain("Calibration Summary");
+    expect(out).toContain("High confidence");
+    expect(out).toContain("Med  confidence");
+    expect(out).toContain("Low  confidence");
+    expect(out).toContain("Tasks with self-eval: 1");
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("calibration summary omits 'without self-eval' line when all tasks have self-eval", async () => {
+    mockLoadSuite.mockResolvedValue([task]);
+    mockRunSession.mockResolvedValue(
+      fakeSession({ evaluation: { passed: true, confidence: 0.9, reasoning: "ok" } })
+    );
+
+    await agentEvalCommand.parseAsync(["--calibrate"], { from: "user" });
+
+    const out = logSpy.mock.calls.flat().join("\n");
+    expect(out).not.toContain("without self-eval");
+  });
 });

--- a/tools/cli/src/commands/agent-eval.ts
+++ b/tools/cli/src/commands/agent-eval.ts
@@ -7,6 +7,7 @@ import {
   runSession,
   runEvalSuite,
   loadSuite,
+  calibrate,
   DEFAULT_SESSION_CONFIG,
   DEFAULT_FEEDBACK_LOOP_CONFIG,
   type SessionConfig,
@@ -15,6 +16,7 @@ import {
   type TaskRunResult,
   type DeterministicChecks,
   type EvalReport,
+  type CalibrationSummary,
 } from "@mbe/agent-core";
 import { findMonorepoRoot } from "../monorepo-root.js";
 
@@ -26,8 +28,7 @@ const execFileAsync = promisify(execFile);
  * The agent invocation + post-run verification (the {@link TaskRunner}) is the
  * integration seam: it runs the real `runSession` and executes the fixture's
  * verify scripts. The scoring/aggregation core it feeds is unit-tested in
- * @mbe/agent-core. Out of scope for this slice: the LLM-judge half of scoring
- * (#1945) and calibration (#1946).
+ * @mbe/agent-core.
  */
 export const agentEvalCommand = new Command("eval")
   .description("Run the golden-task eval suite through the agent and score the results")
@@ -36,6 +37,7 @@ export const agentEvalCommand = new Command("eval")
   .option("-m, --model <model>", "Model to run the agent with", DEFAULT_SESSION_CONFIG.model)
   .option("--json", "Emit the EvalReport as JSON", false)
   .option("--threshold <pct>", "Exit non-zero if suite pass rate is below this percent")
+  .option("--calibrate", "Print self-grade vs ground-truth calibration summary", false)
   .action(
     async (options: {
       suite: string;
@@ -43,6 +45,7 @@ export const agentEvalCommand = new Command("eval")
       model: string;
       json: boolean;
       threshold?: string;
+      calibrate: boolean;
     }) => {
       const repoPath = resolve(process.cwd());
       const suiteDir = resolve(repoPath, options.suite);
@@ -69,6 +72,10 @@ export const agentEvalCommand = new Command("eval")
         console.log(JSON.stringify(report, null, 2));
       } else {
         printReport(report);
+      }
+
+      if (options.calibrate) {
+        printCalibration(calibrate(report));
       }
 
       if (options.threshold !== undefined) {
@@ -154,6 +161,30 @@ async function verify(
     return true;
   } catch {
     return false;
+  }
+}
+
+function printCalibration(summary: CalibrationSummary): void {
+  console.log("");
+  console.log("Calibration Summary (self-grade vs ground-truth)");
+  console.log("─────────────────────────────────────────────────");
+
+  const fmtBucket = (label: string, b: { count: number; passRate: number }): void => {
+    if (b.count === 0) {
+      console.log(`  ${label}: no tasks`);
+    } else {
+      console.log(
+        `  ${label}: ${b.count} task${b.count === 1 ? "" : "s"}, actual pass rate ${(b.passRate * 100).toFixed(1)}%`
+      );
+    }
+  };
+
+  fmtBucket("High confidence (>=70%)", summary.high);
+  fmtBucket("Med  confidence (40-69%)", summary.medium);
+  fmtBucket("Low  confidence (<40%)", summary.low);
+  console.log(`  Tasks with self-eval: ${summary.totalWithSelfEval}`);
+  if (summary.totalWithoutSelfEval > 0) {
+    console.log(`  Tasks without self-eval (excluded): ${summary.totalWithoutSelfEval}`);
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds `calibrate(report) → CalibrationSummary` as a pure function in `packages/agent-core/src/eval/calibrate.ts` — no I/O, no side effects
- Buckets each task's `selfEvaluation.confidence` (high ≥0.7 / medium 0.4–0.69 / low <0.4) against the harness ground-truth `passed` flag and reports actual pass rates per bucket
- Exports `calibrate`, `CalibrationBucket`, and `CalibrationSummary` from `@mbe/agent-core`
- Wires `--calibrate` flag into `mbe agent eval` that prints the calibration summary after the standard report
- Reuses existing `EvalReport`, `TaskScore`, and `SessionResult["evaluation"]` shapes — no new result types invented

## Test plan

- [ ] 7 unit tests in `calibrate.test.ts` covering: mixed buckets, empty report, tasks without self-eval, all-pass/all-fail edge cases, boundary values (exactly 0.7 and 0.4), and immutability
- [ ] 2 CLI tests in `agent-eval.test.ts` covering: calibration output printed with `--calibrate`, no "without self-eval" line when all tasks have evaluations
- [ ] `pnpm --dir packages/agent-core lint` — clean
- [ ] `pnpm --dir packages/agent-core typecheck` — clean
- [ ] `pnpm --dir packages/agent-core test` — 1250 tests pass
- [ ] `pnpm --dir tools/cli lint` — clean
- [ ] `pnpm --dir tools/cli typecheck` — clean
- [ ] `pnpm --dir tools/cli test` — 398 tests pass
- [ ] `pnpm --filter @mbe/cli start check-adr` — no violations
- [ ] `pnpm --filter @mbe/cli start check-deps` — no violations
- [ ] `pnpm regen --check` — all generated artifacts up to date

Closes #1946