### PR TITLE
fix(reservations): bump post-visit email test timeout to 15s (fixes broken main)

### DIFF
--- a/services/reservations/src/routes/reservations.test.ts
+++ b/services/reservations/src/routes/reservations.test.ts
@@ -721,7 +721,9 @@ describe("Reservation Routes", () => {
         );
 
         await appWithNotifier.close();
-      });
+        // Builds a fresh Fastify app (buildApp + ready), which can exceed the
+        // 5s default on a loaded CI runner — give it generous headroom.
+      }, 15000);
     });
   });
 


### PR DESCRIPTION
## Problem
Main CI Gate is **red** (issue #2482). Root cause: the reservations test `triggers post-visit email when status transitions to COMPLETED` (`services/reservations/src/routes/reservations.test.ts:669`) **timed out at 5000ms** on a loaded CI runner. The whole file ran 85s in CI vs ~2s locally — this test builds a fresh Fastify app (`buildApp` + `ready()`) per-test, and the 5s default wasn't enough headroom under CI load.

Not the eval PR #2481 the auto-issue blamed — that's an unrelated package; this is a flaky-timeout in a recently-added feature test (post-visit email, commit ac59856b).

## Fix
Bump the timeout on the single app-building post-visit test to 15s. Surgical, test-only.

## Verification
- Test passes locally (1.6s)
- Only test in the file that builds a per-test app; shared app (line 131) is amortized

Closes #2482