### PR TITLE
feat(scripts): PID-aware merge-train lockfile guard

### DIFF
--- a/.claude/skills/implement-queue/SKILL.md
+++ b/.claude/skills/implement-queue/SKILL.md
@@ -104,27 +104,39 @@ Merge one PR at a time, oldest green first. **Exactly one merge train may run at
 
 ### Acquire the merge-train lock (before merging anything)
 
-The lock lives in the shared git common dir, so it is visible to every worktree/session of this repo. Acquisition is an atomic `mkdir`; a lock whose mtime is older than 45 min is treated as crashed and reclaimed.
+The lock lives in the shared git common dir, so it is visible to every worktree/session of this repo. The guard is implemented in `scripts/merge-train-lock.mjs` — PID-aware, stale-reclaiming (45-min mtime window), and fully tested. Use it via Node:
 
-```bash
-LOCK="$(git rev-parse --git-common-dir)/mbe-merge-train.lock"
-if ! mkdir "$LOCK" 2>/dev/null; then
-  if [ -n "$(find "$LOCK" -maxdepth 0 -mmin +45 2>/dev/null)" ]; then
-    rm -rf "$LOCK" && mkdir "$LOCK"        # stale (>45m, crashed owner) → reclaim
-  else
-    echo "merge-train lock held by another session — SKIP Phase 3 this iteration."
-    # Do NOT run the merge train. Drop to monitor-only (report open PR state) and
-    # go to Phase 4. Another session owns the train; racing it is the bug we are preventing.
-  fi
-fi
+```js
+import {
+  acquireMergeTrainLock,
+  releaseMergeTrainLock,
+  heartbeatMergeTrainLock,
+} from "./scripts/merge-train-lock.mjs";
+
+const result = acquireMergeTrainLock(); // { acquired: true } or { acquired: false, owner: <pid> }
+if (!result.acquired) {
+  console.log(`merge-train lock held by PID ${result.owner} — SKIP Phase 3 this iteration.`);
+  // Do NOT run the merge train. Drop to monitor-only (report open PR state) and go to Phase 4.
+}
 ```
 
-If you did not acquire the lock, **skip the entire merge loop below** and proceed to Phase 4 in monitor-only mode (report PR state; merge nothing).
-
-If you did acquire it: `touch "$LOCK"` at the **start of each PR iteration** as a heartbeat (keeps a legitimately long train from being reclaimed), and **release it when the train ends** — on completion, on circuit-break, or on any abort:
+Or as a one-liner from the shell (e.g. in a bash orchestration wrapper):
 
 ```bash
-rm -rf "$LOCK"
+node -e "
+  import('./scripts/merge-train-lock.mjs').then(({ acquireMergeTrainLock }) => {
+    const r = acquireMergeTrainLock();
+    process.stdout.write(JSON.stringify(r) + '\n');
+  });
+"
+```
+
+If `acquired` is `false`, **skip the entire merge loop below** and proceed to Phase 4 in monitor-only mode (report PR state; merge nothing).
+
+If `acquired` is `true`: call `heartbeatMergeTrainLock()` at the **start of each PR iteration** (keeps a legitimately long train from being reclaimed), and **release it when the train ends** — on completion, on circuit-break, or on any abort:
+
+```js
+releaseMergeTrainLock();
 ```
 
 For each green PR (lock held):
@@ -171,7 +183,7 @@ If CI fails on a PR: one fix attempt in the main session (small fixes) or create
 
 ## Phase 4: Loop or Stop
 
-- **Release the merge-train lock** (`rm -rf "$(git rev-parse --git-common-dir)/mbe-merge-train.lock"`) before looping or stopping — if you acquired it in Phase 3. (A crash leaves it for the 45-min staleness reclaim; releasing explicitly frees the next session immediately.)
+- **Release the merge-train lock** (`releaseMergeTrainLock()` from `scripts/merge-train-lock.mjs`) before looping or stopping — if you acquired it in Phase 3. (A crash leaves it for the 45-min staleness reclaim; releasing explicitly frees the next session immediately.)
 - More `ready` issues and time/budget remain → back to Phase 0.
 - **Circuit breaker:** 3 consecutive failures (agents or merge-train CI) → release the lock, then stop and report.
 - Report per iteration: issues claimed, PRs created, PRs merged, failures.

--- a/scripts/__tests__/merge-train-lock.test.mjs
+++ b/scripts/__tests__/merge-train-lock.test.mjs
@@ -1,0 +1,146 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+describe("merge-train-lock", () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "merge-train-lock-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // ── acquireMergeTrainLock ──────────────────────────────────────────────────
+
+  describe("acquireMergeTrainLock", () => {
+    test("acquires the lock when none exists and writes current PID", async () => {
+      const { acquireMergeTrainLock } = await import("../merge-train-lock.mjs");
+      const result = acquireMergeTrainLock({ lockDir: tmpDir });
+
+      expect(result.acquired).toBe(true);
+      const pidFile = path.join(tmpDir, "mbe-merge-train.lock", "pid");
+      expect(fs.existsSync(pidFile)).toBe(true);
+      expect(parseInt(fs.readFileSync(pidFile, "utf8").trim(), 10)).toBe(process.pid);
+    });
+
+    test("returns {acquired:false, owner} when lock is held by a live PID", async () => {
+      const { acquireMergeTrainLock } = await import("../merge-train-lock.mjs");
+
+      // Simulate a live owner by using our own PID (definitely alive)
+      const livePid = process.pid;
+      const isAlive = () => true; // injectable: always alive
+
+      // First acquire
+      acquireMergeTrainLock({ lockDir: tmpDir });
+
+      // Second acquire (contended) — override isPidAlive so it thinks the owner is live
+      const result = acquireMergeTrainLock({ lockDir: tmpDir, isPidAlive: isAlive });
+
+      expect(result.acquired).toBe(false);
+      expect(typeof result.owner).toBe("number");
+      expect(result.owner).toBe(livePid);
+    });
+
+    test("reclaims stale lock when owner PID is dead", async () => {
+      const { acquireMergeTrainLock } = await import("../merge-train-lock.mjs");
+
+      // Set up a stale lock with a dead PID
+      const lockPath = path.join(tmpDir, "mbe-merge-train.lock");
+      fs.mkdirSync(lockPath);
+      fs.writeFileSync(path.join(lockPath, "pid"), "999999999"); // non-existent PID
+
+      const deadPid = () => false; // injectable: always dead
+
+      const result = acquireMergeTrainLock({ lockDir: tmpDir, isPidAlive: deadPid });
+
+      expect(result.acquired).toBe(true);
+      // PID file should now contain current process PID
+      const pidFile = path.join(lockPath, "pid");
+      expect(parseInt(fs.readFileSync(pidFile, "utf8").trim(), 10)).toBe(process.pid);
+    });
+
+    test("reclaims stale lock when mtime is older than staleness window", async () => {
+      const { acquireMergeTrainLock } = await import("../merge-train-lock.mjs");
+
+      // Set up an old lock with our own PID (so isPidAlive would say true normally)
+      const lockPath = path.join(tmpDir, "mbe-merge-train.lock");
+      fs.mkdirSync(lockPath);
+      fs.writeFileSync(path.join(lockPath, "pid"), String(process.pid));
+
+      // Backdate mtime by 50 minutes (past the 45-min window)
+      const oldTime = new Date(Date.now() - 50 * 60 * 1000);
+      fs.utimesSync(lockPath, oldTime, oldTime);
+
+      const result = acquireMergeTrainLock({ lockDir: tmpDir });
+
+      expect(result.acquired).toBe(true);
+    });
+
+    test("does not crash on corrupt/empty pid file — treats as reclaimable", async () => {
+      const { acquireMergeTrainLock } = await import("../merge-train-lock.mjs");
+
+      const lockPath = path.join(tmpDir, "mbe-merge-train.lock");
+      fs.mkdirSync(lockPath);
+      fs.writeFileSync(path.join(lockPath, "pid"), ""); // empty / corrupt
+
+      const result = acquireMergeTrainLock({ lockDir: tmpDir });
+
+      expect(result.acquired).toBe(true);
+    });
+  });
+
+  // ── releaseMergeTrainLock ──────────────────────────────────────────────────
+
+  describe("releaseMergeTrainLock", () => {
+    test("removes the lock directory on release", async () => {
+      const { acquireMergeTrainLock, releaseMergeTrainLock } =
+        await import("../merge-train-lock.mjs");
+
+      acquireMergeTrainLock({ lockDir: tmpDir });
+      const lockPath = path.join(tmpDir, "mbe-merge-train.lock");
+      expect(fs.existsSync(lockPath)).toBe(true);
+
+      releaseMergeTrainLock({ lockDir: tmpDir });
+      expect(fs.existsSync(lockPath)).toBe(false);
+    });
+
+    test("is a no-op when lock does not exist", async () => {
+      const { releaseMergeTrainLock } = await import("../merge-train-lock.mjs");
+
+      // Should not throw when called without a prior acquire
+      expect(() => releaseMergeTrainLock({ lockDir: tmpDir })).not.toThrow();
+    });
+  });
+
+  // ── heartbeat ─────────────────────────────────────────────────────────────
+
+  describe("heartbeatMergeTrainLock", () => {
+    test("touches the lock directory mtime so it is not reclaimed as stale", async () => {
+      const { acquireMergeTrainLock, heartbeatMergeTrainLock } =
+        await import("../merge-train-lock.mjs");
+
+      acquireMergeTrainLock({ lockDir: tmpDir });
+      const lockPath = path.join(tmpDir, "mbe-merge-train.lock");
+
+      // Backdate mtime so it looks stale
+      const oldTime = new Date(Date.now() - 50 * 60 * 1000);
+      fs.utimesSync(lockPath, oldTime, oldTime);
+
+      heartbeatMergeTrainLock({ lockDir: tmpDir });
+
+      const newMtime = fs.statSync(lockPath).mtimeMs;
+      // After heartbeat, mtime should be recent (within last 5 seconds)
+      expect(Date.now() - newMtime).toBeLessThan(5000);
+    });
+
+    test("is a no-op when lock does not exist", async () => {
+      const { heartbeatMergeTrainLock } = await import("../merge-train-lock.mjs");
+
+      expect(() => heartbeatMergeTrainLock({ lockDir: tmpDir })).not.toThrow();
+    });
+  });
+});

--- a/scripts/merge-train-lock.mjs
+++ b/scripts/merge-train-lock.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+/**
+ * merge-train-lock.mjs — PID-aware merge-train lockfile guard.
+ *
+ * Prevents concurrent merge-train /loop sessions from racing and
+ * duplicate-fixing the same branch. The lock lives inside the git
+ * common dir so it is shared across all worktrees of the same repo.
+ *
+ * Public API:
+ *   acquireMergeTrainLock(opts?)  → { acquired: true } | { acquired: false, owner: number }
+ *   releaseMergeTrainLock(opts?)  → void
+ *   heartbeatMergeTrainLock(opts?) → void
+ *   defaultLockDir()               → string  (git common dir path)
+ *
+ * Options (all optional, primarily for testing):
+ *   lockDir   {string}   — directory that contains the lock sub-dir (default: git common dir)
+ *   isPidAlive {fn}      — (pid: number) => boolean  injectable liveness check
+ *   staleMs   {number}   — staleness window in ms (default: 45 minutes)
+ *
+ * Lock layout:
+ *   <lockDir>/mbe-merge-train.lock/   ← atomic mkdir creates this
+ *   <lockDir>/mbe-merge-train.lock/pid  ← owner PID as a decimal string
+ *
+ * Staleness reclaim: if the lock directory mtime is older than staleMs
+ * OR the PID recorded in the pid file is no longer alive, the lock is
+ * treated as crashed and reclaimed.
+ *
+ * @module merge-train-lock
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const LOCK_NAME = "mbe-merge-train.lock";
+const DEFAULT_STALE_MS = 45 * 60 * 1000; // 45 minutes
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the git common dir for the current repository.
+ * Falls back to the current working directory if git is unavailable.
+ */
+function defaultLockDir() {
+  try {
+    const result = execFileSync("git", ["rev-parse", "--git-common-dir"], {
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return result.trim();
+  } catch {
+    return process.cwd();
+  }
+}
+
+/**
+ * Default liveness check using process.kill(pid, 0).
+ * Returns true if the process exists (signal 0 does not kill it).
+ */
+function defaultIsPidAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Reads the PID from the lock's pid file.
+ * Returns null if the file is missing or contains non-numeric content.
+ */
+function readLockPid(lockPath) {
+  const pidFile = path.join(lockPath, "pid");
+  try {
+    const raw = fs.readFileSync(pidFile, "utf8").trim();
+    const pid = parseInt(raw, 10);
+    return Number.isFinite(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Writes the current process PID into the lock directory.
+ */
+function writeLockPid(lockPath) {
+  fs.writeFileSync(path.join(lockPath, "pid"), String(process.pid));
+}
+
+/**
+ * Returns true if the lock's mtime is older than staleMs.
+ */
+function isStaleByTime(lockPath, staleMs) {
+  try {
+    const { mtimeMs } = fs.statSync(lockPath);
+    return Date.now() - mtimeMs > staleMs;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Removes the lock directory unconditionally.
+ */
+function removeLock(lockPath) {
+  fs.rmSync(lockPath, { recursive: true, force: true });
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Attempts to acquire the merge-train lock.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.lockDir]      — directory containing the lock (default: git common dir)
+ * @param {function} [opts.isPidAlive] — (pid: number) => boolean  (default: signal-0 check)
+ * @param {number} [opts.staleMs]      — staleness window in ms (default: 45 min)
+ * @returns {{ acquired: true } | { acquired: false, owner: number }}
+ */
+function acquireMergeTrainLock(opts = {}) {
+  const lockDir = opts.lockDir ?? defaultLockDir();
+  const isPidAlive = opts.isPidAlive ?? defaultIsPidAlive;
+  const staleMs = opts.staleMs ?? DEFAULT_STALE_MS;
+
+  const lockPath = path.join(lockDir, LOCK_NAME);
+
+  // Fast path: atomic mkdir succeeds → we own the lock.
+  try {
+    fs.mkdirSync(lockPath);
+    writeLockPid(lockPath);
+    return { acquired: true };
+  } catch (err) {
+    if (err.code !== "EEXIST") {
+      throw err;
+    }
+  }
+
+  // Lock already exists — check if it should be reclaimed.
+  const ownerPid = readLockPid(lockPath);
+  const stale = isStaleByTime(lockPath, staleMs) || ownerPid === null || !isPidAlive(ownerPid);
+
+  if (stale) {
+    removeLock(lockPath);
+    fs.mkdirSync(lockPath);
+    writeLockPid(lockPath);
+    return { acquired: true };
+  }
+
+  // Lock is held by a live owner — fall back to monitor-only.
+  return { acquired: false, owner: ownerPid };
+}
+
+/**
+ * Releases the merge-train lock.
+ * Safe to call when no lock is held (no-op).
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.lockDir] — directory containing the lock (default: git common dir)
+ */
+function releaseMergeTrainLock(opts = {}) {
+  const lockDir = opts.lockDir ?? defaultLockDir();
+  const lockPath = path.join(lockDir, LOCK_NAME);
+  removeLock(lockPath);
+}
+
+/**
+ * Touches the lock directory mtime to prevent stale-reclaim during a
+ * long-running merge train. Call once per PR iteration.
+ * Safe to call when no lock is held (no-op).
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.lockDir] — directory containing the lock (default: git common dir)
+ */
+function heartbeatMergeTrainLock(opts = {}) {
+  const lockDir = opts.lockDir ?? defaultLockDir();
+  const lockPath = path.join(lockDir, LOCK_NAME);
+  try {
+    const now = new Date();
+    fs.utimesSync(lockPath, now, now);
+  } catch {
+    // Lock does not exist — no-op.
+  }
+}
+
+export { acquireMergeTrainLock, releaseMergeTrainLock, heartbeatMergeTrainLock, defaultLockDir };


### PR DESCRIPTION
## Summary

- Adds `scripts/merge-train-lock.mjs` — a real, tested PID-aware merge-train lock guard replacing the honor-system inline shell in the implement-queue skill doc.
- The guard uses atomic `mkdir` for acquisition, writes the owner PID to a `pid` file inside the lock dir, reclaims stale locks when the owner PID is dead (`process.kill(pid, 0)` → ESRCH) or the lock mtime is older than 45 minutes, and exposes fully injectable seams for deterministic testing.
- Updates `.claude/skills/implement-queue/SKILL.md` Phase 3 to call the real module instead of the inline bash snippet.

## Public API

```js
import {
  acquireMergeTrainLock,   // → { acquired: true } | { acquired: false, owner: <pid> }
  releaseMergeTrainLock,   // → void (no-op if not held)
  heartbeatMergeTrainLock, // → void (touch mtime; call per-PR iteration to prevent stale reclaim)
  defaultLockDir,          // → string (git common dir)
} from "./scripts/merge-train-lock.mjs";
```

## Test plan

- [x] `acquires the lock when none exists and writes current PID` — GREEN
- [x] `returns {acquired:false, owner} when lock is held by a live PID` — GREEN
- [x] `reclaims stale lock when owner PID is dead` — GREEN
- [x] `reclaims stale lock when mtime is older than staleness window` — GREEN
- [x] `does not crash on corrupt/empty pid file — treats as reclaimable` — GREEN
- [x] `removes the lock directory on release` — GREEN
- [x] `is a no-op when lock does not exist (release)` — GREEN
- [x] `touches the lock directory mtime so it is not reclaimed as stale (heartbeat)` — GREEN
- [x] `is a no-op when lock does not exist (heartbeat)` — GREEN
- [x] `pnpm lint` — passes (scripts package has no lint script; lint-staged covers only `.ts`/`.tsx`)
- [x] `check-adr` — no violations
- [x] `check-deps` — no version mismatches
- [x] `pnpm regen` — no artifact drift

Closes #2532