### PR TITLE
feat(api-client): typed ProblemDetails error union; hospitality pages consume it

### DIFF
--- a/apps/hospitality/src/pages/GuestsPage.tsx
+++ b/apps/hospitality/src/pages/GuestsPage.tsx
@@ -12,6 +12,7 @@ import {
   Stat,
   Text,
 } from "@mattbutlerengineering/rialto";
+import { ApiClientError } from "@mbe/api-client";
 import { ErrorRetryBanner } from "../components/ErrorRetryBanner";
 import type { GuestSegment } from "@mbe/types";
 import { useVenue } from "../contexts/VenueContext.js";
@@ -247,7 +248,13 @@ export function GuestsPage({ _useGuestDirectory }: GuestsPageProps = {}) {
         </div>
       )}
 
-      {error && <ErrorRetryBanner error={error.message} onRetry={refetch} onDismiss={() => {}} />}
+      {error && (
+        <ErrorRetryBanner
+          error={error instanceof ApiClientError ? error.problemDetails.detail : error.message}
+          onRetry={refetch}
+          onDismiss={() => {}}
+        />
+      )}
 
       <Text className={styles.srOnly} aria-live="polite" role="status">
         {`${guests.length} guest${guests.length !== 1 ? "s" : ""} shown`}

--- a/apps/hospitality/src/pages/SettingsPage.tsx
+++ b/apps/hospitality/src/pages/SettingsPage.tsx
@@ -90,19 +90,6 @@ function SettingsLoadingSkeleton() {
   );
 }
 
-/* ── Error extraction ──────────────────────── */
-
-function extractErrorMessage(err: unknown, fallback: string): string {
-  if (err instanceof ApiClientError) {
-    const detail = err.response.detail ?? err.response.message;
-    return detail ? `${fallback}: ${detail}` : err.message;
-  }
-  if (err instanceof Error) {
-    return err.message;
-  }
-  return fallback;
-}
-
 /* ── Main component ─────────────────────────── */
 
 export function SettingsPage() {
@@ -138,7 +125,14 @@ export function SettingsPage() {
         setSuccessMessage("Settings saved");
         setTimeout(() => setSuccessMessage(null), 3000);
       } catch (err) {
-        setError(extractErrorMessage(err, "Failed to save settings"));
+        if (err instanceof ApiClientError) {
+          const detail = err.problemDetails.detail;
+          setError(`Failed to save settings: ${detail}`);
+        } else if (err instanceof Error) {
+          setError(err.message);
+        } else {
+          setError("Failed to save settings");
+        }
       } finally {
         setIsSaving(false);
       }
@@ -156,7 +150,14 @@ export function SettingsPage() {
     return (
       <div>
         <PageHeader title="Settings" description="Manage your account settings and preferences" />
-        <ErrorRetryBanner error={loadError.message} onRetry={refetch} />
+        <ErrorRetryBanner
+          error={
+            loadError instanceof ApiClientError
+              ? loadError.problemDetails.detail
+              : loadError.message
+          }
+          onRetry={refetch}
+        />
       </div>
     );
   }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -13897,6 +13897,36 @@
       };
     }
   </file>
+  <file path="packages/api-client/src/problem-details.ts">
+    export function parseProblemDetails(raw: unknown, httpStatus: number): ProblemDetails {
+      const parsed = ProblemDetailsSchema.safeParse(raw);
+      if (parsed.success) {
+        return parsed.data;
+      }
+    
+      const fallbackDetail = extractDetail(raw, httpStatus);
+    
+      return {
+        type: "about:blank",
+        title: httpStatusTitle(httpStatus),
+        status: httpStatus,
+        detail: fallbackDetail,
+      };
+    }
+    function extractDetail(raw: unknown, httpStatus: number): string {
+      if (typeof raw === "string" && raw.length > 0 && !raw.trimStart().startsWith("<")) {
+        return raw;
+      }
+      if (typeof raw === "object" && raw !== null) {
+        const obj = raw as Record<string, unknown>;
+        const candidate = obj.detail ?? obj.message ?? obj.error;
+        if (typeof candidate === "string" && candidate.length > 0) {
+          return candidate;
+        }
+      }
+      return httpStatusTitle(httpStatus);
+    }
+  </file>
   <file path="packages/api-client/src/reservations.ts">
     export interface ListReservationsParams {
       page?: number;
@@ -15129,7 +15159,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -15159,18 +15159,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms.txt
+++ b/llms.txt
@@ -3574,6 +3574,14 @@
       }) { /* ... */ }
     </item>
   </file>
+  <file path="packages/api-client/src/problem-details.ts">
+    <item priority="high">
+      export function parseProblemDetails(raw: unknown, httpStatus: number): ProblemDetails { /* ... */ }
+    </item>
+    <item priority="medium">
+      function extractDetail(raw: unknown, httpStatus: number): string { /* ... */ }
+    </item>
+  </file>
   <file path="packages/api-client/src/reservations.ts">
     <item priority="low">
       interface ListReservationsParams {

--- a/metrics/ai-antipattern-baselines.json
+++ b/metrics/ai-antipattern-baselines.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-21T01:59:38.341Z",
+  "generatedAt": "2026-06-21T02:33:34.597Z",
   "patterns": {
     "magicTimeouts": {
       "count": 32,
@@ -14,7 +14,7 @@
       "description": "Test functions containing no expect() calls"
     },
     "hardcodedRoutes": {
-      "count": 522,
+      "count": 524,
       "description": "Hardcoded /api/... route strings instead of route constants"
     },
     "anyType": {

--- a/packages/api-client/llms-full.txt
+++ b/packages/api-client/llms-full.txt
@@ -183,6 +183,36 @@
       };
     }
   </file>
+  <file path="src/problem-details.ts">
+    export function parseProblemDetails(raw: unknown, httpStatus: number): ProblemDetails {
+      const parsed = ProblemDetailsSchema.safeParse(raw);
+      if (parsed.success) {
+        return parsed.data;
+      }
+    
+      const fallbackDetail = extractDetail(raw, httpStatus);
+    
+      return {
+        type: "about:blank",
+        title: httpStatusTitle(httpStatus),
+        status: httpStatus,
+        detail: fallbackDetail,
+      };
+    }
+    function extractDetail(raw: unknown, httpStatus: number): string {
+      if (typeof raw === "string" && raw.length > 0 && !raw.trimStart().startsWith("<")) {
+        return raw;
+      }
+      if (typeof raw === "object" && raw !== null) {
+        const obj = raw as Record<string, unknown>;
+        const candidate = obj.detail ?? obj.message ?? obj.error;
+        if (typeof candidate === "string" && candidate.length > 0) {
+          return candidate;
+        }
+      }
+      return httpStatusTitle(httpStatus);
+    }
+  </file>
   <file path="src/reservations.ts">
     export interface ListReservationsParams {
       page?: number;

--- a/packages/api-client/llms.txt
+++ b/packages/api-client/llms.txt
@@ -120,6 +120,14 @@
       }) { /* ... */ }
     </item>
   </file>
+  <file path="src/problem-details.ts">
+    <item priority="high">
+      export function parseProblemDetails(raw: unknown, httpStatus: number): ProblemDetails { /* ... */ }
+    </item>
+    <item priority="medium">
+      function extractDetail(raw: unknown, httpStatus: number): string { /* ... */ }
+    </item>
+  </file>
   <file path="src/reservations.ts">
     <item priority="low">
       interface ListReservationsParams {

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -1,7 +1,8 @@
-import type { ApiError } from "@mbe/types";
+import type { ApiError, ProblemDetails } from "@mbe/types";
 import { ApiErrorSchema } from "@mbe/types";
 import type { z } from "zod";
 import { retry } from "./retry.js";
+import { parseProblemDetails } from "./problem-details.js";
 
 /**
  * Describes the value types accepted in a query-params object.
@@ -90,7 +91,12 @@ export class ApiClient {
     const response = await fetchWithRetry(url, fetchOptions, effectiveMaxRetries);
 
     if (!response.ok) {
+      const contentType = response.headers.get("content-type") ?? "";
+      const isProblemJson = contentType.includes("application/problem+json");
       const raw = await response.json().catch(() => null);
+
+      const problemDetails = parseProblemDetails(raw, response.status);
+
       const parsed = ApiErrorSchema.safeParse(raw);
       // If the response body validates against ApiErrorSchema, use it directly.
       // Otherwise, build a fallback from status line defaults and layer the raw
@@ -115,7 +121,21 @@ export class ApiClient {
           ...rawObj,
         };
       }
-      const clientError = new ApiClientError(error, method, path);
+
+      // When the service explicitly sent application/problem+json, prefer the
+      // parsed ProblemDetails shape so callers can always use `problemDetails`.
+      if (isProblemJson) {
+        error = {
+          ...error,
+          type: problemDetails.type,
+          title: problemDetails.title,
+          status: problemDetails.status,
+          detail: problemDetails.detail,
+          instance: problemDetails.instance,
+        };
+      }
+
+      const clientError = new ApiClientError(error, method, path, problemDetails);
       this.config.onError?.(clientError);
       throw clientError;
     }
@@ -250,16 +270,34 @@ function categorizeStatus(code: number): ErrorCategory {
 }
 
 export class ApiClientError extends Error {
+  /**
+   * RFC 7807 ProblemDetails parsed from the response body.
+   * Always present — falls back to a synthesized shape for non-7807 responses.
+   */
+  readonly problemDetails: ProblemDetails;
+
   constructor(
     public response: ApiError,
     public method?: string,
-    public path?: string
+    public path?: string,
+    problemDetails?: ProblemDetails
   ) {
     const prefix = method && path ? `${method} ${path} failed: ` : "";
     const status = response.status ?? response.statusCode;
     const message = response.detail ?? response.message;
     super(`${prefix}${status} ${message}`);
     this.name = "ApiClientError";
+    this.problemDetails =
+      problemDetails ??
+      parseProblemDetails(
+        {
+          type: response.type,
+          title: response.title,
+          status: response.status,
+          detail: response.detail,
+        },
+        status
+      );
   }
 
   get statusCode(): number {

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -91,7 +91,7 @@ export class ApiClient {
     const response = await fetchWithRetry(url, fetchOptions, effectiveMaxRetries);
 
     if (!response.ok) {
-      const contentType = response.headers.get("content-type") ?? "";
+      const contentType = response.headers?.get?.("content-type") ?? "";
       const isProblemJson = contentType.includes("application/problem+json");
       const raw = await response.json().catch(() => null);
 

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,5 +1,6 @@
 export { ApiClient, ApiClientError } from "./client.js";
 export type { ClientConfig, ErrorCategory, PerRequestOptions } from "./client.js";
+export { parseProblemDetails } from "./problem-details.js";
 export { retry } from "./retry.js";
 export type { RetryOptions } from "./retry.js";
 

--- a/packages/api-client/src/problem-details.test.ts
+++ b/packages/api-client/src/problem-details.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { parseProblemDetails } from "./problem-details.js";
+import type { ProblemDetails } from "@mbe/types";
+
+describe("parseProblemDetails", () => {
+  it("parses a well-formed RFC 7807 body", () => {
+    const raw: ProblemDetails = {
+      type: "https://example.com/errors/not-found",
+      title: "Resource Not Found",
+      status: 404,
+      detail: "The guest with id 'g1' does not exist.",
+      instance: "/api/v1/guests/g1",
+    };
+
+    const result = parseProblemDetails(raw, 404);
+
+    expect(result.type).toBe("https://example.com/errors/not-found");
+    expect(result.title).toBe("Resource Not Found");
+    expect(result.status).toBe(404);
+    expect(result.detail).toBe("The guest with id 'g1' does not exist.");
+    expect(result.instance).toBe("/api/v1/guests/g1");
+  });
+
+  it("degrades gracefully for a malformed / partial body", () => {
+    // Body that looks like problem+json but is missing required fields
+    const malformed = { type: "about:blank", oops: true };
+
+    const result = parseProblemDetails(malformed, 500);
+
+    expect(result.status).toBe(500);
+    expect(result.type).toBe("about:blank");
+    expect(typeof result.title).toBe("string");
+    expect(typeof result.detail).toBe("string");
+  });
+
+  it("falls back gracefully for a non-7807 body (plain text / HTML 500)", () => {
+    // plain text string — not even an object
+    const result = parseProblemDetails("Bad Gateway", 502);
+
+    expect(result.status).toBe(502);
+    expect(result.type).toBe("about:blank");
+    expect(typeof result.title).toBe("string");
+    expect(typeof result.detail).toBe("string");
+    // Must not throw
+  });
+});

--- a/packages/api-client/src/problem-details.ts
+++ b/packages/api-client/src/problem-details.ts
@@ -1,0 +1,53 @@
+import { ProblemDetailsSchema } from "@mbe/types";
+import type { ProblemDetails } from "@mbe/types";
+
+/**
+ * Parses an unknown response body into a typed ProblemDetails object.
+ *
+ * - Well-formed RFC 7807 body: parsed as-is.
+ * - Malformed body (partial/missing fields): fallback values filled in.
+ * - Non-7807 body (plain text, HTML, etc.): degrades to a sensible shape.
+ *
+ * Never throws — all parsing is defensive.
+ */
+export function parseProblemDetails(raw: unknown, httpStatus: number): ProblemDetails {
+  const parsed = ProblemDetailsSchema.safeParse(raw);
+  if (parsed.success) {
+    return parsed.data;
+  }
+
+  const fallbackDetail = extractDetail(raw, httpStatus);
+
+  return {
+    type: "about:blank",
+    title: httpStatusTitle(httpStatus),
+    status: httpStatus,
+    detail: fallbackDetail,
+  };
+}
+
+function extractDetail(raw: unknown, httpStatus: number): string {
+  if (typeof raw === "string" && raw.length > 0 && !raw.trimStart().startsWith("<")) {
+    return raw;
+  }
+  if (typeof raw === "object" && raw !== null) {
+    const obj = raw as Record<string, unknown>;
+    const candidate = obj.detail ?? obj.message ?? obj.error;
+    if (typeof candidate === "string" && candidate.length > 0) {
+      return candidate;
+    }
+  }
+  return httpStatusTitle(httpStatus);
+}
+
+function httpStatusTitle(status: number): string {
+  if (status >= 500) return "Server Error";
+  if (status === 429) return "Too Many Requests";
+  if (status === 422) return "Unprocessable Entity";
+  if (status === 409) return "Conflict";
+  if (status === 404) return "Not Found";
+  if (status === 403) return "Forbidden";
+  if (status === 401) return "Unauthorized";
+  if (status === 400) return "Bad Request";
+  return "Error";
+}

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,18 +337,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,7 +337,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),


### PR DESCRIPTION
## Summary

- Adds `parseProblemDetails(raw, httpStatus)` in `@mbe/api-client` that defensively parses RFC 7807 error bodies into a typed `ProblemDetails` shape — handles well-formed 7807 bodies, malformed/partial bodies, and non-7807 fallbacks (plain text, HTML) without throwing
- Adds a `problemDetails: ProblemDetails` readonly field to `ApiClientError` so callers always have a typed shape to read from, regardless of what the server sent
- Deletes the ad-hoc `extractErrorMessage` helper from `SettingsPage` and updates both `SettingsPage` and `GuestsPage` to consume `err.problemDetails.detail` via the typed shape

## Test plan

- [x] 3 new parser unit tests: well-formed RFC 7807 body, malformed/partial body, non-7807 fallback (plain string) — all pass
- [x] All 191 existing api-client tests still pass (194 total)
- [x] All 1048 hospitality tests pass (both SettingsPage + GuestsPage suites)
- [x] `pnpm typecheck` green in both `packages/api-client` and `apps/hospitality`
- [x] `pnpm lint` clean (no errors)
- [x] `pnpm regen` run; artifacts up to date
- [x] `check-adr` + `check-deps` pass

Closes #1998