### PR TITLE
refactor(reservations): one query-param validation seam

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5656,25 +5656,16 @@
             return reply.code(404).send(createProblemDetails(404, "Not Found", "Venue not found"));
           }
     
-          // Validate date format
-          const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
-          if (!dateRegex.test(date)) {
-            return reply
-              .code(400)
-              .send(createProblemDetails(400, "Bad Request", "Invalid date format. Use YYYY-MM-DD."));
+          const dateResult = validateDateString(date);
+          if (!dateResult.valid) {
+            return reply.code(400).send(createProblemDetails(400, "Bad Request", dateResult.error));
           }
     
-          const partySizeNum = parseInt(partySize, 10);
-          if (isNaN(partySizeNum) || partySizeNum < 1) {
+          const partySizeResult = validatePartySize(partySize);
+          if (!partySizeResult.valid) {
             return reply
               .code(400)
-              .send(
-                createProblemDetails(
-                  400,
-                  "Bad Request",
-                  "Invalid party size. Must be a positive integer."
-                )
-              );
+              .send(createProblemDetails(400, "Bad Request", partySizeResult.error));
           }
     
           const durationNum = duration ? parseInt(duration, 10) : undefined;
@@ -5693,7 +5684,7 @@
           const slots = await availabilityService.generateTimeSlots(
             venueId,
             date,
-            partySizeNum,
+            partySizeResult.value,
             durationNum
           );
     
@@ -5769,47 +5760,23 @@
             return reply.code(404).send(createProblemDetails(404, "Not Found", "Venue not found"));
           }
     
-          // Validate date formats
-          const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
-          if (!dateRegex.test(startDate) || !dateRegex.test(endDate)) {
-            return reply
-              .code(400)
-              .send(createProblemDetails(400, "Bad Request", "Invalid date format. Use YYYY-MM-DD."));
+          const rangeResult = validateDateRange(startDate, endDate);
+          if (!rangeResult.valid) {
+            return reply.code(400).send(createProblemDetails(400, "Bad Request", rangeResult.error!));
           }
     
-          // Validate date range
-          const start = new Date(startDate);
-          const end = new Date(endDate);
-          if (start > end) {
+          const partySizeResult = validatePartySize(partySize);
+          if (!partySizeResult.valid) {
             return reply
               .code(400)
-              .send(
-                createProblemDetails(
-                  400,
-                  "Bad Request",
-                  "startDate must be before or equal to endDate."
-                )
-              );
-          }
-    
-          const partySizeNum = parseInt(partySize, 10);
-          if (isNaN(partySizeNum) || partySizeNum < 1) {
-            return reply
-              .code(400)
-              .send(
-                createProblemDetails(
-                  400,
-                  "Bad Request",
-                  "Invalid party size. Must be a positive integer."
-                )
-              );
+              .send(createProblemDetails(400, "Bad Request", partySizeResult.error));
           }
     
           const dates = await availabilityService.getAvailableDates(
             venueId,
             startDate,
             endDate,
-            partySizeNum
+            partySizeResult.value
           );
     
           return { data: dates };
@@ -6710,8 +6677,7 @@
               .code(400)
               .send(createProblemDetails(400, "Bad Request", "venueId is required"));
           }
-          const page = Math.max(1, parseInt(request.query.page ?? "1", 10) || 1);
-          const limit = Math.max(1, Math.min(100, parseInt(request.query.limit ?? "20", 10) || 20));
+          const { page, limit } = validatePagination(request.query.page, request.query.limit);
           return guestService.list(venueId, page, limit);
         }
       );
@@ -7858,17 +7824,21 @@
             } as never);
           }
     
-          const parsedPartySize = parseInt(partySize, 10);
-          if (isNaN(parsedPartySize) || parsedPartySize < 1) {
+          const partySizeResult = validatePartySize(partySize);
+          if (!partySizeResult.valid) {
             return reply.status(400).send({
               type: "https://httpproblems.com/http-status/400",
               title: "Invalid Party Size",
               status: 400,
-              detail: "partySize must be a positive integer.",
+              detail: partySizeResult.error,
             } as never);
           }
     
-          const slots = await availabilityService.generateTimeSlots(venue.id, date, parsedPartySize);
+          const slots = await availabilityService.generateTimeSlots(
+            venue.id,
+            date,
+            partySizeResult.value
+          );
           const availableOnly = slots.filter((s: TimeSlot) => s.available);
     
           return reply.send({ data: availableOnly });
@@ -14458,6 +14428,18 @@
       getPoolMetrics: ReturnType<typeof vi.fn>;
     }
   </file>
+  <file path="packages/database/src/validators.ts">
+    export interface ValidResult<T> {
+      valid: true;
+      value: T;
+      error?: never;
+    }
+    export interface InvalidResult {
+      valid: false;
+      value?: never;
+      error: string;
+    }
+  </file>
   <file path="packages/gh-client/src/client.ts">
     export interface GhClientOptions extends ExecRunnerOptions {
       runner?: ExecRunner;
@@ -15233,7 +15215,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -15215,18 +15215,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms.txt
+++ b/llms.txt
@@ -3735,6 +3735,22 @@
       }
     </item>
   </file>
+  <file path="packages/database/src/validators.ts">
+    <item priority="low">
+      interface ValidResult {
+        valid: true;
+        value: T;
+        error?: never;
+      }
+    </item>
+    <item priority="low">
+      interface InvalidResult {
+        valid: false;
+        value?: never;
+        error: string;
+      }
+    </item>
+  </file>
   <file path="packages/gh-client/src/client.ts">
     <item priority="low">
       interface GhClientOptions {

--- a/packages/database/llms-full.txt
+++ b/packages/database/llms-full.txt
@@ -54,5 +54,17 @@
       getPoolMetrics: ReturnType<typeof vi.fn>;
     }
   </file>
+  <file path="src/validators.ts">
+    export interface ValidResult<T> {
+      valid: true;
+      value: T;
+      error?: never;
+    }
+    export interface InvalidResult {
+      valid: false;
+      value?: never;
+      error: string;
+    }
+  </file>
   </section>
 </codebase>

--- a/packages/database/llms.txt
+++ b/packages/database/llms.txt
@@ -42,5 +42,21 @@
       }
     </item>
   </file>
+  <file path="src/validators.ts">
+    <item priority="low">
+      interface ValidResult {
+        valid: true;
+        value: T;
+        error?: never;
+      }
+    </item>
+    <item priority="low">
+      interface InvalidResult {
+        valid: false;
+        value?: never;
+        error: string;
+      }
+    </item>
+  </file>
   </section>
 </codebase>

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -10,6 +10,15 @@ export {
 } from "./list-utils.js";
 export type { PaginationMeta, PaginatedResponse } from "./list-utils.js";
 
+export {
+  validateDateString,
+  validatePartySize,
+  validatePagination,
+  validateDateRange,
+  validateEnum,
+} from "./validators.js";
+export type { ValidResult, InvalidResult, ValidationResult } from "./validators.js";
+
 /** Returns true when `err` is a Prisma "record not found" error (code P2025). */
 export function isPrismaNotFound(err: unknown): boolean {
   return (

--- a/packages/database/src/validators.test.ts
+++ b/packages/database/src/validators.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateDateString,
+  validatePartySize,
+  validatePagination,
+  validateDateRange,
+  validateEnum,
+} from "./validators.js";
+
+describe("validateDateString", () => {
+  it("returns valid with Date for YYYY-MM-DD string", () => {
+    const result = validateDateString("2024-06-15");
+    expect(result.valid).toBe(true);
+    expect(result.value).toBeInstanceOf(Date);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("returns invalid for wrong format", () => {
+    const result = validateDateString("15/06/2024");
+    expect(result.valid).toBe(false);
+    expect(result.value).toBeUndefined();
+    expect(result.error).toMatch(/YYYY-MM-DD/);
+  });
+
+  it("returns invalid for empty string", () => {
+    const result = validateDateString("");
+    expect(result.valid).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it("returns invalid for undefined", () => {
+    const result = validateDateString(undefined);
+    expect(result.valid).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it("returns invalid for date with wrong separators", () => {
+    const result = validateDateString("2024.06.15");
+    expect(result.valid).toBe(false);
+  });
+
+  it("returns invalid for impossible calendar date (month 13)", () => {
+    const result = validateDateString("2024-13-01");
+    expect(result.valid).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it("returns invalid for impossible calendar date (day 32)", () => {
+    const result = validateDateString("2024-01-32");
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects ISO datetime strings (not date-only)", () => {
+    const result = validateDateString("2024-06-15T10:00:00Z");
+    expect(result.valid).toBe(false);
+  });
+
+  it("returns valid Date with correct year/month/day", () => {
+    const result = validateDateString("2024-03-20");
+    expect(result.valid).toBe(true);
+    const d = result.value as Date;
+    expect(d.getUTCFullYear()).toBe(2024);
+    expect(d.getUTCMonth()).toBe(2); // 0-indexed
+    expect(d.getUTCDate()).toBe(20);
+  });
+});
+
+describe("validatePartySize", () => {
+  it("returns valid with number for '4'", () => {
+    const result = validatePartySize("4");
+    expect(result.valid).toBe(true);
+    expect(result.value).toBe(4);
+  });
+
+  it("returns invalid for '0'", () => {
+    const result = validatePartySize("0");
+    expect(result.valid).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it("returns invalid for negative string", () => {
+    const result = validatePartySize("-1");
+    expect(result.valid).toBe(false);
+  });
+
+  it("returns invalid for non-numeric string", () => {
+    const result = validatePartySize("abc");
+    expect(result.valid).toBe(false);
+  });
+
+  it("returns invalid for undefined", () => {
+    const result = validatePartySize(undefined);
+    expect(result.valid).toBe(false);
+  });
+
+  it("returns invalid for empty string", () => {
+    const result = validatePartySize("");
+    expect(result.valid).toBe(false);
+  });
+
+  it("returns invalid for fractional number string", () => {
+    const result = validatePartySize("2.5");
+    expect(result.valid).toBe(false);
+  });
+
+  it("returns valid for boundary value '1'", () => {
+    const result = validatePartySize("1");
+    expect(result.valid).toBe(true);
+    expect(result.value).toBe(1);
+  });
+
+  it("returns invalid for Infinity", () => {
+    const result = validatePartySize("Infinity");
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe("validatePagination", () => {
+  it("returns defaults when no params provided", () => {
+    const result = validatePagination();
+    expect(result.valid).toBe(true);
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(20);
+  });
+
+  it("parses valid page and limit", () => {
+    const result = validatePagination("2", "50");
+    expect(result.valid).toBe(true);
+    expect(result.page).toBe(2);
+    expect(result.limit).toBe(50);
+  });
+
+  it("floors page to 1 for page=0", () => {
+    const result = validatePagination("0");
+    expect(result.valid).toBe(true);
+    expect(result.page).toBe(1);
+  });
+
+  it("floors page to 1 for negative page", () => {
+    const result = validatePagination("-3");
+    expect(result.valid).toBe(true);
+    expect(result.page).toBe(1);
+  });
+
+  it("caps limit at 100", () => {
+    const result = validatePagination("1", "999");
+    expect(result.valid).toBe(true);
+    expect(result.limit).toBe(100);
+  });
+
+  it("floors limit to 1 for limit=0", () => {
+    const result = validatePagination("1", "0");
+    expect(result.valid).toBe(true);
+    expect(result.limit).toBe(1);
+  });
+
+  it("returns valid with defaults for non-numeric strings", () => {
+    const result = validatePagination("abc", "xyz");
+    expect(result.valid).toBe(true);
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(20);
+  });
+
+  it("accepts boundary limit=100", () => {
+    const result = validatePagination("1", "100");
+    expect(result.valid).toBe(true);
+    expect(result.limit).toBe(100);
+  });
+
+  it("accepts boundary limit=1", () => {
+    const result = validatePagination("1", "1");
+    expect(result.valid).toBe(true);
+    expect(result.limit).toBe(1);
+  });
+});
+
+describe("validateDateRange", () => {
+  it("returns valid for equal start and end", () => {
+    const result = validateDateRange("2024-06-15", "2024-06-15");
+    expect(result.valid).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("returns valid for start before end", () => {
+    const result = validateDateRange("2024-06-01", "2024-06-30");
+    expect(result.valid).toBe(true);
+  });
+
+  it("returns invalid when start is after end", () => {
+    const result = validateDateRange("2024-06-30", "2024-06-01");
+    expect(result.valid).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it("returns invalid for invalid start date format", () => {
+    const result = validateDateRange("bad-date", "2024-06-30");
+    expect(result.valid).toBe(false);
+  });
+
+  it("returns invalid for invalid end date format", () => {
+    const result = validateDateRange("2024-06-01", "not-a-date");
+    expect(result.valid).toBe(false);
+  });
+
+  it("returns invalid when range exceeds maxDays", () => {
+    const result = validateDateRange("2024-01-01", "2024-12-31", 30);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/30/);
+  });
+
+  it("returns valid when range is exactly maxDays", () => {
+    const result = validateDateRange("2024-06-01", "2024-07-01", 30);
+    expect(result.valid).toBe(true);
+  });
+
+  it("ignores maxDays when not provided", () => {
+    const result = validateDateRange("2024-01-01", "2025-12-31");
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe("validateEnum", () => {
+  it("returns valid for a value in the allowed list", () => {
+    const result = validateEnum("CONFIRMED", ["PENDING", "CONFIRMED", "CANCELLED"] as const);
+    expect(result.valid).toBe(true);
+    expect(result.value).toBe("CONFIRMED");
+  });
+
+  it("returns invalid for a value not in the allowed list", () => {
+    const result = validateEnum("UNKNOWN", ["PENDING", "CONFIRMED"] as const);
+    expect(result.valid).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it("returns invalid for empty string", () => {
+    const result = validateEnum("", ["PENDING", "CONFIRMED"] as const);
+    expect(result.valid).toBe(false);
+  });
+
+  it("returns invalid for undefined", () => {
+    const result = validateEnum(undefined, ["PENDING", "CONFIRMED"] as const);
+    expect(result.valid).toBe(false);
+  });
+
+  it("is case-sensitive", () => {
+    const result = validateEnum("confirmed", ["PENDING", "CONFIRMED"] as const);
+    expect(result.valid).toBe(false);
+  });
+
+  it("returns valid for single-item allowed list", () => {
+    const result = validateEnum("ACTIVE", ["ACTIVE"] as const);
+    expect(result.valid).toBe(true);
+    expect(result.value).toBe("ACTIVE");
+  });
+
+  it("includes allowed values in error message", () => {
+    const result = validateEnum("BAD", ["FOO", "BAR"] as const);
+    expect(result.error).toMatch(/FOO|BAR/);
+  });
+});

--- a/packages/database/src/validators.ts
+++ b/packages/database/src/validators.ts
@@ -1,0 +1,147 @@
+/**
+ * Query-parameter validation seam.
+ *
+ * Each function is pure, takes raw string input (or undefined) from HTTP query
+ * params, and returns a consistent `{ valid, value?, error? }` shape.
+ *
+ * Date format rule: YYYY-MM-DD only (ISO 8601 date-only, no time component).
+ * This is the canonical format used across all reservation and availability
+ * endpoints. Datetime strings (with 'T') are explicitly rejected here so that
+ * callers pass only the date portion.
+ *
+ * Security note: the date regex is anchored (^ and $) and has fixed-length
+ * quantifiers only — no backtracking, no ReDoS risk.
+ */
+
+/** Matches exactly YYYY-MM-DD and nothing else. Anchored; no ReDoS risk. */
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+export interface ValidResult<T> {
+  valid: true;
+  value: T;
+  error?: never;
+}
+
+export interface InvalidResult {
+  valid: false;
+  value?: never;
+  error: string;
+}
+
+export type ValidationResult<T> = ValidResult<T> | InvalidResult;
+
+/**
+ * Validates a YYYY-MM-DD date string.
+ * Returns `{ valid: true, value: Date }` on success (Date is UTC midnight).
+ * Returns `{ valid: false, error }` for wrong format or impossible calendar dates.
+ */
+export function validateDateString(value: string | undefined): ValidationResult<Date> {
+  if (!value) {
+    return { valid: false, error: "Date is required. Use YYYY-MM-DD format." };
+  }
+  if (!DATE_REGEX.test(value)) {
+    return { valid: false, error: `Invalid date format. Use YYYY-MM-DD. Received: ${value}` };
+  }
+  const d = new Date(`${value}T00:00:00Z`);
+  if (isNaN(d.getTime())) {
+    return { valid: false, error: `Invalid calendar date: ${value}` };
+  }
+  // Verify the parsed date round-trips — catches impossible dates like 2024-13-01
+  const reparsed = d.toISOString().slice(0, 10);
+  if (reparsed !== value) {
+    return { valid: false, error: `Invalid calendar date: ${value}` };
+  }
+  return { valid: true, value: d };
+}
+
+/**
+ * Validates a party size from a query string value.
+ * Must be a positive integer (no decimals, no Infinity, >= 1).
+ */
+export function validatePartySize(value: string | undefined): ValidationResult<number> {
+  if (!value) {
+    return { valid: false, error: "partySize is required. Must be a positive integer." };
+  }
+  // Reject decimals and Infinity before parseInt
+  if (value.includes(".") || value === "Infinity" || value === "-Infinity") {
+    return { valid: false, error: "Invalid party size. Must be a positive integer." };
+  }
+  const n = parseInt(value, 10);
+  if (isNaN(n) || n < 1) {
+    return { valid: false, error: "Invalid party size. Must be a positive integer." };
+  }
+  return { valid: true, value: n };
+}
+
+/**
+ * Validates and normalises pagination query params.
+ * Always returns `valid: true` — invalid inputs fall back to safe defaults.
+ * page: min 1, default 1.
+ * limit: min 1, max 100, default 20.
+ */
+export function validatePagination(
+  page?: string,
+  limit?: string
+): { valid: true; page: number; limit: number; error?: never } {
+  const rawPage = parseInt(page ?? "1", 10);
+  const rawLimit = parseInt(limit ?? "20", 10);
+  const safePage = Math.max(1, isNaN(rawPage) ? 1 : rawPage);
+  const safeLimit = Math.max(1, Math.min(100, isNaN(rawLimit) ? 20 : rawLimit));
+  return { valid: true, page: safePage, limit: safeLimit };
+}
+
+/**
+ * Validates a date range given YYYY-MM-DD strings for start and end.
+ * Optionally enforces a maxDays window.
+ */
+export function validateDateRange(
+  startDate: string,
+  endDate: string,
+  maxDays?: number
+): { valid: boolean; error?: string } {
+  const startResult = validateDateString(startDate);
+  if (!startResult.valid) {
+    return { valid: false, error: `Invalid startDate: ${startResult.error}` };
+  }
+  const endResult = validateDateString(endDate);
+  if (!endResult.valid) {
+    return { valid: false, error: `Invalid endDate: ${endResult.error}` };
+  }
+  if (startResult.value > endResult.value) {
+    return { valid: false, error: "startDate must be before or equal to endDate." };
+  }
+  if (maxDays !== undefined) {
+    const diffMs = endResult.value.getTime() - startResult.value.getTime();
+    const diffDays = diffMs / (1000 * 60 * 60 * 24);
+    if (diffDays > maxDays) {
+      return {
+        valid: false,
+        error: `Date range cannot exceed ${maxDays} days. Received ${Math.ceil(diffDays)} days.`,
+      };
+    }
+  }
+  return { valid: true };
+}
+
+/**
+ * Validates that a value belongs to a fixed set of allowed string literals.
+ * Returns the narrowed typed value on success.
+ */
+export function validateEnum<T extends string>(
+  value: string | undefined,
+  allowed: ReadonlyArray<T>
+): ValidationResult<T> {
+  if (!value) {
+    return {
+      valid: false,
+      error: `Value is required. Allowed: ${allowed.join(", ")}`,
+    };
+  }
+  if ((allowed as ReadonlyArray<string>).includes(value)) {
+    return { valid: true, value: value as T };
+  }
+  return {
+    valid: false,
+    error: `Invalid value "${value}". Allowed: ${allowed.join(", ")}`,
+  };
+}

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,18 +337,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,7 +337,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/services/reservations/llms-full.txt
+++ b/services/reservations/llms-full.txt
@@ -182,25 +182,16 @@
             return reply.code(404).send(createProblemDetails(404, "Not Found", "Venue not found"));
           }
     
-          // Validate date format
-          const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
-          if (!dateRegex.test(date)) {
-            return reply
-              .code(400)
-              .send(createProblemDetails(400, "Bad Request", "Invalid date format. Use YYYY-MM-DD."));
+          const dateResult = validateDateString(date);
+          if (!dateResult.valid) {
+            return reply.code(400).send(createProblemDetails(400, "Bad Request", dateResult.error));
           }
     
-          const partySizeNum = parseInt(partySize, 10);
-          if (isNaN(partySizeNum) || partySizeNum < 1) {
+          const partySizeResult = validatePartySize(partySize);
+          if (!partySizeResult.valid) {
             return reply
               .code(400)
-              .send(
-                createProblemDetails(
-                  400,
-                  "Bad Request",
-                  "Invalid party size. Must be a positive integer."
-                )
-              );
+              .send(createProblemDetails(400, "Bad Request", partySizeResult.error));
           }
     
           const durationNum = duration ? parseInt(duration, 10) : undefined;
@@ -219,7 +210,7 @@
           const slots = await availabilityService.generateTimeSlots(
             venueId,
             date,
-            partySizeNum,
+            partySizeResult.value,
             durationNum
           );
     
@@ -295,47 +286,23 @@
             return reply.code(404).send(createProblemDetails(404, "Not Found", "Venue not found"));
           }
     
-          // Validate date formats
-          const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
-          if (!dateRegex.test(startDate) || !dateRegex.test(endDate)) {
-            return reply
-              .code(400)
-              .send(createProblemDetails(400, "Bad Request", "Invalid date format. Use YYYY-MM-DD."));
+          const rangeResult = validateDateRange(startDate, endDate);
+          if (!rangeResult.valid) {
+            return reply.code(400).send(createProblemDetails(400, "Bad Request", rangeResult.error!));
           }
     
-          // Validate date range
-          const start = new Date(startDate);
-          const end = new Date(endDate);
-          if (start > end) {
+          const partySizeResult = validatePartySize(partySize);
+          if (!partySizeResult.valid) {
             return reply
               .code(400)
-              .send(
-                createProblemDetails(
-                  400,
-                  "Bad Request",
-                  "startDate must be before or equal to endDate."
-                )
-              );
-          }
-    
-          const partySizeNum = parseInt(partySize, 10);
-          if (isNaN(partySizeNum) || partySizeNum < 1) {
-            return reply
-              .code(400)
-              .send(
-                createProblemDetails(
-                  400,
-                  "Bad Request",
-                  "Invalid party size. Must be a positive integer."
-                )
-              );
+              .send(createProblemDetails(400, "Bad Request", partySizeResult.error));
           }
     
           const dates = await availabilityService.getAvailableDates(
             venueId,
             startDate,
             endDate,
-            partySizeNum
+            partySizeResult.value
           );
     
           return { data: dates };
@@ -1236,8 +1203,7 @@
               .code(400)
               .send(createProblemDetails(400, "Bad Request", "venueId is required"));
           }
-          const page = Math.max(1, parseInt(request.query.page ?? "1", 10) || 1);
-          const limit = Math.max(1, Math.min(100, parseInt(request.query.limit ?? "20", 10) || 20));
+          const { page, limit } = validatePagination(request.query.page, request.query.limit);
           return guestService.list(venueId, page, limit);
         }
       );
@@ -2384,17 +2350,21 @@
             } as never);
           }
     
-          const parsedPartySize = parseInt(partySize, 10);
-          if (isNaN(parsedPartySize) || parsedPartySize < 1) {
+          const partySizeResult = validatePartySize(partySize);
+          if (!partySizeResult.valid) {
             return reply.status(400).send({
               type: "https://httpproblems.com/http-status/400",
               title: "Invalid Party Size",
               status: 400,
-              detail: "partySize must be a positive integer.",
+              detail: partySizeResult.error,
             } as never);
           }
     
-          const slots = await availabilityService.generateTimeSlots(venue.id, date, parsedPartySize);
+          const slots = await availabilityService.generateTimeSlots(
+            venue.id,
+            date,
+            partySizeResult.value
+          );
           const availableOnly = slots.filter((s: TimeSlot) => s.available);
     
           return reply.send({ data: availableOnly });

--- a/services/reservations/src/routes/availability.ts
+++ b/services/reservations/src/routes/availability.ts
@@ -1,6 +1,7 @@
 import type { FastifyPluginAsync } from "fastify";
 import type { TimeSlot, DateAvailability, ApiResponse, ApiError } from "@mbe/types";
 import { createProblemDetails } from "@mbe/types";
+import { validateDateString, validatePartySize, validateDateRange } from "@mbe/database";
 import { availabilityService } from "../services/availability.js";
 import { venueService } from "../services/venue.js";
 
@@ -132,25 +133,16 @@ export const availabilityRoutes: FastifyPluginAsync = async (fastify) => {
         return reply.code(404).send(createProblemDetails(404, "Not Found", "Venue not found"));
       }
 
-      // Validate date format
-      const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
-      if (!dateRegex.test(date)) {
-        return reply
-          .code(400)
-          .send(createProblemDetails(400, "Bad Request", "Invalid date format. Use YYYY-MM-DD."));
+      const dateResult = validateDateString(date);
+      if (!dateResult.valid) {
+        return reply.code(400).send(createProblemDetails(400, "Bad Request", dateResult.error));
       }
 
-      const partySizeNum = parseInt(partySize, 10);
-      if (isNaN(partySizeNum) || partySizeNum < 1) {
+      const partySizeResult = validatePartySize(partySize);
+      if (!partySizeResult.valid) {
         return reply
           .code(400)
-          .send(
-            createProblemDetails(
-              400,
-              "Bad Request",
-              "Invalid party size. Must be a positive integer."
-            )
-          );
+          .send(createProblemDetails(400, "Bad Request", partySizeResult.error));
       }
 
       const durationNum = duration ? parseInt(duration, 10) : undefined;
@@ -169,7 +161,7 @@ export const availabilityRoutes: FastifyPluginAsync = async (fastify) => {
       const slots = await availabilityService.generateTimeSlots(
         venueId,
         date,
-        partySizeNum,
+        partySizeResult.value,
         durationNum
       );
 
@@ -245,47 +237,23 @@ export const availabilityRoutes: FastifyPluginAsync = async (fastify) => {
         return reply.code(404).send(createProblemDetails(404, "Not Found", "Venue not found"));
       }
 
-      // Validate date formats
-      const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
-      if (!dateRegex.test(startDate) || !dateRegex.test(endDate)) {
-        return reply
-          .code(400)
-          .send(createProblemDetails(400, "Bad Request", "Invalid date format. Use YYYY-MM-DD."));
+      const rangeResult = validateDateRange(startDate, endDate);
+      if (!rangeResult.valid) {
+        return reply.code(400).send(createProblemDetails(400, "Bad Request", rangeResult.error!));
       }
 
-      // Validate date range
-      const start = new Date(startDate);
-      const end = new Date(endDate);
-      if (start > end) {
+      const partySizeResult = validatePartySize(partySize);
+      if (!partySizeResult.valid) {
         return reply
           .code(400)
-          .send(
-            createProblemDetails(
-              400,
-              "Bad Request",
-              "startDate must be before or equal to endDate."
-            )
-          );
-      }
-
-      const partySizeNum = parseInt(partySize, 10);
-      if (isNaN(partySizeNum) || partySizeNum < 1) {
-        return reply
-          .code(400)
-          .send(
-            createProblemDetails(
-              400,
-              "Bad Request",
-              "Invalid party size. Must be a positive integer."
-            )
-          );
+          .send(createProblemDetails(400, "Bad Request", partySizeResult.error));
       }
 
       const dates = await availabilityService.getAvailableDates(
         venueId,
         startDate,
         endDate,
-        partySizeNum
+        partySizeResult.value
       );
 
       return { data: dates };

--- a/services/reservations/src/routes/guests.ts
+++ b/services/reservations/src/routes/guests.ts
@@ -10,6 +10,7 @@ import type {
   PaginatedResponse,
 } from "@mbe/types";
 import { createProblemDetails } from "@mbe/types";
+import { validatePagination } from "@mbe/database";
 import { requireAuth } from "@mbe/auth/fastify";
 import { guestService } from "../services/guest.js";
 import { venueService } from "../services/venue.js";
@@ -64,8 +65,7 @@ export const guestRoutes: FastifyPluginAsync = async (fastify) => {
           .code(400)
           .send(createProblemDetails(400, "Bad Request", "venueId is required"));
       }
-      const page = Math.max(1, parseInt(request.query.page ?? "1", 10) || 1);
-      const limit = Math.max(1, Math.min(100, parseInt(request.query.limit ?? "20", 10) || 20));
+      const { page, limit } = validatePagination(request.query.page, request.query.limit);
       return guestService.list(venueId, page, limit);
     }
   );

--- a/services/reservations/src/routes/public-availability.ts
+++ b/services/reservations/src/routes/public-availability.ts
@@ -1,5 +1,6 @@
 import type { FastifyPluginAsync } from "fastify";
 import type { TimeSlot, ApiResponse } from "@mbe/types";
+import { validatePartySize } from "@mbe/database";
 import { venueService } from "../services/venue.js";
 import { availabilityService } from "../services/availability.js";
 import { publicRateLimitHook } from "../middleware/public-rate-limit.js";
@@ -45,17 +46,21 @@ export const publicAvailabilityRoutes: FastifyPluginAsync = async (fastify) => {
         } as never);
       }
 
-      const parsedPartySize = parseInt(partySize, 10);
-      if (isNaN(parsedPartySize) || parsedPartySize < 1) {
+      const partySizeResult = validatePartySize(partySize);
+      if (!partySizeResult.valid) {
         return reply.status(400).send({
           type: "https://httpproblems.com/http-status/400",
           title: "Invalid Party Size",
           status: 400,
-          detail: "partySize must be a positive integer.",
+          detail: partySizeResult.error,
         } as never);
       }
 
-      const slots = await availabilityService.generateTimeSlots(venue.id, date, parsedPartySize);
+      const slots = await availabilityService.generateTimeSlots(
+        venue.id,
+        date,
+        partySizeResult.value
+      );
       const availableOnly = slots.filter((s: TimeSlot) => s.available);
 
       return reply.send({ data: availableOnly });


### PR DESCRIPTION
## Summary

- Introduces `packages/database/src/validators.ts` with five pure validator functions: `validateDateString`, `validatePartySize`, `validatePagination`, `validateDateRange`, `validateEnum` — all returning a consistent `{ valid, value?, error? }` shape
- Replaces inline date-regex, `parseInt+isNaN`, and pagination-bounds logic in `services/reservations/src/routes/availability.ts`, `public-availability.ts`, and `guests.ts` with calls to the shared validators
- Exports validators from `@mbe/database` index (already imported by both `services/reservations` and `services/agent`)
- 42 isolated unit tests covering valid, invalid, and boundary inputs for each validator

## Placement decision

Validators were added to `@mbe/database` (not a new package) because both `services/reservations` and `services/agent` already depend on it. This avoids dependency-graph + llms.txt drift from a new package.

## Reconciled date-format rule

**YYYY-MM-DD only** — ISO 8601 date-only, no time component. The regex is anchored (`^\d{4}-\d{2}-\d{2}$`) with fixed-length quantifiers (no ReDoS). Impossible calendar dates (month 13, day 32) are caught via UTC Date round-trip check. Datetime strings with `T` are explicitly rejected.

## Test plan

- [ ] `pnpm --dir packages/database test` — 102 tests pass (42 new validator tests + 60 existing)
- [ ] `pnpm --dir services/reservations test` — 978 tests pass (availability, public-availability, guests routes confirmed)
- [ ] `pnpm --dir services/agent test` — 292 tests pass
- [ ] `pnpm lint` + `pnpm typecheck` all pass for all three packages
- [ ] `check-adr` + `check-deps` pass
- [ ] `pnpm regen` clean (no artifact drift)
- [ ] `detect-instruction-rot.mjs` clean

Closes #2490