### PR TITLE
fix(hospitality): route ApiClientError through typed problemDetails in use-form-state

### DIFF
--- a/apps/hospitality/llms-full.txt
+++ b/apps/hospitality/llms-full.txt
@@ -252,7 +252,11 @@
         try {
           await onSubmit(parsed.data);
         } catch (err) {
-          setError(err instanceof Error ? err.message : "An error occurred");
+          if (err instanceof ApiClientError) {
+            setError(err.problemDetails.detail ?? err.response.message);
+          } else {
+            setError(err instanceof Error ? err.message : "An error occurred");
+          }
         } finally {
           setIsPending(false);
         }

--- a/apps/hospitality/src/hooks/use-form-state.test.ts
+++ b/apps/hospitality/src/hooks/use-form-state.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { z } from "zod";
+import { ApiClientError } from "@mbe/api-client";
 import { useFormState } from "./use-form-state.js";
 
 const guestSchema = z.object({
@@ -124,6 +125,32 @@ describe("useFormState - submit failure", () => {
 
     expect(typeof result.current.error).toBe("string");
     expect((result.current.error?.length ?? 0) > 0).toBe(true);
+  });
+
+  it("uses problemDetails.detail (not debug message) when error is ApiClientError", async () => {
+    const apiError = new ApiClientError(
+      {
+        error: "Validation Error",
+        message: "Validation failed",
+        statusCode: 422,
+        detail: "Name is required",
+        status: 422,
+      },
+      "PATCH",
+      "/api/v1/guests/123"
+    );
+    const onSubmit = vi.fn().mockRejectedValue(apiError);
+    const { result } = renderHook(() =>
+      useFormState({ name: "Alice", email: "" }, onSubmit, guestSchema)
+    );
+
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+
+    // Should show the clean detail, not the debug string like "PATCH /api/v1/guests/123 failed: 422 ..."
+    expect(result.current.error).toBe("Name is required");
+    expect(result.current.error).not.toContain("PATCH /api/v1/guests/123 failed");
   });
 });
 

--- a/apps/hospitality/src/hooks/use-form-state.test.ts
+++ b/apps/hospitality/src/hooks/use-form-state.test.ts
@@ -137,7 +137,7 @@ describe("useFormState - submit failure", () => {
         status: 422,
       },
       "PATCH",
-      "/api/v1/guests/123"
+      "/guests/123"
     );
     const onSubmit = vi.fn().mockRejectedValue(apiError);
     const { result } = renderHook(() =>
@@ -148,9 +148,9 @@ describe("useFormState - submit failure", () => {
       await result.current.handleSubmit();
     });
 
-    // Should show the clean detail, not the debug string like "PATCH /api/v1/guests/123 failed: 422 ..."
+    // Should show the clean detail, not the debug string like "PATCH /guests/123 failed: 422 ..."
     expect(result.current.error).toBe("Name is required");
-    expect(result.current.error).not.toContain("PATCH /api/v1/guests/123 failed");
+    expect(result.current.error).not.toContain("PATCH /guests/123 failed");
   });
 });
 

--- a/apps/hospitality/src/hooks/use-form-state.ts
+++ b/apps/hospitality/src/hooks/use-form-state.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useMemo } from "react";
 import type { ZodSchema } from "zod";
+import { ApiClientError } from "@mbe/api-client";
 
 export interface UseFormStateResult<T extends Record<string, unknown>> {
   fields: T;
@@ -42,7 +43,11 @@ export function useFormState<T extends Record<string, unknown>>(
     try {
       await onSubmit(parsed.data);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "An error occurred");
+      if (err instanceof ApiClientError) {
+        setError(err.problemDetails.detail ?? err.response.message);
+      } else {
+        setError(err instanceof Error ? err.message : "An error occurred");
+      }
     } finally {
       setIsPending(false);
     }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3098,7 +3098,11 @@
         try {
           await onSubmit(parsed.data);
         } catch (err) {
-          setError(err instanceof Error ? err.message : "An error occurred");
+          if (err instanceof ApiClientError) {
+            setError(err.problemDetails.detail ?? err.response.message);
+          } else {
+            setError(err instanceof Error ? err.message : "An error occurred");
+          }
         } finally {
           setIsPending(false);
         }
@@ -15159,7 +15163,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -15163,18 +15163,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,18 +337,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,7 +337,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),


### PR DESCRIPTION
## Summary

- `use-form-state.ts` catch block now checks `instanceof ApiClientError` first and uses `err.problemDetails.detail` (the clean RFC 7807 detail string) instead of `err.message` (the debug string like `"PATCH /api/v1/guests/123 failed: 422 Validation failed"`)
- Falls back to `err.response.message` for `ApiClientError` cases where `detail` is null
- Generic `Error` path unchanged for non-API errors

## Test plan

- [x] New test: `"uses problemDetails.detail (not debug message) when error is ApiClientError"` — verified RED before implementation, GREEN after
- [x] All 15 use-form-state tests pass
- [x] All 84 test files / 1049 tests pass
- [x] `pnpm lint` — 0 errors
- [x] `pnpm typecheck` — passes (0 errors after rialto built)
- [x] `check-adr` and `check-deps` — no violations
- [x] `pnpm regen` — llms-full.txt updated, no other artifact drift

Closes #2517