### PR TITLE
fix(deploy): retry create-deployment to absorb transient DO BuildRateLimit

### DIFF
--- a/.github/workflows/deploy-services.yml
+++ b/.github/workflows/deploy-services.yml
@@ -132,7 +132,21 @@ jobs:
             exit 1
           fi
           echo "Triggering deployment for app $APP_ID"
-          doctl apps create-deployment "$APP_ID" --wait
+          # Retry to absorb transient DO build failures (BuildRateLimit from concurrent
+          # builds / the doctl+Pulumi dual-deploy race). create-deployment is safe to
+          # re-issue: each call starts a fresh deployment and the latest one wins.
+          for attempt in 1 2 3; do
+            if doctl apps create-deployment "$APP_ID" --wait; then
+              echo "Deployment succeeded on attempt $attempt"
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "::warning::Deployment attempt $attempt failed (likely transient DO BuildRateLimit); retrying after backoff"
+              sleep $((attempt * 60))
+            fi
+          done
+          echo "::error::Deployment failed after 3 attempts"
+          exit 1
 
   verify:
     name: Post-Deploy Verification


### PR DESCRIPTION
## Problem

`#2473` — system health reports `deploys: unhealthy`. Root cause: the latest `deploy-services` run (commit 0a2c728d, #2488) failed with `users-api → BuildJobExitNonZero` while two sibling components hit `BuildRateLimit` (DO concurrent-build throttle).

Diagnosis: users-api prod build (`tsc -p tsconfig.build.json`) **compiles clean on current main** — verified locally. #2488 (SMS waitlist) doesn't touch users-api. So the failure was transient DO build infra (BuildRateLimit / doctl+Pulumi dual-deploy race), not a code break. This class of flake recurs.

## Fix

Wrap `doctl apps create-deployment --wait` in a bounded 3-attempt retry with linear backoff. create-deployment is idempotent (each call starts a fresh deployment, latest wins), so retrying safely absorbs transient throttling.

## Test plan

- [ ] CI green
- [ ] Next merge to main triggers a fresh deploy-services run → goes green → `deploys` health recovers (auto-health sensor flips #2473)

Closes #2473