### PR TITLE
test(reservations): fix cross-file fake-timer leak in reminder.test

### DIFF
--- a/services/reservations/src/services/reminder.test.ts
+++ b/services/reservations/src/services/reminder.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { findReservationsNeedingReminder } from "./reminder.js";
 
 vi.mock("./database.js", async () => {
@@ -17,6 +17,13 @@ import { prisma } from "./database.js";
 beforeEach(() => {
   vi.clearAllMocks();
   vi.useFakeTimers();
+});
+
+// Restore real timers so frozen fake time does not leak into other test files
+// sharded into the same vitest worker (e.g. guest-risk's date-decay logic,
+// which flips risky→standard under a leaked setSystemTime).
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("findReservationsNeedingReminder", () => {


### PR DESCRIPTION
## Problem
`services/reservations/src/services/reminder.test.ts` calls `vi.useFakeTimers()` in `beforeEach` but never restores them. When vitest shards it into the same worker as `guest-risk.test.ts`, the leaked `setSystemTime` ages no-show dates past the 12-month decay window, flipping risky→standard and failing the suite **flakily on unrelated PRs** (observed on #2497, #2501, #2500, #2502).

## Fix
Add `afterEach(() => vi.useRealTimers())` — matching the pattern already used in `hold.test.ts`, `confirm-hold.test.ts`, and `public-rate-limit.test.ts`.

## Test plan
- [x] Full reservations suite green locally (63 files, 887 tests)
- [ ] CI green

Test-only change.