### PR TITLE
feat(hospitality): show cancellation fee in staff CancelReservationDialog before confirm

### DIFF
--- a/apps/hospitality/llms-full.txt
+++ b/apps/hospitality/llms-full.txt
@@ -391,6 +391,20 @@
     export const CURRENT_USER_QUERY_KEY = "currentUser" as const;
     export const USERS_QUERY_KEY = "users" as const;
   </file>
+  <file path="src/hooks/useVenuePolicy.ts">
+    interface PublicVenueDepositResponse {
+      data?: {
+        deposit?: {
+          enabled: boolean;
+          amountCents: number | null;
+          freeCancellationHours: number | null;
+          lateCancellationFeePercent: number | null;
+          noShowFeePercent: number | null;
+        };
+      };
+    }
+    export const VENUE_POLICY_QUERY_KEY = "venue-policy" as const;
+  </file>
   <file path="src/hooks/useVenueReadiness.ts">
     export type SetupStep = "onboarding" | "operating-hours" | "floor-plan";
     export interface VenueReadiness {
@@ -455,6 +469,15 @@
   </file>
   </section>
   <section priority="medium" role="utils">
+  <file path="src/utils/cancellation-fee.ts">
+    export interface CancellationPolicy {
+      depositAmountCents: number;
+      freeCancellationHours: number | null;
+      lateCancellationFeePercent: number | null;
+      noShowFeePercent: number | null;
+    }
+    export type FeeType = "none" | "late" | "noshow";
+  </file>
   <file path="src/utils/format.ts">
     export function formatLongDate(dateStr: string): string {
       return new Date(dateStr + "T00:00:00").toLocaleDateString(LOCALE, {

--- a/apps/hospitality/llms.txt
+++ b/apps/hospitality/llms.txt
@@ -297,6 +297,19 @@
       export const USERS_QUERY_KEY: unknown;
     </item>
   </file>
+  <file path="src/hooks/useVenuePolicy.ts">
+    <item priority="high">
+      interface PublicVenueDepositResponse {
+        data?: {
+          deposit?: {
+            enabled: boolean;
+            amountCen...;
+      }
+    </item>
+    <item priority="high">
+      export const VENUE_POLICY_QUERY_KEY: unknown;
+    </item>
+  </file>
   <file path="src/hooks/useVenueReadiness.ts">
     <item priority="low">
       type SetupStep = "onboarding" | "operating-hours" | "floor-plan";
@@ -370,6 +383,19 @@
   </file>
   </section>
   <section priority="medium" role="utils">
+  <file path="src/utils/cancellation-fee.ts">
+    <item priority="low">
+      interface CancellationPolicy {
+        depositAmountCents: number;
+        freeCancellationHours: number | null;
+        lateCancellationFeePercent: number | null;
+        noShowFeePercent: number | null;
+      }
+    </item>
+    <item priority="low">
+      type FeeType = "none" | "late" | "noshow";
+    </item>
+  </file>
   <file path="src/utils/format.ts">
     <item priority="high">
       export function formatLongDate(dateStr: string): string { /* ... */ }

--- a/apps/hospitality/src/components/timeline/CancelReservationDialog.module.css
+++ b/apps/hospitality/src/components/timeline/CancelReservationDialog.module.css
@@ -155,3 +155,18 @@
   background: color-mix(in srgb, var(--rialto-error) 40%, transparent);
   cursor: not-allowed;
 }
+
+.feeBanner {
+  background: var(--rialto-surface-recessed);
+  border: 1px solid var(--rialto-border);
+  border-radius: var(--rialto-radius-default);
+  padding: var(--rialto-space-sm) var(--rialto-space-md);
+  font-size: var(--rialto-text-sm);
+  color: var(--rialto-text-secondary);
+}
+
+.feeBannerWarning {
+  background: var(--rialto-warning-muted, var(--rialto-surface-recessed));
+  border-color: var(--rialto-warning, var(--rialto-border));
+  color: var(--rialto-text-primary);
+}

--- a/apps/hospitality/src/components/timeline/CancelReservationDialog.test.tsx
+++ b/apps/hospitality/src/components/timeline/CancelReservationDialog.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { CancelReservationDialog } from "./CancelReservationDialog.js";
+import type { CancellationPolicy } from "../../utils/cancellation-fee.js";
 
 // Mock scrollIntoView for JSDOM
 window.HTMLElement.prototype.scrollIntoView = vi.fn();
@@ -124,6 +125,70 @@ describe("CancelReservationDialog", () => {
 
     await waitFor(() => {
       resolveConfirm!(undefined);
+    });
+  });
+
+  describe("cancellation fee display", () => {
+    // reservationTime is 4 hours from now → within a 24h free window (free)
+    const futureReservation = new Date(Date.now() + 4 * 60 * 60 * 1000);
+    // pastReservation is 1 hour ago → no-show
+    const pastReservation = new Date(Date.now() - 1 * 60 * 60 * 1000);
+    // lateReservation is 1 hour from now → within free window... let&apos;s use 2h free window
+    // so "late" = 1h from now with 2h free window (too late but before reservation)
+    const lateReservation = new Date(Date.now() + 1 * 60 * 60 * 1000);
+
+    const basePolicy: CancellationPolicy = {
+      depositAmountCents: 5000,
+      freeCancellationHours: 2,
+      lateCancellationFeePercent: 50,
+      noShowFeePercent: 100,
+    };
+
+    it("shows no fee for free cancellation (within free window)", () => {
+      // 4h from now with 2h free window → free
+      render(
+        <CancelReservationDialog
+          {...defaultProps}
+          policy={basePolicy}
+          reservationTime={futureReservation}
+          currency="usd"
+        />
+      );
+      expect(screen.getByText(/no cancellation fee/i)).toBeDefined();
+      expect(screen.getByText(/\$50\.00/)).toBeDefined();
+    });
+
+    it("shows late cancellation fee", () => {
+      // 1h from now with 2h free window → late
+      render(
+        <CancelReservationDialog
+          {...defaultProps}
+          policy={basePolicy}
+          reservationTime={lateReservation}
+          currency="usd"
+        />
+      );
+      expect(screen.getByText(/late cancellation fee/i)).toBeDefined();
+      expect(screen.getByText(/\$25\.00/)).toBeDefined();
+    });
+
+    it("shows no-show fee", () => {
+      render(
+        <CancelReservationDialog
+          {...defaultProps}
+          policy={basePolicy}
+          reservationTime={pastReservation}
+          currency="usd"
+        />
+      );
+      expect(screen.getByText(/no-show fee/i)).toBeDefined();
+      expect(screen.getByText(/\$50\.00 forfeited/i)).toBeDefined();
+    });
+
+    it("shows no fee when policy is not provided", () => {
+      render(<CancelReservationDialog {...defaultProps} />);
+      // No fee section at all
+      expect(screen.queryByText(/cancellation fee/i)).toBeNull();
     });
   });
 });

--- a/apps/hospitality/src/components/timeline/CancelReservationDialog.tsx
+++ b/apps/hospitality/src/components/timeline/CancelReservationDialog.tsx
@@ -1,5 +1,8 @@
 import { useState } from "react";
 import { Button, Select, TextArea, Stack, Text } from "@mattbutlerengineering/rialto";
+import type { CancellationPolicy } from "../../utils/cancellation-fee.js";
+import { evaluateCancellationFee } from "../../utils/cancellation-fee.js";
+import { formatCurrencyFromCents } from "../../utils/format.js";
 import styles from "./CancelReservationDialog.module.css";
 
 interface CancelReservationDialogProps {
@@ -7,6 +10,12 @@ interface CancelReservationDialogProps {
   guestName: string | null;
   onConfirm: (reason: string, note: string) => Promise<void>;
   onClose: () => void;
+  /** Venue cancellation policy. When provided, shows the computed fee before confirm. */
+  policy?: CancellationPolicy | null;
+  /** The reservation start time. Required when `policy` is provided. */
+  reservationTime?: Date;
+  /** ISO currency code (e.g. "usd"). Defaults to "usd". */
+  currency?: string;
 }
 
 const CANCELLATION_REASONS = [
@@ -16,11 +25,30 @@ const CANCELLATION_REASONS = [
   { value: "other", label: "Other" },
 ];
 
+function buildFeeLabel(
+  feeType: "none" | "late" | "noshow",
+  feeAmountCents: number,
+  refundAmountCents: number,
+  currency: string
+): string {
+  switch (feeType) {
+    case "none":
+      return `No cancellation fee — full refund of ${formatCurrencyFromCents(refundAmountCents, currency)}`;
+    case "late":
+      return `Late cancellation fee: ${formatCurrencyFromCents(feeAmountCents, currency)} — refund ${formatCurrencyFromCents(refundAmountCents, currency)}`;
+    case "noshow":
+      return `No-show fee: ${formatCurrencyFromCents(feeAmountCents, currency)} forfeited — refund ${formatCurrencyFromCents(refundAmountCents, currency)}`;
+  }
+}
+
 export function CancelReservationDialog({
   reservationId: _reservationId,
   guestName,
   onConfirm,
   onClose,
+  policy,
+  reservationTime,
+  currency = "usd",
 }: CancelReservationDialogProps) {
   const [reason, setReason] = useState<string>("guest_cancelled");
   const [note, setNote] = useState<string>("");
@@ -28,6 +56,10 @@ export function CancelReservationDialog({
   const [error, setError] = useState<string | null>(null);
 
   const displayName = guestName ?? "Guest";
+
+  // Compute fee at render time — no setState in effects
+  const feeResult =
+    policy && reservationTime ? evaluateCancellationFee(policy, reservationTime, new Date()) : null;
 
   const handleConfirm = async () => {
     setIsLoading(true);
@@ -59,6 +91,22 @@ export function CancelReservationDialog({
           </div>
 
           {error && <div className={styles.errorBanner}>{error}</div>}
+
+          {feeResult && (
+            <div
+              className={`${styles.feeBanner} ${feeResult.feeType !== "none" ? styles.feeBannerWarning : ""}`}
+              data-testid="cancellation-fee-banner"
+            >
+              <Text variant="caption">
+                {buildFeeLabel(
+                  feeResult.feeType,
+                  feeResult.feeAmountCents,
+                  feeResult.refundAmountCents,
+                  currency
+                )}
+              </Text>
+            </div>
+          )}
 
           <Stack gap="md">
             <Select

--- a/apps/hospitality/src/hooks/useVenuePolicy.ts
+++ b/apps/hospitality/src/hooks/useVenuePolicy.ts
@@ -1,0 +1,64 @@
+/**
+ * Fetches the venue cancellation policy for use in the staff cancel dialog.
+ *
+ * Uses the public `/public/v1/venues/:slug` endpoint (same source as the booking
+ * widget) which is the only API surface that exposes deposit/policy fields.
+ * No auth required, but we still use the api client for consistency.
+ */
+import { useQuery } from "@tanstack/react-query";
+import { useApiClient } from "./useApiClient.js";
+import type { CancellationPolicy } from "../utils/cancellation-fee.js";
+
+interface PublicVenueDepositResponse {
+  data?: {
+    deposit?: {
+      enabled: boolean;
+      amountCents: number | null;
+      freeCancellationHours: number | null;
+      lateCancellationFeePercent: number | null;
+      noShowFeePercent: number | null;
+    };
+  };
+}
+
+export const VENUE_POLICY_QUERY_KEY = "venue-policy" as const;
+
+/**
+ * Returns the cancellation policy for a venue by slug.
+ * Returns `null` when no deposit is enabled or policy fields are absent.
+ */
+export function useVenuePolicy(slug: string | undefined): {
+  policy: CancellationPolicy | null;
+  isLoading: boolean;
+} {
+  const api = useApiClient();
+
+  const query = useQuery({
+    queryKey: [VENUE_POLICY_QUERY_KEY, slug],
+    queryFn: async (): Promise<CancellationPolicy | null> => {
+      if (!slug) return null;
+      try {
+        const body = await api.client.get<PublicVenueDepositResponse>(
+          `/public/v1/venues/${encodeURIComponent(slug)}`
+        );
+        const deposit = body.data?.deposit;
+        if (!deposit?.enabled || deposit.amountCents == null) return null;
+        return {
+          depositAmountCents: deposit.amountCents,
+          freeCancellationHours: deposit.freeCancellationHours,
+          lateCancellationFeePercent: deposit.lateCancellationFeePercent,
+          noShowFeePercent: deposit.noShowFeePercent,
+        };
+      } catch {
+        return null;
+      }
+    },
+    enabled: !!slug,
+    staleTime: 5 * 60 * 1000, // 5 minutes — policy rarely changes during a shift
+  });
+
+  return {
+    policy: query.data ?? null,
+    isLoading: query.isLoading,
+  };
+}

--- a/apps/hospitality/src/pages/TimelinePage.test.tsx
+++ b/apps/hospitality/src/pages/TimelinePage.test.tsx
@@ -18,6 +18,9 @@ vi.mock("../hooks/useSSESync.js", () => ({
   useSSEEventFeed: vi.fn(() => []),
 }));
 vi.mock("../hooks/useTimelineData.js", () => ({ useTimelineData: vi.fn() }));
+vi.mock("../hooks/useVenuePolicy.js", () => ({
+  useVenuePolicy: vi.fn().mockReturnValue({ policy: null, isLoading: false }),
+}));
 // Block transitive resolution of packages unavailable in this worktree environment
 vi.mock("../hooks/useApiClient.js", () => ({ useApiClient: vi.fn() }));
 vi.mock("../hooks/useReservations.js", () => ({

--- a/apps/hospitality/src/pages/TimelinePage.tsx
+++ b/apps/hospitality/src/pages/TimelinePage.tsx
@@ -11,6 +11,7 @@ import { GuestCard } from "../components/crm/GuestCard.js";
 import { useVenue } from "../contexts/VenueContext.js";
 import { useSSEStatus } from "../hooks/useSSESync.js";
 import { useTimelineData } from "../hooks/useTimelineData.js";
+import { useVenuePolicy } from "../hooks/useVenuePolicy.js";
 import { PageHeader } from "../components/PageHeader";
 import styles from "./TimelinePage.module.css";
 
@@ -183,8 +184,11 @@ function ReservationDetails({ reservation, onEdit, onSeat, onCancel }: Reservati
 }
 
 export function TimelinePage() {
-  const { selectedVenueId } = useVenue();
+  const { selectedVenueId, selectedVenue } = useVenue();
   const { isConnected } = useSSEStatus();
+
+  // Fetch cancellation policy for the selected venue — used by CancelReservationDialog
+  const { policy: venuePolicy } = useVenuePolicy(selectedVenue?.slug);
 
   const { params, setParam } = useUrlParams(timelineFilterSchema, TIMELINE_DEFAULTS);
   const todayStr = useMemo(() => new Date().toLocaleDateString("en-CA"), []);
@@ -494,6 +498,9 @@ export function TimelinePage() {
           guestName={selectedReservation.guestName}
           onConfirm={handleCancel}
           onClose={() => setShowCancelDialog(false)}
+          policy={venuePolicy}
+          reservationTime={new Date(selectedReservation.startTime)}
+          currency={selectedVenue?.currencyCode?.toLowerCase() ?? "usd"}
         />
       )}
       {showEditDrawer && selectedReservation && (

--- a/apps/hospitality/src/utils/cancellation-fee.ts
+++ b/apps/hospitality/src/utils/cancellation-fee.ts
@@ -1,0 +1,73 @@
+/**
+ * Cancellation fee evaluation for staff-facing dialogs.
+ *
+ * Copied verbatim from services/reservations/src/services/cancellation-policy.ts
+ * (pure functions, no IO). DO NOT add fee math here — keep in sync with the service.
+ */
+
+export interface CancellationPolicy {
+  depositAmountCents: number;
+  freeCancellationHours: number | null;
+  lateCancellationFeePercent: number | null;
+  noShowFeePercent: number | null;
+}
+
+export type FeeType = "none" | "late" | "noshow";
+
+export interface CancellationFeeResult {
+  feeType: FeeType;
+  feeAmountCents: number;
+  refundAmountCents: number;
+}
+
+/**
+ * Evaluates the cancellation fee given a policy, the reservation time, and the
+ * current time (i.e. when the cancellation is happening).
+ *
+ * Money is always integer cents; fractional cents are floored.
+ * Returns a "none/full-refund" result when policy is null.
+ */
+export function evaluateCancellationFee(
+  policy: CancellationPolicy | null,
+  reservationTime: Date,
+  cancellationTime: Date
+): CancellationFeeResult {
+  if (policy === null || policy.freeCancellationHours === null) {
+    return {
+      feeType: "none",
+      feeAmountCents: 0,
+      refundAmountCents: policy?.depositAmountCents ?? 0,
+    };
+  }
+
+  const reservationMs = reservationTime.getTime();
+  const cancellationMs = cancellationTime.getTime();
+  const deposit = policy.depositAmountCents;
+
+  if (cancellationMs >= reservationMs) {
+    const feePercent = policy.noShowFeePercent ?? 100;
+    const feeAmountCents = Math.floor((deposit * feePercent) / 100);
+    return {
+      feeType: "noshow",
+      feeAmountCents,
+      refundAmountCents: deposit - feeAmountCents,
+    };
+  }
+
+  const freeCutoffMs = reservationMs - policy.freeCancellationHours * 60 * 60 * 1000;
+  if (cancellationMs <= freeCutoffMs) {
+    return {
+      feeType: "none",
+      feeAmountCents: 0,
+      refundAmountCents: deposit,
+    };
+  }
+
+  const feePercent = policy.lateCancellationFeePercent ?? 0;
+  const feeAmountCents = Math.floor((deposit * feePercent) / 100);
+  return {
+    feeType: "late",
+    feeAmountCents,
+    refundAmountCents: deposit - feeAmountCents,
+  };
+}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -15229,18 +15229,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3257,6 +3257,20 @@
     export const CURRENT_USER_QUERY_KEY = "currentUser" as const;
     export const USERS_QUERY_KEY = "users" as const;
   </file>
+  <file path="apps/hospitality/src/hooks/useVenuePolicy.ts">
+    interface PublicVenueDepositResponse {
+      data?: {
+        deposit?: {
+          enabled: boolean;
+          amountCents: number | null;
+          freeCancellationHours: number | null;
+          lateCancellationFeePercent: number | null;
+          noShowFeePercent: number | null;
+        };
+      };
+    }
+    export const VENUE_POLICY_QUERY_KEY = "venue-policy" as const;
+  </file>
   <file path="apps/hospitality/src/hooks/useVenueReadiness.ts">
     export type SetupStep = "onboarding" | "operating-hours" | "floor-plan";
     export interface VenueReadiness {
@@ -15215,7 +15229,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),
@@ -16252,6 +16277,15 @@
       const diffHours = Math.round(diffMins / 60);
       return rtf.format(diffHours, "hour");
     }
+  </file>
+  <file path="apps/hospitality/src/utils/cancellation-fee.ts">
+    export interface CancellationPolicy {
+      depositAmountCents: number;
+      freeCancellationHours: number | null;
+      lateCancellationFeePercent: number | null;
+      noShowFeePercent: number | null;
+    }
+    export type FeeType = "none" | "late" | "noshow";
   </file>
   <file path="apps/hospitality/src/utils/format.ts">
     export function formatLongDate(dateStr: string): string {

--- a/llms.txt
+++ b/llms.txt
@@ -1148,6 +1148,19 @@
       export const USERS_QUERY_KEY: unknown;
     </item>
   </file>
+  <file path="apps/hospitality/src/hooks/useVenuePolicy.ts">
+    <item priority="high">
+      interface PublicVenueDepositResponse {
+        data?: {
+          deposit?: {
+            enabled: boolean;
+            amountCen...;
+      }
+    </item>
+    <item priority="high">
+      export const VENUE_POLICY_QUERY_KEY: unknown;
+    </item>
+  </file>
   <file path="apps/hospitality/src/hooks/useVenueReadiness.ts">
     <item priority="low">
       type SetupStep = "onboarding" | "operating-hours" | "floor-plan";
@@ -4632,6 +4645,19 @@
   <file path="apps/gen/src/utils/relative-time.ts">
     <item priority="high">
       export function relativeTime(date: Date): string { /* ... */ }
+    </item>
+  </file>
+  <file path="apps/hospitality/src/utils/cancellation-fee.ts">
+    <item priority="low">
+      interface CancellationPolicy {
+        depositAmountCents: number;
+        freeCancellationHours: number | null;
+        lateCancellationFeePercent: number | null;
+        noShowFeePercent: number | null;
+      }
+    </item>
+    <item priority="low">
+      type FeeType = "none" | "late" | "noshow";
     </item>
   </file>
   <file path="apps/hospitality/src/utils/format.ts">

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,18 +337,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,7 +337,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),


### PR DESCRIPTION
Closes #2487

## Summary
- Wire `TimelinePage` to fetch venue cancellation policy via new `useVenuePolicy` hook (public `/public/v1/venues/:slug` endpoint — only surface that exposes deposit/policy fields)
- `CancelReservationDialog` receives `policy`, `reservationTime`, `currency` props; computes fee at render time using `evaluateCancellationFee` (no setState-in-effect)
- Shows plain-language fee summary before staff confirms cancellation
- New `cancellation-fee.ts` utility (pure copy of service function — no IO, safe to inline in app)

## Test plan
- [ ] Free cancellation case: policy with 2h free window, reservation 4h away → shows "No cancellation fee — full refund of $X.XX"
- [ ] Late cancellation case: policy with 2h free window, reservation 1h away → shows "Late cancellation fee: $X.XX — refund $X.XX"
- [ ] No-show case: reservation time has passed → shows "No-show fee: $X.XX forfeited — refund $X.XX"
- [ ] No-policy case: no policy prop passed → no fee banner rendered