### PR TITLE
fix(security): replace hardcoded HMAC fallback in manage-token with startup assertion

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -15172,18 +15172,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2150,6 +2150,15 @@
   </file>
   </section>
   <section priority="medium" role="config">
+  <file path="services/reservations/src/config/manage-token.ts">
+    export interface ManageTokenConfig {
+      secret: string;
+    }
+    interface ManageTokenConfigInput {
+      nodeEnv: string | undefined;
+      secret: string | undefined;
+    }
+  </file>
   <file path="services/reservations/src/config/stripe.ts">
     export interface StripeConfig {
       secretKey: string;
@@ -15163,7 +15172,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),
@@ -15661,6 +15681,13 @@
         nodeEnv: process.env.NODE_ENV,
         secretKey: process.env.STRIPE_SECRET_KEY,
         webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
+      });
+    
+      // Validate manage-token HMAC secret at startup — throws in production if missing.
+      // In test/dev, warns but continues to allow local development without real tokens.
+      getManageTokenConfig({
+        nodeEnv: process.env.NODE_ENV,
+        secret: process.env.MANAGE_TOKEN_SECRET,
       });
     
       const fastify = await createServiceApp(

--- a/llms.txt
+++ b/llms.txt
@@ -547,6 +547,19 @@
   </file>
   </section>
   <section priority="medium" role="config">
+  <file path="services/reservations/src/config/manage-token.ts">
+    <item priority="low">
+      interface ManageTokenConfig {
+        secret: string;
+      }
+    </item>
+    <item priority="high">
+      interface ManageTokenConfigInput {
+        nodeEnv: string | undefined;
+        secret: string | undefined;
+      }
+    </item>
+  </file>
   <file path="services/reservations/src/config/stripe.ts">
     <item priority="low">
       interface StripeConfig {

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,18 +337,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,7 +337,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/services/reservations/.env.example
+++ b/services/reservations/.env.example
@@ -16,8 +16,8 @@ CORS_ORIGINS=http://localhost:3000
 AUTH_AUTHORITY=https://your-tenant.auth0.com
 AUTH_AUDIENCE=https://api.mattbutlerengineering.com
 
-# Guest self-service manage page
-# MANAGE_TOKEN_SECRET=change-me-in-production
+# Guest self-service manage page (REQUIRED in production — use a strong random secret)
+MANAGE_TOKEN_SECRET=change-me-in-prod
 
 # Post-visit email unsubscribe tokens
 # UNSUBSCRIBE_TOKEN_SECRET=change-me-in-production

--- a/services/reservations/llms-full.txt
+++ b/services/reservations/llms-full.txt
@@ -1,5 +1,14 @@
 <codebase path="services/reservations">
   <section priority="medium" role="config">
+  <file path="src/config/manage-token.ts">
+    export interface ManageTokenConfig {
+      secret: string;
+    }
+    interface ManageTokenConfigInput {
+      nodeEnv: string | undefined;
+      secret: string | undefined;
+    }
+  </file>
   <file path="src/config/stripe.ts">
     export interface StripeConfig {
       secretKey: string;
@@ -5890,6 +5899,13 @@
         nodeEnv: process.env.NODE_ENV,
         secretKey: process.env.STRIPE_SECRET_KEY,
         webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
+      });
+    
+      // Validate manage-token HMAC secret at startup — throws in production if missing.
+      // In test/dev, warns but continues to allow local development without real tokens.
+      getManageTokenConfig({
+        nodeEnv: process.env.NODE_ENV,
+        secret: process.env.MANAGE_TOKEN_SECRET,
       });
     
       const fastify = await createServiceApp(

--- a/services/reservations/llms.txt
+++ b/services/reservations/llms.txt
@@ -1,5 +1,18 @@
 <codebase path="services/reservations">
   <section priority="medium" role="config">
+  <file path="src/config/manage-token.ts">
+    <item priority="low">
+      interface ManageTokenConfig {
+        secret: string;
+      }
+    </item>
+    <item priority="high">
+      interface ManageTokenConfigInput {
+        nodeEnv: string | undefined;
+        secret: string | undefined;
+      }
+    </item>
+  </file>
   <file path="src/config/stripe.ts">
     <item priority="low">
       interface StripeConfig {

--- a/services/reservations/src/app.ts
+++ b/services/reservations/src/app.ts
@@ -44,6 +44,7 @@ import {
 import { createLapsedGuestMonitor } from "./services/lapsed-guest-cron.js";
 import { prisma } from "./services/database.js";
 import { getStripeConfig } from "./config/stripe.js";
+import { getManageTokenConfig } from "./config/manage-token.js";
 import { ReservationEventEmitter } from "./services/events.js";
 
 export interface ReservationsAppOptions extends AppOptions {
@@ -64,6 +65,13 @@ export async function buildApp(options: ReservationsAppOptions = {}): Promise<Fa
     nodeEnv: process.env.NODE_ENV,
     secretKey: process.env.STRIPE_SECRET_KEY,
     webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
+  });
+
+  // Validate manage-token HMAC secret at startup — throws in production if missing.
+  // In test/dev, warns but continues to allow local development without real tokens.
+  getManageTokenConfig({
+    nodeEnv: process.env.NODE_ENV,
+    secret: process.env.MANAGE_TOKEN_SECRET,
   });
 
   const fastify = await createServiceApp(

--- a/services/reservations/src/config/manage-token.test.ts
+++ b/services/reservations/src/config/manage-token.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { getManageTokenConfig } from "./manage-token.js";
+
+describe("getManageTokenConfig", () => {
+  describe("in production (NODE_ENV=production)", () => {
+    it("throws when MANAGE_TOKEN_SECRET is absent", () => {
+      expect(() => getManageTokenConfig({ nodeEnv: "production", secret: undefined })).toThrow(
+        /MANAGE_TOKEN_SECRET/
+      );
+    });
+
+    it("throws when MANAGE_TOKEN_SECRET is empty string", () => {
+      expect(() => getManageTokenConfig({ nodeEnv: "production", secret: "" })).toThrow(
+        /MANAGE_TOKEN_SECRET/
+      );
+    });
+
+    it("returns the secret when present", () => {
+      const config = getManageTokenConfig({
+        nodeEnv: "production",
+        secret: "a-real-prod-secret",
+      });
+      expect(config.secret).toBe("a-real-prod-secret");
+    });
+  });
+
+  describe("in non-production (NODE_ENV=development)", () => {
+    it("allows absent secret with a warning (does not throw)", () => {
+      const config = getManageTokenConfig({ nodeEnv: "development", secret: undefined });
+      expect(config.secret).toBe("");
+    });
+
+    it("allows empty secret with a warning (does not throw)", () => {
+      const config = getManageTokenConfig({ nodeEnv: "development", secret: "" });
+      expect(config.secret).toBe("");
+    });
+
+    it("returns the provided secret when set", () => {
+      const config = getManageTokenConfig({ nodeEnv: "development", secret: "dev-secret" });
+      expect(config.secret).toBe("dev-secret");
+    });
+  });
+
+  describe("in test environment (NODE_ENV=test)", () => {
+    it("allows absent secret without throwing", () => {
+      const config = getManageTokenConfig({ nodeEnv: "test", secret: undefined });
+      expect(config.secret).toBe("");
+    });
+  });
+});

--- a/services/reservations/src/config/manage-token.ts
+++ b/services/reservations/src/config/manage-token.ts
@@ -1,0 +1,35 @@
+export interface ManageTokenConfig {
+  secret: string;
+}
+
+interface ManageTokenConfigInput {
+  nodeEnv: string | undefined;
+  secret: string | undefined;
+}
+
+/**
+ * Validates the MANAGE_TOKEN_SECRET environment variable and returns a typed config.
+ *
+ * In production: throws if MANAGE_TOKEN_SECRET is absent or empty.
+ * In non-production: warns loudly but allows empty values (local dev without real tokens).
+ */
+export function getManageTokenConfig(input: ManageTokenConfigInput): ManageTokenConfig {
+  const isProduction = input.nodeEnv === "production";
+  const secret = input.secret ?? "";
+
+  if (isProduction) {
+    if (!secret) {
+      throw new Error(
+        "MANAGE_TOKEN_SECRET is required in production. Set this environment variable to a strong random secret."
+      );
+    }
+  } else {
+    if (!secret) {
+      console.warn(
+        "[WARN] MANAGE_TOKEN_SECRET is not set. Manage tokens will use an empty secret — do not deploy this to production."
+      );
+    }
+  }
+
+  return { secret };
+}

--- a/services/reservations/src/middleware/require-manage-token.test.ts
+++ b/services/reservations/src/middleware/require-manage-token.test.ts
@@ -91,7 +91,7 @@ describe("requireManageToken preHandler", () => {
 
   it("returns 410 RFC 7807 for expired token", async () => {
     const { createHmac } = await import("crypto");
-    const secret = process.env.MANAGE_TOKEN_SECRET || "dev-secret-do-not-use-in-prod";
+    const secret = process.env.MANAGE_TOKEN_SECRET ?? "";
     const expiry = Date.now() - 1000;
     const payload = `res_1:jane@example.com:${expiry}`;
     const signature = createHmac("sha256", secret).update(payload).digest("hex");

--- a/services/reservations/src/routes/confirm-attendance.test.ts
+++ b/services/reservations/src/routes/confirm-attendance.test.ts
@@ -143,7 +143,7 @@ describe("PATCH /public/v1/reservations/confirm", () => {
 
   it("returns 410 for expired token (preHandler — RFC 7807)", async () => {
     const { createHmac } = await import("crypto");
-    const secret = process.env.MANAGE_TOKEN_SECRET || "dev-secret-do-not-use-in-prod";
+    const secret = process.env.MANAGE_TOKEN_SECRET ?? "";
     const expiry = Date.now() - 1000;
     const payload = `res_1:jane@example.com:${expiry}`;
     const signature = createHmac("sha256", secret).update(payload).digest("hex");

--- a/services/reservations/src/routes/public-reservations.ts
+++ b/services/reservations/src/routes/public-reservations.ts
@@ -5,8 +5,12 @@ import { venueService } from "../services/venue.js";
 import { confirmHold } from "../services/confirm-hold.js";
 import { publicRateLimitHook } from "../middleware/public-rate-limit.js";
 import { decrementHoldCount } from "../middleware/public-rate-limit.js";
+import { getManageTokenConfig } from "../config/manage-token.js";
 
-const TOKEN_SECRET = process.env.MANAGE_TOKEN_SECRET || "dev-secret-do-not-use-in-prod";
+const TOKEN_SECRET = getManageTokenConfig({
+  nodeEnv: process.env.NODE_ENV,
+  secret: process.env.MANAGE_TOKEN_SECRET,
+}).secret;
 
 export function generateManageToken(reservationId: string, guestEmail: string): string {
   const expiry = Date.now() + 7 * 24 * 60 * 60 * 1000;


### PR DESCRIPTION
## Summary

- Add `src/config/manage-token.ts` with `getManageTokenConfig()` that throws in production when `MANAGE_TOKEN_SECRET` is absent/empty, and warns-but-continues in dev/test — mirroring the existing `getStripeConfig()` pattern exactly
- Wire the assertion into `buildApp()` so a misconfigured prod deploy fails fast at startup, not per-request
- Replace the `|| "dev-secret-do-not-use-in-prod"` fallback in `public-reservations.ts` with a call to `getManageTokenConfig`
- Update two test files (`require-manage-token.test.ts`, `confirm-attendance.test.ts`) that also used the hardcoded fallback to construct HMAC signatures — changed to `?? ""`
- Uncomment `MANAGE_TOKEN_SECRET` in `.env.example` with placeholder `change-me-in-prod`

Closes #2387

## Test plan

- [x] New `src/config/manage-token.test.ts` with 7 tests covering prod-throws and dev/test-allows cases
- [x] All 66 test files / 951 tests pass in `services/reservations`
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `check-adr` — no violations
- [x] `check-deps` — no violations
- [x] `pnpm regen` — llms artifacts regenerated and staged; no other drift
- [x] `detect-instruction-rot.mjs` — clean

## Adjacent security smell (noted, not fixed — out of scope)

`services/reservations/src/services/post-visit-notifier.ts` line 4 has the same pattern for `UNSUBSCRIBE_TOKEN_SECRET`:
```ts
process.env.UNSUBSCRIBE_TOKEN_SECRET || "dev-unsubscribe-secret-do-not-use-in-prod"
```
This should receive the same treatment in a follow-up issue.