### PR TITLE
refactor(hospitality): useTimelineData orchestration hook — TimelinePage becomes layout

### DIFF
--- a/apps/hospitality/llms-full.txt
+++ b/apps/hospitality/llms-full.txt
@@ -367,6 +367,16 @@
       enabled?: boolean;
     }
   </file>
+  <file path="src/hooks/useTimelineData.ts">
+    export interface UseTimelineDataParams {
+      venueId: string | undefined;
+      date: string;
+    }
+    export interface CancelArgs {
+      reason: string;
+      note: string;
+    }
+  </file>
   <file path="src/hooks/useUsers.ts">
     export const CURRENT_USER_QUERY_KEY = "currentUser" as const;
     export const USERS_QUERY_KEY = "users" as const;

--- a/apps/hospitality/llms.txt
+++ b/apps/hospitality/llms.txt
@@ -273,6 +273,20 @@
       }
     </item>
   </file>
+  <file path="src/hooks/useTimelineData.ts">
+    <item priority="low">
+      interface UseTimelineDataParams {
+        venueId: string | undefined;
+        date: string;
+      }
+    </item>
+    <item priority="low">
+      interface CancelArgs {
+        reason: string;
+        note: string;
+      }
+    </item>
+  </file>
   <file path="src/hooks/useUsers.ts">
     <item priority="high">
       export const CURRENT_USER_QUERY_KEY: unknown;

--- a/apps/hospitality/src/hooks/useTimelineData.test.ts
+++ b/apps/hospitality/src/hooks/useTimelineData.test.ts
@@ -1,0 +1,366 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+import { useTimelineData } from "./useTimelineData.js";
+import type { Reservation, Table } from "@mbe/types";
+
+/* ── Mocks ──────────────────────────────────────────── */
+
+const mockReservationsList = vi.fn();
+const mockTablesList = vi.fn();
+const mockReservationsUpdate = vi.fn();
+const mockReservationsCancelWithReason = vi.fn();
+const mockReservationsWalkIn = vi.fn();
+const mockTablesUpdateStatus = vi.fn();
+
+vi.mock("./useApiClient.js", () => ({
+  useApiClient: () => ({
+    reservations: {
+      list: mockReservationsList,
+      update: mockReservationsUpdate,
+      cancelWithReason: mockReservationsCancelWithReason,
+      walkIn: mockReservationsWalkIn,
+    },
+    tables: {
+      list: mockTablesList,
+      updateStatus: mockTablesUpdateStatus,
+    },
+  }),
+}));
+
+/* ── Helpers ────────────────────────────────────────── */
+
+function makeReservation(overrides: Partial<Reservation> = {}): Reservation {
+  const todayStr = new Date().toLocaleDateString("en-CA");
+  return {
+    id: "r1",
+    date: todayStr,
+    startTime: "2026-05-10T18:00:00",
+    endTime: "2026-05-10T20:00:00",
+    partySize: 4,
+    status: "CONFIRMED",
+    notes: null,
+    cancellationReason: null,
+    cancellationNote: null,
+    guestName: "Alice",
+    guestEmail: null,
+    guestPhone: null,
+    guestId: null,
+    userId: null,
+    occasion: null,
+    seatingPreference: null,
+    tableId: "t1",
+    venueId: "venue-1",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeTable(overrides: Partial<Table> = {}): Table {
+  return {
+    id: "t1",
+    name: "Table 1",
+    tableNumber: "T1",
+    capacity: 4,
+    minCovers: 1,
+    maxCovers: null,
+    location: null,
+    isActive: true,
+    priority: 1,
+    status: "AVAILABLE",
+    venueId: "venue-1",
+    floorPlanId: null,
+    shapeMetadata: null,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+/* ── Tests ──────────────────────────────────────────── */
+
+describe("useTimelineData", () => {
+  const todayStr = new Date().toLocaleDateString("en-CA");
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("query composition", () => {
+    it("fetches reservations for the given venueId and date", async () => {
+      const reservations = [makeReservation()];
+      mockReservationsList.mockResolvedValue({ data: reservations });
+      mockTablesList.mockResolvedValue({ data: [] });
+
+      const { result } = renderHook(() => useTimelineData({ venueId: "venue-1", date: todayStr }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(mockReservationsList).toHaveBeenCalledWith(
+        expect.objectContaining({ venueId: "venue-1", date: todayStr })
+      );
+    });
+
+    it("fetches tables for the given venueId", async () => {
+      mockReservationsList.mockResolvedValue({ data: [] });
+      mockTablesList.mockResolvedValue({ data: [makeTable()] });
+
+      const { result } = renderHook(() => useTimelineData({ venueId: "venue-1", date: todayStr }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(mockTablesList).toHaveBeenCalledWith(expect.objectContaining({ venueId: "venue-1" }));
+    });
+
+    it("returns sorted tables by priority desc then name asc", async () => {
+      const tables = [
+        makeTable({ id: "t3", name: "Charlie", tableNumber: "T3", priority: 1 }),
+        makeTable({ id: "t1", name: "Alpha", tableNumber: "T1", priority: 2 }),
+        makeTable({ id: "t2", name: "Bravo", tableNumber: "T2", priority: 2 }),
+      ];
+      mockReservationsList.mockResolvedValue({ data: [] });
+      mockTablesList.mockResolvedValue({ data: tables });
+
+      const { result } = renderHook(() => useTimelineData({ venueId: "venue-1", date: todayStr }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      const ids = result.current.tables.map((t) => t.id);
+      expect(ids).toEqual(["t1", "t2", "t3"]);
+    });
+
+    it("filters reservations to the selected date", async () => {
+      const today = todayStr;
+      const otherDay = "2026-01-01";
+      const reservations = [
+        makeReservation({ id: "r1", date: today }),
+        makeReservation({ id: "r2", date: otherDay }),
+      ];
+      mockReservationsList.mockResolvedValue({ data: reservations });
+      mockTablesList.mockResolvedValue({ data: [] });
+
+      const { result } = renderHook(() => useTimelineData({ venueId: "venue-1", date: today }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(result.current.reservations.every((r) => r.date === today)).toBe(true);
+      expect(result.current.reservations.some((r) => r.id === "r2")).toBe(false);
+    });
+
+    it("returns combined loading state", async () => {
+      mockReservationsList.mockReturnValue(new Promise(() => {}));
+      mockTablesList.mockReturnValue(new Promise(() => {}));
+
+      const { result } = renderHook(() => useTimelineData({ venueId: "venue-1", date: todayStr }), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    it("returns combined fetch error (reservations)", async () => {
+      mockReservationsList.mockRejectedValue(new Error("Reservations failed"));
+      mockTablesList.mockResolvedValue({ data: [] });
+
+      const { result } = renderHook(() => useTimelineData({ venueId: "venue-1", date: todayStr }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(result.current.fetchError?.message).toBe("Reservations failed");
+    });
+
+    it("does not fetch when venueId is undefined", () => {
+      const { result } = renderHook(() => useTimelineData({ venueId: undefined, date: todayStr }), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.isLoading).toBe(false);
+      expect(mockReservationsList).not.toHaveBeenCalled();
+      expect(mockTablesList).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("mutation: seatGuest", () => {
+    it("calls reservations.update and tables.updateStatus then invalidates", async () => {
+      mockReservationsList.mockResolvedValue({ data: [] });
+      mockTablesList.mockResolvedValue({ data: [] });
+      mockReservationsUpdate.mockResolvedValue({ id: "r1", status: "CONFIRMED" });
+      mockTablesUpdateStatus.mockResolvedValue({});
+
+      const { result } = renderHook(() => useTimelineData({ venueId: "venue-1", date: todayStr }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        await result.current.seatGuest(makeReservation());
+      });
+
+      expect(mockReservationsUpdate).toHaveBeenCalledWith("r1", { status: "CONFIRMED" });
+      expect(mockTablesUpdateStatus).toHaveBeenCalledWith("t1", "OCCUPIED");
+    });
+
+    it("throws when seatGuest fails", async () => {
+      mockReservationsList.mockResolvedValue({ data: [] });
+      mockTablesList.mockResolvedValue({ data: [] });
+      mockReservationsUpdate.mockRejectedValue(new Error("Seat failed"));
+
+      const { result } = renderHook(() => useTimelineData({ venueId: "venue-1", date: todayStr }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await expect(
+        act(async () => {
+          await result.current.seatGuest(makeReservation());
+        })
+      ).rejects.toThrow("Seat failed");
+    });
+  });
+
+  describe("mutation: cancelReservation", () => {
+    it("calls reservations.cancelWithReason then invalidates", async () => {
+      mockReservationsList.mockResolvedValue({ data: [] });
+      mockTablesList.mockResolvedValue({ data: [] });
+      mockReservationsCancelWithReason.mockResolvedValue({});
+
+      const { result } = renderHook(() => useTimelineData({ venueId: "venue-1", date: todayStr }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        await result.current.cancelReservation("r1", { reason: "no_show", note: "test" });
+      });
+
+      expect(mockReservationsCancelWithReason).toHaveBeenCalledWith("r1", {
+        cancellationReason: "no_show",
+        cancellationNote: "test",
+      });
+    });
+
+    it("throws when cancelReservation fails", async () => {
+      mockReservationsList.mockResolvedValue({ data: [] });
+      mockTablesList.mockResolvedValue({ data: [] });
+      mockReservationsCancelWithReason.mockRejectedValue(new Error("Cancel failed"));
+
+      const { result } = renderHook(() => useTimelineData({ venueId: "venue-1", date: todayStr }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await expect(
+        act(async () => {
+          await result.current.cancelReservation("r1", { reason: "no_show", note: "" });
+        })
+      ).rejects.toThrow("Cancel failed");
+    });
+  });
+
+  describe("mutation: updateReservation", () => {
+    it("calls reservations.update and returns updated reservation", async () => {
+      mockReservationsList.mockResolvedValue({ data: [] });
+      mockTablesList.mockResolvedValue({ data: [] });
+      const updated = makeReservation({ partySize: 6 });
+      mockReservationsUpdate.mockResolvedValue(updated);
+
+      const { result } = renderHook(() => useTimelineData({ venueId: "venue-1", date: todayStr }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      let returnValue: Reservation | undefined;
+      await act(async () => {
+        returnValue = await result.current.updateReservation("r1", { partySize: 6 });
+      });
+
+      expect(mockReservationsUpdate).toHaveBeenCalledWith("r1", { partySize: 6 });
+      expect(returnValue?.partySize).toBe(6);
+    });
+  });
+
+  describe("mutation: createWalkIn", () => {
+    it("calls reservations.walkIn then invalidates", async () => {
+      mockReservationsList.mockResolvedValue({ data: [] });
+      mockTablesList.mockResolvedValue({ data: [] });
+      mockReservationsWalkIn.mockResolvedValue({ id: "r-walkin" });
+
+      const { result } = renderHook(() => useTimelineData({ venueId: "venue-1", date: todayStr }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      const walkInData = { partySize: 2, tableId: "t1", venueId: "venue-1", guestName: "Walkin" };
+      await act(async () => {
+        await result.current.createWalkIn(walkInData);
+      });
+
+      expect(mockReservationsWalkIn).toHaveBeenCalledWith(walkInData);
+    });
+  });
+
+  describe("mutation: updateTableStatus", () => {
+    it("calls tables.updateStatus then invalidates", async () => {
+      mockReservationsList.mockResolvedValue({ data: [] });
+      mockTablesList.mockResolvedValue({ data: [] });
+      mockTablesUpdateStatus.mockResolvedValue({});
+
+      const { result } = renderHook(() => useTimelineData({ venueId: "venue-1", date: todayStr }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        await result.current.updateTableStatus("t1", "OCCUPIED");
+      });
+
+      expect(mockTablesUpdateStatus).toHaveBeenCalledWith("t1", "OCCUPIED");
+    });
+  });
+
+  describe("stats computation", () => {
+    it("computes correct stats from reservations", async () => {
+      const reservations = [
+        makeReservation({ id: "r1", status: "CONFIRMED", partySize: 4, date: todayStr }),
+        makeReservation({ id: "r2", status: "PENDING", partySize: 2, date: todayStr }),
+        makeReservation({ id: "r3", status: "CANCELLED", partySize: 3, date: todayStr }),
+      ];
+      mockReservationsList.mockResolvedValue({ data: reservations });
+      mockTablesList.mockResolvedValue({ data: [] });
+
+      const { result } = renderHook(() => useTimelineData({ venueId: "venue-1", date: todayStr }), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.stats.confirmed).toBe(1);
+      expect(result.current.stats.pending).toBe(1);
+      expect(result.current.stats.total).toBe(3);
+      expect(result.current.stats.totalCovers).toBe(6); // 4 + 2 (CANCELLED excluded)
+    });
+  });
+});

--- a/apps/hospitality/src/hooks/useTimelineData.ts
+++ b/apps/hospitality/src/hooks/useTimelineData.ts
@@ -1,0 +1,161 @@
+import { useMemo } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import type { Reservation, Table, TableStatus, UpdateReservationRequest } from "@mbe/types";
+import { useReservations, RESERVATIONS_QUERY_KEY } from "./useReservations.js";
+import { useTables, TABLES_QUERY_KEY } from "./useTables.js";
+import { useApiClient } from "./useApiClient.js";
+
+/* ── Params ─────────────────────────────────────────── */
+
+export interface UseTimelineDataParams {
+  venueId: string | undefined;
+  date: string;
+}
+
+/* ── Cancel args ────────────────────────────────────── */
+
+export interface CancelArgs {
+  reason: string;
+  note: string;
+}
+
+/* ── Stats ──────────────────────────────────────────── */
+
+export interface TimelineStats {
+  confirmed: number;
+  pending: number;
+  totalCovers: number;
+  total: number;
+}
+
+/* ── Result ─────────────────────────────────────────── */
+
+export interface UseTimelineDataResult {
+  reservations: Reservation[];
+  tables: Table[];
+  isLoading: boolean;
+  fetchError: Error | null;
+  stats: TimelineStats;
+  seatGuest: (reservation: Reservation) => Promise<Reservation>;
+  cancelReservation: (id: string, args: CancelArgs) => Promise<void>;
+  updateReservation: (id: string, data: UpdateReservationRequest) => Promise<Reservation>;
+  createWalkIn: (data: {
+    partySize: number;
+    tableId: string;
+    venueId: string;
+    guestName?: string;
+  }) => Promise<void>;
+  updateTableStatus: (tableId: string, status: TableStatus) => Promise<void>;
+}
+
+/* ── Hook ───────────────────────────────────────────── */
+
+export function useTimelineData({ venueId, date }: UseTimelineDataParams): UseTimelineDataResult {
+  const api = useApiClient();
+  const queryClient = useQueryClient();
+
+  const enabled = !!venueId;
+
+  const {
+    data: allReservations,
+    isLoading: reservationsLoading,
+    error: reservationsError,
+  } = useReservations({
+    venueId,
+    date,
+    limit: 200,
+    enabled,
+  });
+
+  const {
+    data: rawTables,
+    isLoading: tablesLoading,
+    error: tablesError,
+  } = useTables({
+    venueId,
+    limit: 100,
+    enabled,
+  });
+
+  const isLoading = reservationsLoading || tablesLoading;
+  const fetchError = reservationsError ?? tablesError;
+
+  const tables = useMemo(() => {
+    if (!rawTables) return [];
+    return [...rawTables].sort((a, b) => {
+      if (a.priority !== b.priority) return b.priority - a.priority;
+      return (a.tableNumber || a.name).localeCompare(b.tableNumber || b.name);
+    });
+  }, [rawTables]);
+
+  const reservations = useMemo(
+    () => (allReservations ?? []).filter((r) => r.date === date),
+    [allReservations, date]
+  );
+
+  const stats = useMemo<TimelineStats>(() => {
+    const confirmed = reservations.filter((r) => r.status === "CONFIRMED").length;
+    const pending = reservations.filter((r) => r.status === "PENDING").length;
+    const totalCovers = reservations
+      .filter((r) => r.status !== "CANCELLED" && r.status !== "NO_SHOW")
+      .reduce((sum, r) => sum + r.partySize, 0);
+    return { confirmed, pending, totalCovers, total: reservations.length };
+  }, [reservations]);
+
+  const invalidateAll = () => {
+    queryClient.invalidateQueries({ queryKey: [RESERVATIONS_QUERY_KEY] });
+    queryClient.invalidateQueries({ queryKey: [TABLES_QUERY_KEY] });
+  };
+
+  const seatGuest = async (reservation: Reservation): Promise<Reservation> => {
+    const updated = await api.reservations.update(reservation.id, { status: "CONFIRMED" });
+    await api.tables.updateStatus(reservation.tableId, "OCCUPIED");
+    invalidateAll();
+    return updated;
+  };
+
+  const cancelReservation = async (id: string, { reason, note }: CancelArgs): Promise<void> => {
+    await api.reservations.cancelWithReason(id, {
+      cancellationReason: reason,
+      cancellationNote: note,
+    });
+    invalidateAll();
+  };
+
+  const updateReservation = async (
+    id: string,
+    data: UpdateReservationRequest
+  ): Promise<Reservation> => {
+    const updated = await api.reservations.update(id, data);
+    invalidateAll();
+    return updated;
+  };
+
+  const createWalkIn = async (data: {
+    partySize: number;
+    tableId: string;
+    venueId: string;
+    guestName?: string;
+  }): Promise<void> => {
+    await api.reservations.walkIn(data);
+    invalidateAll();
+  };
+
+  const updateTableStatus = async (tableId: string, status: TableStatus): Promise<void> => {
+    await api.tables.updateStatus(tableId, status);
+    invalidateAll();
+  };
+
+  return {
+    reservations,
+    tables,
+    isLoading,
+    fetchError,
+    stats,
+    seatGuest,
+    cancelReservation,
+    updateReservation,
+    createWalkIn,
+    updateTableStatus,
+  };
+}

--- a/apps/hospitality/src/pages/TimelinePage.test.tsx
+++ b/apps/hospitality/src/pages/TimelinePage.test.tsx
@@ -6,10 +6,8 @@ import { TimelinePage } from "./TimelinePage.js";
 import { useVenue } from "../contexts/VenueContext.js";
 import type { VenueContextValue } from "../contexts/VenueContext.js";
 import { useSSEStatus } from "../hooks/useSSESync.js";
-import { useReservations } from "../hooks/useReservations.js";
-import type { UseReservationsResult } from "../hooks/useReservations.js";
-import { useTables } from "../hooks/useTables.js";
-import type { UseTablesResult } from "../hooks/useTables.js";
+import { useTimelineData } from "../hooks/useTimelineData.js";
+import type { UseTimelineDataResult } from "../hooks/useTimelineData.js";
 import type { Reservation, Table } from "@mbe/types";
 import React from "react";
 
@@ -19,19 +17,14 @@ vi.mock("../hooks/useSSESync.js", () => ({
   useSSESync: vi.fn(() => ({ reconnect: vi.fn() })),
   useSSEEventFeed: vi.fn(() => []),
 }));
+vi.mock("../hooks/useTimelineData.js", () => ({ useTimelineData: vi.fn() }));
+// Block transitive resolution of packages unavailable in this worktree environment
+vi.mock("../hooks/useApiClient.js", () => ({ useApiClient: vi.fn() }));
 vi.mock("../hooks/useReservations.js", () => ({
   useReservations: vi.fn(),
   RESERVATIONS_QUERY_KEY: "reservations",
 }));
 vi.mock("../hooks/useTables.js", () => ({ useTables: vi.fn(), TABLES_QUERY_KEY: "tables" }));
-
-const mockApiClient = {
-  tables: { list: vi.fn(), updateStatus: vi.fn() },
-  reservations: { list: vi.fn(), update: vi.fn(), cancelWithReason: vi.fn(), walkIn: vi.fn() },
-};
-vi.mock("../hooks/useApiClient.js", () => ({
-  useApiClient: () => mockApiClient,
-}));
 
 vi.mock("../components/PageHeader", () => ({
   PageHeader: ({ title }: { title: string }) => <div data-testid="page-header">{title}</div>,
@@ -200,6 +193,7 @@ vi.mock("@mattbutlerengineering/rialto", () => ({
       {children}
     </div>
   ),
+  Divider: () => <hr />,
 }));
 
 // Mock matchMedia for useIsMobile hook
@@ -280,52 +274,41 @@ function makeTable(overrides: Partial<Table> = {}): Table {
   };
 }
 
+function makeTimelineData(overrides: Partial<UseTimelineDataResult> = {}): UseTimelineDataResult {
+  const todayStr = new Date().toLocaleDateString("en-CA");
+  const defaultReservation = makeReservation({ date: todayStr });
+  const defaultTable = makeTable();
+  return {
+    reservations: [defaultReservation],
+    tables: [defaultTable],
+    isLoading: false,
+    fetchError: null,
+    stats: { confirmed: 1, pending: 0, totalCovers: 4, total: 1 },
+    seatGuest: vi.fn().mockResolvedValue(defaultReservation),
+    cancelReservation: vi.fn().mockResolvedValue(undefined),
+    updateReservation: vi.fn().mockResolvedValue(defaultReservation),
+    createWalkIn: vi.fn().mockResolvedValue(undefined),
+    updateTableStatus: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
 describe("TimelinePage", () => {
   const todayStr = new Date().toLocaleDateString("en-CA");
-
   const defaultReservation = makeReservation({ guestName: "Alice", date: todayStr });
-  const defaultTable = makeTable();
 
-  function mockHooksWithData(
-    overrides: {
-      reservations?: Reservation[] | undefined;
-      tables?: Table[] | undefined;
-      isConnected?: boolean;
-      reservationsLoading?: boolean;
-      tablesLoading?: boolean;
-      reservationsError?: Error | null;
-      tablesError?: Error | null;
-    } = {}
-  ) {
-    const {
-      reservations = [defaultReservation],
-      tables = [defaultTable],
-      isConnected = true,
-      reservationsLoading = false,
-      tablesLoading = false,
-      reservationsError = null,
-      tablesError = null,
-    } = overrides;
+  const testQueryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
 
-    vi.mocked(useReservations).mockReturnValue({
-      data: reservations,
-      isLoading: reservationsLoading,
-      error: reservationsError,
-      refetch: vi.fn(),
-    } satisfies UseReservationsResult);
-
-    vi.mocked(useTables).mockReturnValue({
-      data: tables,
-      isLoading: tablesLoading,
-      error: tablesError,
-      refetch: vi.fn(),
-    } satisfies UseTablesResult);
-
-    vi.mocked(useSSEStatus).mockReturnValue({
-      isConnected,
-      error: null,
-    });
-  }
+  const renderPage = () =>
+    render(
+      <QueryClientProvider client={testQueryClient}>
+        <MemoryRouter>
+          <TimelinePage />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -361,21 +344,9 @@ describe("TimelinePage", () => {
       })
     );
 
-    mockHooksWithData();
+    vi.mocked(useSSEStatus).mockReturnValue({ isConnected: true, error: null });
+    vi.mocked(useTimelineData).mockReturnValue(makeTimelineData());
   });
-
-  const testQueryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
-
-  const renderPage = () =>
-    render(
-      <QueryClientProvider client={testQueryClient}>
-        <MemoryRouter>
-          <TimelinePage />
-        </MemoryRouter>
-      </QueryClientProvider>
-    );
 
   it("renders the timeline page header", async () => {
     renderPage();
@@ -406,13 +377,10 @@ describe("TimelinePage", () => {
     expect(screen.getByTestId("walkin-dialog")).toBeDefined();
   });
 
-  it("passes venue and date params to TQ hooks on mount", async () => {
+  it("passes venue and date params to useTimelineData", async () => {
     renderPage();
-    expect(vi.mocked(useReservations)).toHaveBeenCalledWith(
+    expect(vi.mocked(useTimelineData)).toHaveBeenCalledWith(
       expect.objectContaining({ venueId: "venue-1", date: todayStr })
-    );
-    expect(vi.mocked(useTables)).toHaveBeenCalledWith(
-      expect.objectContaining({ venueId: "venue-1" })
     );
   });
 
@@ -456,7 +424,7 @@ describe("TimelinePage", () => {
       });
       fireEvent.click(screen.getByLabelText("Previous day"));
       await waitFor(() => {
-        expect(vi.mocked(useReservations)).toHaveBeenCalledWith(
+        expect(vi.mocked(useTimelineData)).toHaveBeenCalledWith(
           expect.objectContaining({ date: "2026-05-09" })
         );
       });
@@ -469,7 +437,7 @@ describe("TimelinePage", () => {
       });
       fireEvent.click(screen.getByLabelText("Next day"));
       await waitFor(() => {
-        expect(vi.mocked(useReservations)).toHaveBeenCalledWith(
+        expect(vi.mocked(useTimelineData)).toHaveBeenCalledWith(
           expect.objectContaining({ date: "2026-05-11" })
         );
       });
@@ -499,7 +467,7 @@ describe("TimelinePage", () => {
       fireEvent.click(screen.getByText("Today"));
       const today = new Date().toLocaleDateString("en-CA");
       await waitFor(() => {
-        expect(vi.mocked(useReservations)).toHaveBeenCalledWith(
+        expect(vi.mocked(useTimelineData)).toHaveBeenCalledWith(
           expect.objectContaining({ date: today })
         );
       });
@@ -520,9 +488,11 @@ describe("TimelinePage", () => {
     });
 
     it("displays guest email when present", async () => {
-      mockHooksWithData({
-        reservations: [{ ...defaultReservation, guestEmail: "alice@example.com" }],
-      });
+      vi.mocked(useTimelineData).mockReturnValue(
+        makeTimelineData({
+          reservations: [{ ...defaultReservation, guestEmail: "alice@example.com" }],
+        })
+      );
       renderPage();
       await waitFor(() => {
         expect(screen.getByTestId("res-r1")).toBeDefined();
@@ -534,9 +504,11 @@ describe("TimelinePage", () => {
     });
 
     it("displays guest phone when present", async () => {
-      mockHooksWithData({
-        reservations: [{ ...defaultReservation, guestPhone: "555-1234" }],
-      });
+      vi.mocked(useTimelineData).mockReturnValue(
+        makeTimelineData({
+          reservations: [{ ...defaultReservation, guestPhone: "555-1234" }],
+        })
+      );
       renderPage();
       await waitFor(() => {
         expect(screen.getByTestId("res-r1")).toBeDefined();
@@ -548,9 +520,11 @@ describe("TimelinePage", () => {
     });
 
     it("displays notes when present", async () => {
-      mockHooksWithData({
-        reservations: [{ ...defaultReservation, notes: "Window seat preferred" }],
-      });
+      vi.mocked(useTimelineData).mockReturnValue(
+        makeTimelineData({
+          reservations: [{ ...defaultReservation, notes: "Window seat preferred" }],
+        })
+      );
       renderPage();
       await waitFor(() => {
         expect(screen.getByTestId("res-r1")).toBeDefined();
@@ -562,9 +536,11 @@ describe("TimelinePage", () => {
     });
 
     it("shows party size with correct pluralization", async () => {
-      mockHooksWithData({
-        reservations: [{ ...defaultReservation, guestName: "Solo", partySize: 1 }],
-      });
+      vi.mocked(useTimelineData).mockReturnValue(
+        makeTimelineData({
+          reservations: [{ ...defaultReservation, guestName: "Solo", partySize: 1 }],
+        })
+      );
       renderPage();
       await waitFor(() => {
         expect(screen.getByTestId("res-r1")).toBeDefined();
@@ -591,9 +567,11 @@ describe("TimelinePage", () => {
     });
 
     it("does not show Seat Guest button for non-CONFIRMED reservations", async () => {
-      mockHooksWithData({
-        reservations: [{ ...defaultReservation, status: "PENDING" as const }],
-      });
+      vi.mocked(useTimelineData).mockReturnValue(
+        makeTimelineData({
+          reservations: [{ ...defaultReservation, status: "PENDING" as const }],
+        })
+      );
       renderPage();
       await waitFor(() => {
         expect(screen.getByTestId("res-r1")).toBeDefined();
@@ -606,9 +584,11 @@ describe("TimelinePage", () => {
     });
 
     it("does not show Cancel Reservation button for CANCELLED reservations", async () => {
-      mockHooksWithData({
-        reservations: [{ ...defaultReservation, status: "CANCELLED" as const }],
-      });
+      vi.mocked(useTimelineData).mockReturnValue(
+        makeTimelineData({
+          reservations: [{ ...defaultReservation, status: "CANCELLED" as const }],
+        })
+      );
       renderPage();
       await waitFor(() => {
         expect(screen.getByTestId("res-r1")).toBeDefined();
@@ -622,18 +602,9 @@ describe("TimelinePage", () => {
   });
 
   describe("seat guest flow", () => {
-    it("calls API to update reservation and table status", async () => {
-      mockHooksWithData({
-        reservations: [{ ...defaultReservation, table: { tableNumber: "T1", name: "Table 1" } }],
-      });
-      const updatedRes = {
-        id: "r1",
-        guestName: "Alice",
-        status: "CONFIRMED",
-        tableId: "t1",
-      };
-      mockApiClient.reservations.update.mockResolvedValue(updatedRes);
-      mockApiClient.tables.updateStatus.mockResolvedValue({});
+    it("calls seatGuest from useTimelineData", async () => {
+      const seatGuest = vi.fn().mockResolvedValue(defaultReservation);
+      vi.mocked(useTimelineData).mockReturnValue(makeTimelineData({ seatGuest }));
 
       renderPage();
       await waitFor(() => {
@@ -645,15 +616,13 @@ describe("TimelinePage", () => {
       });
       fireEvent.click(screen.getByText("Seat Guest"));
       await waitFor(() => {
-        expect(mockApiClient.reservations.update).toHaveBeenCalledWith("r1", {
-          status: "CONFIRMED",
-        });
+        expect(seatGuest).toHaveBeenCalledWith(expect.objectContaining({ id: "r1" }));
       });
-      expect(mockApiClient.tables.updateStatus).toHaveBeenCalledWith("t1", "OCCUPIED");
     });
 
-    it("sets error when seat API fails", async () => {
-      mockApiClient.reservations.update.mockRejectedValue(new Error("Seat failed"));
+    it("sets error when seatGuest fails", async () => {
+      const seatGuest = vi.fn().mockRejectedValue(new Error("Seat failed"));
+      vi.mocked(useTimelineData).mockReturnValue(makeTimelineData({ seatGuest }));
 
       renderPage();
       await waitFor(() => {
@@ -672,11 +641,9 @@ describe("TimelinePage", () => {
   });
 
   describe("cancel reservation flow", () => {
-    it("opens cancel dialog and calls API on confirm", async () => {
-      mockHooksWithData({
-        reservations: [{ ...defaultReservation, table: { tableNumber: "T1", name: "Table 1" } }],
-      });
-      mockApiClient.reservations.cancelWithReason.mockResolvedValue({});
+    it("opens cancel dialog and calls cancelReservation on confirm", async () => {
+      const cancelReservation = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(useTimelineData).mockReturnValue(makeTimelineData({ cancelReservation }));
 
       renderPage();
       await waitFor(() => {
@@ -692,9 +659,9 @@ describe("TimelinePage", () => {
       });
       fireEvent.click(screen.getByTestId("cancel-confirm"));
       await waitFor(() => {
-        expect(mockApiClient.reservations.cancelWithReason).toHaveBeenCalledWith("r1", {
-          cancellationReason: "no_show",
-          cancellationNote: "test note",
+        expect(cancelReservation).toHaveBeenCalledWith("r1", {
+          reason: "no_show",
+          note: "test note",
         });
       });
     });
@@ -718,8 +685,9 @@ describe("TimelinePage", () => {
       });
     });
 
-    it("sets error when cancel API fails", async () => {
-      mockApiClient.reservations.cancelWithReason.mockRejectedValue(new Error("Cancel failed"));
+    it("sets error when cancelReservation fails", async () => {
+      const cancelReservation = vi.fn().mockRejectedValue(new Error("Cancel failed"));
+      vi.mocked(useTimelineData).mockReturnValue(makeTimelineData({ cancelReservation }));
 
       renderPage();
       await waitFor(() => {
@@ -742,12 +710,10 @@ describe("TimelinePage", () => {
   });
 
   describe("edit reservation flow", () => {
-    it("opens edit drawer and calls API on save", async () => {
-      mockHooksWithData({
-        reservations: [{ ...defaultReservation, table: { tableNumber: "T1", name: "Table 1" } }],
-      });
-      const updatedRes = { id: "r1", guestName: "Alice", partySize: 6, status: "CONFIRMED" };
-      mockApiClient.reservations.update.mockResolvedValue(updatedRes);
+    it("opens edit drawer and calls updateReservation on save", async () => {
+      const updated = { ...defaultReservation, partySize: 6 };
+      const updateReservation = vi.fn().mockResolvedValue(updated);
+      vi.mocked(useTimelineData).mockReturnValue(makeTimelineData({ updateReservation }));
 
       renderPage();
       await waitFor(() => {
@@ -763,7 +729,7 @@ describe("TimelinePage", () => {
       });
       fireEvent.click(screen.getByTestId("edit-save"));
       await waitFor(() => {
-        expect(mockApiClient.reservations.update).toHaveBeenCalledWith("r1", { partySize: 6 });
+        expect(updateReservation).toHaveBeenCalledWith("r1", { partySize: 6 });
       });
     });
 
@@ -786,8 +752,9 @@ describe("TimelinePage", () => {
       });
     });
 
-    it("sets error when edit API fails", async () => {
-      mockApiClient.reservations.update.mockRejectedValue(new Error("Update failed"));
+    it("sets error when updateReservation fails", async () => {
+      const updateReservation = vi.fn().mockRejectedValue(new Error("Update failed"));
+      vi.mocked(useTimelineData).mockReturnValue(makeTimelineData({ updateReservation }));
 
       renderPage();
       await waitFor(() => {
@@ -810,10 +777,11 @@ describe("TimelinePage", () => {
   });
 
   describe("walk-in flow", () => {
-    it("calls API to create walk-in", async () => {
-      mockHooksWithData({ reservations: [] });
-      const walkInRes = { id: "r-walkin", guestName: "Walk-in Guest", partySize: 2 };
-      mockApiClient.reservations.walkIn.mockResolvedValue(walkInRes);
+    it("calls createWalkIn from useTimelineData", async () => {
+      const createWalkIn = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(useTimelineData).mockReturnValue(
+        makeTimelineData({ reservations: [], createWalkIn })
+      );
 
       renderPage();
       await waitFor(() => {
@@ -825,14 +793,15 @@ describe("TimelinePage", () => {
       });
       fireEvent.click(screen.getByTestId("walkin-confirm"));
       await waitFor(() => {
-        expect(mockApiClient.reservations.walkIn).toHaveBeenCalledWith(
+        expect(createWalkIn).toHaveBeenCalledWith(
           expect.objectContaining({ partySize: 2, tableId: "t1", venueId: "venue-1" })
         );
       });
     });
 
-    it("sets error when walk-in API fails", async () => {
-      mockApiClient.reservations.walkIn.mockRejectedValue(new Error("Walk-in failed"));
+    it("sets error when createWalkIn fails", async () => {
+      const createWalkIn = vi.fn().mockRejectedValue(new Error("Walk-in failed"));
+      vi.mocked(useTimelineData).mockReturnValue(makeTimelineData({ createWalkIn }));
 
       renderPage();
       await waitFor(() => {
@@ -866,22 +835,24 @@ describe("TimelinePage", () => {
   });
 
   describe("table status changes", () => {
-    it("calls API to update table status", async () => {
-      mockApiClient.tables.updateStatus.mockResolvedValue({});
+    it("calls updateTableStatus from useTimelineData", async () => {
+      const updateTableStatus = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(useTimelineData).mockReturnValue(makeTimelineData({ updateTableStatus }));
+
       renderPage();
       await waitFor(() => {
         expect(screen.getByTestId("table-status-t1")).toBeDefined();
       });
       fireEvent.click(screen.getByTestId("table-status-t1"));
       await waitFor(() => {
-        expect(mockApiClient.tables.updateStatus).toHaveBeenCalledWith("t1", "OCCUPIED");
+        expect(updateTableStatus).toHaveBeenCalledWith("t1", "OCCUPIED");
       });
     });
   });
 
   describe("SSE connection indicator", () => {
     it("shows Offline when disconnected", async () => {
-      mockHooksWithData({ isConnected: false });
+      vi.mocked(useSSEStatus).mockReturnValue({ isConnected: false, error: null });
       renderPage();
       await waitFor(() => {
         expect(screen.getByText("Offline")).toBeDefined();
@@ -891,10 +862,12 @@ describe("TimelinePage", () => {
 
   describe("error and empty states", () => {
     it("shows error message when data fetch fails", async () => {
-      mockHooksWithData({
-        reservationsError: new Error("Network error"),
-        reservations: undefined,
-      });
+      vi.mocked(useTimelineData).mockReturnValue(
+        makeTimelineData({
+          fetchError: new Error("Network error"),
+          reservations: [],
+        })
+      );
       renderPage();
       await waitFor(() => {
         expect(screen.getByRole("alert")).toBeDefined();
@@ -902,58 +875,35 @@ describe("TimelinePage", () => {
       expect(screen.getByText("Network error")).toBeDefined();
     });
 
-    it("shows error from tables hook", async () => {
-      mockHooksWithData({
-        tablesError: new Error("Tables failed"),
-        tables: undefined,
-      });
-      renderPage();
-      await waitFor(() => {
-        expect(screen.getByRole("alert")).toBeDefined();
-      });
-      expect(screen.getByText("Tables failed")).toBeDefined();
-    });
-
     it("shows empty state when no tables exist", async () => {
-      mockHooksWithData({ reservations: [], tables: [] });
+      vi.mocked(useTimelineData).mockReturnValue(
+        makeTimelineData({ reservations: [], tables: [] })
+      );
       renderPage();
       await waitFor(() => {
         expect(screen.getByText("No tables configured for this venue.")).toBeDefined();
       });
     });
 
-    it("disables hooks when no venue is selected", async () => {
+    it("passes disabled params to useTimelineData when no venue is selected", async () => {
       vi.mocked(useVenue).mockReturnValue(makeVenueContext({ selectedVenueId: null, venues: [] }));
       renderPage();
       await waitFor(() => {
         expect(screen.getByTestId("page-header")).toBeDefined();
       });
-      expect(vi.mocked(useReservations)).toHaveBeenCalledWith(
-        expect.objectContaining({ enabled: false })
-      );
-      expect(vi.mocked(useTables)).toHaveBeenCalledWith(
-        expect.objectContaining({ enabled: false })
+      expect(vi.mocked(useTimelineData)).toHaveBeenCalledWith(
+        expect.objectContaining({ venueId: undefined })
       );
     });
   });
 
   describe("stats display", () => {
     it("shows pending count when there are pending reservations", async () => {
-      mockHooksWithData({
-        reservations: [
-          defaultReservation,
-          {
-            id: "r2",
-            guestName: "Bob",
-            date: todayStr,
-            startTime: "2026-05-10T19:00:00",
-            endTime: "2026-05-10T21:00:00",
-            partySize: 2,
-            status: "PENDING" as const,
-            tableId: "t1",
-          },
-        ],
-      });
+      vi.mocked(useTimelineData).mockReturnValue(
+        makeTimelineData({
+          stats: { confirmed: 1, pending: 1, totalCovers: 6, total: 2 },
+        })
+      );
       renderPage();
       await waitFor(() => {
         expect(screen.getByText("pending")).toBeDefined();
@@ -1014,8 +964,8 @@ describe("TimelinePage", () => {
 
     it("opens edit drawer from mobile reservation details", async () => {
       setMobile();
-      const updatedRes = { id: "r1", guestName: "Alice", partySize: 6, status: "CONFIRMED" };
-      mockApiClient.reservations.update.mockResolvedValue(updatedRes);
+      const updateReservation = vi.fn().mockResolvedValue(defaultReservation);
+      vi.mocked(useTimelineData).mockReturnValue(makeTimelineData({ updateReservation }));
 
       renderPage();
       await waitFor(() => {
@@ -1031,8 +981,6 @@ describe("TimelinePage", () => {
 
     it("opens cancel dialog from mobile reservation details", async () => {
       setMobile();
-      mockApiClient.reservations.cancelWithReason.mockResolvedValue({});
-
       renderPage();
       await waitFor(() => {
         expect(screen.getByTestId("res-r1")).toBeDefined();
@@ -1047,9 +995,8 @@ describe("TimelinePage", () => {
 
     it("seats guest from mobile reservation details", async () => {
       setMobile();
-      const updatedRes = { id: "r1", guestName: "Alice", status: "CONFIRMED", tableId: "t1" };
-      mockApiClient.reservations.update.mockResolvedValue(updatedRes);
-      mockApiClient.tables.updateStatus.mockResolvedValue({});
+      const seatGuest = vi.fn().mockResolvedValue(defaultReservation);
+      vi.mocked(useTimelineData).mockReturnValue(makeTimelineData({ seatGuest }));
 
       renderPage();
       await waitFor(() => {
@@ -1059,9 +1006,7 @@ describe("TimelinePage", () => {
       const drawer = await waitFor(() => screen.getByTestId("drawer"));
       fireEvent.click(within(drawer).getByText("Seat Guest"));
       await waitFor(() => {
-        expect(mockApiClient.reservations.update).toHaveBeenCalledWith("r1", {
-          status: "CONFIRMED",
-        });
+        expect(seatGuest).toHaveBeenCalledWith(expect.objectContaining({ id: "r1" }));
       });
     });
   });

--- a/apps/hospitality/src/pages/TimelinePage.tsx
+++ b/apps/hospitality/src/pages/TimelinePage.tsx
@@ -1,9 +1,8 @@
 import { useState, useEffect, useMemo, useCallback } from "react";
 import { z } from "zod";
 import { useUrlParams } from "../hooks/use-url-params.js";
-import { useQueryClient } from "@tanstack/react-query";
 import { Drawer, Button, Divider, Stack, Text, Card } from "@mattbutlerengineering/rialto";
-import type { Reservation, TableStatus, UpdateReservationRequest } from "@mbe/types";
+import type { Reservation, Table, TableStatus, UpdateReservationRequest } from "@mbe/types";
 import { TimelineGrid, TimelineMobileView } from "../components/timeline";
 import { CancelReservationDialog } from "../components/timeline/CancelReservationDialog";
 import { EditReservationDrawer } from "../components/timeline/EditReservationDrawer";
@@ -11,9 +10,7 @@ import { WalkInDialog } from "../components/timeline/WalkInDialog";
 import { GuestCard } from "../components/crm/GuestCard.js";
 import { useVenue } from "../contexts/VenueContext.js";
 import { useSSEStatus } from "../hooks/useSSESync.js";
-import { useReservations, RESERVATIONS_QUERY_KEY } from "../hooks/useReservations.js";
-import { useTables, TABLES_QUERY_KEY } from "../hooks/useTables.js";
-import { useApiClient } from "../hooks/useApiClient.js";
+import { useTimelineData } from "../hooks/useTimelineData.js";
 import { PageHeader } from "../components/PageHeader";
 import styles from "./TimelinePage.module.css";
 
@@ -62,6 +59,7 @@ function getStatusBadgeClass(status: Reservation["status"]): string {
 
 interface ReservationDetailsProps {
   reservation: Reservation;
+  tables: Table[];
   onEdit: () => void;
   onSeat: () => void;
   onCancel: () => void;
@@ -187,8 +185,6 @@ function ReservationDetails({ reservation, onEdit, onSeat, onCancel }: Reservati
 export function TimelinePage() {
   const { selectedVenueId } = useVenue();
   const { isConnected } = useSSEStatus();
-  const api = useApiClient();
-  const queryClient = useQueryClient();
 
   const { params, setParam } = useUrlParams(timelineFilterSchema, TIMELINE_DEFAULTS);
   const todayStr = useMemo(() => new Date().toLocaleDateString("en-CA"), []);
@@ -201,50 +197,18 @@ export function TimelinePage() {
   const [showWalkInDialog, setShowWalkInDialog] = useState(false);
   const isMobile = useIsMobile();
 
-  // Data fetching via TanStack Query hooks
   const {
-    data: allReservations,
-    isLoading: reservationsLoading,
-    error: reservationsError,
-  } = useReservations({
-    venueId: selectedVenueId ?? undefined,
-    date: selectedDate,
-    limit: 200,
-    enabled: !!selectedVenueId,
-  });
-
-  const {
-    data: rawTables,
-    isLoading: tablesLoading,
-    error: tablesError,
-  } = useTables({
-    venueId: selectedVenueId ?? undefined,
-    limit: 100,
-    enabled: !!selectedVenueId,
-  });
-
-  const isLoading = reservationsLoading || tablesLoading;
-  const fetchError = reservationsError ?? tablesError;
-
-  // Sort tables by priority, then by name
-  const tables = useMemo(() => {
-    if (!rawTables) return [];
-    return [...rawTables].sort((a, b) => {
-      if (a.priority !== b.priority) return b.priority - a.priority;
-      return (a.tableNumber || a.name).localeCompare(b.tableNumber || b.name);
-    });
-  }, [rawTables]);
-
-  // Filter reservations to the selected date
-  const reservations = useMemo(
-    () => (allReservations ?? []).filter((r) => r.date === selectedDate),
-    [allReservations, selectedDate]
-  );
-
-  const invalidateAll = useCallback(() => {
-    queryClient.invalidateQueries({ queryKey: [RESERVATIONS_QUERY_KEY] });
-    queryClient.invalidateQueries({ queryKey: [TABLES_QUERY_KEY] });
-  }, [queryClient]);
+    reservations,
+    tables,
+    isLoading,
+    fetchError,
+    stats,
+    seatGuest,
+    cancelReservation,
+    updateReservation,
+    createWalkIn,
+    updateTableStatus,
+  } = useTimelineData({ venueId: selectedVenueId ?? undefined, date: selectedDate });
 
   const handlePreviousDay = useCallback(() => {
     const prev = new Date(selectedDate + "T00:00:00");
@@ -268,9 +232,7 @@ export function TimelinePage() {
 
   const handleSeat = async (reservation: Reservation) => {
     try {
-      await api.reservations.update(reservation.id, { status: "CONFIRMED" });
-      await api.tables.updateStatus(reservation.tableId, "OCCUPIED");
-      invalidateAll();
+      await seatGuest(reservation);
       setSelectedReservation(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to seat guest");
@@ -280,11 +242,7 @@ export function TimelinePage() {
   const handleCancel = async (reason: string, note: string) => {
     if (!selectedReservation) return;
     try {
-      await api.reservations.cancelWithReason(selectedReservation.id, {
-        cancellationReason: reason,
-        cancellationNote: note,
-      });
-      invalidateAll();
+      await cancelReservation(selectedReservation.id, { reason, note });
       setShowCancelDialog(false);
       setSelectedReservation(null);
     } catch (err) {
@@ -294,8 +252,7 @@ export function TimelinePage() {
 
   const handleEdit = async (id: string, data: UpdateReservationRequest) => {
     try {
-      const updated = await api.reservations.update(id, data);
-      invalidateAll();
+      const updated = await updateReservation(id, data);
       setSelectedReservation(updated);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to update reservation");
@@ -309,16 +266,14 @@ export function TimelinePage() {
     guestName?: string;
   }) => {
     try {
-      await api.reservations.walkIn(data);
-      invalidateAll();
+      await createWalkIn(data);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to create walk-in");
     }
   };
 
   const handleTableStatusChange = async (tableId: string, _status: TableStatus) => {
-    await api.tables.updateStatus(tableId, _status);
-    invalidateAll();
+    await updateTableStatus(tableId, _status);
   };
 
   // Format date for display
@@ -330,16 +285,6 @@ export function TimelinePage() {
   });
 
   const isToday = selectedDate === todayStr;
-
-  // Stats
-  const stats = useMemo(() => {
-    const confirmed = reservations.filter((r) => r.status === "CONFIRMED").length;
-    const pending = reservations.filter((r) => r.status === "PENDING").length;
-    const totalCovers = reservations
-      .filter((r) => r.status !== "CANCELLED" && r.status !== "NO_SHOW")
-      .reduce((sum, r) => sum + r.partySize, 0);
-    return { confirmed, pending, totalCovers, total: reservations.length };
-  }, [reservations]);
 
   return (
     <div className={styles.root}>
@@ -512,6 +457,7 @@ export function TimelinePage() {
 
             <ReservationDetails
               reservation={selectedReservation}
+              tables={tables}
               onEdit={() => setShowEditDrawer(true)}
               onSeat={() => handleSeat(selectedReservation)}
               onCancel={() => setShowCancelDialog(true)}
@@ -532,6 +478,7 @@ export function TimelinePage() {
           {selectedReservation && (
             <ReservationDetails
               reservation={selectedReservation}
+              tables={tables}
               onEdit={() => setShowEditDrawer(true)}
               onSeat={() => handleSeat(selectedReservation)}
               onCancel={() => setShowCancelDialog(true)}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -15074,18 +15074,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3213,6 +3213,16 @@
       enabled?: boolean;
     }
   </file>
+  <file path="apps/hospitality/src/hooks/useTimelineData.ts">
+    export interface UseTimelineDataParams {
+      venueId: string | undefined;
+      date: string;
+    }
+    export interface CancelArgs {
+      reason: string;
+      note: string;
+    }
+  </file>
   <file path="apps/hospitality/src/hooks/useUsers.ts">
     export const CURRENT_USER_QUERY_KEY = "currentUser" as const;
     export const USERS_QUERY_KEY = "users" as const;
@@ -14986,7 +14996,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms.txt
+++ b/llms.txt
@@ -1105,6 +1105,20 @@
       }
     </item>
   </file>
+  <file path="apps/hospitality/src/hooks/useTimelineData.ts">
+    <item priority="low">
+      interface UseTimelineDataParams {
+        venueId: string | undefined;
+        date: string;
+      }
+    </item>
+    <item priority="low">
+      interface CancelArgs {
+        reason: string;
+        note: string;
+      }
+    </item>
+  </file>
   <file path="apps/hospitality/src/hooks/useUsers.ts">
     <item priority="high">
       export const CURRENT_USER_QUERY_KEY: unknown;

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,18 +337,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,7 +337,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),


### PR DESCRIPTION
## Summary

- Extracts `useTimelineData` hook that owns both queries (`useReservations`, `useTables`), all mutations (`seatGuest`, `cancelReservation`, `updateReservation`, `createWalkIn`, `updateTableStatus`), and `queryClient` invalidation side effects
- `TimelinePage` now consumes a single `useTimelineData` call — inline queryClient plumbing removed
- Hook unit-tested without rendering (15 tests covering query composition, mutation → invalidation, stats, error handling)
- Page test simplified to mock one hook instead of 4+ hooks; 43 page tests via single fake hook injection

## Gate results

- `pnpm lint`: 0 errors (205 pre-existing warnings)
- `pnpm typecheck`: only pre-existing `src/main.tsx` error (rialto dist not built in worktree — confirmed present on HEAD before changes)
- `pnpm test`: 80 test files passed, 1012 tests passed (pre-push hook with rialto built)
- `check-adr` + `check-deps`: no violations
- `pnpm regen`: all artifacts up to date, `detect-instruction-rot`: no rot

Closes #2065