### PR TITLE
feat(telemetry): cost telemetry for mbe agent run + antipattern ratchet pre-push gate

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -11,6 +11,17 @@ if ! node scripts/check-destructive-migrations.js; then
   exit 1
 fi
 
+# Guard: antipattern ratchet — block any push that increases an AI antipattern count.
+# Uses the same script as CI (check-adr + check-deps job) so gates never drift.
+if ! node scripts/check-ai-antipatterns.mjs; then
+  echo ""
+  echo "ERROR: AI antipattern ratchet failed — one or more pattern counts increased above baseline."
+  echo "Fix the regression or run 'node scripts/check-ai-antipatterns.mjs --update' to accept it."
+  echo "Emergency bypass: git push --no-verify"
+  echo ""
+  exit 1
+fi
+
 # Verify pnpm-lock.yaml is in sync with all package.json files.
 # This prevents the recurring CI failure where agents push code
 # that changes package.json without running pnpm install.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1244,15 +1244,26 @@
       });
   </file>
   <file path="tools/cli/src/commands/agent.ts">
-    function formatDuration(ms: number): string {
-      const seconds = Math.floor(ms / 1000);
-      if (seconds < 60) return `${seconds}s`;
-      const minutes = Math.floor(seconds / 60);
-      const remaining = seconds % 60;
-      return `${minutes}m ${remaining}s`;
+    interface SpendRecord {
+      date: string;
+      timestamp: string;
+      costUsd: number;
+      issueNumber: number | null;
+      model: string;
+      inputTokens: number;
+      outputTokens: number;
+      numTurns: number;
     }
-    function formatCost(usd: number): string {
-      return `$${usd.toFixed(4)}`;
+    function logSpend(record: SpendRecord): void {
+      try {
+        const logDir = dirname(SPEND_LOG_PATH);
+        if (!existsSync(logDir)) {
+          mkdirSync(logDir, { recursive: true });
+        }
+        appendFileSync(SPEND_LOG_PATH, JSON.stringify(record) + "\n");
+      } catch {
+        // Silently swallow — spend logging is best-effort
+      }
     }
   </file>
   <file path="tools/cli/src/commands/check-deps.ts">

--- a/llms.txt
+++ b/llms.txt
@@ -390,11 +390,17 @@
     </item>
   </file>
   <file path="tools/cli/src/commands/agent.ts">
-    <item priority="medium">
-      function formatDuration(ms: number): string { /* ... */ }
+    <item priority="high">
+      interface SpendRecord {
+        date: string;
+        timestamp: string;
+        costUsd: number;
+        issueNumber: number | null;
+        model: string;
+      }
     </item>
     <item priority="medium">
-      function formatCost(usd: number): string { /* ... */ }
+      function logSpend(record: SpendRecord): void { /* ... */ }
     </item>
   </file>
   <file path="tools/cli/src/commands/check-deps.ts">

--- a/metrics/ai-antipattern-baselines.json
+++ b/metrics/ai-antipattern-baselines.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-21T02:33:34.597Z",
+  "generatedAt": "2026-06-21T06:31:19.555Z",
   "patterns": {
     "magicTimeouts": {
       "count": 32,

--- a/scripts/__tests__/antipattern-hook.test.mjs
+++ b/scripts/__tests__/antipattern-hook.test.mjs
@@ -1,0 +1,120 @@
+/**
+ * Hook seam test for the antipattern ratchet pre-push gate.
+ *
+ * Verifies that `node scripts/check-ai-antipatterns.mjs` exits non-zero when
+ * a ratchet increase is detected, and exits 0 when the count is at/under
+ * baseline — matching the behaviour wired into .husky/pre-push.
+ *
+ * Uses a temp directory with a fixture baseline so the real codebase baseline
+ * is never mutated.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_PATH = resolve(
+  fileURLToPath(import.meta.url),
+  "..",
+  "..",
+  "check-ai-antipatterns.mjs"
+);
+
+function makeBaseline(patterns) {
+  return {
+    generatedAt: new Date().toISOString(),
+    patterns: Object.fromEntries(
+      Object.entries(patterns).map(([k, count]) => [k, { count, description: k }])
+    ),
+  };
+}
+
+describe("antipattern ratchet pre-push gate (hook seam)", () => {
+  let dir;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "antipattern-hook-test-"));
+    // Create a src dir with no antipatterns so all scanned counts are 0
+    mkdirSync(join(dir, "src"), { recursive: true });
+    mkdirSync(join(dir, "metrics"), { recursive: true });
+    writeFileSync(join(dir, "src", "index.ts"), "export const x = 1;\n");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true });
+  });
+
+  it("exits 0 when current counts are at or under baseline", () => {
+    // Baseline counts of 0 match the empty src/ scan — no regression
+    const baseline = makeBaseline({
+      magicTimeouts: 0,
+      emptyCatch: 0,
+      noopTestAssertions: 0,
+      hardcodedRoutes: 0,
+      anyType: 0,
+      consoleLogs: 0,
+      unusedParams: 0,
+      mockShapeMismatch: 0,
+    });
+    writeFileSync(join(dir, "metrics", "ai-antipattern-baselines.json"), JSON.stringify(baseline));
+
+    const result = spawnSync("node", [SCRIPT_PATH], {
+      cwd: dir,
+      encoding: "utf-8",
+      timeout: 15000,
+    });
+
+    expect(result.status).toBe(0);
+  });
+
+  it("exits non-zero when a pattern count increased above baseline", () => {
+    // Baseline claims 0 anyType, but src/ has one `as any` cast → regression
+    writeFileSync(join(dir, "src", "index.ts"), "const x = val as any;\n");
+
+    const baseline = makeBaseline({
+      magicTimeouts: 0,
+      emptyCatch: 0,
+      noopTestAssertions: 0,
+      hardcodedRoutes: 0,
+      anyType: 0, // baseline says 0, scan will find 1 → ratchet triggers
+      consoleLogs: 0,
+      unusedParams: 0,
+      mockShapeMismatch: 0,
+    });
+    writeFileSync(join(dir, "metrics", "ai-antipattern-baselines.json"), JSON.stringify(baseline));
+
+    const result = spawnSync("node", [SCRIPT_PATH], {
+      cwd: dir,
+      encoding: "utf-8",
+      timeout: 15000,
+    });
+
+    expect(result.status).not.toBe(0);
+  });
+
+  it("exits 0 when counts decreased below baseline (improvement allowed)", () => {
+    // Baseline says 5 anyType but src has 0 — improvement, not regression
+    const baseline = makeBaseline({
+      magicTimeouts: 0,
+      emptyCatch: 0,
+      noopTestAssertions: 0,
+      hardcodedRoutes: 0,
+      anyType: 5,
+      consoleLogs: 0,
+      unusedParams: 0,
+      mockShapeMismatch: 0,
+    });
+    writeFileSync(join(dir, "metrics", "ai-antipattern-baselines.json"), JSON.stringify(baseline));
+
+    const result = spawnSync("node", [SCRIPT_PATH], {
+      cwd: dir,
+      encoding: "utf-8",
+      timeout: 15000,
+    });
+
+    expect(result.status).toBe(0);
+  });
+});

--- a/scripts/__tests__/collect-agent-cost.test.mjs
+++ b/scripts/__tests__/collect-agent-cost.test.mjs
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { collectAgentCost } from "../collect-agent-cost.mjs";
+
+function makeTmpDir() {
+  return mkdtempSync(join(tmpdir(), "collect-agent-cost-test-"));
+}
+
+describe("collectAgentCost", () => {
+  let dir;
+
+  beforeEach(() => {
+    dir = makeTmpDir();
+    mkdirSync(join(dir, ".claude"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true });
+  });
+
+  it("returns available: false when no spend file exists", () => {
+    const result = collectAgentCost(join(dir, ".claude", "agent-spend.jsonl"));
+    expect(result.available).toBe(false);
+  });
+
+  it("returns available: false when spend file has no entries", () => {
+    const spendPath = join(dir, ".claude", "agent-spend.jsonl");
+    writeFileSync(spendPath, "\n");
+    const result = collectAgentCost(spendPath);
+    expect(result.available).toBe(false);
+  });
+
+  it("returns available: true with cost when at least one in-window entry exists", () => {
+    const spendPath = join(dir, ".claude", "agent-spend.jsonl");
+    const today = new Date().toISOString().slice(0, 10);
+    writeFileSync(
+      spendPath,
+      JSON.stringify({
+        date: today,
+        timestamp: new Date().toISOString(),
+        costUsd: 0.5,
+        model: "claude-sonnet-4-6",
+      }) + "\n"
+    );
+    const result = collectAgentCost(spendPath);
+    expect(result.available).toBe(true);
+    expect(result.spend_today_usd).toBe(0.5);
+    expect(result.spend_7d_usd).toBe(0.5);
+    expect(result.sessions_7d).toBe(1);
+  });
+
+  it("surfaces token and turn fields when present in entries", () => {
+    const spendPath = join(dir, ".claude", "agent-spend.jsonl");
+    const today = new Date().toISOString().slice(0, 10);
+    writeFileSync(
+      spendPath,
+      JSON.stringify({
+        date: today,
+        timestamp: new Date().toISOString(),
+        costUsd: 0.42,
+        model: "claude-sonnet-4-6",
+        inputTokens: 1000,
+        outputTokens: 500,
+        numTurns: 8,
+      }) +
+        "\n" +
+        JSON.stringify({
+          date: today,
+          timestamp: new Date().toISOString(),
+          costUsd: 0.1,
+          model: "claude-sonnet-4-6",
+          inputTokens: 200,
+          outputTokens: 100,
+          numTurns: 3,
+        }) +
+        "\n"
+    );
+    const result = collectAgentCost(spendPath);
+    expect(result.available).toBe(true);
+    expect(result.total_input_tokens_7d).toBe(1200);
+    expect(result.total_output_tokens_7d).toBe(600);
+    expect(result.avg_turns_per_session).toBe(5.5);
+  });
+
+  it("parses legacy cost-only records (no token fields) without throwing", () => {
+    const spendPath = join(dir, ".claude", "agent-spend.jsonl");
+    const today = new Date().toISOString().slice(0, 10);
+    writeFileSync(
+      spendPath,
+      JSON.stringify({ date: today, costUsd: 0.25, issueNumber: 99, model: null }) + "\n"
+    );
+    const result = collectAgentCost(spendPath);
+    expect(result.available).toBe(true);
+    expect(result.spend_today_usd).toBe(0.25);
+    // Token fields absent in legacy records — should be 0 not NaN
+    expect(result.total_input_tokens_7d).toBe(0);
+    expect(result.total_output_tokens_7d).toBe(0);
+    expect(result.avg_turns_per_session).toBe(0);
+  });
+
+  it("ignores entries older than 7 days for 7d aggregates", () => {
+    const spendPath = join(dir, ".claude", "agent-spend.jsonl");
+    const today = new Date().toISOString().slice(0, 10);
+    const oldDate = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    writeFileSync(
+      spendPath,
+      JSON.stringify({
+        date: oldDate,
+        costUsd: 1.0,
+        inputTokens: 9999,
+        outputTokens: 9999,
+        numTurns: 50,
+      }) +
+        "\n" +
+        JSON.stringify({
+          date: today,
+          costUsd: 0.1,
+          inputTokens: 100,
+          outputTokens: 50,
+          numTurns: 2,
+        }) +
+        "\n"
+    );
+    const result = collectAgentCost(spendPath);
+    expect(result.sessions_7d).toBe(1);
+    expect(result.spend_7d_usd).toBe(0.1);
+    expect(result.total_input_tokens_7d).toBe(100);
+  });
+});

--- a/scripts/collect-agent-cost.mjs
+++ b/scripts/collect-agent-cost.mjs
@@ -1,0 +1,81 @@
+/**
+ * Pure collector for agent cost telemetry from .claude/agent-spend.jsonl.
+ *
+ * Extracted from sensor-report.mjs so it can be unit-tested without the
+ * @mbe/gh-client dependency and without triggering the sensor-report runner.
+ *
+ * Record schema (appended by log-agent-cost.js and mbe agent run):
+ *   { date, timestamp, costUsd, issueNumber, model }          // legacy
+ *   { date, timestamp, costUsd, issueNumber, model,           // v2 (this PR)
+ *     inputTokens, outputTokens, numTurns }
+ *
+ * BACKWARD-COMPAT: records without token/turn fields parse fine; those
+ * fields default to 0 in aggregates.
+ */
+
+import { readFileSync, existsSync } from "node:fs";
+
+/**
+ * Parse a JSONL file, silently skipping malformed lines.
+ * @param {string} filePath
+ * @returns {unknown[]}
+ */
+function readJsonl(filePath) {
+  if (!existsSync(filePath)) return [];
+  return readFileSync(filePath, "utf-8")
+    .split("\n")
+    .filter((l) => l.trim())
+    .map((l) => {
+      try {
+        return JSON.parse(l);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Aggregate agent cost telemetry from agent-spend.jsonl.
+ *
+ * @param {string} spendPath - Absolute path to the .claude/agent-spend.jsonl file.
+ * @param {Date} [now] - Reference timestamp (defaults to current time; injectable for tests).
+ * @returns {object} Aggregated metrics or { available: false } when no data.
+ */
+export function collectAgentCost(spendPath, now = new Date()) {
+  const sevenDaysAgo = new Date(now - 7 * 24 * 60 * 60 * 1000);
+  const entries = readJsonl(spendPath);
+  if (entries.length === 0) return { available: false };
+
+  const sevenDayEntries = entries.filter((e) => {
+    const entryDate = new Date(e.date || e.timestamp);
+    return entryDate >= sevenDaysAgo;
+  });
+
+  if (sevenDayEntries.length === 0) return { available: false };
+
+  const todayStr = now.toISOString().slice(0, 10);
+  const todayEntries = entries.filter((e) => (e.date || e.timestamp || "").startsWith(todayStr));
+
+  const totalSpend7d = sevenDayEntries.reduce((sum, e) => sum + (e.costUsd ?? e.cost_usd ?? 0), 0);
+  const todaySpend = todayEntries.reduce((sum, e) => sum + (e.costUsd ?? e.cost_usd ?? 0), 0);
+
+  // Token / turn aggregates — default 0 for legacy cost-only records
+  const totalInputTokens7d = sevenDayEntries.reduce((sum, e) => sum + (e.inputTokens ?? 0), 0);
+  const totalOutputTokens7d = sevenDayEntries.reduce((sum, e) => sum + (e.outputTokens ?? 0), 0);
+  const totalTurns7d = sevenDayEntries.reduce((sum, e) => sum + (e.numTurns ?? 0), 0);
+
+  return {
+    available: true,
+    spend_today_usd: Math.round(todaySpend * 100) / 100,
+    spend_7d_usd: Math.round(totalSpend7d * 100) / 100,
+    sessions_7d: sevenDayEntries.length,
+    avg_cost_per_session:
+      sevenDayEntries.length > 0
+        ? Math.round((totalSpend7d / sevenDayEntries.length) * 100) / 100
+        : 0,
+    total_input_tokens_7d: totalInputTokens7d,
+    total_output_tokens_7d: totalOutputTokens7d,
+    avg_turns_per_session: sevenDayEntries.length > 0 ? totalTurns7d / sevenDayEntries.length : 0,
+  };
+}

--- a/scripts/sensor-report.mjs
+++ b/scripts/sensor-report.mjs
@@ -16,6 +16,7 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync, statSy
 import { dirname, resolve, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createGhClient } from "@mbe/gh-client";
+import { collectAgentCost } from "./collect-agent-cost.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
@@ -48,15 +49,6 @@ function safe(fn, fallback = null) {
 
 function readJson(path) {
   return JSON.parse(readFileSync(path, "utf-8"));
-}
-
-function readJsonl(path) {
-  if (!existsSync(path)) return [];
-  return readFileSync(path, "utf-8")
-    .split("\n")
-    .filter((l) => l.trim())
-    .map((l) => safe(() => JSON.parse(l)))
-    .filter(Boolean);
 }
 
 /* ── Sensor collectors ───────────────────────────────── */
@@ -97,27 +89,9 @@ function collectPrMetrics() {
   };
 }
 
-function collectAgentCost() {
+function collectAgentCostSensor() {
   const spendPath = resolve(ROOT, ".claude", "agent-spend.jsonl");
-  const entries = readJsonl(spendPath);
-  if (entries.length === 0) return { available: false };
-
-  const sevenDayEntries = entries.filter((e) => new Date(e.date || e.timestamp) >= sevenDaysAgo);
-  const totalSpend7d = sevenDayEntries.reduce((sum, e) => sum + (e.costUsd ?? e.cost_usd ?? 0), 0);
-  const todayStr = now.toISOString().slice(0, 10);
-  const todayEntries = entries.filter((e) => (e.date || e.timestamp || "").startsWith(todayStr));
-  const todaySpend = todayEntries.reduce((sum, e) => sum + (e.costUsd ?? e.cost_usd ?? 0), 0);
-
-  return {
-    available: true,
-    spend_today_usd: Math.round(todaySpend * 100) / 100,
-    spend_7d_usd: Math.round(totalSpend7d * 100) / 100,
-    sessions_7d: sevenDayEntries.length,
-    avg_cost_per_session:
-      sevenDayEntries.length > 0
-        ? Math.round((totalSpend7d / sevenDayEntries.length) * 100) / 100
-        : 0,
-  };
+  return collectAgentCost(spendPath, now);
 }
 
 function collectCiHealth() {
@@ -319,7 +293,7 @@ const report = {
   sensors: {
     acmm: collectAcmm(),
     prMetrics: collectPrMetrics(),
-    agentCost: collectAgentCost(),
+    agentCost: collectAgentCostSensor(),
     ciHealth: collectCiHealth(),
     lighthouse: collectLighthouse(),
     issues: collectGitHubIssues(),

--- a/temp-chaos-target.tsx
+++ b/temp-chaos-target.tsx
@@ -1,10 +1,7 @@
-import React from "react";
 
 export default function MyComponent() {
-  React.useEffect(() => { console.error("CHAOS-ERROR: Synthetic bug for #MyComponent"); }, []);
-
   return (
-    <div aria-label="test-label">
+    <div >
       <h1>Hello</h1>
     </div>
   );

--- a/temp-chaos-target.tsx
+++ b/temp-chaos-target.tsx
@@ -1,7 +1,10 @@
+import React from "react";
 
 export default function MyComponent() {
+  React.useEffect(() => { console.error("CHAOS-ERROR: Synthetic bug for #MyComponent"); }, []);
+
   return (
-    <div >
+    <div aria-label="test-label">
       <h1>Hello</h1>
     </div>
   );

--- a/tools/cli/src/__tests__/agent-cost-logging.test.ts
+++ b/tools/cli/src/__tests__/agent-cost-logging.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Cost logging integration seam for `mbe agent run`.
+ *
+ * Isolated in its own file so vi.mock("node:fs") does not bleed into the
+ * main agent.test.ts suite (ESM module mocks are file-scoped in Vitest).
+ *
+ * Verifies that the claude-adapter completion path appends one well-formed
+ * spend record to .claude/agent-spend.jsonl with cost+tokens+turns+model.
+ */
+
+// ── Captured fs writes ────────────────────────────────────────────────────
+
+const appendCalls = vi.hoisted(() => ({ data: [] as Array<[string, string]> }));
+
+// Mock node:fs so no real files are touched.
+vi.mock("node:fs", async (importOriginal) => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  type NodeFs = typeof import("node:fs");
+  const actual = await importOriginal<NodeFs>();
+  return {
+    ...actual,
+    appendFileSync: vi.fn((path: string, data: string) => {
+      appendCalls.data.push([path, data]);
+    }),
+    existsSync: vi.fn(() => true),
+    mkdirSync: vi.fn(),
+    readFileSync: actual.readFileSync,
+  };
+});
+
+// ── @mbe/agent-core mock ──────────────────────────────────────────────────
+
+vi.mock("@mbe/agent-core", () => ({
+  runSession: vi.fn(),
+  DEFAULT_SESSION_CONFIG: {
+    model: "claude-sonnet-4-6",
+    maxBudgetUsd: 1.0,
+    maxTurns: 50,
+    baseBranch: "main",
+    allowedTools: [],
+  },
+  DEFAULT_FEEDBACK_LOOP_CONFIG: {},
+  loadSuite: vi.fn(),
+  runEvalSuite: vi.fn(),
+  resolveBudget: vi.fn(() => ({ budgetUsd: 1.0, maxTurns: 50 })),
+  resolveModel: vi.fn(() => "claude-sonnet-4-6"),
+  resolveModelId: vi.fn((tier: string) => tier),
+  routeModelWithReason: vi.fn(() => ({
+    tier: "standard",
+    modelId: "claude-sonnet-4-6",
+    reason: "default",
+  })),
+  AllAdaptersUnavailableError: class AllAdaptersUnavailableError extends Error {
+    cooldowns = new Map();
+    constructor(msg?: string) {
+      super(msg ?? "All adapters unavailable");
+      this.name = "AllAdaptersUnavailableError";
+    }
+  },
+  createWorktree: vi.fn(),
+  removeWorktree: vi.fn(),
+}));
+
+// Mock node:child_process (needed by fetchIssueForRouting inside agent.ts).
+vi.mock("node:child_process", () => {
+  const PROMISIFY_CUSTOM = Symbol.for("nodejs.util.promisify.custom");
+  const execFile = Object.assign(vi.fn(), {
+    [PROMISIFY_CUSTOM]: () => Promise.resolve({ stdout: "{}", stderr: "" }),
+  });
+  return { execFile };
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe("agent run – cost logging seam", () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    appendCalls.data = [];
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
+  });
+
+  it("appends a well-formed record (cost+tokens+turns+model) after a successful run", async () => {
+    const { runSession } = await import("@mbe/agent-core");
+    vi.mocked(runSession).mockResolvedValue({
+      sessionId: "log-test",
+      status: "succeeded",
+      branchName: "fix/log-test",
+      prUrl: null,
+      costUsd: 0.0456,
+      tokenUsage: { inputTokens: 1234, outputTokens: 567 },
+      durationMs: 3000,
+      numTurns: 7,
+      resultText: "",
+      errors: [],
+    });
+
+    const { agentCommand } = await import("../commands/agent.js");
+    await agentCommand.commands[0].parseAsync(
+      ["Fix the logging bug", "--model", "claude-sonnet-4-6"],
+      { from: "user" }
+    );
+
+    expect(exitSpy).toHaveBeenCalledWith(0);
+
+    const spendCalls = appendCalls.data.filter(([p]) => String(p).endsWith("agent-spend.jsonl"));
+    expect(spendCalls.length).toBe(1);
+
+    const record = JSON.parse(String(spendCalls[0][1]).trim());
+    expect(record.costUsd).toBe(0.0456);
+    expect(record.inputTokens).toBe(1234);
+    expect(record.outputTokens).toBe(567);
+    expect(record.numTurns).toBe(7);
+    expect(record.model).toBe("claude-sonnet-4-6");
+    expect(typeof record.date).toBe("string");
+    expect(typeof record.timestamp).toBe("string");
+  });
+
+  it("still appends a record when the session fails", async () => {
+    const { runSession } = await import("@mbe/agent-core");
+    vi.mocked(runSession).mockResolvedValue({
+      sessionId: "log-fail",
+      status: "failed",
+      branchName: "fix/log-fail",
+      prUrl: null,
+      costUsd: 0.012,
+      tokenUsage: { inputTokens: 100, outputTokens: 20 },
+      durationMs: 500,
+      numTurns: 2,
+      resultText: "",
+      errors: ["boom"],
+    });
+
+    const { agentCommand } = await import("../commands/agent.js");
+    await agentCommand.commands[0].parseAsync(["Bad task"], { from: "user" });
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    const spendCalls = appendCalls.data.filter(([p]) => String(p).endsWith("agent-spend.jsonl"));
+    expect(spendCalls.length).toBe(1);
+    const record = JSON.parse(String(spendCalls[0][1]).trim());
+    expect(record.costUsd).toBe(0.012);
+    expect(record.numTurns).toBe(2);
+  });
+});

--- a/tools/cli/src/commands/agent.ts
+++ b/tools/cli/src/commands/agent.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
-import { resolve } from "node:path";
+import { resolve, dirname, join } from "node:path";
+import { appendFileSync, existsSync, mkdirSync } from "node:fs";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import type { SessionConfig, SessionEvent } from "@mbe/agent-core";
@@ -32,6 +33,45 @@ import { createAgentApiClient } from "../cli-api-client.js";
 // ── Helpers ──────────────────────────────────────────────────────────────
 
 const AGENT_API_URL = process.env.AGENT_API_URL ?? "http://localhost:3003";
+
+/** Absolute path to the canonical agent spend log. */
+const SPEND_LOG_PATH = join(
+  dirname(new URL(import.meta.url).pathname),
+  "..",
+  "..",
+  "..",
+  "..",
+  ".claude",
+  "agent-spend.jsonl"
+);
+
+interface SpendRecord {
+  date: string;
+  timestamp: string;
+  costUsd: number;
+  issueNumber: number | null;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  numTurns: number;
+}
+
+/**
+ * Append one spend record to .claude/agent-spend.jsonl.
+ * Scoped to `mbe agent run` (claude adapter) completions only.
+ * Never throws — logging failure must not crash the CLI.
+ */
+function logSpend(record: SpendRecord): void {
+  try {
+    const logDir = dirname(SPEND_LOG_PATH);
+    if (!existsSync(logDir)) {
+      mkdirSync(logDir, { recursive: true });
+    }
+    appendFileSync(SPEND_LOG_PATH, JSON.stringify(record) + "\n");
+  } catch {
+    // Silently swallow — spend logging is best-effort
+  }
+}
 
 function formatDuration(ms: number): string {
   const seconds = Math.floor(ms / 1000);
@@ -311,6 +351,18 @@ agentCommand
 
         try {
           const result = await runSession(config, (event) => handleEvent(event, options.verbose));
+
+          // Log spend telemetry to .claude/agent-spend.jsonl (best-effort).
+          logSpend({
+            date: new Date().toISOString().slice(0, 10),
+            timestamp: new Date().toISOString(),
+            costUsd: result.costUsd,
+            issueNumber: null,
+            model: config.model,
+            inputTokens: result.tokenUsage.inputTokens,
+            outputTokens: result.tokenUsage.outputTokens,
+            numTurns: result.numTurns,
+          });
 
           console.log("");
           console.log("Result");


### PR DESCRIPTION
## Summary

- **A — Cost telemetry**: `mbe agent run` (claude adapter) now auto-appends a spend record to `.claude/agent-spend.jsonl` at session completion with `costUsd`, `inputTokens`, `outputTokens`, `numTurns`, and `model`. Legacy cost-only records remain backward-compatible. `collectAgentCost()` extracted into `scripts/collect-agent-cost.mjs` (pure module, no `@mbe/gh-client` dep) and extended to surface `total_input_tokens_7d`, `total_output_tokens_7d`, and `avg_turns_per_session`. `sensor-report.mjs` delegates to it.
- **B — Antipattern ratchet pre-push gate**: `.husky/pre-push` now runs `node scripts/check-ai-antipatterns.mjs` after the destructive-migration guard, using the identical command to CI. Exits non-zero on any ratchet increase with fix guidance + bypass note; passes at/under-baseline.

## Test plan

- [ ] `scripts/__tests__/collect-agent-cost.test.mjs` — 6 tests: available flag, token/turn aggregation, legacy cost-only record parsing, 7d window filtering
- [ ] `scripts/__tests__/antipattern-hook.test.mjs` — 3 hook seam tests: exit 0 at baseline, exit non-zero on increase, exit 0 on decrease
- [ ] `tools/cli/src/__tests__/agent-cost-logging.test.ts` — 2 integration tests: well-formed record on success, record still appended on failure
- [ ] Scripts suite: 322 passed
- [ ] CLI suite: 400 passed
- [ ] `pnpm lint` — clean
- [ ] `pnpm typecheck` — clean
- [ ] `check-adr` + `check-deps` — no violations
- [ ] `pnpm regen --check` — all artifacts up to date

Closes #2527