### PR TITLE
refactor(service-bootstrap): fp decorator guard + auth0 stub hardening

### DIFF
--- a/packages/service-bootstrap/src/health-routes.test.ts
+++ b/packages/service-bootstrap/src/health-routes.test.ts
@@ -38,9 +38,14 @@ const mockLatencyTracker = {
 
 const mockCheckAuth0 = vi.fn().mockResolvedValue({ status: "ok", latency: 50 });
 
+/**
+ * Always pass an explicit checkAuth0 stub — omitting it lets the default fall
+ * through to the real JWKS fetch and makes tests flaky on network outages.
+ */
 function createTestOptions(overrides?: Partial<HealthRoutesOptions>): HealthRoutesOptions {
   return {
     db: mockDb,
+    // Explicit stub: prevents live Auth0 JWKS calls in any package-level test.
     checkAuth0: mockCheckAuth0,
     routes: [
       { path: "/health", operationId: "getHealth" },
@@ -68,6 +73,18 @@ describe("registerHealthRoutes", () => {
   afterEach(async () => {
     await app.close();
     vi.clearAllMocks();
+  });
+
+  it("throws when required fastify decorators are missing", async () => {
+    const bareApp = Fastify({ logger: false });
+    bareApp.decorate("apiVersion", "v1");
+    bareApp.decorate("sunsetDate", "2027-01-01");
+    // Intentionally omit latencyTracker, rateLimitMonitor, getErrorRates
+    await expect(async () => {
+      await bareApp.register(registerHealthRoutes, createTestOptions());
+      await bareApp.ready();
+    }).rejects.toThrow();
+    await bareApp.close();
   });
 
   it("registers all specified routes", async () => {
@@ -234,6 +251,18 @@ describe("registerHealthRoutes", () => {
 
     expect(mockLatencyTracker.record).toHaveBeenCalledWith(expect.any(Number));
     expect(mockLatencyTracker.checkAnomaly).toHaveBeenCalledWith(expect.any(Number));
+  });
+
+  it("uses the provided checkAuth0 stub and does not call the real JWKS endpoint", async () => {
+    mockPrisma.$queryRaw.mockResolvedValueOnce([{ "?column?": 1 }]);
+    await app.register(registerHealthRoutes, createTestOptions());
+    await app.ready();
+
+    await app.inject({ method: "GET", url: "/health" });
+
+    // The stub must have been called — not the real JWKS fetch
+    expect(mockCheckAuth0).toHaveBeenCalledTimes(1);
+    expect(mockCheckAuth0).toHaveBeenCalledWith();
   });
 
   it("detects latency anomaly and marks database check as error", async () => {

--- a/packages/service-bootstrap/src/health-routes.ts
+++ b/packages/service-bootstrap/src/health-routes.ts
@@ -239,7 +239,13 @@ const healthRoutesPlugin: FastifyPluginAsync<HealthRoutesOptions> = async (
   }
 };
 
+// Note: dependencies: ["error-rate-tracker"] was considered but omitted — the fp
+// `dependencies` check requires the named plugin to already be registered, which
+// breaks package-level tests that set decorators manually without errorRatePlugin_.
+// The decorators guard below is the safe win: it catches missing decorators at
+// registration time without requiring a full plugin chain.
 export const registerHealthRoutes = fp(healthRoutesPlugin, {
   name: "health-routes",
   fastify: "5.x",
+  decorators: { fastify: ["latencyTracker", "rateLimitMonitor", "getErrorRates"] },
 });


### PR DESCRIPTION
## Summary

- **Item 1 (DONE):** Added `decorators: { fastify: ["latencyTracker","rateLimitMonitor","getErrorRates"] }` to the `registerHealthRoutes` fp options. This catches missing decorators at registration time (boot-time assertion) rather than surfacing as a `TypeError: Cannot read properties of undefined` during request handling. Added a test that verifies registration throws when those decorators are absent.

- **Item 2 (NO-OP):** The `isAnomaly:true → checks.database.status==='error'` path is already covered by the package-level test "detects latency anomaly and marks database check as error" in `health-routes.test.ts`. No `createLatencyTracker` module-mocks exist in any of the three service `health.test.ts` files — there are no dead mocks to remove.

- **Item 3 (DONE):** The `checkAuth0: mockCheckAuth0` stub was already present in `createTestOptions()` but lacked documentation. Added a JSDoc comment + inline comment making the intent explicit (omitting it falls through to live Auth0 JWKS fetch). Added a test asserting the stub is called and not the real endpoint, to prevent future silent removal.

- **Item 4 (DEFERRED):** Services already pass the full `DatabaseInstance<T>` as `db: HealthDb` — the `HealthDb` interface in `health-routes.ts` already narrows the surface at the type level. Exporting a separate `healthDb` binding from each service's `database.ts` would require touching 3 service files for a runtime-equivalent change. Deferred as low-value churn; the type narrowing is already in place.

## Note on `dependencies: ["error-rate-tracker"]`

This was considered for Item 1 but omitted. The fp `dependencies` array requires the named plugin to be registered before `registerHealthRoutes`, which breaks the 13 package-level tests that create a bare Fastify instance and set decorators manually (without going through `createServiceApp` and `errorRatePlugin_`). The `decorators` guard alone is the safe win — it catches missing decorators without requiring a full plugin chain, and does not break any existing test pattern.

## Test plan

- [ ] `pnpm test` in `packages/service-bootstrap` — 129 tests pass (2 new tests added)
- [ ] `pnpm lint` + `pnpm typecheck` in `packages/service-bootstrap` — clean
- [ ] `pnpm --filter @mbe/cli start check-adr` — no violations
- [ ] `pnpm --filter @mbe/cli start check-deps` — no mismatches
- [ ] `pnpm regen` — no artifact drift
- [ ] Pre-push hook ran 18 turbo tasks (build + typecheck + test across 5 packages) — all 18 successful

Closes #2511