### PR TITLE
fix(reservations): atomic CAS on deposit state transitions (apply/refund/forfeit)

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -15162,7 +15162,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -11480,10 +11480,13 @@
         this.name = "DepositNotFoundError";
       }
     }
-    export interface CreateDepositOptions {
-      reservationId: string;
-      amountCents: number;
-      currency?: string;
+    export class DepositConcurrentUpdateError extends Error {
+      constructor(id: string, action: string) {
+        super(
+          `Deposit ${id} concurrent update conflict: lost race on ${action}. Another transition completed first.`
+        );
+        this.name = "DepositConcurrentUpdateError";
+      }
     }
   </file>
   <file path="services/reservations/src/services/events.ts">
@@ -15159,7 +15162,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -15162,18 +15162,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms.txt
+++ b/llms.txt
@@ -2252,11 +2252,9 @@
         
       }
     </item>
-    <item priority="low">
-      interface CreateDepositOptions {
-        reservationId: string;
-        amountCents: number;
-        currency?: string;
+    <item priority="high">
+      class DepositConcurrentUpdateError {
+        
       }
     </item>
   </file>

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,18 +337,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,7 +337,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/services/reservations/llms-full.txt
+++ b/services/reservations/llms-full.txt
@@ -5181,10 +5181,13 @@
         this.name = "DepositNotFoundError";
       }
     }
-    export interface CreateDepositOptions {
-      reservationId: string;
-      amountCents: number;
-      currency?: string;
+    export class DepositConcurrentUpdateError extends Error {
+      constructor(id: string, action: string) {
+        super(
+          `Deposit ${id} concurrent update conflict: lost race on ${action}. Another transition completed first.`
+        );
+        this.name = "DepositConcurrentUpdateError";
+      }
     }
   </file>
   <file path="src/services/events.ts">

--- a/services/reservations/llms.txt
+++ b/services/reservations/llms.txt
@@ -373,11 +373,9 @@
         
       }
     </item>
-    <item priority="low">
-      interface CreateDepositOptions {
-        reservationId: string;
-        amountCents: number;
-        currency?: string;
+    <item priority="high">
+      class DepositConcurrentUpdateError {
+        
       }
     </item>
   </file>

--- a/services/reservations/src/routes/deposits.test.ts
+++ b/services/reservations/src/routes/deposits.test.ts
@@ -6,6 +6,7 @@ const { mockDepositDb, mockGuestDb } = vi.hoisted(() => ({
     findUnique: vi.fn(),
     create: vi.fn(),
     update: vi.fn(),
+    updateMany: vi.fn(),
   },
   mockGuestDb: {
     findUnique: vi.fn(),
@@ -195,11 +196,12 @@ describe("Deposit API routes", () => {
       });
       const appliedDeposit = makeDeposit({ status: "applied", appliedAt: new Date() });
 
-      // getById (route check) + apply (service getById + service update)
+      // getById (route check) + apply (service._requireDeposit + CAS + post-CAS fetch)
       mockDepositDb.findUnique
         .mockResolvedValueOnce(heldDeposit) // route existence check
-        .mockResolvedValueOnce(heldDeposit); // service._requireDeposit
-      mockDepositDb.update.mockResolvedValueOnce(appliedDeposit);
+        .mockResolvedValueOnce(heldDeposit) // service._requireDeposit
+        .mockResolvedValueOnce(appliedDeposit); // post-CAS fetch
+      mockDepositDb.updateMany.mockResolvedValueOnce({ count: 1 });
       mockPaymentIntents.capture.mockResolvedValueOnce({
         id: "pi_test_123",
         status: "succeeded",
@@ -267,9 +269,10 @@ describe("Deposit API routes", () => {
       const refundedDeposit = makeDeposit({ status: "refunded", refundedAt: new Date() });
 
       mockDepositDb.findUnique
-        .mockResolvedValueOnce(heldDeposit)
-        .mockResolvedValueOnce(heldDeposit);
-      mockDepositDb.update.mockResolvedValueOnce(refundedDeposit);
+        .mockResolvedValueOnce(heldDeposit) // route existence check
+        .mockResolvedValueOnce(heldDeposit) // service._requireDeposit
+        .mockResolvedValueOnce(refundedDeposit); // post-CAS fetch
+      mockDepositDb.updateMany.mockResolvedValueOnce({ count: 1 });
       mockPaymentIntents.cancel.mockResolvedValueOnce({
         id: "pi_test_123",
         status: "canceled",
@@ -320,9 +323,10 @@ describe("Deposit API routes", () => {
       const forfeitedDeposit = makeDeposit({ status: "forfeited", forfeitedAt: new Date() });
 
       mockDepositDb.findUnique
-        .mockResolvedValueOnce(heldDeposit)
-        .mockResolvedValueOnce(heldDeposit);
-      mockDepositDb.update.mockResolvedValueOnce(forfeitedDeposit);
+        .mockResolvedValueOnce(heldDeposit) // route existence check
+        .mockResolvedValueOnce(heldDeposit) // service._requireDeposit
+        .mockResolvedValueOnce(forfeitedDeposit); // post-CAS fetch
+      mockDepositDb.updateMany.mockResolvedValueOnce({ count: 1 });
       mockPaymentIntents.capture.mockResolvedValueOnce({
         id: "pi_test_123",
         status: "succeeded",

--- a/services/reservations/src/services/deposit.test.ts
+++ b/services/reservations/src/services/deposit.test.ts
@@ -5,6 +5,7 @@ const { mockDepositDb, mockGuestDb } = vi.hoisted(() => ({
     findUnique: vi.fn(),
     create: vi.fn(),
     update: vi.fn(),
+    updateMany: vi.fn(),
   },
   mockGuestDb: {
     findUnique: vi.fn(),
@@ -185,14 +186,15 @@ describe("DepositService", () => {
         appliedAt: new Date(),
       });
       mockDepositDb.findUnique.mockResolvedValueOnce(heldDeposit);
-      mockDepositDb.update.mockResolvedValueOnce(appliedDeposit);
+      mockDepositDb.updateMany.mockResolvedValueOnce({ count: 1 });
+      mockDepositDb.findUnique.mockResolvedValueOnce(appliedDeposit);
       mockPaymentIntents.capture.mockResolvedValueOnce({ id: "pi_test_123", status: "succeeded" });
 
       const result = await depositService.apply("dep-123");
 
-      expect(mockDepositDb.update).toHaveBeenCalledWith(
+      expect(mockDepositDb.updateMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { id: "dep-123" },
+          where: { id: "dep-123", status: "held" },
           data: expect.objectContaining({
             status: "applied",
             appliedAt: expect.any(Date),
@@ -211,10 +213,22 @@ describe("DepositService", () => {
       );
     });
 
+    it("throws a conflict error if the CAS races (updateMany returns count 0) without calling Stripe", async () => {
+      const heldDeposit = makeDeposit({ status: "held", stripePaymentIntentId: "pi_test_123" });
+      mockDepositDb.findUnique.mockResolvedValueOnce(heldDeposit);
+      mockDepositDb.updateMany.mockResolvedValueOnce({ count: 0 }); // lost the race
+
+      await expect(depositService.apply("dep-123")).rejects.toThrow(
+        /conflict|lost.*race|concurrent/i
+      );
+      expect(mockPaymentIntents.capture).not.toHaveBeenCalled();
+    });
+
     it("passes an idempotency key keyed on depositId + action to Stripe", async () => {
       const heldDeposit = makeDeposit({ status: "held", stripePaymentIntentId: "pi_test_123" });
       mockDepositDb.findUnique.mockResolvedValueOnce(heldDeposit);
-      mockDepositDb.update.mockResolvedValueOnce(makeDeposit({ status: "applied" }));
+      mockDepositDb.updateMany.mockResolvedValueOnce({ count: 1 });
+      mockDepositDb.findUnique.mockResolvedValueOnce(makeDeposit({ status: "applied" }));
       mockPaymentIntents.capture.mockResolvedValueOnce({ id: "pi_test_123", status: "succeeded" });
 
       await depositService.apply("dep-123");
@@ -228,10 +242,11 @@ describe("DepositService", () => {
       const order: string[] = [];
       const heldDeposit = makeDeposit({ status: "held", stripePaymentIntentId: "pi_test_123" });
       mockDepositDb.findUnique.mockResolvedValueOnce(heldDeposit);
-      mockDepositDb.update.mockImplementationOnce(async () => {
+      mockDepositDb.updateMany.mockImplementationOnce(async () => {
         order.push("db");
-        return makeDeposit({ status: "applied" });
+        return { count: 1 };
       });
+      mockDepositDb.findUnique.mockResolvedValueOnce(makeDeposit({ status: "applied" }));
       mockPaymentIntents.capture.mockImplementationOnce(async () => {
         order.push("stripe");
         return { id: "pi_test_123", status: "succeeded" };
@@ -245,15 +260,17 @@ describe("DepositService", () => {
     it("rolls back DB to held when Stripe capture fails after the DB update", async () => {
       const heldDeposit = makeDeposit({ status: "held", stripePaymentIntentId: "pi_test_123" });
       mockDepositDb.findUnique.mockResolvedValueOnce(heldDeposit);
-      mockDepositDb.update
-        .mockResolvedValueOnce(makeDeposit({ status: "applied", appliedAt: new Date() }))
-        .mockResolvedValueOnce(heldDeposit);
+      mockDepositDb.updateMany.mockResolvedValueOnce({ count: 1 });
+      mockDepositDb.findUnique.mockResolvedValueOnce(
+        makeDeposit({ status: "applied", appliedAt: new Date() })
+      );
+      mockDepositDb.update.mockResolvedValueOnce(heldDeposit);
       mockPaymentIntents.capture.mockRejectedValueOnce(new Error("stripe boom"));
 
       await expect(depositService.apply("dep-123")).rejects.toThrow(/stripe boom/);
 
-      expect(mockDepositDb.update).toHaveBeenCalledTimes(2);
-      expect(mockDepositDb.update).toHaveBeenLastCalledWith(
+      expect(mockDepositDb.update).toHaveBeenCalledTimes(1);
+      expect(mockDepositDb.update).toHaveBeenCalledWith(
         expect.objectContaining({
           where: { id: "dep-123" },
           data: expect.objectContaining({ status: "held", appliedAt: null }),
@@ -264,9 +281,11 @@ describe("DepositService", () => {
     it("surfaces the original Stripe error when the rollback DB write also fails", async () => {
       const heldDeposit = makeDeposit({ status: "held", stripePaymentIntentId: "pi_test_123" });
       mockDepositDb.findUnique.mockResolvedValueOnce(heldDeposit);
-      mockDepositDb.update
-        .mockResolvedValueOnce(makeDeposit({ status: "applied", appliedAt: new Date() }))
-        .mockRejectedValueOnce(new Error("db down")); // rollback write fails
+      mockDepositDb.updateMany.mockResolvedValueOnce({ count: 1 });
+      mockDepositDb.findUnique.mockResolvedValueOnce(
+        makeDeposit({ status: "applied", appliedAt: new Date() })
+      );
+      mockDepositDb.update.mockRejectedValueOnce(new Error("db down")); // rollback write fails
       mockPaymentIntents.capture.mockRejectedValueOnce(new Error("stripe boom"));
 
       // The caller must see the original Stripe failure, not the rollback DB error.
@@ -279,14 +298,15 @@ describe("DepositService", () => {
       const heldDeposit = makeDeposit({ status: "held", stripePaymentIntentId: "pi_test_123" });
       const refundedDeposit = makeDeposit({ status: "refunded", refundedAt: new Date() });
       mockDepositDb.findUnique.mockResolvedValueOnce(heldDeposit);
-      mockDepositDb.update.mockResolvedValueOnce(refundedDeposit);
+      mockDepositDb.updateMany.mockResolvedValueOnce({ count: 1 });
+      mockDepositDb.findUnique.mockResolvedValueOnce(refundedDeposit);
       mockPaymentIntents.cancel.mockResolvedValueOnce({ id: "pi_test_123", status: "canceled" });
 
       const result = await depositService.refund("dep-123");
 
-      expect(mockDepositDb.update).toHaveBeenCalledWith(
+      expect(mockDepositDb.updateMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { id: "dep-123" },
+          where: { id: "dep-123", status: "held" },
           data: expect.objectContaining({
             status: "refunded",
             refundedAt: expect.any(Date),
@@ -305,10 +325,22 @@ describe("DepositService", () => {
       );
     });
 
+    it("throws a conflict error if the CAS races (updateMany returns count 0) without calling Stripe", async () => {
+      const heldDeposit = makeDeposit({ status: "held", stripePaymentIntentId: "pi_test_123" });
+      mockDepositDb.findUnique.mockResolvedValueOnce(heldDeposit);
+      mockDepositDb.updateMany.mockResolvedValueOnce({ count: 0 }); // lost the race
+
+      await expect(depositService.refund("dep-123")).rejects.toThrow(
+        /conflict|lost.*race|concurrent/i
+      );
+      expect(mockPaymentIntents.cancel).not.toHaveBeenCalled();
+    });
+
     it("passes an idempotency key keyed on depositId + action to Stripe", async () => {
       const heldDeposit = makeDeposit({ status: "held", stripePaymentIntentId: "pi_test_123" });
       mockDepositDb.findUnique.mockResolvedValueOnce(heldDeposit);
-      mockDepositDb.update.mockResolvedValueOnce(makeDeposit({ status: "refunded" }));
+      mockDepositDb.updateMany.mockResolvedValueOnce({ count: 1 });
+      mockDepositDb.findUnique.mockResolvedValueOnce(makeDeposit({ status: "refunded" }));
       mockPaymentIntents.cancel.mockResolvedValueOnce({ id: "pi_test_123", status: "canceled" });
 
       await depositService.refund("dep-123");
@@ -321,15 +353,17 @@ describe("DepositService", () => {
     it("rolls back DB to held when Stripe cancel fails after the DB update", async () => {
       const heldDeposit = makeDeposit({ status: "held", stripePaymentIntentId: "pi_test_123" });
       mockDepositDb.findUnique.mockResolvedValueOnce(heldDeposit);
-      mockDepositDb.update
-        .mockResolvedValueOnce(makeDeposit({ status: "refunded", refundedAt: new Date() }))
-        .mockResolvedValueOnce(heldDeposit);
+      mockDepositDb.updateMany.mockResolvedValueOnce({ count: 1 });
+      mockDepositDb.findUnique.mockResolvedValueOnce(
+        makeDeposit({ status: "refunded", refundedAt: new Date() })
+      );
+      mockDepositDb.update.mockResolvedValueOnce(heldDeposit);
       mockPaymentIntents.cancel.mockRejectedValueOnce(new Error("stripe boom"));
 
       await expect(depositService.refund("dep-123")).rejects.toThrow(/stripe boom/);
 
-      expect(mockDepositDb.update).toHaveBeenCalledTimes(2);
-      expect(mockDepositDb.update).toHaveBeenLastCalledWith(
+      expect(mockDepositDb.update).toHaveBeenCalledTimes(1);
+      expect(mockDepositDb.update).toHaveBeenCalledWith(
         expect.objectContaining({
           where: { id: "dep-123" },
           data: expect.objectContaining({ status: "held", refundedAt: null }),
@@ -343,14 +377,15 @@ describe("DepositService", () => {
       const heldDeposit = makeDeposit({ status: "held", stripePaymentIntentId: "pi_test_123" });
       const forfeitedDeposit = makeDeposit({ status: "forfeited", forfeitedAt: new Date() });
       mockDepositDb.findUnique.mockResolvedValueOnce(heldDeposit);
-      mockDepositDb.update.mockResolvedValueOnce(forfeitedDeposit);
+      mockDepositDb.updateMany.mockResolvedValueOnce({ count: 1 });
+      mockDepositDb.findUnique.mockResolvedValueOnce(forfeitedDeposit);
       mockPaymentIntents.capture.mockResolvedValueOnce({ id: "pi_test_123", status: "succeeded" });
 
       const result = await depositService.forfeit("dep-123");
 
-      expect(mockDepositDb.update).toHaveBeenCalledWith(
+      expect(mockDepositDb.updateMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { id: "dep-123" },
+          where: { id: "dep-123", status: "held" },
           data: expect.objectContaining({
             status: "forfeited",
             forfeitedAt: expect.any(Date),
@@ -369,10 +404,22 @@ describe("DepositService", () => {
       );
     });
 
+    it("throws a conflict error if the CAS races (updateMany returns count 0) without calling Stripe", async () => {
+      const heldDeposit = makeDeposit({ status: "held", stripePaymentIntentId: "pi_test_123" });
+      mockDepositDb.findUnique.mockResolvedValueOnce(heldDeposit);
+      mockDepositDb.updateMany.mockResolvedValueOnce({ count: 0 }); // lost the race
+
+      await expect(depositService.forfeit("dep-123")).rejects.toThrow(
+        /conflict|lost.*race|concurrent/i
+      );
+      expect(mockPaymentIntents.capture).not.toHaveBeenCalled();
+    });
+
     it("passes an idempotency key keyed on depositId + action to Stripe", async () => {
       const heldDeposit = makeDeposit({ status: "held", stripePaymentIntentId: "pi_test_123" });
       mockDepositDb.findUnique.mockResolvedValueOnce(heldDeposit);
-      mockDepositDb.update.mockResolvedValueOnce(makeDeposit({ status: "forfeited" }));
+      mockDepositDb.updateMany.mockResolvedValueOnce({ count: 1 });
+      mockDepositDb.findUnique.mockResolvedValueOnce(makeDeposit({ status: "forfeited" }));
       mockPaymentIntents.capture.mockResolvedValueOnce({ id: "pi_test_123", status: "succeeded" });
 
       await depositService.forfeit("dep-123");
@@ -385,15 +432,17 @@ describe("DepositService", () => {
     it("rolls back DB to held when Stripe capture fails after the DB update", async () => {
       const heldDeposit = makeDeposit({ status: "held", stripePaymentIntentId: "pi_test_123" });
       mockDepositDb.findUnique.mockResolvedValueOnce(heldDeposit);
-      mockDepositDb.update
-        .mockResolvedValueOnce(makeDeposit({ status: "forfeited", forfeitedAt: new Date() }))
-        .mockResolvedValueOnce(heldDeposit);
+      mockDepositDb.updateMany.mockResolvedValueOnce({ count: 1 });
+      mockDepositDb.findUnique.mockResolvedValueOnce(
+        makeDeposit({ status: "forfeited", forfeitedAt: new Date() })
+      );
+      mockDepositDb.update.mockResolvedValueOnce(heldDeposit);
       mockPaymentIntents.capture.mockRejectedValueOnce(new Error("stripe boom"));
 
       await expect(depositService.forfeit("dep-123")).rejects.toThrow(/stripe boom/);
 
-      expect(mockDepositDb.update).toHaveBeenCalledTimes(2);
-      expect(mockDepositDb.update).toHaveBeenLastCalledWith(
+      expect(mockDepositDb.update).toHaveBeenCalledTimes(1);
+      expect(mockDepositDb.update).toHaveBeenCalledWith(
         expect.objectContaining({
           where: { id: "dep-123" },
           data: expect.objectContaining({ status: "held", forfeitedAt: null }),
@@ -410,16 +459,17 @@ describe("DepositService", () => {
         refundedAt: new Date(),
       });
       mockDepositDb.findUnique.mockResolvedValueOnce(heldDeposit);
-      mockDepositDb.update.mockResolvedValueOnce(partialDeposit);
+      mockDepositDb.updateMany.mockResolvedValueOnce({ count: 1 });
+      mockDepositDb.findUnique.mockResolvedValueOnce(partialDeposit);
       mockPaymentIntents.capture.mockResolvedValueOnce({ id: "pi_test_123", status: "succeeded" });
       mockPaymentIntents.retrieve.mockResolvedValueOnce({ latest_charge: "ch_1" });
       mockRefunds.create.mockResolvedValueOnce({ id: "re_1", status: "succeeded", amount: 3000 });
 
       const result = await depositService.refundPartial("dep-123", 3000);
 
-      expect(mockDepositDb.update).toHaveBeenCalledWith(
+      expect(mockDepositDb.updateMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { id: "dep-123" },
+          where: { id: "dep-123", status: "held" },
           data: expect.objectContaining({
             status: "partial_refunded",
             refundedAt: expect.any(Date),
@@ -444,14 +494,26 @@ describe("DepositService", () => {
       await expect(depositService.refundPartial("dep-nope", 3000)).rejects.toThrow(/not found/i);
     });
 
+    it("throws a conflict error if the CAS races (updateMany returns count 0) without calling Stripe", async () => {
+      const heldDeposit = makeDeposit({ status: "held", stripePaymentIntentId: "pi_test_123" });
+      mockDepositDb.findUnique.mockResolvedValueOnce(heldDeposit);
+      mockDepositDb.updateMany.mockResolvedValueOnce({ count: 0 }); // lost the race
+
+      await expect(depositService.refundPartial("dep-123", 3000)).rejects.toThrow(
+        /conflict|lost.*race|concurrent/i
+      );
+      expect(mockPaymentIntents.capture).not.toHaveBeenCalled();
+    });
+
     it("updates DB to partial_refunded before calling Stripe (DB-first ordering)", async () => {
       const order: string[] = [];
       const heldDeposit = makeDeposit({ status: "held", stripePaymentIntentId: "pi_test_123" });
       mockDepositDb.findUnique.mockResolvedValueOnce(heldDeposit);
-      mockDepositDb.update.mockImplementationOnce(async () => {
+      mockDepositDb.updateMany.mockImplementationOnce(async () => {
         order.push("db");
-        return makeDeposit({ status: "partial_refunded" });
+        return { count: 1 };
       });
+      mockDepositDb.findUnique.mockResolvedValueOnce(makeDeposit({ status: "partial_refunded" }));
       mockPaymentIntents.capture.mockImplementationOnce(async () => {
         order.push("capture");
         return { id: "pi_test_123", status: "succeeded" };
@@ -470,7 +532,8 @@ describe("DepositService", () => {
     it("passes a stable idempotency key on the capture", async () => {
       const heldDeposit = makeDeposit({ status: "held", stripePaymentIntentId: "pi_test_123" });
       mockDepositDb.findUnique.mockResolvedValueOnce(heldDeposit);
-      mockDepositDb.update.mockResolvedValueOnce(makeDeposit({ status: "partial_refunded" }));
+      mockDepositDb.updateMany.mockResolvedValueOnce({ count: 1 });
+      mockDepositDb.findUnique.mockResolvedValueOnce(makeDeposit({ status: "partial_refunded" }));
       mockPaymentIntents.capture.mockResolvedValueOnce({ id: "pi_test_123", status: "succeeded" });
       mockPaymentIntents.retrieve.mockResolvedValueOnce({ latest_charge: "ch_1" });
       mockRefunds.create.mockResolvedValueOnce({ id: "re_1", status: "succeeded", amount: 3000 });
@@ -485,7 +548,8 @@ describe("DepositService", () => {
     it("passes a stable idempotency key on the refund", async () => {
       const heldDeposit = makeDeposit({ status: "held", stripePaymentIntentId: "pi_test_123" });
       mockDepositDb.findUnique.mockResolvedValueOnce(heldDeposit);
-      mockDepositDb.update.mockResolvedValueOnce(makeDeposit({ status: "partial_refunded" }));
+      mockDepositDb.updateMany.mockResolvedValueOnce({ count: 1 });
+      mockDepositDb.findUnique.mockResolvedValueOnce(makeDeposit({ status: "partial_refunded" }));
       mockPaymentIntents.capture.mockResolvedValueOnce({ id: "pi_test_123", status: "succeeded" });
       mockPaymentIntents.retrieve.mockResolvedValueOnce({ latest_charge: "ch_1" });
       mockRefunds.create.mockResolvedValueOnce({ id: "re_1", status: "succeeded", amount: 3000 });
@@ -501,18 +565,21 @@ describe("DepositService", () => {
     it("rolls back DB to held when the CAPTURE fails (no money moved)", async () => {
       const heldDeposit = makeDeposit({ status: "held", stripePaymentIntentId: "pi_test_123" });
       mockDepositDb.findUnique.mockResolvedValueOnce(heldDeposit);
-      mockDepositDb.update
-        .mockResolvedValueOnce(makeDeposit({ status: "partial_refunded", refundedAt: new Date() }))
-        .mockResolvedValueOnce(heldDeposit);
+      mockDepositDb.updateMany.mockResolvedValueOnce({ count: 1 });
+      mockDepositDb.findUnique.mockResolvedValueOnce(
+        makeDeposit({ status: "partial_refunded", refundedAt: new Date() })
+      );
+      mockDepositDb.update.mockResolvedValueOnce(heldDeposit);
       mockPaymentIntents.capture.mockRejectedValueOnce(new Error("stripe capture boom"));
 
       await expect(depositService.refundPartial("dep-123", 3000)).rejects.toThrow(
         /stripe capture boom/
       );
 
-      // First update = partial_refunded (DB-first); second update = rollback to held.
-      expect(mockDepositDb.update).toHaveBeenCalledTimes(2);
-      expect(mockDepositDb.update).toHaveBeenLastCalledWith(
+      // CAS write via updateMany + rollback via update.
+      expect(mockDepositDb.updateMany).toHaveBeenCalledTimes(1);
+      expect(mockDepositDb.update).toHaveBeenCalledTimes(1);
+      expect(mockDepositDb.update).toHaveBeenCalledWith(
         expect.objectContaining({
           where: { id: "dep-123" },
           data: expect.objectContaining({ status: "held", refundedAt: null }),
@@ -528,7 +595,8 @@ describe("DepositService", () => {
       // the error surface so the refund can be retried idempotently.
       const heldDeposit = makeDeposit({ status: "held", stripePaymentIntentId: "pi_test_123" });
       mockDepositDb.findUnique.mockResolvedValueOnce(heldDeposit);
-      mockDepositDb.update.mockResolvedValueOnce(
+      mockDepositDb.updateMany.mockResolvedValueOnce({ count: 1 });
+      mockDepositDb.findUnique.mockResolvedValueOnce(
         makeDeposit({ status: "partial_refunded", refundedAt: new Date() })
       );
       mockPaymentIntents.capture.mockResolvedValueOnce({ id: "pi_test_123", status: "succeeded" });
@@ -539,13 +607,9 @@ describe("DepositService", () => {
         /stripe refund boom/
       );
 
-      // Only the DB-first write happened — no rollback to held.
-      expect(mockDepositDb.update).toHaveBeenCalledTimes(1);
-      expect(mockDepositDb.update).toHaveBeenCalledWith(
-        expect.objectContaining({
-          data: expect.objectContaining({ status: "partial_refunded" }),
-        })
-      );
+      // Only the CAS write happened — no rollback to held.
+      expect(mockDepositDb.updateMany).toHaveBeenCalledTimes(1);
+      expect(mockDepositDb.update).not.toHaveBeenCalled();
     });
 
     it("is re-entrant: a retry already in partial_refunded replays Stripe without re-transitioning", async () => {
@@ -562,6 +626,7 @@ describe("DepositService", () => {
       const result = await depositService.refundPartial("dep-123", 3000);
 
       // No DB write on the retry — the row is already partial_refunded.
+      expect(mockDepositDb.updateMany).not.toHaveBeenCalled();
       expect(mockDepositDb.update).not.toHaveBeenCalled();
       // Stripe steps replay with their idempotency keys.
       expect(mockPaymentIntents.capture).toHaveBeenCalledWith("pi_test_123", undefined, {
@@ -581,7 +646,7 @@ describe("DepositService", () => {
       await expect(depositService.refundPartial("dep-123", 6000)).rejects.toThrow(
         /invalid.*amount/i
       );
-      expect(mockDepositDb.update).not.toHaveBeenCalled();
+      expect(mockDepositDb.updateMany).not.toHaveBeenCalled();
       expect(mockPaymentIntents.capture).not.toHaveBeenCalled();
     });
 
@@ -590,19 +655,65 @@ describe("DepositService", () => {
       mockDepositDb.findUnique.mockResolvedValueOnce(heldDeposit);
 
       await expect(depositService.refundPartial("dep-123", -1)).rejects.toThrow(/invalid.*amount/i);
-      expect(mockDepositDb.update).not.toHaveBeenCalled();
+      expect(mockDepositDb.updateMany).not.toHaveBeenCalled();
     });
 
     it("does not call Stripe refund when refundAmountCents is 0 (still transitions + captures)", async () => {
       const heldDeposit = makeDeposit({ status: "held", stripePaymentIntentId: "pi_test_123" });
       mockDepositDb.findUnique.mockResolvedValueOnce(heldDeposit);
-      mockDepositDb.update.mockResolvedValueOnce(makeDeposit({ status: "partial_refunded" }));
+      mockDepositDb.updateMany.mockResolvedValueOnce({ count: 1 });
+      mockDepositDb.findUnique.mockResolvedValueOnce(makeDeposit({ status: "partial_refunded" }));
       mockPaymentIntents.capture.mockResolvedValueOnce({ id: "pi_test_123", status: "succeeded" });
 
       await depositService.refundPartial("dep-123", 0);
 
       expect(mockPaymentIntents.capture).toHaveBeenCalled();
       expect(mockRefunds.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("CAS concurrency: two different actions on the same held deposit", () => {
+    it("exactly one wins the race; the loser throws before calling Stripe", async () => {
+      // Simulate: apply races refund on the same held deposit.
+      // The winner's updateMany returns { count: 1 }; the loser's returns { count: 0 }.
+      const heldDeposit = makeDeposit({ status: "held", stripePaymentIntentId: "pi_test_123" });
+      const appliedDeposit = makeDeposit({ status: "applied", appliedAt: new Date() });
+
+      // Both reads see the same held row (concurrent fetch).
+      mockDepositDb.findUnique
+        .mockResolvedValueOnce(heldDeposit) // apply reads
+        .mockResolvedValueOnce(heldDeposit) // refund reads
+        .mockResolvedValueOnce(appliedDeposit); // apply's post-CAS fetch
+
+      // apply wins the CAS; refund loses.
+      mockDepositDb.updateMany
+        .mockResolvedValueOnce({ count: 1 }) // apply wins
+        .mockResolvedValueOnce({ count: 0 }); // refund loses
+
+      mockPaymentIntents.capture.mockResolvedValueOnce({
+        id: "pi_test_123",
+        status: "succeeded",
+      });
+
+      const applyPromise = depositService.apply("dep-123");
+      const refundPromise = depositService.refund("dep-123");
+
+      const [applyResult, refundError] = await Promise.allSettled([applyPromise, refundPromise]);
+
+      expect(applyResult.status).toBe("fulfilled");
+      expect(
+        (applyResult as PromiseFulfilledResult<Awaited<ReturnType<typeof depositService.apply>>>)
+          .value.status
+      ).toBe("applied");
+
+      expect(refundError.status).toBe("rejected");
+      expect((refundError as PromiseRejectedResult).reason.message).toMatch(
+        /conflict|lost.*race|concurrent/i
+      );
+
+      // Stripe called exactly once (the winner's capture); the loser never reached Stripe.
+      expect(mockPaymentIntents.capture).toHaveBeenCalledTimes(1);
+      expect(mockPaymentIntents.cancel).not.toHaveBeenCalled();
     });
   });
 });

--- a/services/reservations/src/services/deposit.test.ts
+++ b/services/reservations/src/services/deposit.test.ts
@@ -635,6 +635,28 @@ describe("DepositService", () => {
       expect(result.status).toBe("partial_refunded");
     });
 
+    it("does NOT roll back to held when a re-entrant retry's capture fails (card already captured)", async () => {
+      // The first attempt already captured the card and moved the row to
+      // partial_refunded. A transient failure on the re-entrant capture replay
+      // must NOT roll back to `held` — that would lie about the charge and let a
+      // later `refund`/`forfeit` act on an already-captured intent.
+      const partialDeposit = makeDeposit({
+        status: "partial_refunded",
+        stripePaymentIntentId: "pi_test_123",
+        refundedAt: new Date(),
+      });
+      mockDepositDb.findUnique.mockResolvedValueOnce(partialDeposit);
+      mockPaymentIntents.capture.mockRejectedValueOnce(new Error("transient network blip"));
+
+      await expect(depositService.refundPartial("dep-123", 3000)).rejects.toThrow(
+        /transient network blip/
+      );
+
+      // Re-entrant path: no transition (updateMany) and — crucially — no rollback (update).
+      expect(mockDepositDb.updateMany).not.toHaveBeenCalled();
+      expect(mockDepositDb.update).not.toHaveBeenCalled();
+    });
+
     it("rejects a refund amount greater than the deposit", async () => {
       const heldDeposit = makeDeposit({
         status: "held",

--- a/services/reservations/src/services/deposit.ts
+++ b/services/reservations/src/services/deposit.ts
@@ -200,6 +200,7 @@ export class DepositService {
     // Re-entry guard: a retry after a refund failure arrives already in
     // `partial_refunded`. Only transition + write the row when coming from `held`.
     let updated = deposit;
+    let didTransition = false;
     if (deposit.status !== "partial_refunded") {
       transitionDeposit(deposit.status, "partial_refunded"); // throws if invalid
 
@@ -216,6 +217,7 @@ export class DepositService {
 
       // Fetch the updated row to return consistent state.
       updated = await this._requireDeposit(depositId);
+      didTransition = true;
     }
 
     if (deposit.stripePaymentIntentId) {
@@ -227,7 +229,13 @@ export class DepositService {
       try {
         await this.stripe.capturePaymentIntent(deposit.stripePaymentIntentId, captureKey);
       } catch (error) {
-        await this._rollbackToHeld(depositId, "refundedAt").catch(() => {});
+        // Only roll back if THIS invocation transitioned the row. On a re-entrant
+        // retry (already `partial_refunded`), the card was captured on the first
+        // attempt — rolling back to `held` would corrupt state (held row, captured
+        // card). The same idempotency key makes the capture retry safe.
+        if (didTransition) {
+          await this._rollbackToHeld(depositId, "refundedAt").catch(() => {});
+        }
         throw error;
       }
 

--- a/services/reservations/src/services/deposit.ts
+++ b/services/reservations/src/services/deposit.ts
@@ -10,6 +10,15 @@ export class DepositNotFoundError extends Error {
   }
 }
 
+export class DepositConcurrentUpdateError extends Error {
+  constructor(id: string, action: string) {
+    super(
+      `Deposit ${id} concurrent update conflict: lost race on ${action}. Another transition completed first.`
+    );
+    this.name = "DepositConcurrentUpdateError";
+  }
+}
+
 export interface CreateDepositOptions {
   reservationId: string;
   amountCents: number;
@@ -123,10 +132,19 @@ export class DepositService {
     const deposit = await this._requireDeposit(depositId);
     transitionDeposit(deposit.status, "refunded"); // throws if invalid
 
-    const updated = await prisma.deposit.update({
-      where: { id: depositId },
+    // Atomic compare-and-swap: only update if the row is still in the observed
+    // status. count === 0 means another concurrent transition won the race.
+    const { count } = await prisma.deposit.updateMany({
+      where: { id: depositId, status: deposit.status },
       data: { status: "refunded", refundedAt: new Date() },
     });
+
+    if (count === 0) {
+      throw new DepositConcurrentUpdateError(depositId, "refund");
+    }
+
+    // Fetch the updated row to return consistent state.
+    const updated = await this._requireDeposit(depositId);
 
     if (deposit.stripePaymentIntentId) {
       try {
@@ -184,10 +202,20 @@ export class DepositService {
     let updated = deposit;
     if (deposit.status !== "partial_refunded") {
       transitionDeposit(deposit.status, "partial_refunded"); // throws if invalid
-      updated = await prisma.deposit.update({
-        where: { id: depositId },
+
+      // Atomic compare-and-swap: only update if the row is still in the observed
+      // status. count === 0 means another concurrent transition won the race.
+      const { count } = await prisma.deposit.updateMany({
+        where: { id: depositId, status: deposit.status },
         data: { status: "partial_refunded", refundedAt: new Date() },
       });
+
+      if (count === 0) {
+        throw new DepositConcurrentUpdateError(depositId, "refundPartial");
+      }
+
+      // Fetch the updated row to return consistent state.
+      updated = await this._requireDeposit(depositId);
     }
 
     if (deposit.stripePaymentIntentId) {
@@ -244,10 +272,19 @@ export class DepositService {
     const deposit = await this._requireDeposit(depositId);
     transitionDeposit(deposit.status, targetStatus); // throws if invalid
 
-    const updated = await prisma.deposit.update({
-      where: { id: depositId },
+    // Atomic compare-and-swap: only update if the row is still in the observed
+    // status. count === 0 means another concurrent transition won the race.
+    const { count } = await prisma.deposit.updateMany({
+      where: { id: depositId, status: deposit.status },
       data: { status: targetStatus, [timestampField]: new Date() },
     });
+
+    if (count === 0) {
+      throw new DepositConcurrentUpdateError(depositId, action);
+    }
+
+    // Fetch the updated row to return consistent state.
+    const updated = await this._requireDeposit(depositId);
 
     if (deposit.stripePaymentIntentId) {
       try {


### PR DESCRIPTION
## Summary

- Replaces the read-check-write pattern in `apply`, `refund`, `forfeit`, and `refundPartial` with an atomic compare-and-swap using `prisma.deposit.updateMany({ where: { id, status: <observedStatus> } })`.
- A `count === 0` result from `updateMany` means a concurrent transition already changed the row — throws `DepositConcurrentUpdateError` **before** any Stripe call, preventing two different concurrent actions (e.g. `apply` + `refund`) from both hitting the same PaymentIntent with distinct idempotency keys.
- Fetches the updated row via `findUnique` after a successful CAS to return consistent state to callers.
- Adds `DepositConcurrentUpdateError` as a new exported error class.
- Updates all existing deposit service tests and route tests to the `updateMany` mock shape.
- Adds a new concurrency test: two concurrent different transitions on one `held` deposit — exactly one wins, the loser throws, Stripe called once.

## Test plan

- [x] `pnpm lint` — clean (services/reservations)
- [x] `pnpm typecheck` — clean (services/reservations)
- [x] `pnpm test` — 949/949 passing (65 test files)
- [x] `pnpm --filter @mbe/cli start check-adr` — no violations
- [x] `pnpm --filter @mbe/cli start check-deps` — no mismatches
- [x] `pnpm regen` — artifacts regenerated and staged
- [x] `node scripts/detect-instruction-rot.mjs` — no rot

Closes #2507