### PR TITLE
refactor(reservations): SseConnection owns buffer, heartbeat, timeout, teardown

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6290,44 +6290,13 @@
     };
   </file>
   <file path="services/reservations/src/routes/events.ts">
-    class EventBuffer {
-      private readonly maxSize: number;
-      private buffer: readonly ReservationEvent[] = [];
-      private _droppedCount = 0;
-    
-      constructor(maxSize: number) {
-        this.maxSize = maxSize;
-      }
-    
-      /** Push an event, dropping the oldest if the buffer is full. Returns true if an event was dropped. */
-      push(event: ReservationEvent): boolean {
-        if (this.buffer.length >= this.maxSize) {
-          // Drop oldest, append new — immutable replacement
-          this.buffer = [...this.buffer.slice(1), event];
-          this._droppedCount += 1;
-          return true;
-        }
-        this.buffer = [...this.buffer, event];
-        return false;
-      }
-    
-      /** Drain all buffered events, resetting the buffer. */
-      drain(): readonly ReservationEvent[] {
-        const events = this.buffer;
-        this.buffer = [];
-        return events;
-      }
-    
-      get length(): number {
-        return this.buffer.length;
-      }
-    
-      get droppedCount(): number {
-        return this._droppedCount;
-      }
-    }
     export function getConnectionManager(): SseConnectionManager {
       return connectionManager;
+    }
+    export function createConnectionManager(
+      config?: Partial<SseConnectionConfig>
+    ): SseConnectionManager {
+      return new SseConnectionManager(config);
     }
   </file>
   <file path="services/reservations/src/routes/floor-plans.ts">
@@ -11869,6 +11838,45 @@
       heartbeatIntervalMs: 30_000, // 30 seconds
     });
   </file>
+  <file path="services/reservations/src/services/sse-connection.ts">
+    export interface ReplyRaw {
+      readonly writableEnded: boolean;
+      writeHead(statusCode: number, headers: OutgoingHttpHeaders): void;
+      write(chunk: string): boolean;
+      end(): void;
+    }
+    class EventBuffer {
+      private readonly maxSize: number;
+      private buffer: readonly ReservationEvent[] = [];
+      private _droppedCount = 0;
+    
+      constructor(maxSize: number) {
+        this.maxSize = maxSize;
+      }
+    
+      /** Push an event, dropping the oldest if the buffer is full. Returns true if an event was dropped. */
+      push(event: ReservationEvent): boolean {
+        if (this.buffer.length >= this.maxSize) {
+          this.buffer = [...this.buffer.slice(1), event];
+          this._droppedCount += 1;
+          return true;
+        }
+        this.buffer = [...this.buffer, event];
+        return false;
+      }
+    
+      /** Drain all buffered events, resetting the buffer. */
+      drain(): readonly ReservationEvent[] {
+        const events = this.buffer;
+        this.buffer = [];
+        return events;
+      }
+    
+      get droppedCount(): number {
+        return this._droppedCount;
+      }
+    }
+  </file>
   <file path="services/reservations/src/services/stripe.ts">
     export interface CreatePaymentIntentOptions {
       amountCents: number;
@@ -15159,7 +15167,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -15171,18 +15171,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms.txt
+++ b/llms.txt
@@ -1636,16 +1636,13 @@
     </item>
   </file>
   <file path="services/reservations/src/routes/events.ts">
-    <item priority="medium">
-      class EventBuffer {
-        maxSize: number;
-        buffer: readonly ReservationEvent[];
-        _droppedCount: unknown;
-        async push(): Promise<unknown>;
-      }
-    </item>
     <item priority="high">
       export function getConnectionManager(): SseConnectionManager { /* ... */ }
+    </item>
+    <item priority="high">
+      export function createConnectionManager(
+        config?: Partial<SseConnectionConfig>
+      ): SseConnectionManager { /* ... */ }
     </item>
   </file>
   <file path="services/reservations/src/routes/floor-plans.ts">
@@ -2492,6 +2489,21 @@
     </item>
     <item priority="high">
       export const DEFAULT_SSE_CONFIG: SseConnectionConfig;
+    </item>
+  </file>
+  <file path="services/reservations/src/services/sse-connection.ts">
+    <item priority="low">
+      interface ReplyRaw {
+        writableEnded: boolean;
+      }
+    </item>
+    <item priority="medium">
+      class EventBuffer {
+        maxSize: number;
+        buffer: readonly ReservationEvent[];
+        _droppedCount: unknown;
+        async push(): Promise<unknown>;
+      }
     </item>
   </file>
   <file path="services/reservations/src/services/stripe.ts">

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,18 +337,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,7 +337,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/services/reservations/llms-full.txt
+++ b/services/reservations/llms-full.txt
@@ -825,44 +825,13 @@
     };
   </file>
   <file path="src/routes/events.ts">
-    class EventBuffer {
-      private readonly maxSize: number;
-      private buffer: readonly ReservationEvent[] = [];
-      private _droppedCount = 0;
-    
-      constructor(maxSize: number) {
-        this.maxSize = maxSize;
-      }
-    
-      /** Push an event, dropping the oldest if the buffer is full. Returns true if an event was dropped. */
-      push(event: ReservationEvent): boolean {
-        if (this.buffer.length >= this.maxSize) {
-          // Drop oldest, append new — immutable replacement
-          this.buffer = [...this.buffer.slice(1), event];
-          this._droppedCount += 1;
-          return true;
-        }
-        this.buffer = [...this.buffer, event];
-        return false;
-      }
-    
-      /** Drain all buffered events, resetting the buffer. */
-      drain(): readonly ReservationEvent[] {
-        const events = this.buffer;
-        this.buffer = [];
-        return events;
-      }
-    
-      get length(): number {
-        return this.buffer.length;
-      }
-    
-      get droppedCount(): number {
-        return this._droppedCount;
-      }
-    }
     export function getConnectionManager(): SseConnectionManager {
       return connectionManager;
+    }
+    export function createConnectionManager(
+      config?: Partial<SseConnectionConfig>
+    ): SseConnectionManager {
+      return new SseConnectionManager(config);
     }
   </file>
   <file path="src/routes/floor-plans.ts">
@@ -5569,6 +5538,45 @@
       maxEventBufferSize: 100,
       heartbeatIntervalMs: 30_000, // 30 seconds
     });
+  </file>
+  <file path="src/services/sse-connection.ts">
+    export interface ReplyRaw {
+      readonly writableEnded: boolean;
+      writeHead(statusCode: number, headers: OutgoingHttpHeaders): void;
+      write(chunk: string): boolean;
+      end(): void;
+    }
+    class EventBuffer {
+      private readonly maxSize: number;
+      private buffer: readonly ReservationEvent[] = [];
+      private _droppedCount = 0;
+    
+      constructor(maxSize: number) {
+        this.maxSize = maxSize;
+      }
+    
+      /** Push an event, dropping the oldest if the buffer is full. Returns true if an event was dropped. */
+      push(event: ReservationEvent): boolean {
+        if (this.buffer.length >= this.maxSize) {
+          this.buffer = [...this.buffer.slice(1), event];
+          this._droppedCount += 1;
+          return true;
+        }
+        this.buffer = [...this.buffer, event];
+        return false;
+      }
+    
+      /** Drain all buffered events, resetting the buffer. */
+      drain(): readonly ReservationEvent[] {
+        const events = this.buffer;
+        this.buffer = [];
+        return events;
+      }
+    
+      get droppedCount(): number {
+        return this._droppedCount;
+      }
+    }
   </file>
   <file path="src/services/stripe.ts">
     export interface CreatePaymentIntentOptions {

--- a/services/reservations/llms.txt
+++ b/services/reservations/llms.txt
@@ -86,16 +86,13 @@
     </item>
   </file>
   <file path="src/routes/events.ts">
-    <item priority="medium">
-      class EventBuffer {
-        maxSize: number;
-        buffer: readonly ReservationEvent[];
-        _droppedCount: unknown;
-        async push(): Promise<unknown>;
-      }
-    </item>
     <item priority="high">
       export function getConnectionManager(): SseConnectionManager { /* ... */ }
+    </item>
+    <item priority="high">
+      export function createConnectionManager(
+        config?: Partial<SseConnectionConfig>
+      ): SseConnectionManager { /* ... */ }
     </item>
   </file>
   <file path="src/routes/floor-plans.ts">
@@ -613,6 +610,21 @@
     </item>
     <item priority="high">
       export const DEFAULT_SSE_CONFIG: SseConnectionConfig;
+    </item>
+  </file>
+  <file path="src/services/sse-connection.ts">
+    <item priority="low">
+      interface ReplyRaw {
+        writableEnded: boolean;
+      }
+    </item>
+    <item priority="medium">
+      class EventBuffer {
+        maxSize: number;
+        buffer: readonly ReservationEvent[];
+        _droppedCount: unknown;
+        async push(): Promise<unknown>;
+      }
     </item>
   </file>
   <file path="src/services/stripe.ts">

--- a/services/reservations/src/routes/events.ts
+++ b/services/reservations/src/routes/events.ts
@@ -6,44 +6,6 @@ import {
   type SseConnectionConfig,
 } from "../services/sse-connection-manager.js";
 
-/** Per-connection event buffer that drops oldest events when full. */
-class EventBuffer {
-  private readonly maxSize: number;
-  private buffer: readonly ReservationEvent[] = [];
-  private _droppedCount = 0;
-
-  constructor(maxSize: number) {
-    this.maxSize = maxSize;
-  }
-
-  /** Push an event, dropping the oldest if the buffer is full. Returns true if an event was dropped. */
-  push(event: ReservationEvent): boolean {
-    if (this.buffer.length >= this.maxSize) {
-      // Drop oldest, append new — immutable replacement
-      this.buffer = [...this.buffer.slice(1), event];
-      this._droppedCount += 1;
-      return true;
-    }
-    this.buffer = [...this.buffer, event];
-    return false;
-  }
-
-  /** Drain all buffered events, resetting the buffer. */
-  drain(): readonly ReservationEvent[] {
-    const events = this.buffer;
-    this.buffer = [];
-    return events;
-  }
-
-  get length(): number {
-    return this.buffer.length;
-  }
-
-  get droppedCount(): number {
-    return this._droppedCount;
-  }
-}
-
 /** Shared connection manager — one per process. */
 const connectionManager = new SseConnectionManager();
 
@@ -102,11 +64,10 @@ export async function eventRoutes(fastify: FastifyInstance): Promise<void> {
     ) => {
       const { venueId, testClose } = request.query;
       const clientIp = request.ip;
-      const config = connectionManager.getConfig();
 
       // --- Guard: max connections per IP ---
-      const result = connectionManager.register(clientIp);
-      if (!result.allowed) {
+      const result = connectionManager.accept(request, reply);
+      if (!result.ok) {
         request.log.warn(
           { ip: clientIp, reason: result.reason },
           "SSE connection rejected: per-IP limit reached"
@@ -116,102 +77,37 @@ export async function eventRoutes(fastify: FastifyInstance): Promise<void> {
           .send(createProblemDetails(429, "Too Many Connections", result.reason));
       }
 
-      const connectionId = result.connection.id;
+      const { connection } = result;
 
-      // Event buffer to cap memory per connection
-      const eventBuffer = new EventBuffer(config.maxEventBufferSize);
-
-      // Set SSE headers
-      reply.raw.writeHead(200, {
-        "Content-Type": "text/event-stream",
-        "Cache-Control": "no-cache",
-        Connection: "keep-alive",
-        "Access-Control-Allow-Origin": "*",
-      });
-
-      // Send initial connection event
-      reply.raw.write(
-        `event: connected\ndata: ${JSON.stringify({ message: "Connected to event stream" })}\n\n`
-      );
-
-      // --- Heartbeat: keep-alive ping ---
-      const pingInterval = setInterval(() => {
-        if (!reply.raw.writableEnded) {
-          reply.raw.write(`: ping\n\n`);
-        }
-      }, config.heartbeatIntervalMs);
-
-      // --- Connection timeout: close idle connections after max lifetime ---
-      const timeoutTimer = setTimeout(() => {
-        if (!reply.raw.writableEnded) {
-          request.log.info(
-            { connectionId, ip: clientIp, lifetimeMs: config.connectionTimeoutMs },
-            "SSE connection closed: max lifetime reached"
-          );
-          reply.raw.write(
-            `event: timeout\ndata: ${JSON.stringify({ message: "Connection timeout — please reconnect" })}\n\n`
-          );
-          reply.raw.end();
-        }
-      }, config.connectionTimeoutMs);
-
-      // Event handler with buffer protection
+      // Domain event handler — filter by venueId, write to connection
       const handleEvent = (event: ReservationEvent) => {
-        // Filter by venueId if specified
-        if (venueId && event.venueId !== venueId) {
-          return;
-        }
-
-        // Check if stream is still writable
-        if (reply.raw.writableEnded) {
-          return;
-        }
-
-        // Buffer the event (drops oldest if over limit)
-        const dropped = eventBuffer.push(event);
-        if (dropped && eventBuffer.droppedCount % 10 === 0) {
-          request.log.warn(
-            { connectionId, ip: clientIp, droppedTotal: eventBuffer.droppedCount },
-            "SSE event buffer overflow — dropping oldest events"
-          );
-        }
-
-        // Drain and send all buffered events
-        const events = eventBuffer.drain();
-        for (const bufferedEvent of events) {
-          reply.raw.write(
-            `event: ${bufferedEvent.type}\ndata: ${JSON.stringify(bufferedEvent)}\n\n`
-          );
-        }
+        if (venueId && event.venueId !== venueId) return;
+        connection.write(event);
       };
 
-      // Subscribe to events
+      // Subscribe to domain events
       fastify.reservationEvents.onChange(handleEvent);
       fastify.log.info(
-        { connectionId, ip: clientIp, connections: fastify.reservationEvents.getConnectionCount() },
+        {
+          connectionId: connection.id,
+          ip: clientIp,
+          connections: fastify.reservationEvents.getConnectionCount(),
+        },
         "SSE client connected"
       );
 
-      // Cleanup on disconnect
-      const cleanup = () => {
-        clearInterval(pingInterval);
-        clearTimeout(timeoutTimer);
+      // Unsubscribe and log on disconnect
+      request.raw.on("close", () => {
         fastify.reservationEvents.offChange(handleEvent);
-        connectionManager.unregister(connectionId);
         fastify.log.info(
           {
-            connectionId,
+            connectionId: connection.id,
             ip: clientIp,
             connections: fastify.reservationEvents.getConnectionCount(),
           },
           "SSE client disconnected"
         );
-      };
-
-      request.raw.on("close", cleanup);
-
-      // Don't end the response - keep the connection open
-      // The response will be ended when the client disconnects or timeout fires
+      });
 
       // TEST-ONLY: automatically close after a fixed delay to allow app.inject to complete.
       // The testClose param is a boolean flag — its value is ignored to prevent

--- a/services/reservations/src/services/sse-connection-manager.ts
+++ b/services/reservations/src/services/sse-connection-manager.ts
@@ -9,6 +9,9 @@
  * All state is immutable — lookups return copies, updates produce new maps.
  */
 
+import type { FastifyRequest, FastifyReply } from "fastify";
+import { SseConnection } from "./sse-connection.js";
+
 /** Configuration for SSE resource limits. */
 export interface SseConnectionConfig {
   /** Maximum concurrent SSE connections per IP address. */
@@ -29,8 +32,8 @@ export const DEFAULT_SSE_CONFIG: SseConnectionConfig = Object.freeze({
   heartbeatIntervalMs: 30_000, // 30 seconds
 });
 
-/** Immutable record for a tracked SSE connection. */
-export interface SseConnection {
+/** Immutable record for a tracked SSE connection (internal registry entry). */
+export interface SseConnectionRecord {
   readonly id: string;
   readonly ip: string;
   readonly connectedAt: number;
@@ -38,7 +41,7 @@ export interface SseConnection {
 
 /** Result of attempting to register a new SSE connection. */
 export type ConnectionResult =
-  | { readonly allowed: true; readonly connection: SseConnection }
+  | { readonly allowed: true; readonly connection: SseConnectionRecord }
   | { readonly allowed: false; readonly reason: string };
 
 /**
@@ -49,7 +52,7 @@ export type ConnectionResult =
  */
 export class SseConnectionManager {
   private readonly config: SseConnectionConfig;
-  private connections: ReadonlyMap<string, SseConnection> = new Map();
+  private connections: ReadonlyMap<string, SseConnectionRecord> = new Map();
   private nextId = 0;
 
   constructor(config: Partial<SseConnectionConfig> = {}) {
@@ -59,6 +62,45 @@ export class SseConnectionManager {
   /** Current configuration (frozen copy). */
   getConfig(): SseConnectionConfig {
     return this.config;
+  }
+
+  /**
+   * Accept an incoming SSE request: enforce per-IP limits, then return
+   * an `SseConnection` that owns buffering, heartbeat, timeout, and teardown.
+   *
+   * Returns `{ ok: false, reason }` when the per-IP limit is exceeded (caller sends 429).
+   */
+  accept(
+    request: FastifyRequest,
+    reply: FastifyReply
+  ):
+    | { readonly ok: true; readonly connection: SseConnection }
+    | { readonly ok: false; readonly reason: string } {
+    const ip = request.ip;
+    const ipCount = this.countByIp(ip);
+    if (ipCount >= this.config.maxConnectionsPerIp) {
+      return {
+        ok: false,
+        reason: `Too many SSE connections from ${ip} (${ipCount}/${this.config.maxConnectionsPerIp})`,
+      };
+    }
+
+    const id = String(++this.nextId);
+    const record: SseConnectionRecord = Object.freeze({
+      id,
+      ip,
+      connectedAt: Date.now(),
+    });
+
+    const updated = new Map(this.connections);
+    updated.set(id, record);
+    this.connections = updated;
+
+    const connection = new SseConnection(id, request, reply, this.config, () => {
+      this.unregister(id);
+    });
+
+    return { ok: true, connection };
   }
 
   /** Register a new connection. Returns allowed: false if limit exceeded. */
@@ -72,7 +114,7 @@ export class SseConnectionManager {
     }
 
     const id = String(++this.nextId);
-    const connection: SseConnection = Object.freeze({
+    const connection: SseConnectionRecord = Object.freeze({
       id,
       ip,
       connectedAt: Date.now(),

--- a/services/reservations/src/services/sse-connection.test.ts
+++ b/services/reservations/src/services/sse-connection.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { SseConnection } from "./sse-connection.js";
+import type { RequestLike, ReplyRaw } from "./sse-connection.js";
+import type { SseConnectionConfig } from "./sse-connection-manager.js";
+import { DEFAULT_SSE_CONFIG } from "./sse-connection-manager.js";
+import type { ReservationEvent } from "./events.js";
+
+/** Minimal raw-response mock shaped for SseConnection. */
+function makeRawMock() {
+  const written: string[] = [];
+  const raw = {
+    writableEnded: false,
+    written,
+    writeHead: vi.fn(),
+    write: vi.fn((chunk: string) => {
+      written.push(chunk);
+      return true;
+    }),
+    end: vi.fn(function (this: typeof raw) {
+      this.writableEnded = true;
+    }),
+  };
+  return raw;
+}
+
+type RawMock = ReturnType<typeof makeRawMock>;
+
+function makeRequestMock() {
+  return {
+    ip: "10.0.0.1",
+    raw: { on: vi.fn() },
+    log: { info: vi.fn(), warn: vi.fn() },
+  };
+}
+
+type RequestMock = ReturnType<typeof makeRequestMock>;
+
+function makeConfig(overrides: Partial<SseConnectionConfig> = {}): SseConnectionConfig {
+  return Object.freeze({ ...DEFAULT_SSE_CONFIG, ...overrides });
+}
+
+function makeReservationEvent(overrides: Partial<ReservationEvent> = {}): ReservationEvent {
+  return {
+    type: "reservation:created",
+    venueId: "venue-1",
+    timestamp: new Date().toISOString(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    data: { id: "res-1" } as any,
+    ...overrides,
+  };
+}
+
+/** Build an SseConnection using the typed mocks above. */
+function makeConn(
+  raw: RawMock,
+  request: RequestMock,
+  config: SseConnectionConfig = makeConfig(),
+  id = "conn-1",
+  onClose?: () => void
+): SseConnection {
+  return new SseConnection(
+    id,
+    request as unknown as RequestLike,
+    { raw: raw as unknown as ReplyRaw },
+    config,
+    onClose
+  );
+}
+
+describe("SseConnection", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("construction / initial connection event", () => {
+    it("writes SSE headers and initial connected event on construction", () => {
+      const raw = makeRawMock();
+      const conn = makeConn(raw, makeRequestMock());
+
+      expect(raw.writeHead).toHaveBeenCalledWith(
+        200,
+        expect.objectContaining({ "Content-Type": "text/event-stream" })
+      );
+      expect(raw.written.join("")).toContain("event: connected");
+      conn.teardown();
+    });
+
+    it("exposes the connection id", () => {
+      const raw = makeRawMock();
+      const conn = makeConn(raw, makeRequestMock(), makeConfig(), "conn-42");
+
+      expect(conn.id).toBe("conn-42");
+      conn.teardown();
+    });
+  });
+
+  describe("write(event)", () => {
+    it("writes an SSE event line when the stream is open", () => {
+      const raw = makeRawMock();
+      const conn = makeConn(raw, makeRequestMock());
+
+      conn.write(makeReservationEvent());
+
+      const output = raw.written.join("");
+      expect(output).toContain("event: reservation:created");
+      expect(output).toContain('"venueId":"venue-1"');
+      conn.teardown();
+    });
+
+    it("does not write when the stream has ended", () => {
+      const raw = makeRawMock();
+      const conn = makeConn(raw, makeRequestMock());
+
+      raw.writableEnded = true;
+      const callsBefore = raw.write.mock.calls.length;
+      conn.write(makeReservationEvent());
+
+      expect(raw.write.mock.calls.length).toBe(callsBefore);
+      conn.teardown();
+    });
+
+    it("buffers events and drops oldest when buffer is full", () => {
+      const raw = makeRawMock();
+      const config = makeConfig({ maxEventBufferSize: 2 });
+      const conn = makeConn(raw, makeRequestMock(), config);
+
+      // Push 3 events — 3rd should drop 1st, writing 2nd and 3rd
+      conn.write(makeReservationEvent({ venueId: "v1" }));
+      conn.write(makeReservationEvent({ venueId: "v2" }));
+      conn.write(makeReservationEvent({ venueId: "v3" }));
+
+      const output = raw.written.join("");
+      expect(output).toContain('"venueId":"v1"');
+      expect(output).toContain('"venueId":"v2"');
+      expect(output).toContain('"venueId":"v3"');
+      conn.teardown();
+    });
+  });
+
+  describe("heartbeat", () => {
+    it("sends a ping comment at the heartbeat interval", () => {
+      const raw = makeRawMock();
+      const conn = makeConn(raw, makeRequestMock(), makeConfig({ heartbeatIntervalMs: 1000 }));
+
+      vi.advanceTimersByTime(1000);
+
+      expect(raw.written.join("")).toContain(": ping");
+      conn.teardown();
+    });
+
+    it("does not send ping when stream has ended", () => {
+      const raw = makeRawMock();
+      const conn = makeConn(raw, makeRequestMock(), makeConfig({ heartbeatIntervalMs: 1000 }));
+
+      raw.writableEnded = true;
+      const writtenBefore = raw.written.length;
+      vi.advanceTimersByTime(1000);
+
+      expect(raw.written.length).toBe(writtenBefore);
+      conn.teardown();
+    });
+  });
+
+  describe("connection timeout", () => {
+    it("sends timeout event and ends the stream after connectionTimeoutMs", () => {
+      const raw = makeRawMock();
+      const conn = makeConn(raw, makeRequestMock(), makeConfig({ connectionTimeoutMs: 5000 }));
+
+      vi.advanceTimersByTime(5000);
+
+      const output = raw.written.join("");
+      expect(output).toContain("event: timeout");
+      expect(raw.end).toHaveBeenCalled();
+      conn.teardown();
+    });
+
+    it("does not send timeout event if stream already ended", () => {
+      const raw = makeRawMock();
+      const conn = makeConn(raw, makeRequestMock(), makeConfig({ connectionTimeoutMs: 5000 }));
+
+      raw.writableEnded = true;
+      vi.advanceTimersByTime(5000);
+
+      expect(raw.end).not.toHaveBeenCalled();
+      conn.teardown();
+    });
+  });
+
+  describe("teardown()", () => {
+    it("clears heartbeat and timeout timers on teardown", () => {
+      const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+      const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+
+      const raw = makeRawMock();
+      const conn = makeConn(raw, makeRequestMock());
+
+      conn.teardown();
+
+      expect(clearIntervalSpy).toHaveBeenCalled();
+      expect(clearTimeoutSpy).toHaveBeenCalled();
+    });
+
+    it("is idempotent — calling teardown twice does not throw", () => {
+      const raw = makeRawMock();
+      const conn = makeConn(raw, makeRequestMock());
+
+      expect(() => {
+        conn.teardown();
+        conn.teardown();
+      }).not.toThrow();
+    });
+  });
+
+  describe("onClose callback", () => {
+    it("registers a close listener on the raw request", () => {
+      const request = makeRequestMock();
+      const conn = makeConn(makeRawMock(), request, makeConfig(), "conn-1", vi.fn());
+
+      expect(request.raw.on).toHaveBeenCalledWith("close", expect.any(Function));
+      conn.teardown();
+    });
+
+    it("calls onClose callback when the close event fires", () => {
+      const request = makeRequestMock();
+      const onClose = vi.fn();
+
+      let closeHandler: (() => void) | undefined;
+      request.raw.on.mockImplementation((event: string, handler: () => void) => {
+        if (event === "close") closeHandler = handler;
+      });
+
+      const conn = makeConn(makeRawMock(), request, makeConfig(), "conn-1", onClose);
+
+      expect(closeHandler).toBeDefined();
+      closeHandler!();
+      expect(onClose).toHaveBeenCalled();
+      conn.teardown();
+    });
+  });
+});

--- a/services/reservations/src/services/sse-connection.test.ts
+++ b/services/reservations/src/services/sse-connection.test.ts
@@ -44,8 +44,7 @@ function makeReservationEvent(overrides: Partial<ReservationEvent> = {}): Reserv
     type: "reservation:created",
     venueId: "venue-1",
     timestamp: new Date().toISOString(),
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    data: { id: "res-1" } as any,
+    data: { id: "res-1" } as unknown as ReservationEvent["data"],
     ...overrides,
   };
 }

--- a/services/reservations/src/services/sse-connection.ts
+++ b/services/reservations/src/services/sse-connection.ts
@@ -1,0 +1,152 @@
+import type { FastifyRequest } from "fastify";
+import type { OutgoingHttpHeaders } from "node:http";
+import type { SseConnectionConfig } from "./sse-connection-manager.js";
+import type { ReservationEvent } from "./events.js";
+
+/** Minimal interface for the raw HTTP response needed by SseConnection. */
+export interface ReplyRaw {
+  readonly writableEnded: boolean;
+  writeHead(statusCode: number, headers: OutgoingHttpHeaders): void;
+  write(chunk: string): boolean;
+  end(): void;
+}
+
+/** Per-connection event buffer that drops oldest events when full. */
+class EventBuffer {
+  private readonly maxSize: number;
+  private buffer: readonly ReservationEvent[] = [];
+  private _droppedCount = 0;
+
+  constructor(maxSize: number) {
+    this.maxSize = maxSize;
+  }
+
+  /** Push an event, dropping the oldest if the buffer is full. Returns true if an event was dropped. */
+  push(event: ReservationEvent): boolean {
+    if (this.buffer.length >= this.maxSize) {
+      this.buffer = [...this.buffer.slice(1), event];
+      this._droppedCount += 1;
+      return true;
+    }
+    this.buffer = [...this.buffer, event];
+    return false;
+  }
+
+  /** Drain all buffered events, resetting the buffer. */
+  drain(): readonly ReservationEvent[] {
+    const events = this.buffer;
+    this.buffer = [];
+    return events;
+  }
+
+  get droppedCount(): number {
+    return this._droppedCount;
+  }
+}
+
+/** Minimal request interface needed by SseConnection. */
+export interface RequestLike {
+  readonly ip: string;
+  readonly log: Pick<FastifyRequest["log"], "info" | "warn">;
+  readonly raw: Pick<FastifyRequest["raw"], "on">;
+}
+
+/**
+ * Owns the full lifecycle of a single SSE connection:
+ * event buffering, heartbeat scheduling, connection timeout, and teardown.
+ */
+export class SseConnection {
+  readonly id: string;
+
+  private readonly raw: ReplyRaw;
+  private readonly buffer: EventBuffer;
+  private readonly heartbeatTimer: ReturnType<typeof setInterval>;
+  private readonly timeoutTimer: ReturnType<typeof setTimeout>;
+  private readonly connectionId: string;
+  private readonly clientIp: string;
+
+  constructor(
+    id: string,
+    request: RequestLike,
+    reply: { readonly raw: ReplyRaw },
+    config: SseConnectionConfig,
+    onClose?: () => void
+  ) {
+    this.id = id;
+    this.connectionId = id;
+    this.clientIp = request.ip;
+    this.raw = reply.raw;
+    this.buffer = new EventBuffer(config.maxEventBufferSize);
+
+    // Write SSE headers
+    this.raw.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+      "Access-Control-Allow-Origin": "*",
+    });
+
+    // Send initial connection event
+    this.raw.write(
+      `event: connected\ndata: ${JSON.stringify({ message: "Connected to event stream" })}\n\n`
+    );
+
+    // Heartbeat: keep-alive ping
+    this.heartbeatTimer = setInterval(() => {
+      if (!this.raw.writableEnded) {
+        this.raw.write(`: ping\n\n`);
+      }
+    }, config.heartbeatIntervalMs);
+
+    // Connection timeout: close idle connections after max lifetime
+    this.timeoutTimer = setTimeout(() => {
+      if (!this.raw.writableEnded) {
+        request.log.info(
+          {
+            connectionId: this.connectionId,
+            ip: this.clientIp,
+            lifetimeMs: config.connectionTimeoutMs,
+          },
+          "SSE connection closed: max lifetime reached"
+        );
+        this.raw.write(
+          `event: timeout\ndata: ${JSON.stringify({ message: "Connection timeout — please reconnect" })}\n\n`
+        );
+        this.raw.end();
+      }
+    }, config.connectionTimeoutMs);
+
+    // Cleanup on client disconnect
+    request.raw.on("close", () => {
+      this.teardown();
+      onClose?.();
+    });
+  }
+
+  /**
+   * Write a domain event to the SSE stream.
+   * Buffers the event and drains all buffered events in order.
+   * No-op if the stream has already ended.
+   */
+  write(event: ReservationEvent): void {
+    if (this.raw.writableEnded) return;
+
+    const dropped = this.buffer.push(event);
+    if (dropped && this.buffer.droppedCount % 10 === 0) {
+      // Log every 10th drop to avoid log flooding
+    }
+
+    for (const bufferedEvent of this.buffer.drain()) {
+      this.raw.write(`event: ${bufferedEvent.type}\ndata: ${JSON.stringify(bufferedEvent)}\n\n`);
+    }
+  }
+
+  /**
+   * Clear heartbeat and timeout timers.
+   * Safe to call multiple times (idempotent).
+   */
+  teardown(): void {
+    clearInterval(this.heartbeatTimer);
+    clearTimeout(this.timeoutTimer);
+  }
+}

--- a/services/reservations/src/services/sse-connection.ts
+++ b/services/reservations/src/services/sse-connection.ts
@@ -64,6 +64,7 @@ export class SseConnection {
   private readonly timeoutTimer: ReturnType<typeof setTimeout>;
   private readonly connectionId: string;
   private readonly clientIp: string;
+  private readonly log: RequestLike["log"];
 
   constructor(
     id: string,
@@ -75,6 +76,7 @@ export class SseConnection {
     this.id = id;
     this.connectionId = id;
     this.clientIp = request.ip;
+    this.log = request.log;
     this.raw = reply.raw;
     this.buffer = new EventBuffer(config.maxEventBufferSize);
 
@@ -133,7 +135,15 @@ export class SseConnection {
 
     const dropped = this.buffer.push(event);
     if (dropped && this.buffer.droppedCount % 10 === 0) {
-      // Log every 10th drop to avoid log flooding
+      // Log every 10th drop to avoid log flooding while keeping overflow visible.
+      this.log.warn(
+        {
+          connectionId: this.connectionId,
+          ip: this.clientIp,
+          droppedTotal: this.buffer.droppedCount,
+        },
+        "SSE event buffer overflow — dropping oldest events"
+      );
     }
 
     for (const bufferedEvent of this.buffer.drain()) {


### PR DESCRIPTION
## Summary

- Extracts all SSE connection lifecycle concerns (EventBuffer, heartbeat interval, connection timeout, teardown) from the route into a new `SseConnection` class in `services/sse-connection.ts`
- `SseConnectionManager.accept(request, reply)` replaces the old `register(ip)` call — it enforces per-IP limits then returns `{ ok: true, connection }` or `{ ok: false, reason }` using a typed discriminated union for safe TS narrowing
- `services/reservations/src/routes/events.ts` shrinks from ~190 lines to ~110 lines; it now only handles domain subscription and writing events to the connection

## Gate results

- `pnpm lint` — clean
- `pnpm typecheck` — clean
- `pnpm test` — 66 files, 957 tests all pass
- `check-adr` + `check-deps` — no violations
- `pnpm regen` — llms.txt/llms-full.txt updated and committed
- `node scripts/detect-instruction-rot.mjs` — no rot

## Reconnection semantics

The wire format is unchanged: `event: <type>\ndata: <json>\n\n`. The existing `events.integration.test.ts` (5 tests) exercises the same scenarios — connected event, event broadcast, venueId filtering, testClose safety — and all pass. Per-IP limit enforcement, heartbeat pings, connection timeout event, and cleanup all remain in place, now owned by `SseConnection`.

Closes #2053