### PR TITLE
fix(deploy): exclude test files from prod tsc build (users + reservations)

### DIFF
--- a/services/reservations/package.json
+++ b/services/reservations/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch --env-file=.env src/index.ts",
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "build:openapi": "tsx -e \"import { buildApp } from './src/app.js'; (async () => { const app = await buildApp({ logger: false }); await app.ready(); console.log(JSON.stringify(app.swagger(), null, 2)); })()\" > openapi.json",
     "start": "node dist/index.js",
     "test": "vitest run",

--- a/services/reservations/tsconfig.build.json
+++ b/services/reservations/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts", "src/test"]
+}

--- a/services/users/package.json
+++ b/services/users/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch --env-file=.env src/index.ts",
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "build:openapi": "tsx -e \"import { buildApp } from './src/app.js'; (async () => { const app = await buildApp({ logger: false }); await app.ready(); console.log(JSON.stringify(app.swagger(), null, 2)); })()\" > openapi.json",
     "start": "node dist/index.js",
     "test": "vitest run",

--- a/services/users/tsconfig.build.json
+++ b/services/users/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts", "src/test"]
+}


### PR DESCRIPTION
## Problem

All DigitalOcean service deploys have been failing since #2382 (`@mbe/test-fixtures`). The prod `tsc` build compiles test files, which import the `@mbe/test-fixtures` **devDependency** workspace package. DO's production install prunes devDependency workspace packages, so the build hits:

```
src/test/fixtures.ts: error TS2307: Cannot find module '@mbe/test-fixtures'
```

→ `BuildJobExitNonZero` → `deploy-services.yml` fails → deploy circuit breaker trips → deploys 'unhealthy'.

Affected: `services/users/src/test/fixtures.ts`, `services/reservations/src/test/mocks.ts`. Agent service is unaffected.

## Fix

Add `tsconfig.build.json` per service (matching the existing `packages/rialto-catalog` precedent) that excludes test files, and point the `build` script at it. `typecheck` still uses `tsconfig.json`, so test files remain type-checked.

## Verification (local, Node 22)

- `pnpm build` → exit 0 for both services; **no test files emitted to `dist/`**
- `pnpm typecheck` → exit 0 for both (test files still covered)

## Unblocks

- #2458 (circuit breaker tripped — deploys blocked)
- #2473 (system health: deploys unhealthy)
- #2401 (deploy circuit breaker tripped, root-cause investigation)

After merge: deploys go green; reset the circuit breaker with `gh workflow run circuit-breaker.yml -f force=true` if it doesn't auto-clear.