### PR TITLE
fix(deps): scope OTel core override so Pulumi's v1 trace SDK keeps a compatible core

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
       "@opentelemetry/sdk-node@<0.217.0": "^0.217.0",
       "@opentelemetry/exporter-prometheus@<0.217.0": "^0.217.0",
       "@opentelemetry/core@<2.8.0": ">=2.8.0",
+      "@opentelemetry/sdk-trace-base@1.30.1>@opentelemetry/core": "1.30.1",
       "qs@<=6.15.1": "^6.15.2",
       "@babel/core@<=7.29.5": ">=7.29.6",
       "ioredis": "^5.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,7 @@ overrides:
   "@opentelemetry/sdk-node@<0.217.0": ^0.217.0
   "@opentelemetry/exporter-prometheus@<0.217.0": ^0.217.0
   "@opentelemetry/core@<2.8.0": ">=2.8.0"
+  "@opentelemetry/sdk-trace-base@1.30.1>@opentelemetry/core": 1.30.1
   qs@<=6.15.1: ^6.15.2
   "@babel/core@<=7.29.5": ">=7.29.6"
   ioredis: ^5.11.0
@@ -4171,6 +4172,15 @@ packages:
         integrity: sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      "@opentelemetry/api": ">=1.0.0 <1.10.0"
+
+  "@opentelemetry/core@1.30.1":
+    resolution:
+      {
+        integrity: sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==,
+      }
+    engines: { node: ">=14" }
     peerDependencies:
       "@opentelemetry/api": ">=1.0.0 <1.10.0"
 
@@ -17025,6 +17035,11 @@ snapshots:
     dependencies:
       "@opentelemetry/api": 1.9.1
 
+  "@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1)":
+    dependencies:
+      "@opentelemetry/api": 1.9.1
+      "@opentelemetry/semantic-conventions": 1.28.0
+
   "@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
@@ -17372,7 +17387,7 @@ snapshots:
   "@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/core": 2.8.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/core": 1.30.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/resources": 1.30.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.28.0
 


### PR DESCRIPTION
## Problem

Infrastructure deploys have been failing since ~2026-06-17 (`deploys: unhealthy` → circuit breaker tripped, #2473 / #2504). The `Pulumi Deploy → Deploy Infrastructure` job crashes at **module-load time**, before deploying anything (`1 errored`, duration 1s):

```
TypeError: Cannot read properties of undefined (reading 'AlwaysOn')
  at @opentelemetry/sdk-trace-base@1.30.1/src/config.ts:25
```

## Root cause

PR #2361 (2026-06-15) added the override `"@opentelemetry/core@<2.8.0": ">=2.8.0"` to fix **CVE-2026-54285** — correct for production services. But it also force-upgraded `@opentelemetry/core` to `2.8.0` **inside `@pulumi/pulumi@3.245.0`'s bundled `@opentelemetry/sdk-trace-base@1.30.1`** (the OTel **v1** line). v1 `sdk-trace-base` reads a sampler shape (`TracesSamplerValues.AlwaysOn`) that v2 `core` no longer exposes → `undefined.AlwaysOn` crash at `pulumi up`.

- Only the **infra deploy** crashes — it's the only place the v1 SDK loads at runtime. Production services use the **v2** OTel line (Sentry/Langfuse → `core@2.8.0`) and were never affected (`services`, `static_sites`, `ci` all healthy).
- **No clean version bump exists:** latest Pulumi (3.247.0) still pins `sdk-trace-base ^1.30`, and `@opentelemetry/core` 1.x tops out at 1.30.1 with **no CVE-patched release**.

## Fix

Scoped nested pnpm override pinning the matching v1 core only inside Pulumi's subtree:

```json
"@opentelemetry/sdk-trace-base@1.30.1>@opentelemetry/core": "1.30.1"
```

- Production services keep the **CVE-safe `core@2.8.0`** (v2 line) — unchanged.
- Pulumi's v1 SDK gets the compatible `core@1.30.1` it expects; the v1 line is now internally consistent (`core`/`resources`/`semantic-conventions` all 1.x).
- The vulnerable core is re-exposed **only in the ephemeral CI deploy process**, not any internet-facing runtime.

Lockfile verified: `sdk-trace-base@1.30.1` now resolves `@opentelemetry/core: 1.30.1`; no packages dropped (package count 3300 → 3302, the +2 being the new `core@1.30.1` entry + snapshot).

## Test plan

- [ ] CI `Pulumi Deploy → Deploy Infrastructure` job is green (the real proof — currently fails at module load)
- [ ] `deploys` subsystem returns to healthy at `https://mattbutlerengineering.com/health/system`
- [ ] CI Gate (lint/typecheck/test/build/integrity) green
- [ ] No change to production service OTel resolution (still `core@2.8.0`)

Fixes #2473
Fixes #2504