### PR TITLE
refactor(service-bootstrap): health-route factory derives stats internally, 8-param wiring collapses

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -15067,18 +15067,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),
@@ -15227,8 +15216,9 @@
   </file>
   <file path="packages/service-bootstrap/src/health-routes.ts">
     export interface HealthDb {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      readonly prisma: { $queryRaw: (...args: any[]) => Promise<unknown> };
+      readonly prisma: {
+        $queryRaw: (query: TemplateStringsArray, ...values: unknown[]) => Promise<unknown>;
+      };
       readonly getSlowQueryStats: () => SlowQueryStats;
       readonly getServiceStatus: () => ServiceStatus;
       readonly getPoolMetrics: () => PoolMetrics;

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -15067,18 +15067,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5017,14 +5017,8 @@
   <file path="services/agent/src/routes/health.ts">
     export const healthRoutes: FastifyPluginAsync = async (fastify) => {
       await fastify.register(registerHealthRoutes, {
-        prisma,
-        getSlowQueryStats,
-        getServiceStatus,
-        getPoolMetrics,
-        latencyTracker,
+        db,
         checkAuth0,
-        rateLimitMonitor: fastify.rateLimitMonitor,
-        getErrorRates: () => fastify.getErrorRates(),
         routes: [
           { path: "/health", operationId: "getAgentHealth" },
           { path: "/api/gen/health", operationId: "getAgentHealthApiGen" },
@@ -7181,14 +7175,8 @@
   <file path="services/reservations/src/routes/health.ts">
     export const healthRoutes: FastifyPluginAsync = async (fastify) => {
       await fastify.register(registerHealthRoutes, {
-        prisma,
-        getSlowQueryStats,
-        getServiceStatus,
-        getPoolMetrics,
-        latencyTracker,
+        db,
         checkAuth0,
-        rateLimitMonitor: fastify.rateLimitMonitor,
-        getErrorRates: () => fastify.getErrorRates(),
         routes: [
           { path: "/health", operationId: "getHealth" },
           { path: "/api/health", operationId: "getHealthApi" },
@@ -10476,14 +10464,8 @@
   <file path="services/users/src/routes/health.ts">
     export const healthRoutes: FastifyPluginAsync = async (fastify) => {
       await fastify.register(registerHealthRoutes, {
-        prisma,
-        getSlowQueryStats,
-        getServiceStatus,
-        getPoolMetrics,
-        latencyTracker,
+        db,
         checkAuth0,
-        rateLimitMonitor: fastify.rateLimitMonitor,
-        getErrorRates: () => fastify.getErrorRates(),
         routes: [
           { path: "/health", operationId: "getHealth" },
           { path: "/api/v1/users/health", operationId: "getHealthApiUsers" },
@@ -11138,8 +11120,8 @@
   </section>
   <section priority="medium" role="services">
   <file path="services/agent/src/services/database.ts">
+    export const db = createDatabase(PrismaClient as never);
     export const prisma = db.prisma as unknown as PrismaClient;
-    export const getSlowQueryStats = db.getSlowQueryStats;
   </file>
   <file path="services/agent/src/services/liveness-monitor.ts">
     export interface LivenessMonitorConfig {
@@ -11414,8 +11396,8 @@
     }
   </file>
   <file path="services/reservations/src/services/database.ts">
+    export const db = createDatabase(PrismaClient as never);
     export const prisma = db.prisma as unknown as PrismaClient;
-    export const getSlowQueryStats = db.getSlowQueryStats;
   </file>
   <file path="services/reservations/src/services/deposit-state-machine.ts">
     export const VALID_TRANSITIONS: Record<DepositStatus, DepositStatus[]> = {
@@ -12129,8 +12111,8 @@
     }
   </file>
   <file path="services/users/src/services/database.ts">
+    export const db = createDatabase(PrismaClient as never);
     export const prisma = db.prisma as unknown as PrismaClient;
-    export const getSlowQueryStats = db.getSlowQueryStats;
   </file>
   <file path="services/users/src/services/user.ts">
     function mapPrismaUser(user: {
@@ -14293,9 +14275,20 @@
       [key: string]: unknown;
     }
     export interface MockDatabaseService {
+      /** Flat `prisma` re-export — backward-compatible with tests that import prisma directly. */
       prisma: MockPrisma;
+      /** `db` export matching the new services/database.ts shape (db.prisma, db.getSlowQueryStats, …). */
+      db: {
+        prisma: MockPrisma;
+        getSlowQueryStats: ReturnType<typeof vi.fn>;
+        getServiceStatus: ReturnType<typeof vi.fn>;
+        getPoolMetrics: ReturnType<typeof vi.fn>;
+      };
+      /** @deprecated Access via db.getSlowQueryStats instead. */
       getSlowQueryStats: ReturnType<typeof vi.fn>;
+      /** @deprecated Access via db.getServiceStatus instead. */
       getServiceStatus: ReturnType<typeof vi.fn>;
+      /** @deprecated Access via db.getPoolMetrics instead. */
       getPoolMetrics: ReturnType<typeof vi.fn>;
     }
   </file>
@@ -15074,7 +15067,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),
@@ -15222,29 +15226,16 @@
     }
   </file>
   <file path="packages/service-bootstrap/src/health-routes.ts">
+    export interface HealthDb {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      readonly prisma: { $queryRaw: (...args: any[]) => Promise<unknown> };
+      readonly getSlowQueryStats: () => SlowQueryStats;
+      readonly getServiceStatus: () => ServiceStatus;
+      readonly getPoolMetrics: () => PoolMetrics;
+    }
     export interface HealthRouteConfig {
       readonly path: string;
       readonly operationId: string;
-    }
-    export interface HealthRoutesOptions {
-      /** Prisma client instance — must support $queryRaw */
-      readonly prisma: { $queryRaw: (query: TemplateStringsArray) => Promise<unknown> };
-      /** Returns slow query stats from the database module */
-      readonly getSlowQueryStats: () => SlowQueryStats;
-      /** Returns overall service status from the database module */
-      readonly getServiceStatus: () => ServiceStatus;
-      /** Returns pool metrics from the database module */
-      readonly getPoolMetrics: () => PoolMetrics;
-      /** Latency tracker instance for DB ping anomaly detection */
-      readonly latencyTracker: LatencyTracker;
-      /** Auth0 JWKS check function — defaults to the shared checkAuth0 */
-      readonly checkAuth0: (jwksUrl?: string) => Promise<Auth0CheckResult>;
-      /** Rate limit monitor — from createRateLimitMonitor() in create-service-app */
-      readonly rateLimitMonitor: RateLimitMonitor;
-      /** Error rate snapshot getter — from errorRatePlugin_ decoration */
-      readonly getErrorRates: () => ErrorRateSnapshot;
-      /** Routes to register — each gets the same health handler */
-      readonly routes: readonly HealthRouteConfig[];
     }
   </file>
   <file path="packages/service-bootstrap/src/health.ts">

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -15067,7 +15067,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms.txt
+++ b/llms.txt
@@ -4084,7 +4084,8 @@
   <file path="packages/service-bootstrap/src/health-routes.ts">
     <item priority="low">
       interface HealthDb {
-        prisma: { $queryRaw: (...args: any[]) => Promise<unknown> };
+        prisma: {
+          $queryRaw: (query: TemplateStringsArray, ...values:...;
         getSlowQueryStats: () => SlowQueryStats;
         getServiceStatus: () => ServiceStatus;
         getPoolMetrics: () => PoolMetrics;

--- a/llms.txt
+++ b/llms.txt
@@ -2019,10 +2019,10 @@
   <section priority="medium" role="services">
   <file path="services/agent/src/services/database.ts">
     <item priority="high">
-      export const prisma: unknown;
+      export const db: unknown;
     </item>
     <item priority="high">
-      export const getSlowQueryStats: unknown;
+      export const prisma: unknown;
     </item>
   </file>
   <file path="services/agent/src/services/liveness-monitor.ts">
@@ -2187,10 +2187,10 @@
   </file>
   <file path="services/reservations/src/services/database.ts">
     <item priority="high">
-      export const prisma: unknown;
+      export const db: unknown;
     </item>
     <item priority="high">
-      export const getSlowQueryStats: unknown;
+      export const prisma: unknown;
     </item>
   </file>
   <file path="services/reservations/src/services/deposit-state-machine.ts">
@@ -2582,10 +2582,10 @@
   </file>
   <file path="services/users/src/services/database.ts">
     <item priority="high">
-      export const prisma: unknown;
+      export const db: unknown;
     </item>
     <item priority="high">
-      export const getSlowQueryStats: unknown;
+      export const prisma: unknown;
     </item>
   </file>
   <file path="services/users/src/services/user.ts">
@@ -3653,6 +3653,9 @@
     <item priority="low">
       interface MockDatabaseService {
         prisma: MockPrisma;
+        db: {
+          prisma: MockPrisma;
+          getSlowQueryStats: ReturnTy...;
         getSlowQueryStats: ReturnType<typeof vi.fn>;
         getServiceStatus: ReturnType<typeof vi.fn>;
         getPoolMetrics: ReturnType<typeof vi.fn>;
@@ -4080,18 +4083,17 @@
   </file>
   <file path="packages/service-bootstrap/src/health-routes.ts">
     <item priority="low">
-      interface HealthRouteConfig {
-        path: string;
-        operationId: string;
-      }
-    </item>
-    <item priority="low">
-      interface HealthRoutesOptions {
-        prisma: { $queryRaw: (query: TemplateStringsArray) => Promise<unk...;
+      interface HealthDb {
+        prisma: { $queryRaw: (...args: any[]) => Promise<unknown> };
         getSlowQueryStats: () => SlowQueryStats;
         getServiceStatus: () => ServiceStatus;
         getPoolMetrics: () => PoolMetrics;
-        latencyTracker: LatencyTracker;
+      }
+    </item>
+    <item priority="low">
+      interface HealthRouteConfig {
+        path: string;
+        operationId: string;
       }
     </item>
   </file>

--- a/packages/database/llms-full.txt
+++ b/packages/database/llms-full.txt
@@ -37,9 +37,20 @@
       [key: string]: unknown;
     }
     export interface MockDatabaseService {
+      /** Flat `prisma` re-export — backward-compatible with tests that import prisma directly. */
       prisma: MockPrisma;
+      /** `db` export matching the new services/database.ts shape (db.prisma, db.getSlowQueryStats, …). */
+      db: {
+        prisma: MockPrisma;
+        getSlowQueryStats: ReturnType<typeof vi.fn>;
+        getServiceStatus: ReturnType<typeof vi.fn>;
+        getPoolMetrics: ReturnType<typeof vi.fn>;
+      };
+      /** @deprecated Access via db.getSlowQueryStats instead. */
       getSlowQueryStats: ReturnType<typeof vi.fn>;
+      /** @deprecated Access via db.getServiceStatus instead. */
       getServiceStatus: ReturnType<typeof vi.fn>;
+      /** @deprecated Access via db.getPoolMetrics instead. */
       getPoolMetrics: ReturnType<typeof vi.fn>;
     }
   </file>

--- a/packages/database/llms.txt
+++ b/packages/database/llms.txt
@@ -33,6 +33,9 @@
     <item priority="low">
       interface MockDatabaseService {
         prisma: MockPrisma;
+        db: {
+          prisma: MockPrisma;
+          getSlowQueryStats: ReturnTy...;
         getSlowQueryStats: ReturnType<typeof vi.fn>;
         getServiceStatus: ReturnType<typeof vi.fn>;
         getPoolMetrics: ReturnType<typeof vi.fn>;

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -67,8 +67,7 @@ export interface DatabaseInstance<T> {
 export interface PrismaLike {
   $extends: (extension: unknown) => unknown;
   $disconnect: () => Promise<void>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  $queryRaw: (...args: any[]) => Promise<unknown>;
+  $queryRaw: (...args: unknown[]) => Promise<unknown>;
 }
 
 interface PrismaConstructor {

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -64,9 +64,11 @@ export interface DatabaseInstance<T> {
   shutdown: () => Promise<void>;
 }
 
-interface PrismaLike {
+export interface PrismaLike {
   $extends: (extension: unknown) => unknown;
   $disconnect: () => Promise<void>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  $queryRaw: (...args: any[]) => Promise<unknown>;
 }
 
 interface PrismaConstructor {

--- a/packages/database/src/testing.ts
+++ b/packages/database/src/testing.ts
@@ -9,9 +9,20 @@ export interface MockPrisma {
 
 /** Typed mock shape for a service's database.js module. */
 export interface MockDatabaseService {
+  /** Flat `prisma` re-export — backward-compatible with tests that import prisma directly. */
   prisma: MockPrisma;
+  /** `db` export matching the new services/database.ts shape (db.prisma, db.getSlowQueryStats, …). */
+  db: {
+    prisma: MockPrisma;
+    getSlowQueryStats: ReturnType<typeof vi.fn>;
+    getServiceStatus: ReturnType<typeof vi.fn>;
+    getPoolMetrics: ReturnType<typeof vi.fn>;
+  };
+  /** @deprecated Access via db.getSlowQueryStats instead. */
   getSlowQueryStats: ReturnType<typeof vi.fn>;
+  /** @deprecated Access via db.getServiceStatus instead. */
   getServiceStatus: ReturnType<typeof vi.fn>;
+  /** @deprecated Access via db.getPoolMetrics instead. */
   getPoolMetrics: ReturnType<typeof vi.fn>;
 }
 
@@ -67,12 +78,65 @@ export function createMockDatabaseService(
   const defaultPrisma: MockPrisma = { $queryRaw: vi.fn() };
   const mergedPrisma: MockPrisma = { ...defaultPrisma, ...(overrides?.prisma ?? {}) };
 
+  const getSlowQueryStats =
+    overrides?.getSlowQueryStats ?? vi.fn().mockReturnValue(DEFAULT_SLOW_QUERY_STATS);
+  const getServiceStatus =
+    overrides?.getServiceStatus ?? vi.fn().mockReturnValue(DEFAULT_SERVICE_STATUS);
+  const getPoolMetrics = overrides?.getPoolMetrics ?? vi.fn().mockReturnValue(DEFAULT_POOL_METRICS);
+
   return {
     prisma: mergedPrisma,
-    getSlowQueryStats:
-      overrides?.getSlowQueryStats ?? vi.fn().mockReturnValue(DEFAULT_SLOW_QUERY_STATS),
-    getServiceStatus:
-      overrides?.getServiceStatus ?? vi.fn().mockReturnValue(DEFAULT_SERVICE_STATUS),
-    getPoolMetrics: overrides?.getPoolMetrics ?? vi.fn().mockReturnValue(DEFAULT_POOL_METRICS),
+    db: {
+      prisma: mergedPrisma,
+      getSlowQueryStats,
+      getServiceStatus,
+      getPoolMetrics,
+    },
+    getSlowQueryStats,
+    getServiceStatus,
+    getPoolMetrics,
+  };
+}
+
+/** Typed mock for the new services/database.ts module shape: { db, prisma }. */
+export interface MockDatabaseModule {
+  db: {
+    prisma: MockPrisma;
+    getSlowQueryStats: ReturnType<typeof vi.fn>;
+    getServiceStatus: ReturnType<typeof vi.fn>;
+    getPoolMetrics: ReturnType<typeof vi.fn>;
+  };
+  prisma: MockPrisma;
+}
+
+/**
+ * Creates a mock for services/database.ts that exports `{ db, prisma }`.
+ *
+ * Usage inside vi.mock:
+ * ```ts
+ * vi.mock("../services/database.js", async () => {
+ *   const { createMockDatabaseModule } = await import("@mbe/database/testing");
+ *   return createMockDatabaseModule();
+ * });
+ * ```
+ *
+ * Override per-test behaviour:
+ * ```ts
+ * import { db } from "../services/database.js";
+ * vi.mocked(db.getPoolMetrics).mockReturnValueOnce({ ..., isDegraded: true });
+ * ```
+ */
+export function createMockDatabaseModule(
+  overrides?: MockDatabaseServiceOverrides
+): MockDatabaseModule {
+  const mock = createMockDatabaseService(overrides);
+  return {
+    db: {
+      prisma: mock.prisma,
+      getSlowQueryStats: mock.getSlowQueryStats,
+      getServiceStatus: mock.getServiceStatus,
+      getPoolMetrics: mock.getPoolMetrics,
+    },
+    prisma: mock.prisma,
   };
 }

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,18 +337,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,7 +337,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/service-bootstrap/llms-full.txt
+++ b/packages/service-bootstrap/llms-full.txt
@@ -83,8 +83,9 @@
   </file>
   <file path="src/health-routes.ts">
     export interface HealthDb {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      readonly prisma: { $queryRaw: (...args: any[]) => Promise<unknown> };
+      readonly prisma: {
+        $queryRaw: (query: TemplateStringsArray, ...values: unknown[]) => Promise<unknown>;
+      };
       readonly getSlowQueryStats: () => SlowQueryStats;
       readonly getServiceStatus: () => ServiceStatus;
       readonly getPoolMetrics: () => PoolMetrics;

--- a/packages/service-bootstrap/llms-full.txt
+++ b/packages/service-bootstrap/llms-full.txt
@@ -82,29 +82,16 @@
     }
   </file>
   <file path="src/health-routes.ts">
+    export interface HealthDb {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      readonly prisma: { $queryRaw: (...args: any[]) => Promise<unknown> };
+      readonly getSlowQueryStats: () => SlowQueryStats;
+      readonly getServiceStatus: () => ServiceStatus;
+      readonly getPoolMetrics: () => PoolMetrics;
+    }
     export interface HealthRouteConfig {
       readonly path: string;
       readonly operationId: string;
-    }
-    export interface HealthRoutesOptions {
-      /** Prisma client instance — must support $queryRaw */
-      readonly prisma: { $queryRaw: (query: TemplateStringsArray) => Promise<unknown> };
-      /** Returns slow query stats from the database module */
-      readonly getSlowQueryStats: () => SlowQueryStats;
-      /** Returns overall service status from the database module */
-      readonly getServiceStatus: () => ServiceStatus;
-      /** Returns pool metrics from the database module */
-      readonly getPoolMetrics: () => PoolMetrics;
-      /** Latency tracker instance for DB ping anomaly detection */
-      readonly latencyTracker: LatencyTracker;
-      /** Auth0 JWKS check function — defaults to the shared checkAuth0 */
-      readonly checkAuth0: (jwksUrl?: string) => Promise<Auth0CheckResult>;
-      /** Rate limit monitor — from createRateLimitMonitor() in create-service-app */
-      readonly rateLimitMonitor: RateLimitMonitor;
-      /** Error rate snapshot getter — from errorRatePlugin_ decoration */
-      readonly getErrorRates: () => ErrorRateSnapshot;
-      /** Routes to register — each gets the same health handler */
-      readonly routes: readonly HealthRouteConfig[];
     }
   </file>
   <file path="src/health.ts">

--- a/packages/service-bootstrap/llms.txt
+++ b/packages/service-bootstrap/llms.txt
@@ -71,18 +71,17 @@
   </file>
   <file path="src/health-routes.ts">
     <item priority="low">
-      interface HealthRouteConfig {
-        path: string;
-        operationId: string;
-      }
-    </item>
-    <item priority="low">
-      interface HealthRoutesOptions {
-        prisma: { $queryRaw: (query: TemplateStringsArray) => Promise<unk...;
+      interface HealthDb {
+        prisma: { $queryRaw: (...args: any[]) => Promise<unknown> };
         getSlowQueryStats: () => SlowQueryStats;
         getServiceStatus: () => ServiceStatus;
         getPoolMetrics: () => PoolMetrics;
-        latencyTracker: LatencyTracker;
+      }
+    </item>
+    <item priority="low">
+      interface HealthRouteConfig {
+        path: string;
+        operationId: string;
       }
     </item>
   </file>

--- a/packages/service-bootstrap/llms.txt
+++ b/packages/service-bootstrap/llms.txt
@@ -72,7 +72,8 @@
   <file path="src/health-routes.ts">
     <item priority="low">
       interface HealthDb {
-        prisma: { $queryRaw: (...args: any[]) => Promise<unknown> };
+        prisma: {
+          $queryRaw: (query: TemplateStringsArray, ...values:...;
         getSlowQueryStats: () => SlowQueryStats;
         getServiceStatus: () => ServiceStatus;
         getPoolMetrics: () => PoolMetrics;

--- a/packages/service-bootstrap/src/create-service-app.test.ts
+++ b/packages/service-bootstrap/src/create-service-app.test.ts
@@ -126,6 +126,14 @@ describe("createServiceApp", () => {
     expect(app.hasDecorator("rateLimitMonitor")).toBe(true);
   });
 
+  it("decorates with latencyTracker for DB ping anomaly detection", async () => {
+    app = await createServiceApp(createTestConfig());
+    await app.ready();
+    expect(app.hasDecorator("latencyTracker")).toBe(true);
+    expect(typeof app.latencyTracker.record).toBe("function");
+    expect(typeof app.latencyTracker.checkAnomaly).toBe("function");
+  });
+
   it("registers rate limit plugin", async () => {
     const rateLimit = await import("@fastify/rate-limit");
     app = await createServiceApp(createTestConfig());

--- a/packages/service-bootstrap/src/create-service-app.ts
+++ b/packages/service-bootstrap/src/create-service-app.ts
@@ -12,6 +12,7 @@ import {
   createRateLimitMonitor,
   type RateLimitMonitor,
 } from "@mbe/observability";
+import { createLatencyTracker, type LatencyTracker } from "./health.js";
 import { sentryFastifyPlugin } from "@mbe/sentry/node";
 import { errorHandlerPlugin } from "./error-handler.js";
 import { applyVersioning } from "./apply-versioning.js";
@@ -160,6 +161,10 @@ export async function createServiceApp(
   const rateLimitMonitor = createRateLimitMonitor();
   fastify.decorate("rateLimitMonitor", rateLimitMonitor);
 
+  // Latency tracker for DB ping anomaly detection — shared via fastify decorator
+  // so health routes don't need it passed as a parameter
+  fastify.decorate("latencyTracker", createLatencyTracker());
+
   // --- Rate limiting ---
   await fastify.register(rateLimit, {
     max: 100,
@@ -236,5 +241,6 @@ export async function createServiceApp(
 declare module "fastify" {
   interface FastifyInstance {
     rateLimitMonitor: RateLimitMonitor;
+    latencyTracker: LatencyTracker;
   }
 }

--- a/packages/service-bootstrap/src/health-routes.test.ts
+++ b/packages/service-bootstrap/src/health-routes.test.ts
@@ -8,16 +8,19 @@ const mockPrisma = {
   $queryRaw: vi.fn(),
 };
 
-const mockGetSlowQueryStats = vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 });
-const mockGetServiceStatus = vi.fn().mockReturnValue("ok");
-const mockGetPoolMetrics = vi.fn().mockReturnValue({
-  active: 1,
-  idle: 4,
-  busy: 1,
-  size: 5,
-  utilization: 0.2,
-  isDegraded: false,
-});
+const mockDb = {
+  prisma: mockPrisma as never,
+  getSlowQueryStats: vi.fn().mockReturnValue({ count5min: 0, slowestMs: 0 }),
+  getServiceStatus: vi.fn().mockReturnValue("ok"),
+  getPoolMetrics: vi.fn().mockReturnValue({
+    active: 1,
+    idle: 4,
+    busy: 1,
+    size: 5,
+    utilization: 0.2,
+    isDegraded: false,
+  }),
+};
 
 const mockRateLimitMonitor = {
   recordHit: vi.fn(),
@@ -28,27 +31,17 @@ const mockRateLimitMonitor = {
   reset: vi.fn(),
 };
 
-const mockGetErrorRates = vi.fn().mockReturnValue({
-  endpoints: [],
-  degraded: false,
-});
-
-const mockCheckAuth0 = vi.fn().mockResolvedValue({ status: "ok", latency: 50 });
 const mockLatencyTracker = {
   record: vi.fn(),
   checkAnomaly: vi.fn().mockReturnValue({ isAnomaly: false, rollingAvg: 0 }),
 };
 
+const mockCheckAuth0 = vi.fn().mockResolvedValue({ status: "ok", latency: 50 });
+
 function createTestOptions(overrides?: Partial<HealthRoutesOptions>): HealthRoutesOptions {
   return {
-    prisma: mockPrisma as never,
-    getSlowQueryStats: mockGetSlowQueryStats,
-    getServiceStatus: mockGetServiceStatus,
-    getPoolMetrics: mockGetPoolMetrics,
-    latencyTracker: mockLatencyTracker,
+    db: mockDb,
     checkAuth0: mockCheckAuth0,
-    rateLimitMonitor: mockRateLimitMonitor,
-    getErrorRates: mockGetErrorRates,
     routes: [
       { path: "/health", operationId: "getHealth" },
       { path: "/api/v1/test/health", operationId: "getTestHealth" },
@@ -66,6 +59,10 @@ describe("registerHealthRoutes", () => {
     // Decorate with apiVersion (simulating what services do)
     app.decorate("apiVersion", "v1");
     app.decorate("sunsetDate", "2027-01-01");
+    // Decorate with shared observability (from createServiceApp)
+    app.decorate("rateLimitMonitor", mockRateLimitMonitor);
+    app.decorate("latencyTracker", mockLatencyTracker);
+    app.decorate("getErrorRates", () => ({ endpoints: [], degraded: false }));
   });
 
   afterEach(async () => {
@@ -132,7 +129,7 @@ describe("registerHealthRoutes", () => {
 
   it("returns degraded when pool utilization is high", async () => {
     mockPrisma.$queryRaw.mockResolvedValueOnce([{ "?column?": 1 }]);
-    mockGetPoolMetrics.mockReturnValueOnce({
+    mockDb.getPoolMetrics.mockReturnValueOnce({
       active: 5,
       idle: 0,
       busy: 5,
@@ -153,16 +150,23 @@ describe("registerHealthRoutes", () => {
 
   it("returns degraded when error rates are high", async () => {
     mockPrisma.$queryRaw.mockResolvedValueOnce([{ "?column?": 1 }]);
-    mockGetErrorRates.mockReturnValueOnce({
+    // Override getErrorRates on the fastify instance for this test
+    const appWithHighErrors = Fastify({ logger: false });
+    appWithHighErrors.decorate("apiVersion", "v1");
+    appWithHighErrors.decorate("sunsetDate", "2027-01-01");
+    appWithHighErrors.decorate("rateLimitMonitor", mockRateLimitMonitor);
+    appWithHighErrors.decorate("latencyTracker", mockLatencyTracker);
+    appWithHighErrors.decorate("getErrorRates", () => ({
       endpoints: [{ endpoint: "/api/v1/test", total: 20, errors: 5, rate: 0.25 }],
       degraded: true,
-    });
-    await app.register(registerHealthRoutes, createTestOptions());
-    await app.ready();
+    }));
+    await appWithHighErrors.register(registerHealthRoutes, createTestOptions());
+    await appWithHighErrors.ready();
 
-    const response = await app.inject({ method: "GET", url: "/health" });
+    const response = await appWithHighErrors.inject({ method: "GET", url: "/health" });
     const body = JSON.parse(response.body);
 
+    await appWithHighErrors.close();
     expect(body.status).toBe("degraded");
   });
 

--- a/packages/service-bootstrap/src/health-routes.ts
+++ b/packages/service-bootstrap/src/health-routes.ts
@@ -2,9 +2,18 @@ import type { FastifyInstance, FastifyPluginAsync, FastifyRequest } from "fastif
 import fp from "fastify-plugin";
 import type { HealthResponse } from "@mbe/types";
 import { createErrorRateHealthCheck } from "@mbe/observability";
-import type { RateLimitMonitor, ErrorRateSnapshot } from "@mbe/observability";
 import type { SlowQueryStats, PoolMetrics, ServiceStatus } from "@mbe/database";
-import type { LatencyTracker, Auth0CheckResult } from "./health.js";
+import { checkAuth0 as defaultCheckAuth0 } from "./health.js";
+import type { Auth0CheckResult } from "./health.js";
+
+/** Minimal database interface health routes need — satisfied by DatabaseInstance<T>. */
+export interface HealthDb {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly prisma: { $queryRaw: (...args: any[]) => Promise<unknown> };
+  readonly getSlowQueryStats: () => SlowQueryStats;
+  readonly getServiceStatus: () => ServiceStatus;
+  readonly getPoolMetrics: () => PoolMetrics;
+}
 
 export interface HealthRouteConfig {
   readonly path: string;
@@ -12,24 +21,15 @@ export interface HealthRouteConfig {
 }
 
 export interface HealthRoutesOptions {
-  /** Prisma client instance — must support $queryRaw */
-  readonly prisma: { $queryRaw: (query: TemplateStringsArray) => Promise<unknown> };
-  /** Returns slow query stats from the database module */
-  readonly getSlowQueryStats: () => SlowQueryStats;
-  /** Returns overall service status from the database module */
-  readonly getServiceStatus: () => ServiceStatus;
-  /** Returns pool metrics from the database module */
-  readonly getPoolMetrics: () => PoolMetrics;
-  /** Latency tracker instance for DB ping anomaly detection */
-  readonly latencyTracker: LatencyTracker;
-  /** Auth0 JWKS check function — defaults to the shared checkAuth0 */
-  readonly checkAuth0: (jwksUrl?: string) => Promise<Auth0CheckResult>;
-  /** Rate limit monitor — from createRateLimitMonitor() in create-service-app */
-  readonly rateLimitMonitor: RateLimitMonitor;
-  /** Error rate snapshot getter — from errorRatePlugin_ decoration */
-  readonly getErrorRates: () => ErrorRateSnapshot;
+  /** Database instance — prisma + stats are derived from it internally */
+  readonly db: HealthDb;
   /** Routes to register — each gets the same health handler */
   readonly routes: readonly HealthRouteConfig[];
+  /**
+   * Auth0 JWKS check — defaults to the shared checkAuth0 from @mbe/service-bootstrap.
+   * Overrideable for testing without real network calls.
+   */
+  readonly checkAuth0?: () => Promise<Auth0CheckResult>;
 }
 
 const healthSchema = {
@@ -120,17 +120,7 @@ const healthRoutesPlugin: FastifyPluginAsync<HealthRoutesOptions> = async (
   fastify: FastifyInstance,
   opts: HealthRoutesOptions
 ) => {
-  const {
-    prisma,
-    getSlowQueryStats,
-    getServiceStatus,
-    getPoolMetrics,
-    latencyTracker,
-    checkAuth0: checkAuth0Fn,
-    rateLimitMonitor,
-    getErrorRates,
-    routes,
-  } = opts;
+  const { db, routes, checkAuth0 = defaultCheckAuth0 } = opts;
 
   const healthHandler = async (request: FastifyRequest): Promise<HealthResponse> => {
     const checks: Record<string, { status: string; latency?: number; message?: string }> = {};
@@ -140,13 +130,13 @@ const healthRoutesPlugin: FastifyPluginAsync<HealthRoutesOptions> = async (
       sunsetDate: string;
     };
 
-    // Database ping
+    // Database ping — latency tracker comes from the fastify decorator set by createServiceApp
     const dbStart = Date.now();
     try {
-      await prisma.$queryRaw`SELECT 1`;
+      await db.prisma.$queryRaw`SELECT 1`;
       const dbLatency = Date.now() - dbStart;
-      const anomaly = latencyTracker.checkAnomaly(dbLatency);
-      latencyTracker.record(dbLatency);
+      const anomaly = fastify.latencyTracker.checkAnomaly(dbLatency);
+      fastify.latencyTracker.record(dbLatency);
       checks.database = {
         status: anomaly.isAnomaly ? "error" : "ok",
         latency: dbLatency,
@@ -163,9 +153,9 @@ const healthRoutesPlugin: FastifyPluginAsync<HealthRoutesOptions> = async (
     }
 
     // Slow queries
-    const slowQueries = getSlowQueryStats();
+    const slowQueries = db.getSlowQueryStats();
     const dbStatus = checks.database?.status ?? "ok";
-    const slowQueryStatus = getServiceStatus();
+    const slowQueryStatus = db.getServiceStatus();
 
     checks.slow_queries = {
       status: slowQueryStatus,
@@ -173,16 +163,16 @@ const healthRoutesPlugin: FastifyPluginAsync<HealthRoutesOptions> = async (
       latency: slowQueries.slowestMs,
     };
 
-    // Auth0 JWKS
-    const auth0Result = await checkAuth0Fn();
+    // Auth0 JWKS — default uses shared checkAuth0; overrideable for tests
+    const auth0Result = await checkAuth0();
     checks.auth0 = {
       status: auth0Result.status,
       latency: auth0Result.latency,
       ...(auth0Result.message && { message: auth0Result.message }),
     };
 
-    // Rate limits
-    const rateLimitSnapshot = rateLimitMonitor.getSnapshot();
+    // Rate limits — from fastify.rateLimitMonitor (set by createServiceApp)
+    const rateLimitSnapshot = fastify.rateLimitMonitor.getSnapshot();
     checks.rate_limits = {
       status: rateLimitSnapshot.isDegraded ? "degraded" : "ok",
       ...rateLimitSnapshot.stats,
@@ -192,7 +182,7 @@ const healthRoutesPlugin: FastifyPluginAsync<HealthRoutesOptions> = async (
     };
 
     // Pool metrics
-    const poolMetrics = getPoolMetrics();
+    const poolMetrics = db.getPoolMetrics();
     checks.pool = {
       status: poolMetrics.isDegraded ? "degraded" : "ok",
       ...(poolMetrics.isDegraded && {
@@ -207,8 +197,8 @@ const healthRoutesPlugin: FastifyPluginAsync<HealthRoutesOptions> = async (
       },
     };
 
-    // Error rates
-    const errorRateCheck = createErrorRateHealthCheck(getErrorRates());
+    // Error rates — from fastify.getErrorRates() (set by errorRatePlugin_ in createServiceApp)
+    const errorRateCheck = createErrorRateHealthCheck(fastify.getErrorRates());
 
     const hasErrors =
       dbStatus === "error" ||

--- a/packages/service-bootstrap/src/health-routes.ts
+++ b/packages/service-bootstrap/src/health-routes.ts
@@ -8,8 +8,9 @@ import type { Auth0CheckResult } from "./health.js";
 
 /** Minimal database interface health routes need — satisfied by DatabaseInstance<T>. */
 export interface HealthDb {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  readonly prisma: { $queryRaw: (...args: any[]) => Promise<unknown> };
+  readonly prisma: {
+    $queryRaw: (query: TemplateStringsArray, ...values: unknown[]) => Promise<unknown>;
+  };
   readonly getSlowQueryStats: () => SlowQueryStats;
   readonly getServiceStatus: () => ServiceStatus;
   readonly getPoolMetrics: () => PoolMetrics;

--- a/packages/service-bootstrap/src/index.ts
+++ b/packages/service-bootstrap/src/index.ts
@@ -7,7 +7,7 @@ export type { StartServiceServerOptions } from "./start-service-server.js";
 export { createLatencyTracker, checkAuth0 } from "./health.js";
 export type { LatencyTracker, LatencyAnomalyResult, Auth0CheckResult } from "./health.js";
 export { registerHealthRoutes } from "./health-routes.js";
-export type { HealthRoutesOptions, HealthRouteConfig } from "./health-routes.js";
+export type { HealthRoutesOptions, HealthRouteConfig, HealthDb } from "./health-routes.js";
 export {
   createFeatureContext,
   createFeatureFlagsPlugin,

--- a/services/agent/llms-full.txt
+++ b/services/agent/llms-full.txt
@@ -756,14 +756,8 @@
   <file path="src/routes/health.ts">
     export const healthRoutes: FastifyPluginAsync = async (fastify) => {
       await fastify.register(registerHealthRoutes, {
-        prisma,
-        getSlowQueryStats,
-        getServiceStatus,
-        getPoolMetrics,
-        latencyTracker,
+        db,
         checkAuth0,
-        rateLimitMonitor: fastify.rateLimitMonitor,
-        getErrorRates: () => fastify.getErrorRates(),
         routes: [
           { path: "/health", operationId: "getAgentHealth" },
           { path: "/api/gen/health", operationId: "getAgentHealthApiGen" },
@@ -1294,8 +1288,8 @@
   </section>
   <section priority="medium" role="services">
   <file path="src/services/database.ts">
+    export const db = createDatabase(PrismaClient as never);
     export const prisma = db.prisma as unknown as PrismaClient;
-    export const getSlowQueryStats = db.getSlowQueryStats;
   </file>
   <file path="src/services/liveness-monitor.ts">
     export interface LivenessMonitorConfig {

--- a/services/agent/llms.txt
+++ b/services/agent/llms.txt
@@ -158,10 +158,10 @@
   <section priority="medium" role="services">
   <file path="src/services/database.ts">
     <item priority="high">
-      export const prisma: unknown;
+      export const db: unknown;
     </item>
     <item priority="high">
-      export const getSlowQueryStats: unknown;
+      export const prisma: unknown;
     </item>
   </file>
   <file path="src/services/liveness-monitor.ts">

--- a/services/agent/src/routes/health.test.ts
+++ b/services/agent/src/routes/health.test.ts
@@ -3,8 +3,8 @@ import { buildApp } from "../app.js";
 import type { FastifyInstance } from "fastify";
 
 vi.mock("../services/database.js", async () => {
-  const { createMockDatabaseService } = await import("@mbe/database/testing");
-  return createMockDatabaseService({
+  const { createMockDatabaseModule } = await import("@mbe/database/testing");
+  return createMockDatabaseModule({
     prisma: {
       $queryRaw: vi.fn(),
       agentSession: { findMany: vi.fn().mockResolvedValue([]) },
@@ -12,15 +12,11 @@ vi.mock("../services/database.js", async () => {
   });
 });
 
-// Mock @mbe/service-bootstrap health exports (createLatencyTracker, checkAuth0, registerHealthRoutes)
+// Mock @mbe/service-bootstrap to intercept checkAuth0 inside health-routes
 vi.mock("@mbe/service-bootstrap", async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
   return {
     ...actual,
-    createLatencyTracker: vi.fn().mockReturnValue({
-      record: vi.fn(),
-      checkAnomaly: vi.fn().mockReturnValue({ isAnomaly: false, rollingAvg: 0 }),
-    }),
     checkAuth0: vi.fn().mockResolvedValue({ status: "ok", latency: 50 }),
   };
 });
@@ -77,7 +73,7 @@ vi.mock("@mbe/observability", async (importOriginal) => {
   };
 });
 
-import { prisma, getPoolMetrics } from "../services/database.js";
+import { db, prisma } from "../services/database.js";
 
 describe("Health Routes", () => {
   let app: FastifyInstance;
@@ -161,7 +157,7 @@ describe("Health Routes", () => {
 
     it("returns degraded status when pool utilization is high", async () => {
       vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([{ "?column?": 1 }]);
-      vi.mocked(getPoolMetrics).mockReturnValueOnce({
+      vi.mocked(db.getPoolMetrics).mockReturnValueOnce({
         active: 5,
         idle: 0,
         busy: 5,

--- a/services/agent/src/routes/health.ts
+++ b/services/agent/src/routes/health.ts
@@ -1,24 +1,11 @@
 import type { FastifyPluginAsync } from "fastify";
-import { registerHealthRoutes, createLatencyTracker, checkAuth0 } from "@mbe/service-bootstrap";
-import {
-  prisma,
-  getSlowQueryStats,
-  getServiceStatus,
-  getPoolMetrics,
-} from "../services/database.js";
-
-const latencyTracker = createLatencyTracker();
+import { registerHealthRoutes, checkAuth0 } from "@mbe/service-bootstrap";
+import { db } from "../services/database.js";
 
 export const healthRoutes: FastifyPluginAsync = async (fastify) => {
   await fastify.register(registerHealthRoutes, {
-    prisma,
-    getSlowQueryStats,
-    getServiceStatus,
-    getPoolMetrics,
-    latencyTracker,
+    db,
     checkAuth0,
-    rateLimitMonitor: fastify.rateLimitMonitor,
-    getErrorRates: () => fastify.getErrorRates(),
     routes: [
       { path: "/health", operationId: "getAgentHealth" },
       { path: "/api/gen/health", operationId: "getAgentHealthApiGen" },

--- a/services/agent/src/services/database.test.ts
+++ b/services/agent/src/services/database.test.ts
@@ -64,8 +64,8 @@ vi.mock("@prisma/adapter-pg", () => {
   };
 });
 
-const { getSlowQueryStats, getPoolStats, getPoolMetrics, getServiceStatus, prisma } =
-  await import("./database.js");
+const { db, prisma } = await import("./database.js");
+const { getSlowQueryStats, getPoolStats, getPoolMetrics, getServiceStatus } = db;
 
 describe("Database Service", () => {
   beforeEach(() => {

--- a/services/agent/src/services/database.ts
+++ b/services/agent/src/services/database.ts
@@ -1,11 +1,5 @@
 import { createDatabase } from "@mbe/database";
 import { PrismaClient } from "../generated/prisma/index.js";
 
-const db = createDatabase(PrismaClient as never);
-
+export const db = createDatabase(PrismaClient as never);
 export const prisma = db.prisma as unknown as PrismaClient;
-export const getSlowQueryStats = db.getSlowQueryStats;
-export const getPoolStats = db.getPoolStats;
-export const getPoolMetrics = db.getPoolMetrics;
-export const getServiceStatus = db.getServiceStatus;
-export type { PoolMetrics } from "@mbe/database";

--- a/services/reservations/llms-full.txt
+++ b/services/reservations/llms-full.txt
@@ -1735,14 +1735,8 @@
   <file path="src/routes/health.ts">
     export const healthRoutes: FastifyPluginAsync = async (fastify) => {
       await fastify.register(registerHealthRoutes, {
-        prisma,
-        getSlowQueryStats,
-        getServiceStatus,
-        getPoolMetrics,
-        latencyTracker,
+        db,
         checkAuth0,
-        rateLimitMonitor: fastify.rateLimitMonitor,
-        getErrorRates: () => fastify.getErrorRates(),
         routes: [
           { path: "/health", operationId: "getHealth" },
           { path: "/api/health", operationId: "getHealthApi" },
@@ -5128,8 +5122,8 @@
     }
   </file>
   <file path="src/services/database.ts">
+    export const db = createDatabase(PrismaClient as never);
     export const prisma = db.prisma as unknown as PrismaClient;
-    export const getSlowQueryStats = db.getSlowQueryStats;
   </file>
   <file path="src/services/deposit-state-machine.ts">
     export const VALID_TRANSITIONS: Record<DepositStatus, DepositStatus[]> = {

--- a/services/reservations/llms.txt
+++ b/services/reservations/llms.txt
@@ -330,10 +330,10 @@
   </file>
   <file path="src/services/database.ts">
     <item priority="high">
-      export const prisma: unknown;
+      export const db: unknown;
     </item>
     <item priority="high">
-      export const getSlowQueryStats: unknown;
+      export const prisma: unknown;
     </item>
   </file>
   <file path="src/services/deposit-state-machine.ts">

--- a/services/reservations/src/routes/health.test.ts
+++ b/services/reservations/src/routes/health.test.ts
@@ -73,19 +73,15 @@ vi.mock("../services/floor-plan.js", () => ({
 }));
 
 vi.mock("../services/database.js", async () => {
-  const { createMockDatabaseService } = await import("@mbe/database/testing");
-  return createMockDatabaseService();
+  const { createMockDatabaseModule } = await import("@mbe/database/testing");
+  return createMockDatabaseModule();
 });
 
-// Mock @mbe/service-bootstrap health exports (createLatencyTracker, checkAuth0, registerHealthRoutes)
+// Mock @mbe/service-bootstrap to intercept checkAuth0 inside health-routes
 vi.mock("@mbe/service-bootstrap", async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
   return {
     ...actual,
-    createLatencyTracker: vi.fn().mockReturnValue({
-      record: vi.fn(),
-      checkAnomaly: vi.fn().mockReturnValue({ isAnomaly: false, rollingAvg: 0 }),
-    }),
     checkAuth0: vi.fn().mockResolvedValue({ status: "ok", latency: 50 }),
   };
 });
@@ -133,7 +129,7 @@ vi.mock("@mbe/observability", async (importOriginal) => {
   };
 });
 
-import { prisma, getPoolMetrics } from "../services/database.js";
+import { db, prisma } from "../services/database.js";
 
 describe("Health Routes", () => {
   let app: FastifyInstance;
@@ -214,7 +210,7 @@ describe("Health Routes", () => {
 
     it("returns degraded status when pool utilization is high", async () => {
       vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([{ "?column?": 1 }]);
-      vi.mocked(getPoolMetrics).mockReturnValueOnce({
+      vi.mocked(db.getPoolMetrics).mockReturnValueOnce({
         active: 5,
         idle: 0,
         busy: 5,

--- a/services/reservations/src/routes/health.ts
+++ b/services/reservations/src/routes/health.ts
@@ -1,24 +1,11 @@
 import type { FastifyPluginAsync } from "fastify";
-import { registerHealthRoutes, createLatencyTracker, checkAuth0 } from "@mbe/service-bootstrap";
-import {
-  prisma,
-  getSlowQueryStats,
-  getServiceStatus,
-  getPoolMetrics,
-} from "../services/database.js";
-
-const latencyTracker = createLatencyTracker();
+import { registerHealthRoutes, checkAuth0 } from "@mbe/service-bootstrap";
+import { db } from "../services/database.js";
 
 export const healthRoutes: FastifyPluginAsync = async (fastify) => {
   await fastify.register(registerHealthRoutes, {
-    prisma,
-    getSlowQueryStats,
-    getServiceStatus,
-    getPoolMetrics,
-    latencyTracker,
+    db,
     checkAuth0,
-    rateLimitMonitor: fastify.rateLimitMonitor,
-    getErrorRates: () => fastify.getErrorRates(),
     routes: [
       { path: "/health", operationId: "getHealth" },
       { path: "/api/health", operationId: "getHealthApi" },

--- a/services/reservations/src/services/database.test.ts
+++ b/services/reservations/src/services/database.test.ts
@@ -53,7 +53,8 @@ vi.mock("../generated/prisma/index.js", () => ({
   },
 }));
 
-import { getSlowQueryStats, getPoolStats, getPoolMetrics, getServiceStatus } from "./database.js";
+import { db } from "./database.js";
+const { getSlowQueryStats, getPoolStats, getPoolMetrics, getServiceStatus } = db;
 
 describe("database.ts", () => {
   beforeEach(() => {

--- a/services/reservations/src/services/database.ts
+++ b/services/reservations/src/services/database.ts
@@ -1,11 +1,5 @@
 import { createDatabase } from "@mbe/database";
 import { PrismaClient } from "../generated/prisma/index.js";
 
-const db = createDatabase(PrismaClient as never);
-
+export const db = createDatabase(PrismaClient as never);
 export const prisma = db.prisma as unknown as PrismaClient;
-export const getSlowQueryStats = db.getSlowQueryStats;
-export const getPoolStats = db.getPoolStats;
-export const getPoolMetrics = db.getPoolMetrics;
-export const getServiceStatus = db.getServiceStatus;
-export type { PoolMetrics } from "@mbe/database";

--- a/services/users/llms-full.txt
+++ b/services/users/llms-full.txt
@@ -77,14 +77,8 @@
   <file path="src/routes/health.ts">
     export const healthRoutes: FastifyPluginAsync = async (fastify) => {
       await fastify.register(registerHealthRoutes, {
-        prisma,
-        getSlowQueryStats,
-        getServiceStatus,
-        getPoolMetrics,
-        latencyTracker,
+        db,
         checkAuth0,
-        rateLimitMonitor: fastify.rateLimitMonitor,
-        getErrorRates: () => fastify.getErrorRates(),
         routes: [
           { path: "/health", operationId: "getHealth" },
           { path: "/api/v1/users/health", operationId: "getHealthApiUsers" },
@@ -117,8 +111,8 @@
   </section>
   <section priority="medium" role="services">
   <file path="src/services/database.ts">
+    export const db = createDatabase(PrismaClient as never);
     export const prisma = db.prisma as unknown as PrismaClient;
-    export const getSlowQueryStats = db.getSlowQueryStats;
   </file>
   <file path="src/services/user.ts">
     function mapPrismaUser(user: {

--- a/services/users/llms.txt
+++ b/services/users/llms.txt
@@ -46,10 +46,10 @@
   <section priority="medium" role="services">
   <file path="src/services/database.ts">
     <item priority="high">
-      export const prisma: unknown;
+      export const db: unknown;
     </item>
     <item priority="high">
-      export const getSlowQueryStats: unknown;
+      export const prisma: unknown;
     </item>
   </file>
   <file path="src/services/user.ts">

--- a/services/users/src/routes/health.test.ts
+++ b/services/users/src/routes/health.test.ts
@@ -4,19 +4,15 @@ import type { FastifyInstance } from "fastify";
 
 // Mock the database
 vi.mock("../services/database.js", async () => {
-  const { createMockDatabaseService } = await import("@mbe/database/testing");
-  return createMockDatabaseService();
+  const { createMockDatabaseModule } = await import("@mbe/database/testing");
+  return createMockDatabaseModule();
 });
 
-// Mock @mbe/service-bootstrap health exports (createLatencyTracker, checkAuth0, registerHealthRoutes)
+// Mock @mbe/service-bootstrap to intercept checkAuth0 inside health-routes
 vi.mock("@mbe/service-bootstrap", async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
   return {
     ...actual,
-    createLatencyTracker: vi.fn().mockReturnValue({
-      record: vi.fn(),
-      checkAnomaly: vi.fn().mockReturnValue({ isAnomaly: false, rollingAvg: 0 }),
-    }),
     checkAuth0: vi.fn().mockResolvedValue({ status: "ok", latency: 50 }),
   };
 });
@@ -64,7 +60,7 @@ vi.mock("@mbe/observability", async (importOriginal) => {
   };
 });
 
-import { prisma, getPoolMetrics } from "../services/database.js";
+import { db, prisma } from "../services/database.js";
 
 describe("Health Routes", () => {
   let app: FastifyInstance;
@@ -145,7 +141,7 @@ describe("Health Routes", () => {
 
     it("returns degraded status when pool utilization is high", async () => {
       vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([{ "?column?": 1 }]);
-      vi.mocked(getPoolMetrics).mockReturnValueOnce({
+      vi.mocked(db.getPoolMetrics).mockReturnValueOnce({
         active: 5,
         idle: 0,
         busy: 5,

--- a/services/users/src/routes/health.ts
+++ b/services/users/src/routes/health.ts
@@ -1,24 +1,11 @@
 import type { FastifyPluginAsync } from "fastify";
-import { registerHealthRoutes, createLatencyTracker, checkAuth0 } from "@mbe/service-bootstrap";
-import {
-  prisma,
-  getSlowQueryStats,
-  getServiceStatus,
-  getPoolMetrics,
-} from "../services/database.js";
-
-const latencyTracker = createLatencyTracker();
+import { registerHealthRoutes, checkAuth0 } from "@mbe/service-bootstrap";
+import { db } from "../services/database.js";
 
 export const healthRoutes: FastifyPluginAsync = async (fastify) => {
   await fastify.register(registerHealthRoutes, {
-    prisma,
-    getSlowQueryStats,
-    getServiceStatus,
-    getPoolMetrics,
-    latencyTracker,
+    db,
     checkAuth0,
-    rateLimitMonitor: fastify.rateLimitMonitor,
-    getErrorRates: () => fastify.getErrorRates(),
     routes: [
       { path: "/health", operationId: "getHealth" },
       { path: "/api/v1/users/health", operationId: "getHealthApiUsers" },

--- a/services/users/src/services/database.test.ts
+++ b/services/users/src/services/database.test.ts
@@ -79,7 +79,8 @@ vi.mock("@prisma/adapter-pg", () => ({
 }));
 
 // Import the module under test AFTER all mocks are in place
-import { getSlowQueryStats, getPoolStats, getPoolMetrics, getServiceStatus } from "./database.js";
+import { db } from "./database.js";
+const { getSlowQueryStats, getPoolStats, getPoolMetrics, getServiceStatus } = db;
 
 describe("database module", () => {
   beforeEach(() => {

--- a/services/users/src/services/database.ts
+++ b/services/users/src/services/database.ts
@@ -1,11 +1,5 @@
 import { createDatabase } from "@mbe/database";
 import { PrismaClient } from "../generated/prisma/index.js";
 
-const db = createDatabase(PrismaClient as never);
-
+export const db = createDatabase(PrismaClient as never);
 export const prisma = db.prisma as unknown as PrismaClient;
-export const getSlowQueryStats = db.getSlowQueryStats;
-export const getPoolStats = db.getPoolStats;
-export const getPoolMetrics = db.getPoolMetrics;
-export const getServiceStatus = db.getServiceStatus;
-export type { PoolMetrics } from "@mbe/database";


### PR DESCRIPTION
## Summary

- `registerHealthRoutes` reduced from 8 params to 3: `db` (`HealthDb`), `routes`, and optional `checkAuth0`
- New `HealthDb` interface absorbs `prisma`, `getSlowQueryStats`, `getServiceStatus`, `getPoolMetrics` — satisfied by `DatabaseInstance<T>`
- `latencyTracker` moved from per-service `health.ts` singleton to fastify decorator created in `createServiceApp`
- `rateLimitMonitor` and `getErrorRates` were already fastify decorators — unchanged
- `checkAuth0` kept as optional param (default: shared fn) for test interception without network
- Per-service `database.ts` simplified: now exports only `{ db, prisma }` (no individual stat fn re-exports)
- `PrismaLike` interface exported and extended with `$queryRaw` for structural type compatibility
- `createMockDatabaseService` now returns `db` namespace alongside flat exports (fully backward-compatible)
- All 3 services + both packages: 1494 tests passing, lint clean, typecheck clean

## Test plan

- [ ] `pnpm --dir packages/database test` — 60/60 pass
- [ ] `pnpm --dir packages/service-bootstrap test` — 127/127 pass
- [ ] `pnpm --dir services/users test` — 137/137 pass
- [ ] `pnpm --dir services/reservations test` — 878/878 pass
- [ ] `pnpm --dir services/agent test` — 292/292 pass
- [ ] `pnpm --filter @mbe/cli start check-adr && check-deps` — no violations
- [ ] `pnpm regen --check` — no artifact drift
- [ ] `node scripts/detect-instruction-rot.mjs` — no rot detected

Closes #1999