### PR TITLE
feat(sensor): flakyTests collector stub + spike findings (#2536)

### DIFF
--- a/docs/flaky-test-detection-findings.md
+++ b/docs/flaky-test-detection-findings.md
@@ -1,0 +1,70 @@
+# Flaky-Test Detection Spike: Findings
+
+**Date:** 2026-06-21
+**Issue:** #2536
+**Verdict:** NOT FEASIBLE without new infrastructure
+
+## What per-test history exists today
+
+### CI workflow (`ci.yml`)
+
+The Test job runs `pnpm turbo test:coverage` — a turbo-cached vitest run that:
+
+- Emits results to **stdout only** (default vitest reporter)
+- Uploads **coverage JSON** (`coverage-final.json`) to Codecov — coverage is per-file, not per-test
+- **Does NOT** upload a `--reporter=junit` XML artifact or a vitest `--reporter=json` `outputFile`
+- Has **0 GitHub Annotations** on passing test jobs (confirmed via Checks API: `check-runs/{id}/annotations` returns `[]`)
+
+### Vitest configuration
+
+Root `vitest.config.ts` and `scripts/vitest.config.mjs` use the default reporter. The coverage configs in services (`services/*/vitest.config.ts`) specify `reporter: ["text", "json", "html"]` for coverage, not for per-test results. The only `--reporter=json` invocation in CI is a one-off for accessibility tests in the `a11y-attribution` job, and that output file (`a11y-results.json`) is not persisted between runs.
+
+### Stored metrics
+
+`metrics/` contains: `sensor-report.json`, `sensor-report-prev.json`, `ai-antipattern-baselines.json`, `threshold-changes.jsonl`, `process-metrics.jsonl`, `instruction-changes.jsonl`, `acmm-evals.jsonl`. **None contain per-test pass/fail records.**
+
+### GitHub API
+
+- `gh run list` returns workflow-level conclusions (`success`, `failure`) — no per-test granularity
+- `gh api check-runs/{id}/annotations` returns 0 annotations for passing test jobs; only process-exit annotations for failing ones (not per-test failure details)
+- No artifact uploads from unit test jobs; only E2E and smoke test artifacts exist
+
+## Why flaky detection requires same-SHA data
+
+A test is "flaky" only when it both passes **and** fails on the **same commit SHA** (unchanged code). Detecting this requires storing named test outcomes indexed by (test name, SHA) across multiple runs. Nothing in the current pipeline captures named per-test outcomes at any granularity — only aggregate pass/fail for the whole suite.
+
+## Cheapest path to enable flaky detection
+
+**Step 1: Enable JUnit reporter in CI (1 line change, no new deps)**
+
+Add `--reporter=junit --outputFile=test-results/results-{shard}.xml` to the `pnpm turbo test` invocation, or configure vitest per-package with `reporters: ["default", "junit"]` and `outputFile: { junit: "test-results.xml" }`.
+
+Vitest ships a built-in JUnit reporter — zero new dependencies.
+
+**Step 2: Upload test results as workflow artifacts (2–4 lines)**
+
+```yaml
+- uses: actions/upload-artifact@v4
+  if: always()
+  with:
+    name: test-results-node${{ matrix.node-version }}
+    path: "**/test-results*.xml"
+    retention-days: 14
+```
+
+**Step 3: Download and parse in sensor-report (collector already stubbed)**
+
+`collect-flaky-tests.mjs` (see this PR) exports `computeFlakyTests(runs)` where `runs` is an array of `{ sha, testName, passed }` records. Once artifact download + JUnit XML parsing is wired, the sensor activates automatically. The collector returns `{ available: false }` today with a `data_gap` note explaining what is missing.
+
+**Estimated effort:** 1–2 hours for Steps 1–2 (CI changes), 2–3 hours for the download/parse glue in `sensor-report.mjs`. Total: one small agent-sized issue.
+
+**Follow-on issue recommended:** "Enable JUnit reporter + upload test-result artifacts in CI to feed flakyTests sensor"
+
+## What this PR delivers
+
+- This findings document
+- `scripts/collect-flaky-tests.mjs`: pure, dependency-injectable collector module — accepts a `runs` array as input, detects flaky tests (same SHA, mixed outcomes), returns structured output or `{ available: false }` when history is absent
+- `scripts/__tests__/collect-flaky-tests.test.mjs`: unit tests at the collector seam using fixtures (a flaky test, a stable test, empty history)
+- `sensor-report.mjs`: wired with a `flakyTests` sensor entry that calls the collector with no data today — returns `{ available: false, data_gap: "no per-test run history" }`
+
+The collector is fully tested and ready to activate the moment per-test history is available. No speculative infrastructure was built.

--- a/metrics/ai-antipattern-baselines.json
+++ b/metrics/ai-antipattern-baselines.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-21T14:03:07.641Z",
+  "generatedAt": "2026-06-21T15:43:02.287Z",
   "patterns": {
     "magicTimeouts": {
       "count": 32,
@@ -22,7 +22,7 @@
       "description": "TypeScript `as any` casts or `: any` type annotations"
     },
     "consoleLogs": {
-      "count": 761,
+      "count": 762,
       "description": "console.log() calls in production (non-test) source files"
     },
     "unusedParams": {

--- a/scripts/__tests__/collect-flaky-tests.test.mjs
+++ b/scripts/__tests__/collect-flaky-tests.test.mjs
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { computeFlakyTests } from "../collect-flaky-tests.mjs";
+
+describe("computeFlakyTests", () => {
+  it("returns available: false when given no runs", () => {
+    const result = computeFlakyTests([]);
+    expect(result.available).toBe(false);
+    expect(result.data_gap).toBeDefined();
+  });
+
+  it("returns available: false when given null", () => {
+    const result = computeFlakyTests(null);
+    expect(result.available).toBe(false);
+  });
+
+  it("flags a test that both passed and failed on the same SHA as flaky", () => {
+    const runs = [
+      { sha: "abc123", testName: "auth > login", passed: true },
+      { sha: "abc123", testName: "auth > login", passed: false },
+      { sha: "abc123", testName: "auth > logout", passed: true },
+      { sha: "abc123", testName: "auth > logout", passed: true },
+    ];
+    const result = computeFlakyTests(runs);
+    expect(result.available).toBe(true);
+    expect(result.flaky_count).toBe(1);
+    expect(result.flaky_tests).toHaveLength(1);
+    expect(result.flaky_tests[0].testName).toBe("auth > login");
+    expect(result.flaky_tests[0].sha).toBe("abc123");
+    expect(result.flaky_tests[0].passCount).toBeGreaterThan(0);
+    expect(result.flaky_tests[0].failCount).toBeGreaterThan(0);
+  });
+
+  it("does not flag a test that only fails on the same SHA (consistent failure is not flaky)", () => {
+    const runs = [
+      { sha: "abc123", testName: "db > connect", passed: false },
+      { sha: "abc123", testName: "db > connect", passed: false },
+    ];
+    const result = computeFlakyTests(runs);
+    expect(result.available).toBe(true);
+    expect(result.flaky_count).toBe(0);
+    expect(result.flaky_tests).toHaveLength(0);
+  });
+
+  it("does not flag a test that consistently passes", () => {
+    const runs = [
+      { sha: "def456", testName: "api > health", passed: true },
+      { sha: "def456", testName: "api > health", passed: true },
+      { sha: "aaa111", testName: "api > health", passed: true },
+    ];
+    const result = computeFlakyTests(runs);
+    expect(result.available).toBe(true);
+    expect(result.flaky_count).toBe(0);
+  });
+
+  it("detects flakiness across multiple SHAs independently", () => {
+    // flaky on sha1, stable on sha2
+    const runs = [
+      { sha: "sha1", testName: "cache > hit", passed: true },
+      { sha: "sha1", testName: "cache > hit", passed: false },
+      { sha: "sha2", testName: "cache > hit", passed: true },
+      { sha: "sha2", testName: "cache > hit", passed: true },
+    ];
+    const result = computeFlakyTests(runs);
+    expect(result.available).toBe(true);
+    // "cache > hit" is flaky on sha1 — should appear
+    expect(result.flaky_count).toBe(1);
+    expect(result.flaky_tests[0].testName).toBe("cache > hit");
+    expect(result.flaky_tests[0].sha).toBe("sha1");
+  });
+
+  it("returns total_runs and window_shas in the result", () => {
+    const runs = [
+      { sha: "abc", testName: "x", passed: true },
+      { sha: "def", testName: "y", passed: false },
+    ];
+    const result = computeFlakyTests(runs);
+    expect(result.total_runs).toBe(2);
+    expect(result.window_shas).toBeGreaterThan(0);
+  });
+});

--- a/scripts/collect-flaky-tests.mjs
+++ b/scripts/collect-flaky-tests.mjs
@@ -1,0 +1,82 @@
+/**
+ * Pure collector for flaky-test detection.
+ *
+ * A test is "flaky" when it both passes AND fails on the SAME commit SHA
+ * (unchanged code) within a recent window.
+ *
+ * CURRENT STATE: No per-test pass/fail history is stored in this repo today.
+ * CI runs vitest with the default stdout reporter — no JUnit XML, no
+ * --outputFile, and no artifact upload for per-test results. This collector
+ * returns { available: false, data_gap: "..." } until that infrastructure is
+ * enabled.
+ *
+ * See: docs/flaky-test-detection-findings.md for the full spike findings and
+ * the costed recommendation to enable per-test history.
+ *
+ * Input shape (for future use once history exists):
+ *   Array<{
+ *     sha: string,       // commit SHA the test ran against
+ *     testName: string,  // fully-qualified test name (e.g. "suite > test case")
+ *     passed: boolean,   // outcome of this specific run
+ *   }>
+ *
+ * Output shape:
+ *   { available: false, data_gap: string }
+ *   OR
+ *   {
+ *     available: true,
+ *     flaky_count: number,
+ *     flaky_tests: Array<{ testName: string, sha: string, passCount: number, failCount: number }>,
+ *     total_runs: number,
+ *     window_shas: number,
+ *   }
+ */
+
+/**
+ * Detect flaky tests from per-test run history.
+ *
+ * @param {Array<{ sha: string, testName: string, passed: boolean }> | null} runs
+ * @returns {object}
+ */
+export function computeFlakyTests(runs) {
+  if (!runs || runs.length === 0) {
+    return {
+      available: false,
+      data_gap:
+        "No per-test run history found. Enable JUnit reporter and artifact upload in CI — " +
+        "see docs/flaky-test-detection-findings.md for the costed recommendation.",
+    };
+  }
+
+  // Group outcomes by (testName, sha) key.
+  // Key: `${sha}::${testName}` → { passCount, failCount }
+  /** @type {Map<string, { testName: string, sha: string, passCount: number, failCount: number }>} */
+  const groups = new Map();
+
+  for (const run of runs) {
+    const key = `${run.sha}::${run.testName}`;
+    const existing = groups.get(key) ?? {
+      testName: run.testName,
+      sha: run.sha,
+      passCount: 0,
+      failCount: 0,
+    };
+    const updated = run.passed
+      ? { ...existing, passCount: existing.passCount + 1 }
+      : { ...existing, failCount: existing.failCount + 1 };
+    groups.set(key, updated);
+  }
+
+  // A test-SHA pair is flaky when it has at least one pass AND at least one fail.
+  const flakyEntries = [...groups.values()].filter((g) => g.passCount > 0 && g.failCount > 0);
+
+  const uniqueShas = new Set(runs.map((r) => r.sha)).size;
+
+  return {
+    available: true,
+    flaky_count: flakyEntries.length,
+    flaky_tests: flakyEntries,
+    total_runs: runs.length,
+    window_shas: uniqueShas,
+  };
+}

--- a/scripts/sensor-report.mjs
+++ b/scripts/sensor-report.mjs
@@ -21,6 +21,7 @@ import { collectAgentCost } from "./collect-agent-cost.mjs";
 import { computeCodeChurn, CODE_CHURN_THRESHOLD } from "./collect-code-churn.mjs";
 import { computePrCategoryMetrics } from "./collect-pr-metrics.mjs";
 import { collectMutationScore } from "./collect-mutation-score.mjs";
+import { computeFlakyTests } from "./collect-flaky-tests.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
@@ -405,6 +406,7 @@ const report = {
     sessionLogs: collectSessionLogs(),
     codeChurn: collectCodeChurnSensor(),
     mutationScore: collectMutationScoreSensor(),
+    flakyTests: computeFlakyTests([]),
   },
   thresholds: THRESHOLDS,
   regressions: [],
@@ -491,6 +493,11 @@ if (JSON_ONLY) {
       case "mutationScore":
         console.log(
           `   ${name}: ${data.mutation_score}% (${data.killed}/${data.total_mutants} killed, threshold ${data.threshold}%) ${data.passes_threshold ? "PASS" : "BELOW TARGET"}`
+        );
+        break;
+      case "flakyTests":
+        console.log(
+          `   ${name}: ${data.flaky_count} flaky (${data.total_runs} runs, ${data.window_shas} SHAs)`
         );
         break;
       default:


### PR DESCRIPTION
## Verdict: NOT FEASIBLE without new infrastructure

This is a spike-first implementation of issue #2536. Investigation found no per-test pass/fail history exists in CI today, making flaky-test detection impossible without enabling JUnit reporting first.

## Findings summary

**What was checked:**
- `ci.yml` Test job runs `pnpm turbo test:coverage` — stdout only, no `--reporter=junit`, no `outputFile`
- GitHub Annotations API: `check-runs/{id}/annotations` returns **0 annotations** on passing test jobs
- `metrics/` directory: no per-test result storage; only aggregate coverage JSON uploaded to Codecov
- Vitest configs: `reporter: ["text", "json", "html"]` in service configs refers to **coverage** reporters, not per-test result reporters
- Only `--reporter=json` usage in CI is a one-off for a11y tests, result not persisted across runs
- No artifact uploads from unit test jobs; E2E/smoke only
- Flaky test definition: same-SHA pass+fail records required — data genuinely not present

Full findings: `docs/flaky-test-detection-findings.md`

## Cheapest path to enable (costed recommendation)

1. **Enable JUnit reporter** in vitest (built-in, zero new deps): ~1h
2. **Upload test-results artifacts** in CI (`actions/upload-artifact`, 2-4 lines): ~1h  
3. **Wire download + parse into sensor-report.mjs**: ~2-3h

Total: one small agent-sized follow-on issue.

## What this PR delivers

- `docs/flaky-test-detection-findings.md` — full spike findings + costed recommendation
- `scripts/collect-flaky-tests.mjs` — pure, dependency-injectable collector module; returns `{ available: false, data_gap: "..." }` today; **ready to activate** once per-test history is wired
- `scripts/__tests__/collect-flaky-tests.test.mjs` — 7 unit tests at the collector seam (flaky test, stable test, consistent failure, multi-SHA, empty history)
- `scripts/sensor-report.mjs` — `flakyTests` sensor wired; surfaces `data_gap` in the report
- `metrics/ai-antipattern-baselines.json` — ratchet baseline bumped for the intentional `console.log` in sensor output (same pattern as all other sensor cases)

## Gate results

- `pnpm lint`: 41/41 tasks successful (warnings only, no errors)
- `pnpm --filter @mbe/cli start check-adr`: no violations
- `pnpm --filter @mbe/cli start check-deps`: all consistent
- `pnpm regen --check`: all generated artifacts up to date
- `node scripts/detect-instruction-rot.mjs`: no instruction rot
- collector unit tests: 7/7 passing
- `threshold-tuner.test.mjs`: 3 failures are pre-existing on `origin/main` (confirmed), not caused by this PR

Closes #2536