### PR TITLE
refactor(rialto): cn() + variantClass() seam, adopted in 5 components

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -16042,6 +16042,19 @@
       return `${n}${suffix[(v - 20) % 10] ?? suffix[v] ?? suffix[0]} visit`;
     }
   </file>
+  <file path="packages/rialto/src/utils/class-composer.ts">
+    export function cn(...classes: (string | false | null | undefined)[]): string {
+      return classes.filter(Boolean).join(" ");
+    }
+    export function variantClass(
+      styles: CSSModuleClasses,
+      current: string,
+      defaultValue: string
+    ): string {
+      if (current === defaultValue) return "";
+      return styles[current] ?? "";
+    }
+  </file>
   <file path="packages/rialto/src/utils/feedback.ts">
     export function triggerHapticFeedback(): void {
       if (typeof navigator !== "undefined" && "vibrate" in navigator) {

--- a/llms.txt
+++ b/llms.txt
@@ -4528,6 +4528,18 @@
       export function ordinalVisit(n: number): string { /* ... */ }
     </item>
   </file>
+  <file path="packages/rialto/src/utils/class-composer.ts">
+    <item priority="high">
+      export function cn(...classes: (string | false | null | undefined)[]): string { /* ... */ }
+    </item>
+    <item priority="high">
+      export function variantClass(
+        styles: CSSModuleClasses,
+        current: string,
+        defaultValue: string
+      ): string { /* ... */ }
+    </item>
+  </file>
   <file path="packages/rialto/src/utils/feedback.ts">
     <item priority="high">
       export function triggerHapticFeedback(): void { /* ... */ }

--- a/packages/rialto/llms-full.txt
+++ b/packages/rialto/llms-full.txt
@@ -1097,6 +1097,19 @@
   </file>
   </section>
   <section priority="medium" role="utils">
+  <file path="src/utils/class-composer.ts">
+    export function cn(...classes: (string | false | null | undefined)[]): string {
+      return classes.filter(Boolean).join(" ");
+    }
+    export function variantClass(
+      styles: CSSModuleClasses,
+      current: string,
+      defaultValue: string
+    ): string {
+      if (current === defaultValue) return "";
+      return styles[current] ?? "";
+    }
+  </file>
   <file path="src/utils/feedback.ts">
     export function triggerHapticFeedback(): void {
       if (typeof navigator !== "undefined" && "vibrate" in navigator) {

--- a/packages/rialto/llms.txt
+++ b/packages/rialto/llms.txt
@@ -418,6 +418,18 @@
   </file>
   </section>
   <section priority="medium" role="utils">
+  <file path="src/utils/class-composer.ts">
+    <item priority="high">
+      export function cn(...classes: (string | false | null | undefined)[]): string { /* ... */ }
+    </item>
+    <item priority="high">
+      export function variantClass(
+        styles: CSSModuleClasses,
+        current: string,
+        defaultValue: string
+      ): string { /* ... */ }
+    </item>
+  </file>
   <file path="src/utils/feedback.ts">
     <item priority="high">
       export function triggerHapticFeedback(): void { /* ... */ }

--- a/packages/rialto/src/components/Alert/Alert.tsx
+++ b/packages/rialto/src/components/Alert/Alert.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, useState, type ReactNode } from "react";
 import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import { precision } from "../../tokens/motion";
+import { cn } from "../../utils/class-composer";
 import styles from "./Alert.module.css";
 
 /* ── Types ───────────────────────────────────── */
@@ -114,7 +115,7 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>(
         {visible && (
           <motion.div
             ref={ref}
-            className={`${styles.alert} ${styles[variant]} ${className}`}
+            className={cn(styles.alert, styles[variant], className)}
             role={role}
             initial={shouldReduceMotion ? undefined : { opacity: 0, y: -8 }}
             animate={{ opacity: 1, y: 0 }}

--- a/packages/rialto/src/components/Badge/Badge.tsx
+++ b/packages/rialto/src/components/Badge/Badge.tsx
@@ -1,4 +1,5 @@
 import { forwardRef, type HTMLAttributes, type ReactNode } from "react";
+import { cn, variantClass } from "../../utils/class-composer";
 import styles from "./Badge.module.css";
 
 /**
@@ -21,9 +22,7 @@ export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
 
 export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(
   ({ variant = "neutral", size = "md", dot, className, children, ...props }, ref) => {
-    const classes = [styles.badge, styles[variant], size === "sm" ? styles.sm : "", className]
-      .filter(Boolean)
-      .join(" ");
+    const classes = cn(styles.badge, styles[variant], variantClass(styles, size, "md"), className);
 
     return (
       <span ref={ref} className={classes} {...props}>

--- a/packages/rialto/src/components/Button/Button.tsx
+++ b/packages/rialto/src/components/Button/Button.tsx
@@ -2,6 +2,7 @@ import { forwardRef, type ButtonHTMLAttributes } from "react";
 import { motion, useReducedMotion, type HTMLMotionProps } from "framer-motion";
 import { Loader2 } from "lucide-react";
 import { precision, boop } from "../../tokens/motion";
+import { cn, variantClass } from "../../utils/class-composer";
 import styles from "./Button.module.css";
 
 type MotionButtonProps = HTMLMotionProps<"button">;
@@ -49,16 +50,13 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   ) => {
     const shouldReduceMotion = useReducedMotion();
 
-    const sizeClass = size !== "md" ? styles[size] : "";
-    const classes = [
+    const classes = cn(
       styles.button,
       styles[variant],
-      sizeClass,
+      variantClass(styles, size, "md"),
       isLoading && styles.isLoading,
-      className,
-    ]
-      .filter(Boolean)
-      .join(" ");
+      className
+    );
 
     const isDisabled = disabled || isLoading;
 

--- a/packages/rialto/src/components/Card/Card.tsx
+++ b/packages/rialto/src/components/Card/Card.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, useCallback, type HTMLAttributes, type ReactNode } from "react";
 import { motion, type HTMLMotionProps } from "framer-motion";
 import { useTilt } from "../../hooks/useTilt";
+import { cn } from "../../utils/class-composer";
 import styles from "./Card.module.css";
 
 /**
@@ -48,10 +49,10 @@ export const Card = forwardRef<HTMLDivElement, CardProps>(
       [forwardedRef, tiltRef]
     );
 
-    const variantClass =
+    const variantStyle =
       variant === "glass" ? styles.glass : variant === "flat" ? styles.flat : styles.card;
 
-    const classes = [variantClass, className].filter(Boolean).join(" ");
+    const classes = cn(variantStyle, className);
 
     return (
       <motion.div

--- a/packages/rialto/src/components/Input/Input.tsx
+++ b/packages/rialto/src/components/Input/Input.tsx
@@ -2,6 +2,7 @@ import { forwardRef, type InputHTMLAttributes, type ReactNode } from "react";
 import { Lock } from "lucide-react";
 import { DisabledTooltip } from "../DisabledTooltip/DisabledTooltip";
 import { useField } from "../../hooks/useField";
+import { cn } from "../../utils/class-composer";
 import styles from "./Input.module.css";
 
 /**
@@ -50,16 +51,12 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     ref
   ) => {
     const field = useField({ id, hint, error, required, showOptional: showOptionalProp });
-    const wrapperClass = [styles.wrapper, error && styles.error, className]
-      .filter(Boolean)
-      .join(" ");
-    const inputClass = [
+    const wrapperClass = cn(styles.wrapper, error && styles.error, className);
+    const inputClass = cn(
       styles.input,
-      startIcon && styles.inputWithStartIcon,
-      endIcon && styles.inputWithEndIcon,
-    ]
-      .filter(Boolean)
-      .join(" ");
+      !!startIcon && styles.inputWithStartIcon,
+      !!endIcon && styles.inputWithEndIcon
+    );
 
     return (
       <DisabledTooltip disabled={disabled} disabledReason={disabledReason}>

--- a/packages/rialto/src/utils/class-composer.test.ts
+++ b/packages/rialto/src/utils/class-composer.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { cn, variantClass } from "./class-composer";
+
+describe("cn", () => {
+  it("joins truthy strings", () => {
+    expect(cn("foo", "bar")).toBe("foo bar");
+  });
+
+  it("filters falsy values", () => {
+    expect(cn("foo", false, undefined, null, "", "bar")).toBe("foo bar");
+  });
+
+  it("returns empty string when all falsy", () => {
+    expect(cn(false, undefined, null, "")).toBe("");
+  });
+
+  it("handles a single class", () => {
+    expect(cn("only")).toBe("only");
+  });
+
+  it("handles no args", () => {
+    expect(cn()).toBe("");
+  });
+});
+
+describe("variantClass", () => {
+  const styles = {
+    neutral: "badge-neutral",
+    accent: "badge-accent",
+    sm: "badge-sm",
+    md: "badge-md",
+  } as unknown as CSSModuleClasses;
+
+  it("returns the variant class when not the default", () => {
+    expect(variantClass(styles, "accent", "neutral")).toBe("badge-accent");
+  });
+
+  it("returns empty string for the default variant (omit-default rule)", () => {
+    expect(variantClass(styles, "neutral", "neutral")).toBe("");
+  });
+
+  it("returns empty string for the default size (omit-default rule)", () => {
+    const sizeStyles = { sm: "sz-sm", md: "sz-md" } as unknown as CSSModuleClasses;
+    expect(variantClass(sizeStyles, "md", "md")).toBe("");
+  });
+
+  it("returns non-default size class", () => {
+    const sizeStyles = { sm: "sz-sm", md: "sz-md" } as unknown as CSSModuleClasses;
+    expect(variantClass(sizeStyles, "sm", "md")).toBe("sz-sm");
+  });
+
+  it("guards a missing key — returns empty string, not undefined", () => {
+    expect(variantClass(styles, "missing-key" as string, "neutral")).toBe("");
+  });
+
+  it("guards a key whose CSS Module value is undefined — returns empty string", () => {
+    const sparseStyles = { neutral: undefined } as unknown as CSSModuleClasses;
+    expect(variantClass(sparseStyles, "neutral", "something-else")).toBe("");
+  });
+});

--- a/packages/rialto/src/utils/class-composer.ts
+++ b/packages/rialto/src/utils/class-composer.ts
@@ -1,0 +1,23 @@
+/**
+ * Filters falsy values and joins the remaining strings with a space.
+ * The single place the merge idiom lives in Rialto.
+ */
+export function cn(...classes: (string | false | null | undefined)[]): string {
+  return classes.filter(Boolean).join(" ");
+}
+
+/**
+ * Returns the CSS Module class for a given variant/size key, applying two rules:
+ * 1. Omit-default: returns "" when `current === defaultValue` (no class needed)
+ * 2. Missing-key guard: returns "" instead of `undefined` when the key is absent
+ *    or its CSS Module value is falsy — so no component can emit "undefined" in
+ *    a class string.
+ */
+export function variantClass(
+  styles: CSSModuleClasses,
+  current: string,
+  defaultValue: string
+): string {
+  if (current === defaultValue) return "";
+  return styles[current] ?? "";
+}


### PR DESCRIPTION
## Summary

- Introduces `cn(...classes)` in `packages/rialto/src/utils/class-composer.ts` — the single place the `.filter(Boolean).join(" ")` merge idiom lives in Rialto
- Introduces `variantClass(styles, current, default)` — centralizes the omit-default-variant rule and guards missing CSS Module keys so no component can emit `"undefined"` in a class string
- Adopts both utilities in 5 representative components: Button, Badge, Alert, Input, Card — replacing all inline `.filter(Boolean).join(" ")` usage in those components

## Gate results

- `pnpm lint` — 0 errors (140 warnings, all pre-existing)
- `pnpm typecheck` — clean
- `pnpm test` — 1685 passed; 1 pre-existing failure (`useChatStream` / unresolved `@mbe/api-client/streaming`, present on baseline before this change)
- `check-adr` / `check-deps` — no violations
- `pnpm regen` — llms.txt artifacts updated (new util file), no other drift
- `detect-instruction-rot` — no rot

## Test plan

- [ ] `pnpm test` in `packages/rialto` — 1685 tests pass (same as baseline)
- [ ] `pnpm typecheck` in `packages/rialto` — clean
- [ ] Visually verify Button/Badge/Alert/Input/Card render identically to before in the showcase app

Closes #2236