### PR TITLE
refactor(marketing): centralize formatters into shared utils module

### DIFF
--- a/apps/marketing/llms-full.txt
+++ b/apps/marketing/llms-full.txt
@@ -127,4 +127,28 @@
     ];
   </file>
   </section>
+  <section priority="medium" role="utils">
+  <file path="src/utils/formatters.ts">
+    export interface ServiceStatus {
+      readonly name: string;
+      readonly url: string;
+      readonly status: "ok" | "degraded" | "error" | "loading";
+      readonly version?: string;
+      readonly latency?: number;
+      readonly checkedAt?: string;
+    }
+    export function statusColor(status: string): "green" | "yellow" | "red" | "neutral" {
+      switch (status) {
+        case "ok":
+          return "green";
+        case "degraded":
+          return "yellow";
+        case "error":
+          return "red";
+        default:
+          return "neutral";
+      }
+    }
+  </file>
+  </section>
 </codebase>

--- a/apps/marketing/llms-full.txt
+++ b/apps/marketing/llms-full.txt
@@ -142,4 +142,28 @@
     }
   </file>
   </section>
+  <section priority="medium" role="utils">
+  <file path="src/utils/formatters.ts">
+    export interface ServiceStatus {
+      readonly name: string;
+      readonly url: string;
+      readonly status: "ok" | "degraded" | "error" | "loading";
+      readonly version?: string;
+      readonly latency?: number;
+      readonly checkedAt?: string;
+    }
+    export function statusColor(status: string): "green" | "yellow" | "red" | "neutral" {
+      switch (status) {
+        case "ok":
+          return "green";
+        case "degraded":
+          return "yellow";
+        case "error":
+          return "red";
+        default:
+          return "neutral";
+      }
+    }
+  </file>
+  </section>
 </codebase>

--- a/apps/marketing/llms.txt
+++ b/apps/marketing/llms.txt
@@ -75,4 +75,20 @@
     </item>
   </file>
   </section>
+  <section priority="medium" role="utils">
+  <file path="src/utils/formatters.ts">
+    <item priority="low">
+      interface ServiceStatus {
+        name: string;
+        url: string;
+        status: "ok" | "degraded" | "error" | "loading";
+        version?: string;
+        latency?: number;
+      }
+    </item>
+    <item priority="high">
+      export function statusColor(status: string): "green" | "yellow" | "red" | "neutral" { /* ... */ }
+    </item>
+  </file>
+  </section>
 </codebase>

--- a/apps/marketing/llms.txt
+++ b/apps/marketing/llms.txt
@@ -56,4 +56,20 @@
     </item>
   </file>
   </section>
+  <section priority="medium" role="utils">
+  <file path="src/utils/formatters.ts">
+    <item priority="low">
+      interface ServiceStatus {
+        name: string;
+        url: string;
+        status: "ok" | "degraded" | "error" | "loading";
+        version?: string;
+        latency?: number;
+      }
+    </item>
+    <item priority="high">
+      export function statusColor(status: string): "green" | "yellow" | "red" | "neutral" { /* ... */ }
+    </item>
+  </file>
+  </section>
 </codebase>

--- a/apps/marketing/src/data/ai-health.ts
+++ b/apps/marketing/src/data/ai-health.ts
@@ -61,24 +61,9 @@ export interface SensorReport {
   };
 }
 
-export function formatSensorStatus(available: boolean): string {
-  return available ? "Available" : "Unavailable";
-}
-
-export function getSensorColor(available: boolean): "green" | "red" {
-  return available ? "green" : "red";
-}
-
-export function formatPercent(value: number): string {
-  const rounded = Math.round(value * 10) / 10;
-  return rounded % 1 === 0 ? `${rounded}%` : `${rounded}%`;
-}
-
-export function formatTimestamp(value: string | null | undefined): string {
-  if (value == null) return "Never";
-  return new Date(value).toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  });
-}
+export {
+  formatSensorStatus,
+  getSensorColor,
+  formatPercent,
+  formatTimestamp,
+} from "../utils/formatters.js";

--- a/apps/marketing/src/pages/AiHealthPage.tsx
+++ b/apps/marketing/src/pages/AiHealthPage.tsx
@@ -5,8 +5,8 @@ import {
   getSensorColor,
   formatPercent,
   formatTimestamp,
-  type SensorReport,
-} from "../data/ai-health.js";
+} from "../utils/formatters.js";
+import type { SensorReport } from "../data/ai-health.js";
 import styles from "./AiHealthPage.module.css";
 
 export function AiHealthPage() {

--- a/apps/marketing/src/pages/MetricsPage.tsx
+++ b/apps/marketing/src/pages/MetricsPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { Card, Badge, Heading, Text, Spinner } from "@mattbutlerengineering/rialto";
+import { formatRatio, formatDate } from "../utils/formatters.js";
 import styles from "./MetricsPage.module.css";
 
 interface BehavioralGate {
@@ -42,18 +43,6 @@ interface AcmmMetrics {
   readonly history: readonly HistoryEntry[];
   readonly detectedByLevel: Record<string, number>;
   readonly behavioralGates: readonly BehavioralGate[];
-}
-
-function formatPercent(value: number): string {
-  return `${(value * 100).toFixed(1)}%`;
-}
-
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  });
 }
 
 export function MetricsPage() {
@@ -161,9 +150,9 @@ export function MetricsPage() {
               <Text className={styles.gateValue}>
                 L{gate.level}:{" "}
                 {typeof gate.value === "number" && gate.value <= 1
-                  ? formatPercent(gate.value)
+                  ? formatRatio(gate.value)
                   : gate.value}{" "}
-                (threshold: {gate.threshold <= 1 ? formatPercent(gate.threshold) : gate.threshold})
+                (threshold: {gate.threshold <= 1 ? formatRatio(gate.threshold) : gate.threshold})
               </Text>
             </Card>
           ))}
@@ -176,26 +165,22 @@ export function MetricsPage() {
           <Card className={styles.statCard}>
             <Text className={styles.statLabel}>PR Acceptance</Text>
             <Text className={styles.statValue}>
-              {formatPercent(metrics.behavioral.agentPrAcceptanceRate)}
+              {formatRatio(metrics.behavioral.agentPrAcceptanceRate)}
             </Text>
           </Card>
           <Card className={styles.statCard}>
             <Text className={styles.statLabel}>PR Revert Rate</Text>
             <Text className={styles.statValue}>
-              {formatPercent(metrics.behavioral.agentPrRevertRate)}
+              {formatRatio(metrics.behavioral.agentPrRevertRate)}
             </Text>
           </Card>
           <Card className={styles.statCard}>
             <Text className={styles.statLabel}>CI Flake Rate</Text>
-            <Text className={styles.statValue}>
-              {formatPercent(metrics.behavioral.ciFlakeRate)}
-            </Text>
+            <Text className={styles.statValue}>{formatRatio(metrics.behavioral.ciFlakeRate)}</Text>
           </Card>
           <Card className={styles.statCard}>
             <Text className={styles.statLabel}>Eval Pass Rate</Text>
-            <Text className={styles.statValue}>
-              {formatPercent(metrics.behavioral.evalPassRate)}
-            </Text>
+            <Text className={styles.statValue}>{formatRatio(metrics.behavioral.evalPassRate)}</Text>
           </Card>
         </div>
       </section>

--- a/apps/marketing/src/pages/StatusPage.tsx
+++ b/apps/marketing/src/pages/StatusPage.tsx
@@ -1,15 +1,8 @@
 import { useState, useEffect, useCallback } from "react";
 import { Card, Badge, Spinner, Heading, Text } from "@mattbutlerengineering/rialto";
+import { statusColor, statusLabel, overallStatus } from "../utils/formatters.js";
+import type { ServiceStatus } from "../utils/formatters.js";
 import styles from "./StatusPage.module.css";
-
-interface ServiceStatus {
-  readonly name: string;
-  readonly url: string;
-  readonly status: "ok" | "degraded" | "error" | "loading";
-  readonly version?: string;
-  readonly latency?: number;
-  readonly checkedAt?: string;
-}
 
 const SERVICES = [
   { name: "Users API", url: "/api/v1/users/health" },
@@ -24,34 +17,6 @@ const STATIC_SITES = [
 ] as const;
 
 const POLL_INTERVAL_MS = 30_000;
-
-function statusColor(status: string): "green" | "yellow" | "red" | "neutral" {
-  switch (status) {
-    case "ok":
-      return "green";
-    case "degraded":
-      return "yellow";
-    case "error":
-      return "red";
-    default:
-      return "neutral";
-  }
-}
-
-function statusLabel(status: string): string {
-  switch (status) {
-    case "ok":
-      return "Operational";
-    case "degraded":
-      return "Degraded";
-    case "error":
-      return "Down";
-    case "loading":
-      return "Checking...";
-    default:
-      return "Unknown";
-  }
-}
 
 async function checkService(url: string): Promise<Omit<ServiceStatus, "name" | "url">> {
   const start = Date.now();
@@ -99,13 +64,6 @@ async function checkStaticSite(url: string): Promise<Omit<ServiceStatus, "name" 
       checkedAt: new Date().toISOString(),
     };
   }
-}
-
-function overallStatus(statuses: ServiceStatus[]): "ok" | "degraded" | "error" | "loading" {
-  if (statuses.some((s) => s.status === "loading")) return "loading";
-  if (statuses.every((s) => s.status === "ok")) return "ok";
-  if (statuses.some((s) => s.status === "error")) return "error";
-  return "degraded";
 }
 
 export function StatusPage() {

--- a/apps/marketing/src/pages/WeeklyIntakePage.tsx
+++ b/apps/marketing/src/pages/WeeklyIntakePage.tsx
@@ -2,21 +2,8 @@ import { useState } from "react";
 import { Card, Badge, Heading, Text, Button } from "@mattbutlerengineering/rialto";
 import { weeklyResources } from "../data/weekly-intake";
 import type { WeeklyResource } from "../data/weekly-intake";
+import { SOURCE_COLORS, SOURCE_LABELS } from "../utils/formatters.js";
 import styles from "./WeeklyIntakePage.module.css";
-
-const sourceColors: Record<WeeklyResource["source"], "yellow" | "blue" | "purple" | "neutral"> = {
-  "js-weekly": "yellow",
-  "react-weekly": "blue",
-  "ai-weekly": "purple",
-  other: "neutral",
-};
-
-const sourceLabels: Record<WeeklyResource["source"], string> = {
-  "js-weekly": "JS Weekly",
-  "react-weekly": "React Weekly",
-  "ai-weekly": "AI Weekly",
-  other: "Other",
-};
 
 function ResourceCard({ resource }: { readonly resource: WeeklyResource }) {
   return (
@@ -27,8 +14,8 @@ function ResourceCard({ resource }: { readonly resource: WeeklyResource }) {
             {resource.title}
           </Heading>
         </a>
-        <Badge color={sourceColors[resource.source]} size="sm">
-          {sourceLabels[resource.source]}
+        <Badge color={SOURCE_COLORS[resource.source]} size="sm">
+          {SOURCE_LABELS[resource.source]}
         </Badge>
       </div>
       <Text className={styles.description}>{resource.description}</Text>

--- a/apps/marketing/src/utils/formatters.test.ts
+++ b/apps/marketing/src/utils/formatters.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from "vitest";
+import {
+  statusColor,
+  statusLabel,
+  overallStatus,
+  formatSensorStatus,
+  getSensorColor,
+  formatPercent,
+  formatRatio,
+  formatDate,
+  formatTimestamp,
+  SOURCE_COLORS,
+  SOURCE_LABELS,
+} from "./formatters.js";
+import type { ServiceStatus } from "./formatters.js";
+
+describe("statusColor", () => {
+  it("returns green for ok", () => {
+    expect(statusColor("ok")).toBe("green");
+  });
+
+  it("returns yellow for degraded", () => {
+    expect(statusColor("degraded")).toBe("yellow");
+  });
+
+  it("returns red for error", () => {
+    expect(statusColor("error")).toBe("red");
+  });
+
+  it("returns neutral for unknown status", () => {
+    expect(statusColor("loading")).toBe("neutral");
+    expect(statusColor("unknown")).toBe("neutral");
+  });
+});
+
+describe("statusLabel", () => {
+  it("returns Operational for ok", () => {
+    expect(statusLabel("ok")).toBe("Operational");
+  });
+
+  it("returns Degraded for degraded", () => {
+    expect(statusLabel("degraded")).toBe("Degraded");
+  });
+
+  it("returns Down for error", () => {
+    expect(statusLabel("error")).toBe("Down");
+  });
+
+  it("returns Checking... for loading", () => {
+    expect(statusLabel("loading")).toBe("Checking...");
+  });
+
+  it("returns Unknown for unknown status", () => {
+    expect(statusLabel("unknown")).toBe("Unknown");
+  });
+});
+
+describe("overallStatus", () => {
+  const makeStatus = (status: ServiceStatus["status"]): ServiceStatus => ({
+    name: "test",
+    url: "/test",
+    status,
+  });
+
+  it("returns loading when any service is loading", () => {
+    const statuses = [makeStatus("ok"), makeStatus("loading"), makeStatus("error")];
+    expect(overallStatus(statuses)).toBe("loading");
+  });
+
+  it("returns ok when all services are ok", () => {
+    const statuses = [makeStatus("ok"), makeStatus("ok")];
+    expect(overallStatus(statuses)).toBe("ok");
+  });
+
+  it("returns error when any service has error and none loading", () => {
+    const statuses = [makeStatus("ok"), makeStatus("error")];
+    expect(overallStatus(statuses)).toBe("error");
+  });
+
+  it("returns degraded when mixed ok/degraded and no errors", () => {
+    const statuses = [makeStatus("ok"), makeStatus("degraded")];
+    expect(overallStatus(statuses)).toBe("degraded");
+  });
+});
+
+describe("formatSensorStatus", () => {
+  it("returns Available for true", () => {
+    expect(formatSensorStatus(true)).toBe("Available");
+  });
+
+  it("returns Unavailable for false", () => {
+    expect(formatSensorStatus(false)).toBe("Unavailable");
+  });
+});
+
+describe("getSensorColor", () => {
+  it("returns green for available", () => {
+    expect(getSensorColor(true)).toBe("green");
+  });
+
+  it("returns red for unavailable", () => {
+    expect(getSensorColor(false)).toBe("red");
+  });
+});
+
+describe("formatPercent", () => {
+  it("formats integer percentage value", () => {
+    expect(formatPercent(100)).toBe("100%");
+  });
+
+  it("formats zero", () => {
+    expect(formatPercent(0)).toBe("0%");
+  });
+
+  it("rounds to one decimal when not whole", () => {
+    expect(formatPercent(95.5)).toBe("95.5%");
+  });
+});
+
+describe("formatRatio", () => {
+  it("formats a ratio (0-1) as percentage with one decimal", () => {
+    expect(formatRatio(0.951)).toBe("95.1%");
+  });
+
+  it("formats zero ratio", () => {
+    expect(formatRatio(0)).toBe("0.0%");
+  });
+
+  it("formats 1.0 as 100.0%", () => {
+    expect(formatRatio(1)).toBe("100.0%");
+  });
+});
+
+describe("formatDate", () => {
+  it("formats ISO date string to readable format", () => {
+    const result = formatDate("2026-05-09T05:48:08.683Z");
+    expect(result).toContain("2026");
+    expect(result).toContain("May");
+  });
+});
+
+describe("formatTimestamp", () => {
+  it("formats ISO timestamp to readable date", () => {
+    const result = formatTimestamp("2026-05-09T05:48:08.683Z");
+    expect(result).toContain("2026");
+    expect(result).toContain("May");
+  });
+
+  it("handles null gracefully", () => {
+    expect(formatTimestamp(null)).toBe("Never");
+  });
+
+  it("handles undefined gracefully", () => {
+    expect(formatTimestamp(undefined)).toBe("Never");
+  });
+});
+
+describe("SOURCE_COLORS", () => {
+  it("maps js-weekly to yellow", () => {
+    expect(SOURCE_COLORS["js-weekly"]).toBe("yellow");
+  });
+
+  it("maps react-weekly to blue", () => {
+    expect(SOURCE_COLORS["react-weekly"]).toBe("blue");
+  });
+
+  it("maps ai-weekly to purple", () => {
+    expect(SOURCE_COLORS["ai-weekly"]).toBe("purple");
+  });
+
+  it("maps other to neutral", () => {
+    expect(SOURCE_COLORS["other"]).toBe("neutral");
+  });
+});
+
+describe("SOURCE_LABELS", () => {
+  it("maps js-weekly to JS Weekly", () => {
+    expect(SOURCE_LABELS["js-weekly"]).toBe("JS Weekly");
+  });
+
+  it("maps react-weekly to React Weekly", () => {
+    expect(SOURCE_LABELS["react-weekly"]).toBe("React Weekly");
+  });
+
+  it("maps ai-weekly to AI Weekly", () => {
+    expect(SOURCE_LABELS["ai-weekly"]).toBe("AI Weekly");
+  });
+
+  it("maps other to Other", () => {
+    expect(SOURCE_LABELS["other"]).toBe("Other");
+  });
+});

--- a/apps/marketing/src/utils/formatters.ts
+++ b/apps/marketing/src/utils/formatters.ts
@@ -1,0 +1,114 @@
+import type { WeeklyResource } from "../data/weekly-intake.js";
+
+// --- Service status types (shared with StatusPage) ---
+
+export interface ServiceStatus {
+  readonly name: string;
+  readonly url: string;
+  readonly status: "ok" | "degraded" | "error" | "loading";
+  readonly version?: string;
+  readonly latency?: number;
+  readonly checkedAt?: string;
+}
+
+// --- Status color / label / overall ---
+
+export function statusColor(status: string): "green" | "yellow" | "red" | "neutral" {
+  switch (status) {
+    case "ok":
+      return "green";
+    case "degraded":
+      return "yellow";
+    case "error":
+      return "red";
+    default:
+      return "neutral";
+  }
+}
+
+export function statusLabel(status: string): string {
+  switch (status) {
+    case "ok":
+      return "Operational";
+    case "degraded":
+      return "Degraded";
+    case "error":
+      return "Down";
+    case "loading":
+      return "Checking...";
+    default:
+      return "Unknown";
+  }
+}
+
+export function overallStatus(statuses: ServiceStatus[]): "ok" | "degraded" | "error" | "loading" {
+  if (statuses.some((s) => s.status === "loading")) return "loading";
+  if (statuses.every((s) => s.status === "ok")) return "ok";
+  if (statuses.some((s) => s.status === "error")) return "error";
+  return "degraded";
+}
+
+// --- Sensor status ---
+
+export function formatSensorStatus(available: boolean): string {
+  return available ? "Available" : "Unavailable";
+}
+
+export function getSensorColor(available: boolean): "green" | "red" {
+  return available ? "green" : "red";
+}
+
+// --- Number / date formatters ---
+
+/**
+ * Format a whole-number percentage (0–100 input).
+ * e.g. formatPercent(95.5) → "95.5%"
+ */
+export function formatPercent(value: number): string {
+  const rounded = Math.round(value * 10) / 10;
+  return `${rounded}%`;
+}
+
+/**
+ * Format a ratio (0–1 input) as a percentage with one decimal place.
+ * e.g. formatRatio(0.951) → "95.1%"
+ */
+export function formatRatio(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+export function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export function formatTimestamp(value: string | null | undefined): string {
+  if (value == null) return "Never";
+  return new Date(value).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+// --- Weekly source maps ---
+
+export const SOURCE_COLORS: Record<
+  WeeklyResource["source"],
+  "yellow" | "blue" | "purple" | "neutral"
+> = {
+  "js-weekly": "yellow",
+  "react-weekly": "blue",
+  "ai-weekly": "purple",
+  other: "neutral",
+};
+
+export const SOURCE_LABELS: Record<WeeklyResource["source"], string> = {
+  "js-weekly": "JS Weekly",
+  "react-weekly": "React Weekly",
+  "ai-weekly": "AI Weekly",
+  other: "Other",
+};

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -15074,7 +15074,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),
@@ -16133,6 +16144,28 @@
       const suffix = ["th", "st", "nd", "rd"];
       const v = n % 100;
       return `${n}${suffix[(v - 20) % 10] ?? suffix[v] ?? suffix[0]} visit`;
+    }
+  </file>
+  <file path="apps/marketing/src/utils/formatters.ts">
+    export interface ServiceStatus {
+      readonly name: string;
+      readonly url: string;
+      readonly status: "ok" | "degraded" | "error" | "loading";
+      readonly version?: string;
+      readonly latency?: number;
+      readonly checkedAt?: string;
+    }
+    export function statusColor(status: string): "green" | "yellow" | "red" | "neutral" {
+      switch (status) {
+        case "ok":
+          return "green";
+        case "degraded":
+          return "yellow";
+        case "error":
+          return "red";
+        default:
+          return "neutral";
+      }
     }
   </file>
   <file path="packages/rialto/src/utils/class-composer.ts">

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -15062,18 +15062,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms.txt
+++ b/llms.txt
@@ -4555,6 +4555,20 @@
       export function ordinalVisit(n: number): string { /* ... */ }
     </item>
   </file>
+  <file path="apps/marketing/src/utils/formatters.ts">
+    <item priority="low">
+      interface ServiceStatus {
+        name: string;
+        url: string;
+        status: "ok" | "degraded" | "error" | "loading";
+        version?: string;
+        latency?: number;
+      }
+    </item>
+    <item priority="high">
+      export function statusColor(status: string): "green" | "yellow" | "red" | "neutral" { /* ... */ }
+    </item>
+  </file>
   <file path="packages/rialto/src/utils/class-composer.ts">
     <item priority="high">
       export function cn(...classes: (string | false | null | undefined)[]): string { /* ... */ }

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,18 +337,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,7 +337,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),


### PR DESCRIPTION
## Summary

- Add `apps/marketing/src/utils/formatters.ts` as the single source of truth for all status/color/label/percent/date formatters
- `StatusPage`, `MetricsPage`, `AiHealthPage`, and `WeeklyIntakePage` now import from the shared module instead of defining their own
- `data/ai-health.ts` re-exports formatters from the shared module (no duplicate logic)
- 35 pure unit tests cover all exported functions — no React render required

## Key design decisions

- `formatPercent(value)` handles 0–100 input (sensor pass rates); `formatRatio(value)` handles 0–1 input (ACMM behavioral rates) — the two usages in existing code had different semantics and warranted distinct names
- `SOURCE_COLORS` / `SOURCE_LABELS` extracted as named constants from `WeeklyIntakePage`
- `ServiceStatus` interface moved to formatters so `StatusPage` can import the type alongside the functions

## Gate results

- `pnpm lint` — 0 errors, 17 warnings (all pre-existing)
- `pnpm typecheck` — clean
- `pnpm test` — 151/151 passed (16 test files)
- `check-adr` — no violations
- `check-deps` — no mismatches
- `pnpm regen` — llms.txt artifacts updated and committed

Closes #2492