### PR TITLE
refactor(marketing): useDataFetch hook — unify fetch/loading/error/abort in MetricsPage + AiHealthPage

### DIFF
--- a/apps/marketing/llms-full.txt
+++ b/apps/marketing/llms-full.txt
@@ -127,4 +127,19 @@
     ];
   </file>
   </section>
+  <section priority="medium" role="hooks">
+  <file path="src/hooks/useDataFetch.ts">
+    export interface UseDataFetchOptions<T> {
+      url: string;
+      parser?: (data: unknown) => T;
+      deps?: DependencyList;
+    }
+    export interface UseDataFetchReturn<T> {
+      data: T | null;
+      isLoading: boolean;
+      error: Error | null;
+      refetch: () => Promise<void>;
+    }
+  </file>
+  </section>
 </codebase>

--- a/apps/marketing/llms.txt
+++ b/apps/marketing/llms.txt
@@ -56,4 +56,23 @@
     </item>
   </file>
   </section>
+  <section priority="medium" role="hooks">
+  <file path="src/hooks/useDataFetch.ts">
+    <item priority="low">
+      interface UseDataFetchOptions {
+        url: string;
+        parser?: (data: unknown) => T;
+        deps?: DependencyList;
+      }
+    </item>
+    <item priority="low">
+      interface UseDataFetchReturn {
+        data: T | null;
+        isLoading: boolean;
+        error: Error | null;
+        refetch: () => Promise<void>;
+      }
+    </item>
+  </file>
+  </section>
 </codebase>

--- a/apps/marketing/src/hooks/useDataFetch.test.ts
+++ b/apps/marketing/src/hooks/useDataFetch.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useDataFetch } from "./useDataFetch.js";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useDataFetch", () => {
+  describe("success path", () => {
+    it("starts with isLoading=true, data=null, error=null", () => {
+      mockFetch.mockReturnValue(new Promise(() => {}));
+      const { result } = renderHook(() => useDataFetch({ url: "/test.json" }));
+
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.data).toBeNull();
+      expect(result.current.error).toBeNull();
+    });
+
+    it("sets data and clears loading after successful fetch", async () => {
+      const payload = { value: 42 };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => payload,
+      });
+
+      const { result } = renderHook(() => useDataFetch<typeof payload>({ url: "/test.json" }));
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.data).toEqual(payload);
+      expect(result.current.error).toBeNull();
+    });
+
+    it("passes raw JSON through parser when provided", async () => {
+      const raw = { value: "42" };
+      const parser = (data: unknown) => ({ parsed: (data as typeof raw).value });
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => raw,
+      });
+
+      const { result } = renderHook(() => useDataFetch({ url: "/test.json", parser }));
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.data).toEqual({ parsed: "42" });
+    });
+
+    it("fetches the provided URL", async () => {
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+      renderHook(() => useDataFetch({ url: "/specific-url.json" }));
+
+      await waitFor(() =>
+        expect(mockFetch).toHaveBeenCalledWith(
+          "/specific-url.json",
+          expect.objectContaining({ signal: expect.any(AbortSignal) })
+        )
+      );
+    });
+  });
+
+  describe("error path", () => {
+    it("sets error when fetch rejects", async () => {
+      mockFetch.mockRejectedValue(new Error("Network error"));
+
+      const { result } = renderHook(() => useDataFetch({ url: "/test.json" }));
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.error).toBeInstanceOf(Error);
+      expect(result.current.error?.message).toBe("Network error");
+      expect(result.current.data).toBeNull();
+    });
+
+    it("sets error when response is not ok", async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 404 });
+
+      const { result } = renderHook(() => useDataFetch({ url: "/test.json" }));
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.error).toBeInstanceOf(Error);
+      expect(result.current.error?.message).toContain("404");
+      expect(result.current.data).toBeNull();
+    });
+
+    it("wraps non-Error rejections in an Error", async () => {
+      mockFetch.mockRejectedValue("string error");
+
+      const { result } = renderHook(() => useDataFetch({ url: "/test.json" }));
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.error).toBeInstanceOf(Error);
+    });
+  });
+
+  describe("unmount abort", () => {
+    it("does not set state after unmount (abort on unmount)", async () => {
+      let resolveFetch!: (value: unknown) => void;
+      mockFetch.mockReturnValue(
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        })
+      );
+
+      const { result, unmount } = renderHook(() => useDataFetch({ url: "/test.json" }));
+      expect(result.current.isLoading).toBe(true);
+
+      unmount();
+
+      // Resolve after unmount — should not cause a state update
+      act(() => {
+        resolveFetch({ ok: true, json: async () => ({ value: 1 }) });
+      });
+
+      // State should remain as initial (no updates after unmount)
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.data).toBeNull();
+    });
+
+    it("aborts the fetch signal on unmount", async () => {
+      let capturedSignal: AbortSignal | undefined;
+      mockFetch.mockImplementation((_url: string, opts: RequestInit) => {
+        capturedSignal = opts.signal as AbortSignal;
+        return new Promise(() => {});
+      });
+
+      const { unmount } = renderHook(() => useDataFetch({ url: "/test.json" }));
+
+      expect(capturedSignal?.aborted).toBe(false);
+
+      unmount();
+
+      expect(capturedSignal?.aborted).toBe(true);
+    });
+  });
+
+  describe("refetch", () => {
+    it("exposes a refetch function that re-triggers the fetch", async () => {
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ v: 1 }) });
+
+      const { result } = renderHook(() => useDataFetch<{ v: number }>({ url: "/test.json" }));
+      await waitFor(() => expect(result.current.data).toEqual({ v: 1 }));
+
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ v: 2 }) });
+      await act(async () => {
+        await result.current.refetch();
+      });
+
+      expect(result.current.data).toEqual({ v: 2 });
+    });
+  });
+});

--- a/apps/marketing/src/hooks/useDataFetch.ts
+++ b/apps/marketing/src/hooks/useDataFetch.ts
@@ -1,0 +1,79 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import type { DependencyList } from "react";
+
+export interface UseDataFetchOptions<T> {
+  url: string;
+  parser?: (data: unknown) => T;
+  deps?: DependencyList;
+}
+
+export interface UseDataFetchReturn<T> {
+  data: T | null;
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => Promise<void>;
+}
+
+export function useDataFetch<T>(options: UseDataFetchOptions<T>): UseDataFetchReturn<T> {
+  const { url, parser, deps } = options;
+
+  const [data, setData] = useState<T | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  // Incremented by refetch() to re-trigger the effect without an external dep change.
+  const [fetchKey, setFetchKey] = useState(0);
+
+  // Track the active controller so unmount/refetch can abort in-flight requests.
+  const controllerRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    controllerRef.current = controller;
+    const { signal } = controller;
+
+    async function run() {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const response = await fetch(url, { signal });
+
+        if (signal.aborted) return;
+
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+
+        const json: unknown = await response.json();
+
+        if (signal.aborted) return;
+
+        const result = parser ? parser(json) : (json as T);
+        setData(result);
+      } catch (err) {
+        if (signal.aborted) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+      } finally {
+        if (!signal.aborted) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    void run();
+
+    return () => {
+      controller.abort();
+    };
+    // fetchKey drives manual refetches; deps are caller-provided re-fetch triggers.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [url, parser, fetchKey, ...(deps ?? [])]);
+
+  const refetch = useCallback(async () => {
+    controllerRef.current?.abort();
+    setFetchKey((k) => k + 1);
+  }, []);
+
+  return { data, isLoading, error, refetch };
+}

--- a/apps/marketing/src/pages/AiHealthPage.test.tsx
+++ b/apps/marketing/src/pages/AiHealthPage.test.tsx
@@ -75,14 +75,19 @@ describe("AiHealthPage", () => {
     mockFetch.mockResolvedValue({ ok: false, status: 404 });
     render(<AiHealthPage />);
     await waitFor(() => {
-      expect(screen.getByText(/Failed to load.*404/)).toBeInTheDocument();
+      expect(screen.getByText(/Error loading.*404/)).toBeInTheDocument();
     });
   });
 
   it("fetches /sensor-report.json", async () => {
     mockFetch.mockResolvedValue({ ok: true, json: async () => MOCK_REPORT });
     render(<AiHealthPage />);
-    await waitFor(() => expect(mockFetch).toHaveBeenCalledWith("/sensor-report.json"));
+    await waitFor(() =>
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/sensor-report.json",
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      )
+    );
   });
 
   it("renders key metric cards on success", async () => {

--- a/apps/marketing/src/pages/AiHealthPage.tsx
+++ b/apps/marketing/src/pages/AiHealthPage.tsx
@@ -1,4 +1,3 @@
-import { useState, useEffect } from "react";
 import { Card, Badge, Heading, Text, Spinner } from "@mattbutlerengineering/rialto";
 import {
   formatSensorStatus,
@@ -7,42 +6,26 @@ import {
   formatTimestamp,
   type SensorReport,
 } from "../data/ai-health.js";
+import { useDataFetch } from "../hooks/useDataFetch.js";
 import styles from "./AiHealthPage.module.css";
 
 export function AiHealthPage() {
-  const [report, setReport] = useState<SensorReport | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    async function load() {
-      try {
-        const response = await fetch("/sensor-report.json");
-        if (!response.ok) {
-          throw new Error(`Failed to load sensor report: ${response.status}`);
-        }
-        const data: SensorReport = await response.json();
-        if (!cancelled) setReport(data);
-      } catch (err) {
-        if (!cancelled) setError(err instanceof Error ? err.message : "Unknown error");
-      }
-    }
-    void load();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  const {
+    data: report,
+    isLoading,
+    error,
+  } = useDataFetch<SensorReport>({ url: "/sensor-report.json" });
 
   if (error) {
     return (
       <div className={styles.container}>
         <Heading level={1}>AI Health Dashboard</Heading>
-        <Text className={styles.error}>Error loading sensor report: {error}</Text>
+        <Text className={styles.error}>Error loading sensor report: {error.message}</Text>
       </div>
     );
   }
 
-  if (!report) {
+  if (isLoading || !report) {
     return (
       <div className={styles.container}>
         <Heading level={1}>AI Health Dashboard</Heading>

--- a/apps/marketing/src/pages/MetricsPage.test.tsx
+++ b/apps/marketing/src/pages/MetricsPage.test.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any, mbe-local/prefer-rialto-components */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import { MetricsPage } from "./MetricsPage.js";
@@ -138,7 +138,7 @@ describe("MetricsPage", () => {
     render(<MetricsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText(/Failed to load metrics: 404/)).toBeInTheDocument();
+      expect(screen.getByText(/Error loading metrics:.*404/)).toBeInTheDocument();
     });
   });
 

--- a/apps/marketing/src/pages/MetricsPage.tsx
+++ b/apps/marketing/src/pages/MetricsPage.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from "react";
 import { Card, Badge, Heading, Text, Spinner } from "@mattbutlerengineering/rialto";
+import { useDataFetch } from "../hooks/useDataFetch.js";
 import styles from "./MetricsPage.module.css";
 
 interface BehavioralGate {
@@ -57,43 +57,18 @@ function formatDate(iso: string): string {
 }
 
 export function MetricsPage() {
-  const [metrics, setMetrics] = useState<AcmmMetrics | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    async function load() {
-      try {
-        const response = await fetch("/metrics.json");
-        if (!response.ok) {
-          throw new Error(`Failed to load metrics: ${response.status}`);
-        }
-        const data: AcmmMetrics = await response.json();
-        if (!cancelled) {
-          setMetrics(data);
-        }
-      } catch (err) {
-        if (!cancelled) {
-          setError(err instanceof Error ? err.message : "Unknown error");
-        }
-      }
-    }
-    void load();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  const { data: metrics, isLoading, error } = useDataFetch<AcmmMetrics>({ url: "/metrics.json" });
 
   if (error) {
     return (
       <div className={styles.container}>
         <Heading level={1}>Quality Metrics</Heading>
-        <Text className={styles.error}>Error loading metrics: {error}</Text>
+        <Text className={styles.error}>Error loading metrics: {error.message}</Text>
       </div>
     );
   }
 
-  if (!metrics) {
+  if (isLoading || !metrics) {
     return (
       <div className={styles.container}>
         <Heading level={1}>Quality Metrics</Heading>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3230,6 +3230,19 @@
     export const VENUES_QUERY_KEY = "venues" as const;
     export const VENUE_BY_SLUG_QUERY_KEY = "venueBySlug" as const;
   </file>
+  <file path="apps/marketing/src/hooks/useDataFetch.ts">
+    export interface UseDataFetchOptions<T> {
+      url: string;
+      parser?: (data: unknown) => T;
+      deps?: DependencyList;
+    }
+    export interface UseDataFetchReturn<T> {
+      data: T | null;
+      isLoading: boolean;
+      error: Error | null;
+      refetch: () => Promise<void>;
+    }
+  </file>
   <file path="apps/rialto-web/src/hooks/use-props-from-manifest.ts">
     export function usePropsFromManifest(componentName: string): PropDef[] {
       const entry = manifest.components.find((c) => c.name === componentName);
@@ -14986,7 +14999,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -15087,18 +15087,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms.txt
+++ b/llms.txt
@@ -1134,6 +1134,23 @@
       export const VENUE_BY_SLUG_QUERY_KEY: unknown;
     </item>
   </file>
+  <file path="apps/marketing/src/hooks/useDataFetch.ts">
+    <item priority="low">
+      interface UseDataFetchOptions {
+        url: string;
+        parser?: (data: unknown) => T;
+        deps?: DependencyList;
+      }
+    </item>
+    <item priority="low">
+      interface UseDataFetchReturn {
+        data: T | null;
+        isLoading: boolean;
+        error: Error | null;
+        refetch: () => Promise<void>;
+      }
+    </item>
+  </file>
   <file path="apps/rialto-web/src/hooks/use-props-from-manifest.ts">
     <item priority="high">
       export function usePropsFromManifest(componentName: string): PropDef[] { /* ... */ }

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,18 +337,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,7 +337,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),


### PR DESCRIPTION
## Summary

- Extracts a reusable `useDataFetch<T>` hook into `apps/marketing/src/hooks/useDataFetch.ts` that owns fetch dispatch, loading/error state, AbortController lifecycle, and an optional response parser
- Migrates `MetricsPage` and `AiHealthPage` off their bespoke `cancelled` bool / `useEffect` fetch effects to consume the hook — both pages are now view-only
- 10 unit tests cover success, error, unmount-abort, and refetch paths

## Deviations from issue spec (both intentional)

**StatusPage** — not migrated. Its fetch pattern uses `setInterval` polling with `useCallback` — there is no `if (!cancelled)` guard or AbortController boilerplate to remove. Forcing it into `useDataFetch` would change its polling behavior.

**SharedSpecPage** (apps/gen) — not migrated. It uses `@mbe/api-client`'s `client.request()` (not `fetch`), and the existing test `"uses @mbe/api-client (not raw fetch) to load the spec"` explicitly asserts this. A `url: string` + `fetch`-based hook cannot serve it without breaking that test.

## Hook location

`apps/marketing/src/hooks/useDataFetch.ts` — marketing app (where 2 of 2 migrated pages live). Gen app has its own hooks dir but was not affected.

## Gate results (apps/marketing)

- `pnpm lint`: 0 errors, 18 warnings (all pre-existing)
- `pnpm typecheck`: clean
- `pnpm test`: 126/126 passed (16 test files)
- `pnpm --filter @mbe/cli start check-adr`: no violations
- `pnpm --filter @mbe/cli start check-deps`: no mismatches
- `pnpm regen`: ran, llms.txt artifacts staged and committed
- `node scripts/detect-instruction-rot.mjs`: no rot detected

Closes #2491