### PR TITLE
refactor: extract shared cancellation-policy module into @mbe/cancellation-policy

### DIFF
--- a/apps/hospitality/llms-full.txt
+++ b/apps/hospitality/llms-full.txt
@@ -469,15 +469,6 @@
   </file>
   </section>
   <section priority="medium" role="utils">
-  <file path="src/utils/cancellation-fee.ts">
-    export interface CancellationPolicy {
-      depositAmountCents: number;
-      freeCancellationHours: number | null;
-      lateCancellationFeePercent: number | null;
-      noShowFeePercent: number | null;
-    }
-    export type FeeType = "none" | "late" | "noshow";
-  </file>
   <file path="src/utils/format.ts">
     export function formatLongDate(dateStr: string): string {
       return new Date(dateStr + "T00:00:00").toLocaleDateString(LOCALE, {

--- a/apps/hospitality/llms.txt
+++ b/apps/hospitality/llms.txt
@@ -383,19 +383,6 @@
   </file>
   </section>
   <section priority="medium" role="utils">
-  <file path="src/utils/cancellation-fee.ts">
-    <item priority="low">
-      interface CancellationPolicy {
-        depositAmountCents: number;
-        freeCancellationHours: number | null;
-        lateCancellationFeePercent: number | null;
-        noShowFeePercent: number | null;
-      }
-    </item>
-    <item priority="low">
-      type FeeType = "none" | "late" | "noshow";
-    </item>
-  </file>
   <file path="src/utils/format.ts">
     <item priority="high">
       export function formatLongDate(dateStr: string): string { /* ... */ }

--- a/apps/hospitality/package.json
+++ b/apps/hospitality/package.json
@@ -34,6 +34,7 @@
     "@mattbutlerengineering/rialto": "workspace:*",
     "@mbe/api-client": "workspace:*",
     "@mbe/auth": "workspace:*",
+    "@mbe/cancellation-policy": "workspace:*",
     "@mbe/observability": "workspace:*",
     "@mbe/rialto-catalog": "workspace:*",
     "@mbe/sentry": "workspace:*",

--- a/apps/hospitality/src/utils/cancellation-fee.ts
+++ b/apps/hospitality/src/utils/cancellation-fee.ts
@@ -1,73 +1,8 @@
 /**
- * Cancellation fee evaluation for staff-facing dialogs.
+ * Re-exports the shared cancellation policy engine from @mbe/cancellation-policy.
  *
- * Copied verbatim from services/reservations/src/services/cancellation-policy.ts
- * (pure functions, no IO). DO NOT add fee math here — keep in sync with the service.
+ * The canonical fee evaluation logic lives in the shared package; this module
+ * exists for backward-compatibility with existing imports inside apps/hospitality.
  */
-
-export interface CancellationPolicy {
-  depositAmountCents: number;
-  freeCancellationHours: number | null;
-  lateCancellationFeePercent: number | null;
-  noShowFeePercent: number | null;
-}
-
-export type FeeType = "none" | "late" | "noshow";
-
-export interface CancellationFeeResult {
-  feeType: FeeType;
-  feeAmountCents: number;
-  refundAmountCents: number;
-}
-
-/**
- * Evaluates the cancellation fee given a policy, the reservation time, and the
- * current time (i.e. when the cancellation is happening).
- *
- * Money is always integer cents; fractional cents are floored.
- * Returns a "none/full-refund" result when policy is null.
- */
-export function evaluateCancellationFee(
-  policy: CancellationPolicy | null,
-  reservationTime: Date,
-  cancellationTime: Date
-): CancellationFeeResult {
-  if (policy === null || policy.freeCancellationHours === null) {
-    return {
-      feeType: "none",
-      feeAmountCents: 0,
-      refundAmountCents: policy?.depositAmountCents ?? 0,
-    };
-  }
-
-  const reservationMs = reservationTime.getTime();
-  const cancellationMs = cancellationTime.getTime();
-  const deposit = policy.depositAmountCents;
-
-  if (cancellationMs >= reservationMs) {
-    const feePercent = policy.noShowFeePercent ?? 100;
-    const feeAmountCents = Math.floor((deposit * feePercent) / 100);
-    return {
-      feeType: "noshow",
-      feeAmountCents,
-      refundAmountCents: deposit - feeAmountCents,
-    };
-  }
-
-  const freeCutoffMs = reservationMs - policy.freeCancellationHours * 60 * 60 * 1000;
-  if (cancellationMs <= freeCutoffMs) {
-    return {
-      feeType: "none",
-      feeAmountCents: 0,
-      refundAmountCents: deposit,
-    };
-  }
-
-  const feePercent = policy.lateCancellationFeePercent ?? 0;
-  const feeAmountCents = Math.floor((deposit * feePercent) / 100);
-  return {
-    feeType: "late",
-    feeAmountCents,
-    refundAmountCents: deposit - feeAmountCents,
-  };
-}
+export type { CancellationPolicy, FeeType, CancellationFeeResult } from "@mbe/cancellation-policy";
+export { evaluateCancellationFee, formatCancellationTerms } from "@mbe/cancellation-policy";

--- a/docs/architecture/dependency-graph.md
+++ b/docs/architecture/dependency-graph.md
@@ -23,6 +23,7 @@ flowchart TD
     agent_test_utils["agent-test-utils"]
     api_client["api-client"]
     auth["auth"]
+    cancellation_policy["cancellation-policy"]
     config["config"]
     database["database"]
     gh_client["gh-client"]
@@ -52,6 +53,7 @@ flowchart TD
   hospitality --> @mattbutlerengineering/rialto
   hospitality --> api_client
   hospitality --> auth
+  hospitality --> cancellation_policy
   hospitality --> observability
   hospitality --> rialto_catalog
   hospitality --> sentry
@@ -77,6 +79,7 @@ flowchart TD
   agent_service --> agent_test_utils
   agent_service --> config
   reservations_service --> auth
+  reservations_service --> cancellation_policy
   reservations_service --> database
   reservations_service --> service_bootstrap
   reservations_service --> jobs
@@ -104,6 +107,7 @@ flowchart TD
   api_client --> config
   auth --> types
   auth --> config
+  cancellation_policy --> config
   database --> config
   gh_client --> config
   jobs --> config
@@ -150,6 +154,7 @@ flowchart TD
   class agent_test_utils shared
   class api_client shared
   class auth shared
+  class cancellation_policy shared
   class config shared
   class database shared
   class gh_client shared

--- a/infrastructure/worker/dep-graph.json
+++ b/infrastructure/worker/dep-graph.json
@@ -56,6 +56,11 @@
       "path": "packages/auth"
     },
     {
+      "name": "@mbe/cancellation-policy",
+      "type": "package",
+      "path": "packages/cancellation-policy"
+    },
+    {
       "name": "@mbe/config",
       "type": "package",
       "path": "packages/config"
@@ -194,6 +199,11 @@
     },
     {
       "from": "@mbe/hospitality",
+      "to": "@mbe/cancellation-policy",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/hospitality",
       "to": "@mbe/observability",
       "type": "dependency"
     },
@@ -315,6 +325,11 @@
     {
       "from": "@mbe/reservations-service",
       "to": "@mbe/auth",
+      "type": "dependency"
+    },
+    {
+      "from": "@mbe/reservations-service",
+      "to": "@mbe/cancellation-policy",
       "type": "dependency"
     },
     {
@@ -449,6 +464,11 @@
     },
     {
       "from": "@mbe/auth",
+      "to": "@mbe/config",
+      "type": "devDependency"
+    },
+    {
+      "from": "@mbe/cancellation-policy",
       "to": "@mbe/config",
       "type": "devDependency"
     },

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -15229,18 +15229,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -11442,15 +11442,6 @@
       communicationPreference: Guest["communicationPreference"] | null;
     }
   </file>
-  <file path="services/reservations/src/services/cancellation-policy.ts">
-    export interface CancellationPolicy {
-      depositAmountCents: number;
-      freeCancellationHours: number | null;
-      lateCancellationFeePercent: number | null;
-      noShowFeePercent: number | null;
-    }
-    export type FeeType = "none" | "late" | "noshow";
-  </file>
   <file path="services/reservations/src/services/confirm-hold.ts">
     type ConfirmHoldErrorCode =
       | "NOT_FOUND"
@@ -14388,6 +14379,15 @@
       }
     }
   </file>
+  <file path="packages/cancellation-policy/src/cancellation-policy.ts">
+    export interface CancellationPolicy {
+      depositAmountCents: number;
+      freeCancellationHours: number | null;
+      lateCancellationFeePercent: number | null;
+      noShowFeePercent: number | null;
+    }
+    export type FeeType = "none" | "late" | "noshow";
+  </file>
   <file path="packages/database/src/index.ts">
     export function isPrismaNotFound(err: unknown): boolean {
       return (
@@ -15229,7 +15229,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),
@@ -16266,15 +16277,6 @@
       const diffHours = Math.round(diffMins / 60);
       return rtf.format(diffHours, "hour");
     }
-  </file>
-  <file path="apps/hospitality/src/utils/cancellation-fee.ts">
-    export interface CancellationPolicy {
-      depositAmountCents: number;
-      freeCancellationHours: number | null;
-      lateCancellationFeePercent: number | null;
-      noShowFeePercent: number | null;
-    }
-    export type FeeType = "none" | "late" | "noshow";
   </file>
   <file path="apps/hospitality/src/utils/format.ts">
     export function formatLongDate(dateStr: string): string {

--- a/llms.txt
+++ b/llms.txt
@@ -2235,19 +2235,6 @@
       }
     </item>
   </file>
-  <file path="services/reservations/src/services/cancellation-policy.ts">
-    <item priority="low">
-      interface CancellationPolicy {
-        depositAmountCents: number;
-        freeCancellationHours: number | null;
-        lateCancellationFeePercent: number | null;
-        noShowFeePercent: number | null;
-      }
-    </item>
-    <item priority="low">
-      type FeeType = "none" | "late" | "noshow";
-    </item>
-  </file>
   <file path="services/reservations/src/services/confirm-hold.ts">
     <item priority="high">
       type ConfirmHoldErrorCode = "NOT_FOUND" | "EXPIRED" | "SESSION_MISMATCH" | "CONFLICT" | "PACING_EXCEEDED";
@@ -3706,6 +3693,19 @@
       }
     </item>
   </file>
+  <file path="packages/cancellation-policy/src/cancellation-policy.ts">
+    <item priority="low">
+      interface CancellationPolicy {
+        depositAmountCents: number;
+        freeCancellationHours: number | null;
+        lateCancellationFeePercent: number | null;
+        noShowFeePercent: number | null;
+      }
+    </item>
+    <item priority="low">
+      type FeeType = "none" | "late" | "noshow";
+    </item>
+  </file>
   <file path="packages/database/src/index.ts">
     <item priority="high">
       export function isPrismaNotFound(err: unknown): boolean { /* ... */ }
@@ -4645,19 +4645,6 @@
   <file path="apps/gen/src/utils/relative-time.ts">
     <item priority="high">
       export function relativeTime(date: Date): string { /* ... */ }
-    </item>
-  </file>
-  <file path="apps/hospitality/src/utils/cancellation-fee.ts">
-    <item priority="low">
-      interface CancellationPolicy {
-        depositAmountCents: number;
-        freeCancellationHours: number | null;
-        lateCancellationFeePercent: number | null;
-        noShowFeePercent: number | null;
-      }
-    </item>
-    <item priority="low">
-      type FeeType = "none" | "late" | "noshow";
     </item>
   </file>
   <file path="apps/hospitality/src/utils/format.ts">

--- a/packages/cancellation-policy/eslint.config.js
+++ b/packages/cancellation-policy/eslint.config.js
@@ -1,0 +1,3 @@
+import baseConfig from "@mbe/config/eslint/base";
+
+export default baseConfig;

--- a/packages/cancellation-policy/package.json
+++ b/packages/cancellation-policy/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@mbe/cancellation-policy",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "production": "./dist/index.js",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "lint": "eslint src/",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "@mbe/config": "workspace:*",
+    "@types/node": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "license": "MIT"
+}

--- a/packages/cancellation-policy/src/cancellation-policy.test.ts
+++ b/packages/cancellation-policy/src/cancellation-policy.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect } from "vitest";
+import { evaluateCancellationFee, formatCancellationTerms } from "./cancellation-policy.js";
+import type { CancellationPolicy } from "./cancellation-policy.js";
+
+const BASE_DEPOSIT_CENTS = 10000; // $100.00
+
+describe("evaluateCancellationFee", () => {
+  // Policy: 24h free window, 50% late fee, 100% no-show fee
+  const policy: CancellationPolicy = {
+    depositAmountCents: BASE_DEPOSIT_CENTS,
+    freeCancellationHours: 24,
+    lateCancellationFeePercent: 50,
+    noShowFeePercent: 100,
+  };
+
+  const reservationTime = new Date("2026-06-20T19:00:00Z");
+
+  describe("free cancellation (within window)", () => {
+    it("returns feeType 'none' and full refund when cancellation is well within the free window", () => {
+      // Cancelled 48h before reservation
+      const cancellationTime = new Date("2026-06-18T19:00:00Z");
+      const result = evaluateCancellationFee(policy, reservationTime, cancellationTime);
+
+      expect(result.feeType).toBe("none");
+      expect(result.feeAmountCents).toBe(0);
+      expect(result.refundAmountCents).toBe(BASE_DEPOSIT_CENTS);
+      expect(result.depositAction).toBe("refund_full");
+    });
+
+    it("returns feeType 'none' at exactly the boundary (inclusive — 24h before)", () => {
+      // Cancelled exactly 24h before = boundary, should be within free window
+      const cancellationTime = new Date("2026-06-19T19:00:00Z");
+      const result = evaluateCancellationFee(policy, reservationTime, cancellationTime);
+
+      expect(result.feeType).toBe("none");
+      expect(result.feeAmountCents).toBe(0);
+      expect(result.refundAmountCents).toBe(BASE_DEPOSIT_CENTS);
+      expect(result.depositAction).toBe("refund_full");
+    });
+  });
+
+  describe("late cancellation (outside window, before reservation)", () => {
+    it("returns feeType 'late' and partial fee when cancellation is after the free window", () => {
+      // Cancelled 12h before reservation (inside the 24h late window)
+      const cancellationTime = new Date("2026-06-20T07:00:00Z");
+      const result = evaluateCancellationFee(policy, reservationTime, cancellationTime);
+
+      expect(result.feeType).toBe("late");
+      expect(result.feeAmountCents).toBe(5000); // 50% of $100
+      expect(result.refundAmountCents).toBe(5000); // other 50% refunded
+      expect(result.depositAction).toBe("refund_partial");
+    });
+
+    it("rounds fee amount down to nearest cent (integer math)", () => {
+      const oddPolicy: CancellationPolicy = {
+        depositAmountCents: 999, // $9.99
+        freeCancellationHours: 24,
+        lateCancellationFeePercent: 33,
+        noShowFeePercent: 100,
+      };
+      const cancellationTime = new Date("2026-06-20T07:00:00Z");
+      const result = evaluateCancellationFee(oddPolicy, reservationTime, cancellationTime);
+
+      // 33% of 999 = 329.67 → floor = 329 cents
+      expect(result.feeAmountCents).toBe(329);
+      expect(result.refundAmountCents).toBe(999 - 329);
+    });
+  });
+
+  describe("no-show (cancellation at or after reservation time)", () => {
+    it("returns feeType 'noshow' when cancellation is at the reservation time", () => {
+      const cancellationTime = new Date("2026-06-20T19:00:00Z");
+      const result = evaluateCancellationFee(policy, reservationTime, cancellationTime);
+
+      expect(result.feeType).toBe("noshow");
+      expect(result.feeAmountCents).toBe(BASE_DEPOSIT_CENTS); // 100%
+      expect(result.refundAmountCents).toBe(0);
+      expect(result.depositAction).toBe("forfeit");
+    });
+
+    it("returns feeType 'noshow' when cancellation is after the reservation time", () => {
+      const cancellationTime = new Date("2026-06-20T21:00:00Z");
+      const result = evaluateCancellationFee(policy, reservationTime, cancellationTime);
+
+      expect(result.feeType).toBe("noshow");
+      expect(result.feeAmountCents).toBe(BASE_DEPOSIT_CENTS);
+      expect(result.refundAmountCents).toBe(0);
+      expect(result.depositAction).toBe("forfeit");
+    });
+
+    it("partially refunds (not full forfeit) when noShowFeePercent < 100", () => {
+      const partialNoShowPolicy: CancellationPolicy = {
+        depositAmountCents: BASE_DEPOSIT_CENTS,
+        freeCancellationHours: 24,
+        lateCancellationFeePercent: 50,
+        noShowFeePercent: 50, // only 50% no-show fee — guest gets the rest back
+      };
+      const cancellationTime = new Date("2026-06-20T19:00:00Z"); // at reservation time
+
+      const result = evaluateCancellationFee(
+        partialNoShowPolicy,
+        reservationTime,
+        cancellationTime
+      );
+
+      expect(result.feeType).toBe("noshow");
+      expect(result.feeAmountCents).toBe(5000); // 50% of $100
+      expect(result.refundAmountCents).toBe(5000); // other 50% refunded
+      // Must NOT be a full forfeit — a partial refund is owed to the guest.
+      expect(result.depositAction).toBe("refund_partial");
+    });
+
+    it("still forfeits the full deposit when noShowFeePercent is 100", () => {
+      const cancellationTime = new Date("2026-06-20T19:00:00Z");
+      const result = evaluateCancellationFee(policy, reservationTime, cancellationTime);
+
+      expect(result.feeType).toBe("noshow");
+      expect(result.refundAmountCents).toBe(0);
+      expect(result.depositAction).toBe("forfeit");
+    });
+  });
+
+  describe("no policy configured", () => {
+    it("returns full refund with feeType 'none' when policy is null", () => {
+      const cancellationTime = new Date("2026-06-20T07:00:00Z");
+      const result = evaluateCancellationFee(null, reservationTime, cancellationTime);
+
+      expect(result.feeType).toBe("none");
+      expect(result.feeAmountCents).toBe(0);
+      expect(result.refundAmountCents).toBe(0);
+      expect(result.depositAction).toBe("refund_full");
+    });
+
+    it("returns full refund when policy has no freeCancellationHours (no policy configured)", () => {
+      const noWindowPolicy: CancellationPolicy = {
+        depositAmountCents: BASE_DEPOSIT_CENTS,
+        freeCancellationHours: null,
+        lateCancellationFeePercent: null,
+        noShowFeePercent: null,
+      };
+      const cancellationTime = new Date("2026-06-20T18:30:00Z"); // 30 min before
+      const result = evaluateCancellationFee(noWindowPolicy, reservationTime, cancellationTime);
+
+      expect(result.feeType).toBe("none");
+      expect(result.feeAmountCents).toBe(0);
+      expect(result.refundAmountCents).toBe(BASE_DEPOSIT_CENTS);
+      expect(result.depositAction).toBe("refund_full");
+    });
+  });
+
+  describe("100% late cancellation fee", () => {
+    it("deposits full forfeit when lateCancellationFeePercent is 100", () => {
+      const fullFeePolicy: CancellationPolicy = {
+        depositAmountCents: BASE_DEPOSIT_CENTS,
+        freeCancellationHours: 24,
+        lateCancellationFeePercent: 100,
+        noShowFeePercent: 100,
+      };
+      const cancellationTime = new Date("2026-06-20T07:00:00Z");
+      const result = evaluateCancellationFee(fullFeePolicy, reservationTime, cancellationTime);
+
+      expect(result.feeType).toBe("late");
+      expect(result.feeAmountCents).toBe(BASE_DEPOSIT_CENTS);
+      expect(result.refundAmountCents).toBe(0);
+      expect(result.depositAction).toBe("refund_partial");
+    });
+  });
+
+  describe("zero deposit amount", () => {
+    it("returns zero fees when deposit amount is zero", () => {
+      const zeroPolicyFee: CancellationPolicy = {
+        depositAmountCents: 0,
+        freeCancellationHours: 24,
+        lateCancellationFeePercent: 50,
+        noShowFeePercent: 100,
+      };
+      const cancellationTime = new Date("2026-06-20T07:00:00Z");
+      const result = evaluateCancellationFee(zeroPolicyFee, reservationTime, cancellationTime);
+
+      expect(result.feeAmountCents).toBe(0);
+      expect(result.refundAmountCents).toBe(0);
+    });
+  });
+});
+
+describe("formatCancellationTerms", () => {
+  it("returns plain-language summary for standard policy", () => {
+    const policy: CancellationPolicy = {
+      depositAmountCents: 10000,
+      freeCancellationHours: 24,
+      lateCancellationFeePercent: 50,
+      noShowFeePercent: 100,
+    };
+    const result = formatCancellationTerms(policy, "usd");
+
+    expect(result).toContain("24");
+    expect(result).toContain("50%");
+  });
+
+  it("returns 'No cancellation fees' when no policy is configured", () => {
+    const result = formatCancellationTerms(null, "usd");
+    expect(result).toContain("No cancellation fees");
+  });
+
+  it("returns 'No cancellation fees' when freeCancellationHours is null", () => {
+    const policy: CancellationPolicy = {
+      depositAmountCents: 10000,
+      freeCancellationHours: null,
+      lateCancellationFeePercent: null,
+      noShowFeePercent: null,
+    };
+    const result = formatCancellationTerms(policy, "usd");
+    expect(result).toContain("No cancellation fees");
+  });
+});

--- a/packages/cancellation-policy/src/cancellation-policy.ts
+++ b/packages/cancellation-policy/src/cancellation-policy.ts
@@ -1,0 +1,128 @@
+/**
+ * Cancellation policy engine — pure functions, no IO, no DB calls.
+ *
+ * Policy fields live on Venue:
+ *   freeCancellationHours         – hours before reservation where cancellation is free
+ *   lateCancellationFeePercent    – % of deposit charged when cancelled after the free window
+ *   noShowFeePercent              – % of deposit forfeited when reservation time has passed
+ *
+ * Decision tree:
+ *   cancellationTime >= reservationTime  → no-show  (forfeit)
+ *   cancellationTime  > freeCutoff       → late      (partial refund)
+ *   cancellationTime <= freeCutoff       → none      (full refund)
+ */
+
+export interface CancellationPolicy {
+  depositAmountCents: number;
+  freeCancellationHours: number | null;
+  lateCancellationFeePercent: number | null;
+  noShowFeePercent: number | null;
+}
+
+export type FeeType = "none" | "late" | "noshow";
+export type DepositAction = "refund_full" | "refund_partial" | "forfeit";
+
+export interface CancellationFeeResult {
+  feeType: FeeType;
+  feeAmountCents: number;
+  refundAmountCents: number;
+  depositAction: DepositAction;
+}
+
+/**
+ * Evaluates the cancellation fee for a reservation.
+ *
+ * All timestamps are compared in UTC milliseconds — callers must pass
+ * Date objects (or ISO strings coercible to Date).
+ *
+ * Money is always integer cents; fractional cents are floored.
+ */
+export function evaluateCancellationFee(
+  policy: CancellationPolicy | null,
+  reservationTime: Date,
+  cancellationTime: Date
+): CancellationFeeResult {
+  // No policy → always free
+  if (policy === null || policy.freeCancellationHours === null) {
+    return {
+      feeType: "none",
+      feeAmountCents: 0,
+      refundAmountCents: policy?.depositAmountCents ?? 0,
+      depositAction: "refund_full",
+    };
+  }
+
+  const reservationMs = reservationTime.getTime();
+  const cancellationMs = cancellationTime.getTime();
+  const deposit = policy.depositAmountCents;
+
+  // No-show: cancellation at or after reservation time
+  if (cancellationMs >= reservationMs) {
+    const feePercent = policy.noShowFeePercent ?? 100;
+    const feeAmountCents = Math.floor((deposit * feePercent) / 100);
+    const refundAmountCents = deposit - feeAmountCents;
+    return {
+      feeType: "noshow",
+      feeAmountCents,
+      refundAmountCents,
+      // A full forfeit only applies when nothing is owed back to the guest.
+      // When the no-show fee is under 100%, the remainder must be partially
+      // refunded — `forfeit` would wrongly capture the entire deposit.
+      depositAction: refundAmountCents > 0 ? "refund_partial" : "forfeit",
+    };
+  }
+
+  // Boundary: exactly freeCancellationHours before reservation is inclusive (free)
+  const freeCutoffMs = reservationMs - policy.freeCancellationHours * 60 * 60 * 1000;
+  if (cancellationMs <= freeCutoffMs) {
+    return {
+      feeType: "none",
+      feeAmountCents: 0,
+      refundAmountCents: deposit,
+      depositAction: "refund_full",
+    };
+  }
+
+  // Late cancellation: after free window, before reservation
+  const feePercent = policy.lateCancellationFeePercent ?? 0;
+  const feeAmountCents = Math.floor((deposit * feePercent) / 100);
+  return {
+    feeType: "late",
+    feeAmountCents,
+    refundAmountCents: deposit - feeAmountCents,
+    depositAction: "refund_partial",
+  };
+}
+
+/**
+ * Returns a plain-language summary of cancellation terms for display in the
+ * booking widget and cancellation dialog.
+ *
+ * Example: "Free cancellation until 24 hours before your reservation.
+ *           After that, a 50% fee ($50.00) applies."
+ */
+export function formatCancellationTerms(
+  policy: CancellationPolicy | null,
+  currency: string
+): string {
+  if (policy === null || policy.freeCancellationHours === null) {
+    return "No cancellation fees apply.";
+  }
+
+  const feePercent = policy.lateCancellationFeePercent ?? 0;
+  const feeAmount = Math.floor((policy.depositAmountCents * feePercent) / 100);
+  const formattedFee = formatCents(feeAmount, currency);
+
+  return (
+    `Free cancellation up to ${policy.freeCancellationHours} hours before your reservation. ` +
+    `After that, a ${feePercent}% fee (${formattedFee}) applies.`
+  );
+}
+
+function formatCents(cents: number, currency: string): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: currency.toUpperCase(),
+    minimumFractionDigits: 2,
+  }).format(cents / 100);
+}

--- a/packages/cancellation-policy/src/index.ts
+++ b/packages/cancellation-policy/src/index.ts
@@ -1,0 +1,7 @@
+export type {
+  CancellationPolicy,
+  FeeType,
+  DepositAction,
+  CancellationFeeResult,
+} from "./cancellation-policy.js";
+export { evaluateCancellationFee, formatCancellationTerms } from "./cancellation-policy.js";

--- a/packages/cancellation-policy/tsconfig.json
+++ b/packages/cancellation-policy/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@mbe/config/typescript/node",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/cancellation-policy/vitest.config.ts
+++ b/packages/cancellation-policy/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts", "src/index.ts"],
+      thresholds: {
+        lines: 90,
+        branches: 80,
+        functions: 90,
+        statements: 90,
+      },
+    },
+  },
+});

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,18 +337,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,7 +337,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,9 @@ importers:
       "@mbe/auth":
         specifier: workspace:*
         version: link:../../packages/auth
+      "@mbe/cancellation-policy":
+        specifier: workspace:*
+        version: link:../../packages/cancellation-policy
       "@mbe/observability":
         specifier: workspace:*
         version: link:../../packages/observability
@@ -647,6 +650,24 @@ importers:
       react:
         specifier: "catalog:"
         version: 19.2.7
+      typescript:
+        specifier: "catalog:"
+        version: 6.0.3
+      vitest:
+        specifier: "catalog:"
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+
+  packages/cancellation-policy:
+    devDependencies:
+      "@mbe/config":
+        specifier: workspace:*
+        version: link:../config
+      "@types/node":
+        specifier: "catalog:"
+        version: 25.9.3
+      "@vitest/coverage-v8":
+        specifier: "catalog:"
+        version: 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.9)
       typescript:
         specifier: "catalog:"
         version: 6.0.3
@@ -1332,6 +1353,9 @@ importers:
       "@mbe/auth":
         specifier: workspace:*
         version: link:../../packages/auth
+      "@mbe/cancellation-policy":
+        specifier: workspace:*
+        version: link:../../packages/cancellation-policy
       "@mbe/database":
         specifier: workspace:*
         version: link:../../packages/database

--- a/services/reservations/Dockerfile
+++ b/services/reservations/Dockerfile
@@ -17,6 +17,7 @@ COPY packages/observability/package.json ./packages/observability/
 COPY packages/feature-flags/package.json ./packages/feature-flags/
 COPY packages/sentry/package.json ./packages/sentry/
 COPY packages/database/package.json ./packages/database/
+COPY packages/cancellation-policy/package.json ./packages/cancellation-policy/
 COPY packages/service-bootstrap/package.json ./packages/service-bootstrap/
 COPY packages/notifications/package.json ./packages/notifications/
 COPY packages/jobs/package.json ./packages/jobs/
@@ -34,6 +35,7 @@ COPY packages/observability/tsconfig.json ./packages/observability/
 COPY packages/feature-flags/tsconfig.json ./packages/feature-flags/
 COPY packages/sentry/tsconfig.json ./packages/sentry/
 COPY packages/database/tsconfig.json ./packages/database/
+COPY packages/cancellation-policy/tsconfig.json ./packages/cancellation-policy/
 COPY packages/service-bootstrap/tsconfig.json ./packages/service-bootstrap/
 COPY packages/notifications/tsconfig.json ./packages/notifications/
 COPY packages/jobs/tsconfig.json ./packages/jobs/
@@ -51,6 +53,7 @@ COPY packages/observability/src ./packages/observability/src
 COPY packages/feature-flags/src ./packages/feature-flags/src
 COPY packages/sentry/src ./packages/sentry/src
 COPY packages/database/src ./packages/database/src
+COPY packages/cancellation-policy/src ./packages/cancellation-policy/src
 COPY packages/service-bootstrap/src ./packages/service-bootstrap/src
 COPY packages/notifications/src ./packages/notifications/src
 COPY packages/jobs/src ./packages/jobs/src
@@ -64,6 +67,7 @@ RUN pnpm --filter @mbe/types build && \
     pnpm --filter @mbe/feature-flags build && \
     pnpm --filter @mbe/sentry build && \
     pnpm --filter @mbe/database build && \
+    pnpm --filter @mbe/cancellation-policy build && \
     pnpm --filter @mbe/service-bootstrap build && \
     pnpm --filter @mbe/notifications build && \
     pnpm --filter @mbe/jobs build && \
@@ -93,6 +97,7 @@ COPY packages/observability/package.json ./packages/observability/
 COPY packages/feature-flags/package.json ./packages/feature-flags/
 COPY packages/sentry/package.json ./packages/sentry/
 COPY packages/database/package.json ./packages/database/
+COPY packages/cancellation-policy/package.json ./packages/cancellation-policy/
 COPY packages/service-bootstrap/package.json ./packages/service-bootstrap/
 COPY packages/notifications/package.json ./packages/notifications/
 COPY packages/jobs/package.json ./packages/jobs/
@@ -110,6 +115,7 @@ COPY --from=builder /app/packages/observability/dist ./packages/observability/di
 COPY --from=builder /app/packages/feature-flags/dist ./packages/feature-flags/dist
 COPY --from=builder /app/packages/sentry/dist ./packages/sentry/dist
 COPY --from=builder /app/packages/database/dist ./packages/database/dist
+COPY --from=builder /app/packages/cancellation-policy/dist ./packages/cancellation-policy/dist
 COPY --from=builder /app/packages/service-bootstrap/dist ./packages/service-bootstrap/dist
 COPY --from=builder /app/packages/notifications/dist ./packages/notifications/dist
 COPY --from=builder /app/packages/jobs/dist ./packages/jobs/dist

--- a/services/reservations/llms-full.txt
+++ b/services/reservations/llms-full.txt
@@ -5120,15 +5120,6 @@
       communicationPreference: Guest["communicationPreference"] | null;
     }
   </file>
-  <file path="src/services/cancellation-policy.ts">
-    export interface CancellationPolicy {
-      depositAmountCents: number;
-      freeCancellationHours: number | null;
-      lateCancellationFeePercent: number | null;
-      noShowFeePercent: number | null;
-    }
-    export type FeeType = "none" | "late" | "noshow";
-  </file>
   <file path="src/services/confirm-hold.ts">
     type ConfirmHoldErrorCode =
       | "NOT_FOUND"

--- a/services/reservations/llms.txt
+++ b/services/reservations/llms.txt
@@ -340,19 +340,6 @@
       }
     </item>
   </file>
-  <file path="src/services/cancellation-policy.ts">
-    <item priority="low">
-      interface CancellationPolicy {
-        depositAmountCents: number;
-        freeCancellationHours: number | null;
-        lateCancellationFeePercent: number | null;
-        noShowFeePercent: number | null;
-      }
-    </item>
-    <item priority="low">
-      type FeeType = "none" | "late" | "noshow";
-    </item>
-  </file>
   <file path="src/services/confirm-hold.ts">
     <item priority="high">
       type ConfirmHoldErrorCode = "NOT_FOUND" | "EXPIRED" | "SESSION_MISMATCH" | "CONFLICT" | "PACING_EXCEEDED";

--- a/services/reservations/package.json
+++ b/services/reservations/package.json
@@ -27,6 +27,7 @@
     "@fastify/swagger": "^9.7.0",
     "@fastify/swagger-ui": "^6.0.0",
     "@mbe/auth": "workspace:*",
+    "@mbe/cancellation-policy": "workspace:*",
     "@mbe/database": "workspace:*",
     "@mbe/service-bootstrap": "workspace:*",
     "@mbe/jobs": "workspace:*",

--- a/services/reservations/src/services/cancellation-policy.ts
+++ b/services/reservations/src/services/cancellation-policy.ts
@@ -1,128 +1,19 @@
 /**
- * Cancellation policy engine — pure functions, no IO, no DB calls.
+ * Re-exports the shared cancellation policy engine from @mbe/cancellation-policy.
  *
- * Policy fields live on Venue:
- *   freeCancellationHours         – hours before reservation where cancellation is free
- *   lateCancellationFeePercent    – % of deposit charged when cancelled after the free window
- *   noShowFeePercent              – % of deposit forfeited when reservation time has passed
+ * Pure fee evaluation logic lives in the shared package so both this service
+ * and apps/hospitality can import without duplication. The `DepositAction` type
+ * and the `depositAction` field on CancellationFeeResult are part of the shared
+ * contract — they drive Stripe state transitions on the backend and are available
+ * to the frontend for display purposes.
  *
- * Decision tree:
- *   cancellationTime >= reservationTime  → no-show  (forfeit)
- *   cancellationTime  > freeCutoff       → late      (partial refund)
- *   cancellationTime <= freeCutoff       → none      (full refund)
+ * Backend-specific deposit state-machine logic (refund/forfeit/capture calls)
+ * remains in services/deposit.ts.
  */
-
-export interface CancellationPolicy {
-  depositAmountCents: number;
-  freeCancellationHours: number | null;
-  lateCancellationFeePercent: number | null;
-  noShowFeePercent: number | null;
-}
-
-export type FeeType = "none" | "late" | "noshow";
-export type DepositAction = "refund_full" | "refund_partial" | "forfeit";
-
-export interface CancellationFeeResult {
-  feeType: FeeType;
-  feeAmountCents: number;
-  refundAmountCents: number;
-  depositAction: DepositAction;
-}
-
-/**
- * Evaluates the cancellation fee for a reservation.
- *
- * All timestamps are compared in UTC milliseconds — callers must pass
- * Date objects (or ISO strings coercible to Date).
- *
- * Money is always integer cents; fractional cents are floored.
- */
-export function evaluateCancellationFee(
-  policy: CancellationPolicy | null,
-  reservationTime: Date,
-  cancellationTime: Date
-): CancellationFeeResult {
-  // No policy → always free
-  if (policy === null || policy.freeCancellationHours === null) {
-    return {
-      feeType: "none",
-      feeAmountCents: 0,
-      refundAmountCents: policy?.depositAmountCents ?? 0,
-      depositAction: "refund_full",
-    };
-  }
-
-  const reservationMs = reservationTime.getTime();
-  const cancellationMs = cancellationTime.getTime();
-  const deposit = policy.depositAmountCents;
-
-  // No-show: cancellation at or after reservation time
-  if (cancellationMs >= reservationMs) {
-    const feePercent = policy.noShowFeePercent ?? 100;
-    const feeAmountCents = Math.floor((deposit * feePercent) / 100);
-    const refundAmountCents = deposit - feeAmountCents;
-    return {
-      feeType: "noshow",
-      feeAmountCents,
-      refundAmountCents,
-      // A full forfeit only applies when nothing is owed back to the guest.
-      // When the no-show fee is under 100%, the remainder must be partially
-      // refunded — `forfeit` would wrongly capture the entire deposit.
-      depositAction: refundAmountCents > 0 ? "refund_partial" : "forfeit",
-    };
-  }
-
-  // Boundary: exactly freeCancellationHours before reservation is inclusive (free)
-  const freeCutoffMs = reservationMs - policy.freeCancellationHours * 60 * 60 * 1000;
-  if (cancellationMs <= freeCutoffMs) {
-    return {
-      feeType: "none",
-      feeAmountCents: 0,
-      refundAmountCents: deposit,
-      depositAction: "refund_full",
-    };
-  }
-
-  // Late cancellation: after free window, before reservation
-  const feePercent = policy.lateCancellationFeePercent ?? 0;
-  const feeAmountCents = Math.floor((deposit * feePercent) / 100);
-  return {
-    feeType: "late",
-    feeAmountCents,
-    refundAmountCents: deposit - feeAmountCents,
-    depositAction: "refund_partial",
-  };
-}
-
-/**
- * Returns a plain-language summary of cancellation terms for display in the
- * booking widget and cancellation dialog.
- *
- * Example: "Free cancellation until 24 hours before your reservation.
- *           After that, a 50% fee ($50.00) applies."
- */
-export function formatCancellationTerms(
-  policy: CancellationPolicy | null,
-  currency: string
-): string {
-  if (policy === null || policy.freeCancellationHours === null) {
-    return "No cancellation fees apply.";
-  }
-
-  const feePercent = policy.lateCancellationFeePercent ?? 0;
-  const feeAmount = Math.floor((policy.depositAmountCents * feePercent) / 100);
-  const formattedFee = formatCents(feeAmount, currency);
-
-  return (
-    `Free cancellation up to ${policy.freeCancellationHours} hours before your reservation. ` +
-    `After that, a ${feePercent}% fee (${formattedFee}) applies.`
-  );
-}
-
-function formatCents(cents: number, currency: string): string {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: currency.toUpperCase(),
-    minimumFractionDigits: 2,
-  }).format(cents / 100);
-}
+export type {
+  CancellationPolicy,
+  FeeType,
+  DepositAction,
+  CancellationFeeResult,
+} from "@mbe/cancellation-policy";
+export { evaluateCancellationFee, formatCancellationTerms } from "@mbe/cancellation-policy";


### PR DESCRIPTION
## Summary

- Created new `@mbe/cancellation-policy` workspace package with the canonical pure-function fee evaluation logic (`CancellationPolicy`, `FeeType`, `DepositAction`, `CancellationFeeResult`, `evaluateCancellationFee`, `formatCancellationTerms`)
- `services/reservations/src/services/cancellation-policy.ts` now re-exports from the shared package (backward-compatible for its callers including `cancel-reservation.ts`)
- `apps/hospitality/src/utils/cancellation-fee.ts` now re-exports from the shared package (backward-compatible for all existing hospitality importers)
- Duplicate fee logic is gone — one source of truth owns all money math

**Why a new package, not `@mbe/database`:** `@mbe/database` is DB-coupled (pg/Prisma deps) and `apps/hospitality` doesn't depend on it. A zero-dependency pure-math package is semantically correct and avoids pulling DB deps into the frontend.

## Test plan

- [ ] `packages/cancellation-policy`: `pnpm lint && pnpm typecheck && pnpm test` — 15 tests pass
- [ ] `services/reservations`: `pnpm typecheck` passes; `src/services/cancellation-policy.test.ts` 15/15 pass (re-exported from shared module); full suite 978 tests pass
- [ ] `apps/hospitality`: `pnpm test` — 1076 tests pass (including `CancelReservationDialog.test.tsx` which imports `CancellationPolicy` from the re-export)
- [ ] `pnpm --filter @mbe/cli start check-adr` — no violations
- [ ] `pnpm --filter @mbe/cli start check-deps` — no mismatches
- [ ] `pnpm regen` + `pnpm regen --check` — all generated artifacts up to date (dep-graph, llms.txt/llms-full.txt regenerated for new package)
- [ ] `node scripts/detect-instruction-rot.mjs` — no rot detected

Closes #2554