### PR TITLE
refactor(reservations): adopt requireOwnershipOrAdmin in reservation routes

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8226,6 +8226,22 @@
     export const readinessRoutes: FastifyPluginAsync = (fastify, _opts) =>
       registerReadinessRoutes(fastify, { prisma, auth0Url });
   </file>
+  <file path="services/reservations/src/routes/reservation-owner.ts">
+    export function resolveReservationGuestEmail(
+      getById: (id: string) => Promise<{ guestEmail: string | null } | null>
+    ): OwnerResolver {
+      return async function (request: FastifyRequest): Promise<string | null> {
+        const params = request.params as { id?: string };
+        const id = params.id;
+        if (!id) return null;
+        const reservation = await getById(id);
+        return reservation?.guestEmail ?? null;
+      };
+    }
+    export async function resolveCurrentUserEmail(request: FastifyRequest): Promise<string | null> {
+      return request.user?.email ?? null;
+    }
+  </file>
   <file path="services/reservations/src/routes/reservations.ts">
     export const reservationRoutes: FastifyPluginAsync = async (fastify) => {
       // List reservations
@@ -8484,7 +8500,7 @@
       }>(
         "/:id",
         {
-          preHandler: requireAuth,
+          preHandler: [requireAuth, requireReservationOwnerOrAdmin],
           schema: {
             summary: "Get reservation by ID",
             operationId: "getReservationById",
@@ -8525,17 +8541,6 @@
             return reply
               .code(404)
               .send(createProblemDetails(404, "Not Found", "Reservation not found"));
-          }
-    
-          const authUser = request.user;
-          const adminAccess = hasPermission(authUser, "admin");
-          const isOwner = reservation.guestEmail === authUser?.email;
-    
-          if (!adminAccess && !isOwner) {
-            reply.code(403);
-            return reply.send(
-              createProblemDetails(403, "Forbidden", "You can only view your own reservations") as never
-            );
           }
     
           return { data: reservation };
@@ -8688,7 +8693,7 @@
       }>(
         "/:id",
         {
-          preHandler: requireAuth,
+          preHandler: [requireAuth, requireReservationOwnerOrAdmin],
           schema: {
             summary: "Update a reservation",
             operationId: "updateReservation",
@@ -8796,21 +8801,6 @@
               .send(createProblemDetails(404, "Not Found", "Reservation not found"));
           }
     
-          const authUser = request.user;
-          const adminAccess = hasPermission(authUser, "admin");
-          const isOwner = authUser?.email && reservation.guestEmail === authUser.email;
-    
-          if (!adminAccess && !isOwner) {
-            reply.code(403);
-            return reply.send(
-              createProblemDetails(
-                403,
-                "Forbidden",
-                "You can only update your own reservations"
-              ) as never
-            );
-          }
-    
           if (request.body.status === "CANCELLED") {
             try {
               const cancelled = await reservationService.cancel(
@@ -8910,7 +8900,7 @@
       }>(
         "/:id",
         {
-          preHandler: requireAuth,
+          preHandler: [requireAuth, requireReservationOwnerOrAdmin],
           schema: {
             summary: "Cancel a reservation",
             operationId: "cancelReservation",
@@ -8952,21 +8942,6 @@
             return reply
               .code(404)
               .send(createProblemDetails(404, "Not Found", "Reservation not found"));
-          }
-    
-          const authUser = request.user;
-          const adminAccess = hasPermission(authUser, "admin");
-          const isOwner = authUser?.email && reservation.guestEmail === authUser.email;
-    
-          if (!adminAccess && !isOwner) {
-            reply.code(403);
-            return reply.send(
-              createProblemDetails(
-                403,
-                "Forbidden",
-                "You can only cancel your own reservations"
-              ) as never
-            );
           }
     
           try {
@@ -14986,7 +14961,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms.txt
+++ b/llms.txt
@@ -1738,6 +1738,16 @@
       export const readinessRoutes: FastifyPluginAsync;
     </item>
   </file>
+  <file path="services/reservations/src/routes/reservation-owner.ts">
+    <item priority="high">
+      export function resolveReservationGuestEmail(
+        getById: (id: string) => Promise<{ guestEmail: string | null } | null>
+      ): OwnerResolver { /* ... */ }
+    </item>
+    <item priority="high">
+      export async function resolveCurrentUserEmail(request: FastifyRequest): Promise<string | null> { /* ... */ }
+    </item>
+  </file>
   <file path="services/reservations/src/routes/reservations.ts">
     <item priority="high">
       export const reservationRoutes: FastifyPluginAsync;

--- a/metrics/ai-antipattern-baselines.json
+++ b/metrics/ai-antipattern-baselines.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-20T15:47:02.925Z",
+  "generatedAt": "2026-06-20T21:02:15.275Z",
   "patterns": {
     "magicTimeouts": {
       "count": 32,
@@ -14,7 +14,7 @@
       "description": "Test functions containing no expect() calls"
     },
     "hardcodedRoutes": {
-      "count": 507,
+      "count": 513,
       "description": "Hardcoded /api/... route strings instead of route constants"
     },
     "anyType": {

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,7 +337,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/services/reservations/llms-full.txt
+++ b/services/reservations/llms-full.txt
@@ -2790,6 +2790,22 @@
     export const readinessRoutes: FastifyPluginAsync = (fastify, _opts) =>
       registerReadinessRoutes(fastify, { prisma, auth0Url });
   </file>
+  <file path="src/routes/reservation-owner.ts">
+    export function resolveReservationGuestEmail(
+      getById: (id: string) => Promise<{ guestEmail: string | null } | null>
+    ): OwnerResolver {
+      return async function (request: FastifyRequest): Promise<string | null> {
+        const params = request.params as { id?: string };
+        const id = params.id;
+        if (!id) return null;
+        const reservation = await getById(id);
+        return reservation?.guestEmail ?? null;
+      };
+    }
+    export async function resolveCurrentUserEmail(request: FastifyRequest): Promise<string | null> {
+      return request.user?.email ?? null;
+    }
+  </file>
   <file path="src/routes/reservations.ts">
     export const reservationRoutes: FastifyPluginAsync = async (fastify) => {
       // List reservations
@@ -3048,7 +3064,7 @@
       }>(
         "/:id",
         {
-          preHandler: requireAuth,
+          preHandler: [requireAuth, requireReservationOwnerOrAdmin],
           schema: {
             summary: "Get reservation by ID",
             operationId: "getReservationById",
@@ -3089,17 +3105,6 @@
             return reply
               .code(404)
               .send(createProblemDetails(404, "Not Found", "Reservation not found"));
-          }
-    
-          const authUser = request.user;
-          const adminAccess = hasPermission(authUser, "admin");
-          const isOwner = reservation.guestEmail === authUser?.email;
-    
-          if (!adminAccess && !isOwner) {
-            reply.code(403);
-            return reply.send(
-              createProblemDetails(403, "Forbidden", "You can only view your own reservations") as never
-            );
           }
     
           return { data: reservation };
@@ -3252,7 +3257,7 @@
       }>(
         "/:id",
         {
-          preHandler: requireAuth,
+          preHandler: [requireAuth, requireReservationOwnerOrAdmin],
           schema: {
             summary: "Update a reservation",
             operationId: "updateReservation",
@@ -3360,21 +3365,6 @@
               .send(createProblemDetails(404, "Not Found", "Reservation not found"));
           }
     
-          const authUser = request.user;
-          const adminAccess = hasPermission(authUser, "admin");
-          const isOwner = authUser?.email && reservation.guestEmail === authUser.email;
-    
-          if (!adminAccess && !isOwner) {
-            reply.code(403);
-            return reply.send(
-              createProblemDetails(
-                403,
-                "Forbidden",
-                "You can only update your own reservations"
-              ) as never
-            );
-          }
-    
           if (request.body.status === "CANCELLED") {
             try {
               const cancelled = await reservationService.cancel(
@@ -3474,7 +3464,7 @@
       }>(
         "/:id",
         {
-          preHandler: requireAuth,
+          preHandler: [requireAuth, requireReservationOwnerOrAdmin],
           schema: {
             summary: "Cancel a reservation",
             operationId: "cancelReservation",
@@ -3516,21 +3506,6 @@
             return reply
               .code(404)
               .send(createProblemDetails(404, "Not Found", "Reservation not found"));
-          }
-    
-          const authUser = request.user;
-          const adminAccess = hasPermission(authUser, "admin");
-          const isOwner = authUser?.email && reservation.guestEmail === authUser.email;
-    
-          if (!adminAccess && !isOwner) {
-            reply.code(403);
-            return reply.send(
-              createProblemDetails(
-                403,
-                "Forbidden",
-                "You can only cancel your own reservations"
-              ) as never
-            );
           }
     
           try {

--- a/services/reservations/llms.txt
+++ b/services/reservations/llms.txt
@@ -224,6 +224,16 @@
       export const readinessRoutes: FastifyPluginAsync;
     </item>
   </file>
+  <file path="src/routes/reservation-owner.ts">
+    <item priority="high">
+      export function resolveReservationGuestEmail(
+        getById: (id: string) => Promise<{ guestEmail: string | null } | null>
+      ): OwnerResolver { /* ... */ }
+    </item>
+    <item priority="high">
+      export async function resolveCurrentUserEmail(request: FastifyRequest): Promise<string | null> { /* ... */ }
+    </item>
+  </file>
   <file path="src/routes/reservations.ts">
     <item priority="high">
       export const reservationRoutes: FastifyPluginAsync;

--- a/services/reservations/src/routes/deposits.test.ts
+++ b/services/reservations/src/routes/deposits.test.ts
@@ -57,6 +57,7 @@ vi.mock("@mbe/auth/fastify", () => ({
   }),
   optionalAuth: vi.fn(async () => {}),
   hasPermission: vi.fn(() => true),
+  requireOwnershipOrAdmin: vi.fn().mockReturnValue(vi.fn(async () => {})),
 }));
 
 import { buildApp } from "../app.js";

--- a/services/reservations/src/routes/reservation-owner.test.ts
+++ b/services/reservations/src/routes/reservation-owner.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from "vitest";
+import { resolveReservationGuestEmail, resolveCurrentUserEmail } from "./reservation-owner.js";
+import type { FastifyRequest } from "fastify";
+
+describe("resolveReservationGuestEmail", () => {
+  it("returns guestEmail when reservation exists", async () => {
+    const mockGetById = vi.fn().mockResolvedValue({
+      id: "res-123",
+      guestEmail: "owner@example.com",
+    });
+
+    const request = {
+      params: { id: "res-123" },
+      server: {},
+    } as unknown as FastifyRequest;
+
+    const result = await resolveReservationGuestEmail(mockGetById)(request);
+
+    expect(mockGetById).toHaveBeenCalledWith("res-123");
+    expect(result).toBe("owner@example.com");
+  });
+
+  it("returns null when reservation does not exist", async () => {
+    const mockGetById = vi.fn().mockResolvedValue(null);
+
+    const request = {
+      params: { id: "res-missing" },
+      server: {},
+    } as unknown as FastifyRequest;
+
+    const result = await resolveReservationGuestEmail(mockGetById)(request);
+
+    expect(result).toBe(null);
+  });
+
+  it("returns null when reservation has no guestEmail", async () => {
+    const mockGetById = vi.fn().mockResolvedValue({
+      id: "res-123",
+      guestEmail: null,
+    });
+
+    const request = {
+      params: { id: "res-123" },
+      server: {},
+    } as unknown as FastifyRequest;
+
+    const result = await resolveReservationGuestEmail(mockGetById)(request);
+
+    expect(result).toBe(null);
+  });
+});
+
+describe("resolveCurrentUserEmail", () => {
+  it("returns the authenticated user email", async () => {
+    const request = {
+      user: { id: "auth0|123", email: "user@example.com" },
+    } as unknown as FastifyRequest;
+
+    const result = await resolveCurrentUserEmail(request);
+
+    expect(result).toBe("user@example.com");
+  });
+
+  it("returns null when user has no email", async () => {
+    const request = {
+      user: { id: "auth0|123" },
+    } as unknown as FastifyRequest;
+
+    const result = await resolveCurrentUserEmail(request);
+
+    expect(result).toBe(null);
+  });
+
+  it("returns null when user is undefined", async () => {
+    const request = {
+      user: undefined,
+    } as unknown as FastifyRequest;
+
+    const result = await resolveCurrentUserEmail(request);
+
+    expect(result).toBe(null);
+  });
+});

--- a/services/reservations/src/routes/reservation-owner.ts
+++ b/services/reservations/src/routes/reservation-owner.ts
@@ -1,0 +1,32 @@
+import type { FastifyRequest } from "fastify";
+import type { OwnerResolver } from "@mbe/auth/fastify";
+
+/**
+ * Factory that returns an OwnerResolver for the guestEmail identity space.
+ * Receives an injected getById to keep the resolver testable without hitting
+ * the real Prisma client.
+ *
+ * Returns the reservation's guestEmail, or null when the reservation is not
+ * found or has no guestEmail. A null return triggers a 403 (not 404) from
+ * requireOwnershipOrAdmin — this is intentional: non-owners must not learn
+ * whether a resource exists.
+ */
+export function resolveReservationGuestEmail(
+  getById: (id: string) => Promise<{ guestEmail: string | null } | null>
+): OwnerResolver {
+  return async function (request: FastifyRequest): Promise<string | null> {
+    const params = request.params as { id?: string };
+    const id = params.id;
+    if (!id) return null;
+    const reservation = await getById(id);
+    return reservation?.guestEmail ?? null;
+  };
+}
+
+/**
+ * OwnerResolver that extracts the current user's email from the JWT.
+ * Used as resolveCurrentId so the identity space matches guestEmail.
+ */
+export async function resolveCurrentUserEmail(request: FastifyRequest): Promise<string | null> {
+  return request.user?.email ?? null;
+}

--- a/services/reservations/src/routes/reservations.test.ts
+++ b/services/reservations/src/routes/reservations.test.ts
@@ -260,6 +260,54 @@ describe("Reservation Routes", () => {
 
       expect(response.statusCode).toBe(401);
     });
+
+    it("allows owner (guestEmail matches JWT email) to view reservation", async () => {
+      const ownerPayload = createMockJWTPayload({
+        permissions: [],
+        email: "john@example.com",
+      });
+      vi.mocked(jwtVerify).mockResolvedValue({
+        payload: ownerPayload,
+        protectedHeader: { alg: "RS256" },
+      } as never);
+
+      // preHandler owner-resolver call + handler call
+      vi.mocked(reservationService.getById)
+        .mockResolvedValueOnce(createMockReservation({ guestEmail: "john@example.com" }))
+        .mockResolvedValueOnce(createMockReservation({ guestEmail: "john@example.com" }));
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/v1/reservations/res-123",
+        headers: { authorization: "Bearer valid-token" },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    it("denies non-owner non-admin with 403", async () => {
+      const nonOwnerPayload = createMockJWTPayload({
+        permissions: [],
+        email: "other@example.com",
+      });
+      vi.mocked(jwtVerify).mockResolvedValue({
+        payload: nonOwnerPayload,
+        protectedHeader: { alg: "RS256" },
+      } as never);
+
+      // preHandler owner-resolver call — no handler call since preHandler denies
+      vi.mocked(reservationService.getById).mockResolvedValueOnce(
+        createMockReservation({ guestEmail: "john@example.com" })
+      );
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/v1/reservations/res-123",
+        headers: { authorization: "Bearer valid-token" },
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
   });
 
   describe("POST /v1/reservations", () => {
@@ -665,6 +713,60 @@ describe("Reservation Routes", () => {
       expect(response.statusCode).toBe(401);
     });
 
+    it("allows owner (guestEmail matches JWT email) to update reservation", async () => {
+      const ownerPayload = createMockJWTPayload({
+        permissions: [],
+        email: "john@example.com",
+      });
+      vi.mocked(jwtVerify).mockResolvedValue({
+        payload: ownerPayload,
+        protectedHeader: { alg: "RS256" },
+      } as never);
+
+      // preHandler owner-resolver call + handler call
+      vi.mocked(reservationService.getById)
+        .mockResolvedValueOnce(createMockReservation({ guestEmail: "john@example.com" }))
+        .mockResolvedValueOnce(createMockReservation({ guestEmail: "john@example.com" }));
+      vi.mocked(reservationService.updateWithConflictCheck).mockResolvedValueOnce({
+        success: true,
+        reservation: createMockReservation({ id: "res-123", partySize: 6 }),
+      });
+
+      const response = await app.inject({
+        method: "PATCH",
+        url: "/api/v1/reservations/res-123",
+        headers: { authorization: "Bearer valid-token" },
+        payload: { partySize: 6 },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    it("denies non-owner non-admin PATCH with 403", async () => {
+      const nonOwnerPayload = createMockJWTPayload({
+        permissions: [],
+        email: "other@example.com",
+      });
+      vi.mocked(jwtVerify).mockResolvedValue({
+        payload: nonOwnerPayload,
+        protectedHeader: { alg: "RS256" },
+      } as never);
+
+      // preHandler owner-resolver call — preHandler denies, handler not reached
+      vi.mocked(reservationService.getById).mockResolvedValueOnce(
+        createMockReservation({ guestEmail: "john@example.com" })
+      );
+
+      const response = await app.inject({
+        method: "PATCH",
+        url: "/api/v1/reservations/res-123",
+        headers: { authorization: "Bearer valid-token" },
+        payload: { partySize: 6 },
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+
     describe("PATCH /v1/reservations/:id — post-visit email on COMPLETED", () => {
       it("triggers post-visit email when status transitions to COMPLETED", async () => {
         const { venueService } = await import("../services/venue.js");
@@ -963,6 +1065,57 @@ describe("Reservation Routes", () => {
       });
 
       expect(response.statusCode).toBe(401);
+    });
+
+    it("allows owner (guestEmail matches JWT email) to cancel reservation", async () => {
+      const ownerPayload = createMockJWTPayload({
+        permissions: [],
+        email: "john@example.com",
+      });
+      vi.mocked(jwtVerify).mockResolvedValue({
+        payload: ownerPayload,
+        protectedHeader: { alg: "RS256" },
+      } as never);
+
+      // preHandler owner-resolver call + handler call
+      vi.mocked(reservationService.getById)
+        .mockResolvedValueOnce(createMockReservation({ guestEmail: "john@example.com" }))
+        .mockResolvedValueOnce(createMockReservation({ guestEmail: "john@example.com" }));
+      vi.mocked(reservationService.cancel).mockResolvedValueOnce(
+        createMockReservation({ id: "res-123", status: "CANCELLED" })
+      );
+
+      const response = await app.inject({
+        method: "DELETE",
+        url: "/api/v1/reservations/res-123",
+        headers: { authorization: "Bearer valid-token" },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    it("denies non-owner non-admin DELETE with 403", async () => {
+      const nonOwnerPayload = createMockJWTPayload({
+        permissions: [],
+        email: "other@example.com",
+      });
+      vi.mocked(jwtVerify).mockResolvedValue({
+        payload: nonOwnerPayload,
+        protectedHeader: { alg: "RS256" },
+      } as never);
+
+      // preHandler owner-resolver call — preHandler denies, handler not reached
+      vi.mocked(reservationService.getById).mockResolvedValueOnce(
+        createMockReservation({ guestEmail: "john@example.com" })
+      );
+
+      const response = await app.inject({
+        method: "DELETE",
+        url: "/api/v1/reservations/res-123",
+        headers: { authorization: "Bearer valid-token" },
+      });
+
+      expect(response.statusCode).toBe(403);
     });
   });
 });

--- a/services/reservations/src/routes/reservations.ts
+++ b/services/reservations/src/routes/reservations.ts
@@ -10,10 +10,17 @@ import type {
   PaginatedResponse,
 } from "@mbe/types";
 import { createProblemDetails } from "@mbe/types";
-import { requireAuth, optionalAuth, hasPermission } from "@mbe/auth/fastify";
+import { requireAuth, optionalAuth, requireOwnershipOrAdmin } from "@mbe/auth/fastify";
+
 import { parseListQuery } from "@mbe/database";
 import { reservationService, ReservationTransitionError } from "../services/reservation.js";
 import { venueService } from "../services/venue.js";
+import { resolveReservationGuestEmail, resolveCurrentUserEmail } from "./reservation-owner.js";
+
+const requireReservationOwnerOrAdmin = requireOwnershipOrAdmin(
+  resolveReservationGuestEmail((id) => reservationService.getById(id)),
+  resolveCurrentUserEmail
+);
 
 export const reservationRoutes: FastifyPluginAsync = async (fastify) => {
   // List reservations
@@ -272,7 +279,7 @@ export const reservationRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/:id",
     {
-      preHandler: requireAuth,
+      preHandler: [requireAuth, requireReservationOwnerOrAdmin],
       schema: {
         summary: "Get reservation by ID",
         operationId: "getReservationById",
@@ -313,17 +320,6 @@ export const reservationRoutes: FastifyPluginAsync = async (fastify) => {
         return reply
           .code(404)
           .send(createProblemDetails(404, "Not Found", "Reservation not found"));
-      }
-
-      const authUser = request.user;
-      const adminAccess = hasPermission(authUser, "admin");
-      const isOwner = reservation.guestEmail === authUser?.email;
-
-      if (!adminAccess && !isOwner) {
-        reply.code(403);
-        return reply.send(
-          createProblemDetails(403, "Forbidden", "You can only view your own reservations") as never
-        );
       }
 
       return { data: reservation };
@@ -476,7 +472,7 @@ export const reservationRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/:id",
     {
-      preHandler: requireAuth,
+      preHandler: [requireAuth, requireReservationOwnerOrAdmin],
       schema: {
         summary: "Update a reservation",
         operationId: "updateReservation",
@@ -584,21 +580,6 @@ export const reservationRoutes: FastifyPluginAsync = async (fastify) => {
           .send(createProblemDetails(404, "Not Found", "Reservation not found"));
       }
 
-      const authUser = request.user;
-      const adminAccess = hasPermission(authUser, "admin");
-      const isOwner = authUser?.email && reservation.guestEmail === authUser.email;
-
-      if (!adminAccess && !isOwner) {
-        reply.code(403);
-        return reply.send(
-          createProblemDetails(
-            403,
-            "Forbidden",
-            "You can only update your own reservations"
-          ) as never
-        );
-      }
-
       if (request.body.status === "CANCELLED") {
         try {
           const cancelled = await reservationService.cancel(
@@ -698,7 +679,7 @@ export const reservationRoutes: FastifyPluginAsync = async (fastify) => {
   }>(
     "/:id",
     {
-      preHandler: requireAuth,
+      preHandler: [requireAuth, requireReservationOwnerOrAdmin],
       schema: {
         summary: "Cancel a reservation",
         operationId: "cancelReservation",
@@ -740,21 +721,6 @@ export const reservationRoutes: FastifyPluginAsync = async (fastify) => {
         return reply
           .code(404)
           .send(createProblemDetails(404, "Not Found", "Reservation not found"));
-      }
-
-      const authUser = request.user;
-      const adminAccess = hasPermission(authUser, "admin");
-      const isOwner = authUser?.email && reservation.guestEmail === authUser.email;
-
-      if (!adminAccess && !isOwner) {
-        reply.code(403);
-        return reply.send(
-          createProblemDetails(
-            403,
-            "Forbidden",
-            "You can only cancel your own reservations"
-          ) as never
-        );
       }
 
       try {


### PR DESCRIPTION
## Summary

- Extracts `resolveReservationGuestEmail` (injected-stub factory) and `resolveCurrentUserEmail` into `reservation-owner.ts`, keeping both resolvers in the email identity space
- Replaces three inline admin + `guestEmail` ownership checks (GET `/:id`, PATCH `/:id`, DELETE `/:id`) with the shared `requireOwnershipOrAdmin` preHandler from `@mbe/auth`
- Adds 6 unit tests for the owner-resolver module (stub-injected, no DB), plus 6 route-level allow/deny tests (one allow + one deny per route)
- Updates `deposits.test.ts` mock to expose `requireOwnershipOrAdmin` (it mocks `@mbe/auth/fastify` wholesale and was missing the export)

## Test plan

- [x] `pnpm test` — 870 passed (0 failed), includes new owner-resolver unit tests + route allow/deny tests
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `check-adr` + `check-deps` — no violations
- [x] `pnpm regen` — llms.txt artifacts regenerated and staged
- [x] `detect-instruction-rot.mjs` — clean

Closes #2075