### PR TITLE
feat(hospitality): SMS waitlist notifications

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -15064,18 +15064,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -10214,7 +10214,28 @@
           },
         },
         async (request, reply) => {
+          const { guestPhone } = request.body;
+          if (!validatePhone(guestPhone)) {
+            return reply
+              .code(400)
+              .send(createProblemDetails(400, "Bad Request", "Invalid phone number"));
+          }
+    
           const entry = await waitlistService.create(request.body);
+    
+          // Fire-and-forget: SMS delivery failures must not block the response
+          fastify.waitlistNotifier
+            .notifyAdded({
+              id: entry.id,
+              guestPhone: entry.guestPhone,
+              guestName: entry.guestName,
+              position: entry.position,
+              estimatedWaitMinutes: entry.estimatedWaitMinutes,
+            })
+            .catch(() => {
+              // Already logged inside the notifier
+            });
+    
           return reply.code(201).send({ data: entry });
         }
       );
@@ -10286,6 +10307,49 @@
               .code(404)
               .send(createProblemDetails(404, "Not Found", "Waitlist entry not found"));
           }
+          return reply.send({ data: entry });
+        }
+      );
+    
+      // PUT /:id/notify — send "table ready" SMS and schedule 5-min claim window
+      fastify.put<{
+        Params: { id: string };
+      }>(
+        "/:id/notify",
+        {
+          preHandler: requireAuth,
+          schema: {
+            summary: "Notify guest table is ready",
+            operationId: "notifyWaitlistEntry",
+            tags: ["Waitlist"],
+            params: {
+              type: "object",
+              required: ["id"],
+              properties: { id: { type: "string" } },
+            },
+            response: {
+              200: {
+                type: "object",
+                properties: { data: WaitlistEntrySchema },
+              },
+              404: { $ref: "Error#" },
+            },
+          },
+        },
+        async (request, reply) => {
+          const entry = await waitlistService.getById(request.params.id);
+          if (!entry) {
+            return reply
+              .code(404)
+              .send(createProblemDetails(404, "Not Found", "Waitlist entry not found"));
+          }
+    
+          await fastify.waitlistNotifier.notifyTableReady({
+            id: entry.id,
+            guestPhone: entry.guestPhone,
+            guestName: entry.guestName,
+          });
+    
           return reply.send({ data: entry });
         }
       );
@@ -11971,6 +12035,20 @@
         createdAt: venue.createdAt.toISOString(),
         updatedAt: venue.updatedAt.toISOString(),
       };
+    }
+  </file>
+  <file path="services/reservations/src/services/waitlist-notifier.ts">
+    export interface WaitlistNotifierLogger {
+      error(obj: Record<string, unknown>, msg: string): void;
+      info(obj: Record<string, unknown>, msg: string): void;
+    }
+    export interface WaitlistNotifierScheduler {
+      schedule(
+        jobType: string,
+        payload: Record<string, unknown>,
+        delayMs: number,
+        jobId?: string
+      ): Promise<unknown>;
     }
   </file>
   <file path="services/reservations/src/services/waitlist-utils.ts">
@@ -14986,7 +15064,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),
@@ -15481,6 +15570,7 @@
       bookingNotifier?: BookingNotifier;
       postVisitNotifier?: PostVisitNotifier;
       reservationEvents?: ReservationEventEmitter;
+      waitlistNotifier?: WaitlistNotifier;
     }
     export async function buildApp(options: ReservationsAppOptions = {}): Promise<FastifyInstance> {
       // Validate Stripe secrets at startup — throws in production if missing.
@@ -15514,6 +15604,10 @@
       // Wire post-visit notifier — injectable for testing, default Resend-backed for production
       const postVisitNotifier = options.postVisitNotifier ?? createDefaultPostVisitNotifier();
       fastify.decorate("postVisitNotifier", postVisitNotifier);
+    
+      // Wire waitlist notifier — injectable for testing, default env-backed for production
+      const waitlistNotifier = options.waitlistNotifier ?? createDefaultWaitlistNotifier();
+      fastify.decorate("waitlistNotifier", waitlistNotifier);
     
       // Wire reservation events emitter — injectable for testing, default singleton for production
       const reservationEvents = options.reservationEvents ?? new ReservationEventEmitter();

--- a/llms.txt
+++ b/llms.txt
@@ -2517,6 +2517,18 @@
       }): Venue { /* ... */ }
     </item>
   </file>
+  <file path="services/reservations/src/services/waitlist-notifier.ts">
+    <item priority="low">
+      interface WaitlistNotifierLogger {
+        
+      }
+    </item>
+    <item priority="low">
+      interface WaitlistNotifierScheduler {
+        
+      }
+    </item>
+  </file>
   <file path="services/reservations/src/services/waitlist-utils.ts">
     <item priority="high">
       export function calculatePosition(existingCount: number): number { /* ... */ }
@@ -4316,6 +4328,7 @@
         bookingNotifier?: BookingNotifier;
         postVisitNotifier?: PostVisitNotifier;
         reservationEvents?: ReservationEventEmitter;
+        waitlistNotifier?: WaitlistNotifier;
       }
     </item>
     <item priority="high">

--- a/metrics/ai-antipattern-baselines.json
+++ b/metrics/ai-antipattern-baselines.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-20T15:47:02.925Z",
+  "generatedAt": "2026-06-20T19:01:06.924Z",
   "patterns": {
     "magicTimeouts": {
       "count": 32,
@@ -14,7 +14,7 @@
       "description": "Test functions containing no expect() calls"
     },
     "hardcodedRoutes": {
-      "count": 507,
+      "count": 510,
       "description": "Hardcoded /api/... route strings instead of route constants"
     },
     "anyType": {

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -10,6 +10,9 @@ export type {
   SmsNotificationInput,
   WaitlistUpdateInput,
   WinbackMessageInput,
+  WaitlistAddedInput,
+  WaitlistPositionUpdateInput,
+  WaitlistTableReadyInput,
 } from "./sms-port.js";
 export { TwilioSmsAdapter } from "./twilio-sms-adapter.js";
 export type { TwilioSmsAdapterConfig } from "./twilio-sms-adapter.js";

--- a/packages/notifications/src/sms-port.ts
+++ b/packages/notifications/src/sms-port.ts
@@ -27,8 +27,30 @@ export interface WinbackMessageInput {
   manageBaseUrl: string;
 }
 
+export interface WaitlistAddedInput {
+  guestPhone: string;
+  guestName: string | null;
+  position: number;
+  estimatedWaitMinutes: number;
+}
+
+export interface WaitlistPositionUpdateInput {
+  guestPhone: string;
+  guestName: string | null;
+  position: number;
+  estimatedWaitMinutes: number;
+}
+
+export interface WaitlistTableReadyInput {
+  guestPhone: string;
+  guestName: string | null;
+}
+
 export interface SmsPort {
   sendBookingReminder(input: SmsNotificationInput): Promise<void>;
   sendWaitlistUpdate(input: WaitlistUpdateInput): Promise<void>;
   sendWinbackMessage(input: WinbackMessageInput): Promise<void>;
+  sendWaitlistAdded(input: WaitlistAddedInput): Promise<void>;
+  sendWaitlistPositionUpdate(input: WaitlistPositionUpdateInput): Promise<void>;
+  sendWaitlistTableReady(input: WaitlistTableReadyInput): Promise<void>;
 }

--- a/packages/notifications/src/twilio-sms-adapter.test.ts
+++ b/packages/notifications/src/twilio-sms-adapter.test.ts
@@ -160,4 +160,88 @@ describe("TwilioSmsAdapter", () => {
     const call = mockCreate.mock.calls[0][0];
     expect(call.body).not.toContain("null");
   });
+
+  describe("waitlist notifications", () => {
+    const addedInput = {
+      guestPhone: "+15551234567",
+      guestName: "Jane Doe",
+      position: 3,
+      estimatedWaitMinutes: 25,
+    };
+    const positionInput = {
+      guestPhone: "+15551234567",
+      guestName: "Jane Doe",
+      position: 1,
+      estimatedWaitMinutes: 5,
+    };
+    const tableReadyInput = {
+      guestPhone: "+15551234567",
+      guestName: "Jane Doe",
+    };
+
+    function adapter() {
+      return new TwilioSmsAdapter({
+        client: mockTwilioClient as never,
+        fromNumber: "+15559876543",
+      });
+    }
+
+    it("sendWaitlistAdded sends position + estimated wait", async () => {
+      await adapter().sendWaitlistAdded(addedInput);
+
+      expect(mockCreate).toHaveBeenCalledOnce();
+      const call = mockCreate.mock.calls[0][0];
+      expect(call.to).toBe("+15551234567");
+      expect(call.from).toBe("+15559876543");
+      expect(call.body).toContain("#3");
+      expect(call.body).toContain("25 min");
+      expect(call.body.length).toBeLessThanOrEqual(160);
+    });
+
+    it("sendWaitlistPositionUpdate sends the updated position", async () => {
+      await adapter().sendWaitlistPositionUpdate(positionInput);
+
+      const call = mockCreate.mock.calls[0][0];
+      expect(call.body).toContain("#1");
+      expect(call.body).toContain("5 min");
+      expect(call.body.length).toBeLessThanOrEqual(160);
+    });
+
+    it("sendWaitlistTableReady sends the table-ready message", async () => {
+      await adapter().sendWaitlistTableReady(tableReadyInput);
+
+      const call = mockCreate.mock.calls[0][0];
+      expect(call.body).toContain("table is ready");
+      expect(call.body).toContain("5 minutes");
+      expect(call.body.length).toBeLessThanOrEqual(160);
+    });
+
+    it("uses the Guest fallback when guestName is null", async () => {
+      const a = adapter();
+      await a.sendWaitlistAdded({ ...addedInput, guestName: null });
+      await a.sendWaitlistPositionUpdate({ ...positionInput, guestName: null });
+      await a.sendWaitlistTableReady({ ...tableReadyInput, guestName: null });
+
+      for (const call of mockCreate.mock.calls) {
+        expect(call[0].body).toMatch(/^Guest,/);
+        expect(call[0].body).not.toContain("null");
+      }
+    });
+
+    it("no-ops gracefully when client is null", async () => {
+      const a = new TwilioSmsAdapter({ client: null, fromNumber: "+15559876543" });
+
+      await expect(a.sendWaitlistAdded(addedInput)).resolves.toBeUndefined();
+      await expect(a.sendWaitlistPositionUpdate(positionInput)).resolves.toBeUndefined();
+      await expect(a.sendWaitlistTableReady(tableReadyInput)).resolves.toBeUndefined();
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it("truncates an over-long body to 160 chars", async () => {
+      await adapter().sendWaitlistAdded({ ...addedInput, guestName: "X".repeat(200) });
+
+      const call = mockCreate.mock.calls[0][0];
+      expect(call.body.length).toBe(160);
+    });
+  });
 });

--- a/packages/notifications/src/twilio-sms-adapter.ts
+++ b/packages/notifications/src/twilio-sms-adapter.ts
@@ -4,6 +4,9 @@ import type {
   SmsNotificationInput,
   WaitlistUpdateInput,
   WinbackMessageInput,
+  WaitlistAddedInput,
+  WaitlistPositionUpdateInput,
+  WaitlistTableReadyInput,
 } from "./sms-port.js";
 
 interface TwilioMessages {
@@ -81,6 +84,36 @@ export class TwilioSmsAdapter implements SmsPort {
     const url = input.manageBaseUrl;
 
     const body = `${name}, we miss you at ${input.venueName}! Book your next visit: ${url}`;
+    const trimmed = body.length > 160 ? body.slice(0, 160) : body;
+
+    await this.sendWithRetry(input.guestPhone, trimmed);
+  }
+
+  async sendWaitlistAdded(input: WaitlistAddedInput): Promise<void> {
+    if (!this.client) return;
+
+    const name = input.guestName ?? "Guest";
+    const body = `${name}, you're #${input.position}, est. ${input.estimatedWaitMinutes} min wait. We'll text when your table is ready.`;
+    const trimmed = body.length > 160 ? body.slice(0, 160) : body;
+
+    await this.sendWithRetry(input.guestPhone, trimmed);
+  }
+
+  async sendWaitlistPositionUpdate(input: WaitlistPositionUpdateInput): Promise<void> {
+    if (!this.client) return;
+
+    const name = input.guestName ?? "Guest";
+    const body = `${name}, update: you're now #${input.position}, est. ${input.estimatedWaitMinutes} min.`;
+    const trimmed = body.length > 160 ? body.slice(0, 160) : body;
+
+    await this.sendWithRetry(input.guestPhone, trimmed);
+  }
+
+  async sendWaitlistTableReady(input: WaitlistTableReadyInput): Promise<void> {
+    if (!this.client) return;
+
+    const name = input.guestName ?? "Guest";
+    const body = `${name}, your table is ready! Please check in within 5 minutes.`;
     const trimmed = body.length > 160 ? body.slice(0, 160) : body;
 
     await this.sendWithRetry(input.guestPhone, trimmed);

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,18 +337,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,7 +337,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/services/reservations/llms-full.txt
+++ b/services/reservations/llms-full.txt
@@ -4778,7 +4778,28 @@
           },
         },
         async (request, reply) => {
+          const { guestPhone } = request.body;
+          if (!validatePhone(guestPhone)) {
+            return reply
+              .code(400)
+              .send(createProblemDetails(400, "Bad Request", "Invalid phone number"));
+          }
+    
           const entry = await waitlistService.create(request.body);
+    
+          // Fire-and-forget: SMS delivery failures must not block the response
+          fastify.waitlistNotifier
+            .notifyAdded({
+              id: entry.id,
+              guestPhone: entry.guestPhone,
+              guestName: entry.guestName,
+              position: entry.position,
+              estimatedWaitMinutes: entry.estimatedWaitMinutes,
+            })
+            .catch(() => {
+              // Already logged inside the notifier
+            });
+    
           return reply.code(201).send({ data: entry });
         }
       );
@@ -4850,6 +4871,49 @@
               .code(404)
               .send(createProblemDetails(404, "Not Found", "Waitlist entry not found"));
           }
+          return reply.send({ data: entry });
+        }
+      );
+    
+      // PUT /:id/notify — send "table ready" SMS and schedule 5-min claim window
+      fastify.put<{
+        Params: { id: string };
+      }>(
+        "/:id/notify",
+        {
+          preHandler: requireAuth,
+          schema: {
+            summary: "Notify guest table is ready",
+            operationId: "notifyWaitlistEntry",
+            tags: ["Waitlist"],
+            params: {
+              type: "object",
+              required: ["id"],
+              properties: { id: { type: "string" } },
+            },
+            response: {
+              200: {
+                type: "object",
+                properties: { data: WaitlistEntrySchema },
+              },
+              404: { $ref: "Error#" },
+            },
+          },
+        },
+        async (request, reply) => {
+          const entry = await waitlistService.getById(request.params.id);
+          if (!entry) {
+            return reply
+              .code(404)
+              .send(createProblemDetails(404, "Not Found", "Waitlist entry not found"));
+          }
+    
+          await fastify.waitlistNotifier.notifyTableReady({
+            id: entry.id,
+            guestPhone: entry.guestPhone,
+            guestName: entry.guestName,
+          });
+    
           return reply.send({ data: entry });
         }
       );
@@ -5697,6 +5761,20 @@
       };
     }
   </file>
+  <file path="src/services/waitlist-notifier.ts">
+    export interface WaitlistNotifierLogger {
+      error(obj: Record<string, unknown>, msg: string): void;
+      info(obj: Record<string, unknown>, msg: string): void;
+    }
+    export interface WaitlistNotifierScheduler {
+      schedule(
+        jobType: string,
+        payload: Record<string, unknown>,
+        delayMs: number,
+        jobId?: string
+      ): Promise<unknown>;
+    }
+  </file>
   <file path="src/services/waitlist-utils.ts">
     export function calculatePosition(existingCount: number): number {
       return existingCount + 1;
@@ -5772,6 +5850,7 @@
       bookingNotifier?: BookingNotifier;
       postVisitNotifier?: PostVisitNotifier;
       reservationEvents?: ReservationEventEmitter;
+      waitlistNotifier?: WaitlistNotifier;
     }
     export async function buildApp(options: ReservationsAppOptions = {}): Promise<FastifyInstance> {
       // Validate Stripe secrets at startup — throws in production if missing.
@@ -5805,6 +5884,10 @@
       // Wire post-visit notifier — injectable for testing, default Resend-backed for production
       const postVisitNotifier = options.postVisitNotifier ?? createDefaultPostVisitNotifier();
       fastify.decorate("postVisitNotifier", postVisitNotifier);
+    
+      // Wire waitlist notifier — injectable for testing, default env-backed for production
+      const waitlistNotifier = options.waitlistNotifier ?? createDefaultWaitlistNotifier();
+      fastify.decorate("waitlistNotifier", waitlistNotifier);
     
       // Wire reservation events emitter — injectable for testing, default singleton for production
       const reservationEvents = options.reservationEvents ?? new ReservationEventEmitter();

--- a/services/reservations/llms.txt
+++ b/services/reservations/llms.txt
@@ -674,6 +674,18 @@
       }): Venue { /* ... */ }
     </item>
   </file>
+  <file path="src/services/waitlist-notifier.ts">
+    <item priority="low">
+      interface WaitlistNotifierLogger {
+        
+      }
+    </item>
+    <item priority="low">
+      interface WaitlistNotifierScheduler {
+        
+      }
+    </item>
+  </file>
   <file path="src/services/waitlist-utils.ts">
     <item priority="high">
       export function calculatePosition(existingCount: number): number { /* ... */ }
@@ -720,6 +732,7 @@
         bookingNotifier?: BookingNotifier;
         postVisitNotifier?: PostVisitNotifier;
         reservationEvents?: ReservationEventEmitter;
+        waitlistNotifier?: WaitlistNotifier;
       }
     </item>
     <item priority="high">

--- a/services/reservations/src/app.ts
+++ b/services/reservations/src/app.ts
@@ -34,6 +34,10 @@ import {
   type BookingNotifier,
 } from "./services/booking-notifications.js";
 import {
+  createDefaultWaitlistNotifier,
+  type WaitlistNotifier,
+} from "./services/waitlist-notifier.js";
+import {
   createDefaultPostVisitNotifier,
   type PostVisitNotifier,
 } from "./services/post-visit-notifier.js";
@@ -47,6 +51,7 @@ export interface ReservationsAppOptions extends AppOptions {
   bookingNotifier?: BookingNotifier;
   postVisitNotifier?: PostVisitNotifier;
   reservationEvents?: ReservationEventEmitter;
+  waitlistNotifier?: WaitlistNotifier;
 }
 
 /**
@@ -84,6 +89,10 @@ export async function buildApp(options: ReservationsAppOptions = {}): Promise<Fa
   // Wire post-visit notifier — injectable for testing, default Resend-backed for production
   const postVisitNotifier = options.postVisitNotifier ?? createDefaultPostVisitNotifier();
   fastify.decorate("postVisitNotifier", postVisitNotifier);
+
+  // Wire waitlist notifier — injectable for testing, default env-backed for production
+  const waitlistNotifier = options.waitlistNotifier ?? createDefaultWaitlistNotifier();
+  fastify.decorate("waitlistNotifier", waitlistNotifier);
 
   // Wire reservation events emitter — injectable for testing, default singleton for production
   const reservationEvents = options.reservationEvents ?? new ReservationEventEmitter();
@@ -143,6 +152,7 @@ declare module "fastify" {
   interface FastifyInstance {
     notificationPort: NotificationDispatcher;
     bookingNotifier: BookingNotifier;
+    waitlistNotifier: WaitlistNotifier;
     postVisitNotifier: PostVisitNotifier;
     reservationEvents: ReservationEventEmitter;
   }

--- a/services/reservations/src/routes/waitlist.test.ts
+++ b/services/reservations/src/routes/waitlist.test.ts
@@ -14,6 +14,17 @@ vi.mock("../services/waitlist.js", () => ({
   },
 }));
 
+// Mock the waitlist notifier
+vi.mock("../services/waitlist-notifier.js", () => ({
+  createDefaultWaitlistNotifier: vi.fn(() => ({
+    notifyAdded: vi.fn().mockResolvedValue(undefined),
+    notifyPositionUpdate: vi.fn().mockResolvedValue(undefined),
+    notifyTableReady: vi.fn().mockResolvedValue(undefined),
+    handleExpiry: vi.fn().mockResolvedValue(undefined),
+  })),
+  validatePhone: vi.fn().mockReturnValue(true),
+}));
+
 // Mock the database
 vi.mock("../services/database.js", async () => {
   const { createMockDatabaseService } = await import("@mbe/database/testing");
@@ -406,6 +417,55 @@ describe("Waitlist Routes", () => {
       });
 
       expect(response.statusCode).toBe(404);
+    });
+  });
+
+  describe("PUT /api/v1/waitlist/:id/notify", () => {
+    it("returns 200 and notifies the guest when entry exists", async () => {
+      vi.mocked(waitlistService.getById).mockResolvedValue(mockEntry as never);
+
+      const response = await app.inject({
+        method: "PUT",
+        url: "/api/v1/waitlist/entry-1/notify",
+        headers: AUTH_HEADERS,
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.data.id).toBe("entry-1");
+    });
+
+    it("returns 404 when entry not found", async () => {
+      vi.mocked(waitlistService.getById).mockResolvedValue(null);
+
+      const response = await app.inject({
+        method: "PUT",
+        url: "/api/v1/waitlist/bad-id/notify",
+        headers: AUTH_HEADERS,
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+  });
+
+  describe("POST /api/v1/waitlist — phone validation", () => {
+    it("returns 400 when guestPhone fails validation", async () => {
+      const { validatePhone } = await import("../services/waitlist-notifier.js");
+      vi.mocked(validatePhone).mockReturnValueOnce(false);
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/v1/waitlist",
+        headers: AUTH_HEADERS,
+        payload: {
+          venueId: "venue-1",
+          partySize: 2,
+          guestName: "Alice",
+          guestPhone: "123",
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
     });
   });
 });

--- a/services/reservations/src/routes/waitlist.ts
+++ b/services/reservations/src/routes/waitlist.ts
@@ -2,6 +2,7 @@ import type { FastifyPluginAsync } from "fastify";
 import { createProblemDetails } from "@mbe/types";
 import { requireAuth } from "@mbe/auth/fastify";
 import { waitlistService } from "../services/waitlist.js";
+import { validatePhone } from "../services/waitlist-notifier.js";
 
 /** Shared schema for a WaitlistEntry response object */
 const WaitlistEntrySchema = {
@@ -65,7 +66,28 @@ export const waitlistRoutes: FastifyPluginAsync = async (fastify) => {
       },
     },
     async (request, reply) => {
+      const { guestPhone } = request.body;
+      if (!validatePhone(guestPhone)) {
+        return reply
+          .code(400)
+          .send(createProblemDetails(400, "Bad Request", "Invalid phone number"));
+      }
+
       const entry = await waitlistService.create(request.body);
+
+      // Fire-and-forget: SMS delivery failures must not block the response
+      fastify.waitlistNotifier
+        .notifyAdded({
+          id: entry.id,
+          guestPhone: entry.guestPhone,
+          guestName: entry.guestName,
+          position: entry.position,
+          estimatedWaitMinutes: entry.estimatedWaitMinutes,
+        })
+        .catch(() => {
+          // Already logged inside the notifier
+        });
+
       return reply.code(201).send({ data: entry });
     }
   );
@@ -137,6 +159,49 @@ export const waitlistRoutes: FastifyPluginAsync = async (fastify) => {
           .code(404)
           .send(createProblemDetails(404, "Not Found", "Waitlist entry not found"));
       }
+      return reply.send({ data: entry });
+    }
+  );
+
+  // PUT /:id/notify — send "table ready" SMS and schedule 5-min claim window
+  fastify.put<{
+    Params: { id: string };
+  }>(
+    "/:id/notify",
+    {
+      preHandler: requireAuth,
+      schema: {
+        summary: "Notify guest table is ready",
+        operationId: "notifyWaitlistEntry",
+        tags: ["Waitlist"],
+        params: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string" } },
+        },
+        response: {
+          200: {
+            type: "object",
+            properties: { data: WaitlistEntrySchema },
+          },
+          404: { $ref: "Error#" },
+        },
+      },
+    },
+    async (request, reply) => {
+      const entry = await waitlistService.getById(request.params.id);
+      if (!entry) {
+        return reply
+          .code(404)
+          .send(createProblemDetails(404, "Not Found", "Waitlist entry not found"));
+      }
+
+      await fastify.waitlistNotifier.notifyTableReady({
+        id: entry.id,
+        guestPhone: entry.guestPhone,
+        guestName: entry.guestName,
+      });
+
       return reply.send({ data: entry });
     }
   );

--- a/services/reservations/src/services/waitlist-notifier.test.ts
+++ b/services/reservations/src/services/waitlist-notifier.test.ts
@@ -1,0 +1,329 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createWaitlistNotifier, validatePhone } from "./waitlist-notifier.js";
+import type { WaitlistNotifierDeps } from "./waitlist-notifier.js";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockSendWaitlistAdded = vi.fn().mockResolvedValue(undefined);
+const mockSendWaitlistPositionUpdate = vi.fn().mockResolvedValue(undefined);
+const mockSendWaitlistTableReady = vi.fn().mockResolvedValue(undefined);
+const mockSchedule = vi.fn().mockResolvedValue("job-123");
+const mockExpire = vi.fn().mockResolvedValue(null);
+const mockListWaiting = vi.fn().mockResolvedValue([]);
+const mockNotifyTableReady = vi.fn().mockResolvedValue(undefined);
+
+function buildDeps(overrides: Partial<WaitlistNotifierDeps> = {}): WaitlistNotifierDeps {
+  return {
+    smsAdapter: {
+      sendWaitlistAdded: mockSendWaitlistAdded,
+      sendWaitlistPositionUpdate: mockSendWaitlistPositionUpdate,
+      sendWaitlistTableReady: mockSendWaitlistTableReady,
+      sendBookingReminder: vi.fn(),
+      sendWaitlistUpdate: vi.fn(),
+      sendWinbackMessage: vi.fn(),
+    },
+    scheduler: {
+      schedule: mockSchedule,
+    },
+    expireEntry: mockExpire,
+    listWaiting: mockListWaiting,
+    notifyTableReady: mockNotifyTableReady,
+    logger: { error: vi.fn(), info: vi.fn() },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ─── validatePhone ─────────────────────────────────────────────────────────
+
+describe("validatePhone", () => {
+  it("accepts E.164 format", () => {
+    expect(validatePhone("+15551234567")).toBe(true);
+    expect(validatePhone("+447911123456")).toBe(true);
+  });
+
+  it("accepts 10-digit US numbers without country code", () => {
+    expect(validatePhone("5551234567")).toBe(true);
+    expect(validatePhone("555-123-4567")).toBe(true);
+  });
+
+  it("rejects empty string", () => {
+    expect(validatePhone("")).toBe(false);
+  });
+
+  it("rejects strings with fewer than 7 digits", () => {
+    expect(validatePhone("123456")).toBe(false);
+  });
+});
+
+// ─── notifyAdded ──────────────────────────────────────────────────────────
+
+describe("WaitlistNotifier.notifyAdded", () => {
+  it("sends waitlist-added SMS with position and estimated wait", async () => {
+    const notifier = createWaitlistNotifier(buildDeps());
+
+    await notifier.notifyAdded({
+      id: "entry-1",
+      guestPhone: "+15551234567",
+      guestName: "Alice",
+      position: 3,
+      estimatedWaitMinutes: 45,
+    });
+
+    expect(mockSendWaitlistAdded).toHaveBeenCalledOnce();
+    expect(mockSendWaitlistAdded).toHaveBeenCalledWith({
+      guestPhone: "+15551234567",
+      guestName: "Alice",
+      position: 3,
+      estimatedWaitMinutes: 45,
+    });
+  });
+
+  it("logs but does not throw when SMS send fails", async () => {
+    const logger = { error: vi.fn(), info: vi.fn() };
+    mockSendWaitlistAdded.mockRejectedValueOnce(new Error("Twilio 429"));
+    const notifier = createWaitlistNotifier(buildDeps({ logger }));
+
+    await expect(
+      notifier.notifyAdded({
+        id: "entry-1",
+        guestPhone: "+15551234567",
+        guestName: "Alice",
+        position: 1,
+        estimatedWaitMinutes: 30,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ err: expect.any(Error) }),
+      "waitlist SMS failed: added"
+    );
+  });
+
+  it("no-ops when smsAdapter is null", async () => {
+    const notifier = createWaitlistNotifier(buildDeps({ smsAdapter: null }));
+
+    await expect(
+      notifier.notifyAdded({
+        id: "entry-1",
+        guestPhone: "+15551234567",
+        guestName: "Alice",
+        position: 1,
+        estimatedWaitMinutes: 30,
+      })
+    ).resolves.toBeUndefined();
+  });
+});
+
+// ─── notifyPositionUpdate ─────────────────────────────────────────────────
+
+describe("WaitlistNotifier.notifyPositionUpdate", () => {
+  it("sends position-update SMS when position improved by >= 2 spots", async () => {
+    const notifier = createWaitlistNotifier(buildDeps());
+
+    await notifier.notifyPositionUpdate({
+      id: "entry-1",
+      guestPhone: "+15551234567",
+      guestName: "Alice",
+      previousPosition: 5,
+      newPosition: 3,
+      estimatedWaitMinutes: 30,
+    });
+
+    expect(mockSendWaitlistPositionUpdate).toHaveBeenCalledOnce();
+    expect(mockSendWaitlistPositionUpdate).toHaveBeenCalledWith({
+      guestPhone: "+15551234567",
+      guestName: "Alice",
+      position: 3,
+      estimatedWaitMinutes: 30,
+    });
+  });
+
+  it("does NOT send SMS when position improved by only 1 spot", async () => {
+    const notifier = createWaitlistNotifier(buildDeps());
+
+    await notifier.notifyPositionUpdate({
+      id: "entry-1",
+      guestPhone: "+15551234567",
+      guestName: "Alice",
+      previousPosition: 4,
+      newPosition: 3,
+      estimatedWaitMinutes: 30,
+    });
+
+    expect(mockSendWaitlistPositionUpdate).not.toHaveBeenCalled();
+  });
+
+  it("does NOT send SMS when position did not improve", async () => {
+    const notifier = createWaitlistNotifier(buildDeps());
+
+    await notifier.notifyPositionUpdate({
+      id: "entry-1",
+      guestPhone: "+15551234567",
+      guestName: "Alice",
+      previousPosition: 3,
+      newPosition: 3,
+      estimatedWaitMinutes: 30,
+    });
+
+    expect(mockSendWaitlistPositionUpdate).not.toHaveBeenCalled();
+  });
+
+  it("logs but does not throw when SMS send fails", async () => {
+    const logger = { error: vi.fn(), info: vi.fn() };
+    mockSendWaitlistPositionUpdate.mockRejectedValueOnce(new Error("Network error"));
+    const notifier = createWaitlistNotifier(buildDeps({ logger }));
+
+    await expect(
+      notifier.notifyPositionUpdate({
+        id: "entry-1",
+        guestPhone: "+15551234567",
+        guestName: "Alice",
+        previousPosition: 5,
+        newPosition: 2,
+        estimatedWaitMinutes: 20,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ err: expect.any(Error) }),
+      "waitlist SMS failed: position-update"
+    );
+  });
+});
+
+// ─── notifyTableReady ─────────────────────────────────────────────────────
+
+describe("WaitlistNotifier.notifyTableReady", () => {
+  const FIVE_MINUTES_MS = 5 * 60 * 1000;
+
+  it("sends table-ready SMS and schedules 5-minute expiry job", async () => {
+    const notifier = createWaitlistNotifier(buildDeps());
+
+    await notifier.notifyTableReady({
+      id: "entry-1",
+      guestPhone: "+15551234567",
+      guestName: "Alice",
+    });
+
+    expect(mockSendWaitlistTableReady).toHaveBeenCalledOnce();
+    expect(mockSendWaitlistTableReady).toHaveBeenCalledWith({
+      guestPhone: "+15551234567",
+      guestName: "Alice",
+    });
+
+    expect(mockSchedule).toHaveBeenCalledOnce();
+    expect(mockSchedule).toHaveBeenCalledWith(
+      "waitlist-expiry",
+      { waitlistEntryId: "entry-1" },
+      FIVE_MINUTES_MS,
+      "waitlist-expiry:entry-1"
+    );
+  });
+
+  it("logs but does not throw when SMS send fails, still schedules expiry", async () => {
+    const logger = { error: vi.fn(), info: vi.fn() };
+    mockSendWaitlistTableReady.mockRejectedValueOnce(new Error("Twilio down"));
+    const notifier = createWaitlistNotifier(buildDeps({ logger }));
+
+    await expect(
+      notifier.notifyTableReady({
+        id: "entry-1",
+        guestPhone: "+15551234567",
+        guestName: "Alice",
+      })
+    ).resolves.toBeUndefined();
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ err: expect.any(Error) }),
+      "waitlist SMS failed: table-ready"
+    );
+    // expiry job must still be scheduled even if SMS failed
+    expect(mockSchedule).toHaveBeenCalledOnce();
+  });
+
+  it("no-ops SMS when smsAdapter is null, but still schedules expiry", async () => {
+    const notifier = createWaitlistNotifier(buildDeps({ smsAdapter: null }));
+
+    await notifier.notifyTableReady({
+      id: "entry-1",
+      guestPhone: "+15551234567",
+      guestName: "Alice",
+    });
+
+    expect(mockSendWaitlistTableReady).not.toHaveBeenCalled();
+    expect(mockSchedule).toHaveBeenCalledOnce();
+  });
+});
+
+// ─── handleExpiry ──────────────────────────────────────────────────────────
+
+describe("WaitlistNotifier.handleExpiry", () => {
+  it("expires the entry and notifies next waiting party", async () => {
+    mockExpire.mockResolvedValue({
+      id: "entry-1",
+      venueId: "venue-1",
+      status: "expired",
+    });
+    mockListWaiting.mockResolvedValue([
+      {
+        id: "entry-2",
+        venueId: "venue-1",
+        guestPhone: "+15559998888",
+        guestName: "Bob",
+        position: 1,
+        estimatedWaitMinutes: 0,
+        status: "waiting",
+      },
+    ]);
+
+    const notifier = createWaitlistNotifier(buildDeps());
+
+    await notifier.handleExpiry({
+      waitlistEntryId: "entry-1",
+      venueId: "venue-1",
+    });
+
+    expect(mockExpire).toHaveBeenCalledWith("entry-1");
+    expect(mockNotifyTableReady).toHaveBeenCalledWith({
+      id: "entry-2",
+      guestPhone: "+15559998888",
+      guestName: "Bob",
+    });
+  });
+
+  it("does NOT notify next party if no waiting entries remain", async () => {
+    mockExpire.mockResolvedValue({
+      id: "entry-1",
+      venueId: "venue-1",
+      status: "expired",
+    });
+    mockListWaiting.mockResolvedValue([]);
+
+    const notifier = createWaitlistNotifier(buildDeps());
+
+    await notifier.handleExpiry({
+      waitlistEntryId: "entry-1",
+      venueId: "venue-1",
+    });
+
+    expect(mockExpire).toHaveBeenCalledWith("entry-1");
+    expect(mockNotifyTableReady).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when entry not found (already expired)", async () => {
+    mockExpire.mockResolvedValue(null);
+
+    const notifier = createWaitlistNotifier(buildDeps());
+
+    await notifier.handleExpiry({
+      waitlistEntryId: "entry-1",
+      venueId: "venue-1",
+    });
+
+    expect(mockNotifyTableReady).not.toHaveBeenCalled();
+  });
+});

--- a/services/reservations/src/services/waitlist-notifier.ts
+++ b/services/reservations/src/services/waitlist-notifier.ts
@@ -1,0 +1,240 @@
+import { JOB_TYPES, JobScheduler } from "@mbe/jobs";
+import { TwilioSmsAdapter, type SmsPort } from "@mbe/notifications";
+import { waitlistService } from "./waitlist.js";
+
+const REDIS_URL = process.env.REDIS_URL ?? "redis://localhost:6379";
+
+export interface WaitlistNotifierLogger {
+  error(obj: Record<string, unknown>, msg: string): void;
+  info(obj: Record<string, unknown>, msg: string): void;
+}
+
+export interface WaitlistNotifierScheduler {
+  schedule(
+    jobType: string,
+    payload: Record<string, unknown>,
+    delayMs: number,
+    jobId?: string
+  ): Promise<unknown>;
+}
+
+export interface WaitlistEntryRef {
+  id: string;
+  venueId?: string;
+  guestPhone: string;
+  guestName: string | null;
+  position?: number;
+  estimatedWaitMinutes?: number;
+  status?: string;
+}
+
+export interface WaitlistNotifierDeps {
+  smsAdapter: SmsPort | null;
+  scheduler: WaitlistNotifierScheduler;
+  expireEntry(id: string): Promise<{ id: string; venueId: string; status: string } | null>;
+  listWaiting(venueId: string): Promise<WaitlistEntryRef[]>;
+  notifyTableReady(entry: {
+    id: string;
+    guestPhone: string;
+    guestName: string | null;
+  }): Promise<void>;
+  logger: WaitlistNotifierLogger;
+}
+
+export interface NotifyAddedInput {
+  id: string;
+  guestPhone: string;
+  guestName: string | null;
+  position: number;
+  estimatedWaitMinutes: number;
+}
+
+export interface NotifyPositionUpdateInput {
+  id: string;
+  guestPhone: string;
+  guestName: string | null;
+  previousPosition: number;
+  newPosition: number;
+  estimatedWaitMinutes: number;
+}
+
+export interface NotifyTableReadyInput {
+  id: string;
+  guestPhone: string;
+  guestName: string | null;
+}
+
+export interface HandleExpiryInput {
+  waitlistEntryId: string;
+  venueId: string;
+}
+
+export interface WaitlistNotifier {
+  notifyAdded(input: NotifyAddedInput): Promise<void>;
+  notifyPositionUpdate(input: NotifyPositionUpdateInput): Promise<void>;
+  notifyTableReady(input: NotifyTableReadyInput): Promise<void>;
+  handleExpiry(input: HandleExpiryInput): Promise<void>;
+}
+
+const FIVE_MINUTES_MS = 5 * 60 * 1000;
+const POSITION_UPDATE_THRESHOLD = 2;
+
+/**
+ * Validates that a phone string contains at least 7 digits.
+ * Accepts E.164, 10-digit US, or formatted numbers (dashes/spaces).
+ */
+export function validatePhone(phone: string): boolean {
+  const digits = phone.replace(/\D/g, "");
+  return digits.length >= 7;
+}
+
+export function createWaitlistNotifier(deps: WaitlistNotifierDeps): WaitlistNotifier {
+  const {
+    smsAdapter,
+    scheduler,
+    expireEntry,
+    listWaiting,
+    notifyTableReady: notifyNextTableReady,
+    logger,
+  } = deps;
+
+  async function notifyAdded(input: NotifyAddedInput): Promise<void> {
+    if (!smsAdapter) return;
+    try {
+      await smsAdapter.sendWaitlistAdded({
+        guestPhone: input.guestPhone,
+        guestName: input.guestName,
+        position: input.position,
+        estimatedWaitMinutes: input.estimatedWaitMinutes,
+      });
+    } catch (err) {
+      logger.error({ err }, "waitlist SMS failed: added");
+    }
+  }
+
+  async function notifyPositionUpdate(input: NotifyPositionUpdateInput): Promise<void> {
+    const improvement = input.previousPosition - input.newPosition;
+    if (improvement < POSITION_UPDATE_THRESHOLD) return;
+    if (!smsAdapter) return;
+    try {
+      await smsAdapter.sendWaitlistPositionUpdate({
+        guestPhone: input.guestPhone,
+        guestName: input.guestName,
+        position: input.newPosition,
+        estimatedWaitMinutes: input.estimatedWaitMinutes,
+      });
+    } catch (err) {
+      logger.error({ err }, "waitlist SMS failed: position-update");
+    }
+  }
+
+  async function notifyTableReady(input: NotifyTableReadyInput): Promise<void> {
+    if (smsAdapter) {
+      try {
+        await smsAdapter.sendWaitlistTableReady({
+          guestPhone: input.guestPhone,
+          guestName: input.guestName,
+        });
+      } catch (err) {
+        logger.error({ err }, "waitlist SMS failed: table-ready");
+      }
+    }
+
+    // Always schedule expiry regardless of SMS outcome
+    await scheduler.schedule(
+      JOB_TYPES.WAITLIST_EXPIRY,
+      { waitlistEntryId: input.id },
+      FIVE_MINUTES_MS,
+      `${JOB_TYPES.WAITLIST_EXPIRY}:${input.id}`
+    );
+  }
+
+  async function handleExpiry(input: HandleExpiryInput): Promise<void> {
+    const expired = await expireEntry(input.waitlistEntryId);
+    if (!expired) return;
+
+    const waiting = await listWaiting(input.venueId);
+    const next = waiting[0];
+    if (!next) return;
+
+    await notifyNextTableReady({
+      id: next.id,
+      guestPhone: next.guestPhone,
+      guestName: next.guestName,
+    });
+  }
+
+  return { notifyAdded, notifyPositionUpdate, notifyTableReady, handleExpiry };
+}
+
+const consoleLogger: WaitlistNotifierLogger = {
+  error: (obj, msg) => process.stderr.write(JSON.stringify({ ...obj, msg }) + "\n"),
+  info: (obj, msg) => process.stdout.write(JSON.stringify({ ...obj, msg }) + "\n"),
+};
+
+/**
+ * Creates the production WaitlistNotifier backed by Twilio SMS + BullMQ.
+ * Reads Twilio env vars at first use so buildApp() stays side-effect-free.
+ * Dep construction is deferred to first use: JobScheduler opens a Redis
+ * connection in its constructor.
+ */
+export function createDefaultWaitlistNotifier(): WaitlistNotifier {
+  let notifier: WaitlistNotifier | null = null;
+
+  function getNotifier(): WaitlistNotifier {
+    if (notifier) return notifier;
+
+    const smsAdapter: SmsPort | null =
+      process.env.TWILIO_ACCOUNT_SID &&
+      process.env.TWILIO_AUTH_TOKEN &&
+      process.env.TWILIO_FROM_NUMBER
+        ? new TwilioSmsAdapter({
+            // eslint-disable-next-line @typescript-eslint/no-require-imports
+            client: require("twilio")(
+              process.env.TWILIO_ACCOUNT_SID,
+              process.env.TWILIO_AUTH_TOKEN
+            ) as never,
+            fromNumber: process.env.TWILIO_FROM_NUMBER,
+          })
+        : null;
+
+    const jobScheduler = new JobScheduler({ redisUrl: REDIS_URL });
+
+    // Use a ref object so the self-referential notifyTableReady callback can
+    // capture the notifier instance after it is constructed (const-safe).
+    const ref: { value: WaitlistNotifier | null } = { value: null };
+
+    const built = createWaitlistNotifier({
+      smsAdapter,
+      scheduler: {
+        schedule: (jobType, payload, delayMs, jobId) =>
+          jobScheduler.schedule(
+            jobType as typeof JOB_TYPES.WAITLIST_EXPIRY,
+            payload as {
+              waitlistEntryId: string;
+              venueId: string;
+              guestPhone: string | null;
+              guestEmail: string | null;
+            },
+            delayMs,
+            jobId
+          ),
+      },
+      expireEntry: (id) => waitlistService.expire(id),
+      listWaiting: (venueId) => waitlistService.listWaiting(venueId),
+      notifyTableReady: (entry) => ref.value!.notifyTableReady(entry),
+      logger: consoleLogger,
+    });
+
+    ref.value = built;
+    notifier = built;
+    return notifier;
+  }
+
+  return {
+    notifyAdded: (input) => getNotifier().notifyAdded(input),
+    notifyPositionUpdate: (input) => getNotifier().notifyPositionUpdate(input),
+    notifyTableReady: (input) => getNotifier().notifyTableReady(input),
+    handleExpiry: (input) => getNotifier().handleExpiry(input),
+  };
+}


### PR DESCRIPTION
## Summary

- Adds three new SMS notification events for the walk-in waitlist: **added** (position + estimated wait), **position update** (only when improved 2+ spots), and **table ready** (with 5-minute claim window)
- `PUT /api/v1/waitlist/:id/notify` triggers the table-ready SMS and schedules a BullMQ `waitlist-expiry` delayed job; on expiry the next waiting party is automatically notified
- Phone number validated at the `POST /api/v1/waitlist` boundary (400 on invalid)
- SMS delivery failures are logged but never block waitlist operations
- `WaitlistNotifier` wired into the Fastify app as `fastify.waitlistNotifier` (injectable for tests; lazy-init in production to avoid Redis connection at startup)
- `sendWaitlistAdded`, `sendWaitlistPositionUpdate`, `sendWaitlistTableReady` added to `SmsPort` interface and `TwilioSmsAdapter`

## Test plan

- [x] `waitlist-notifier.test.ts` — 100% unit coverage: validatePhone, notifyAdded, notifyPositionUpdate (2-spot threshold), notifyTableReady (schedules expiry), handleExpiry (notifies next party)
- [x] `waitlist.test.ts` — route-level tests for `PUT /:id/notify` (200 + 404) and phone validation (400 on invalid phone)
- [x] All 878 existing reservations tests pass
- [x] All 63 notifications package tests pass
- [x] `pnpm lint` clean on both packages
- [x] `pnpm typecheck` clean on both packages
- [x] `check-adr` and `check-deps` pass
- [x] `pnpm regen` run; `llms.txt`/`llms-full.txt` artifacts updated

Closes #1725