### PR TITLE
chore(reflection): 2026-06 monthly review — promote rialto setState ban to gotchas.md

### DIFF
--- a/.claude/rules/gotchas.md
+++ b/.claude/rules/gotchas.md
@@ -8,6 +8,7 @@ Project-specific traps that have bitten me before. Read these before diving into
 
 - Pre-commit hook runs `eslint --fix` + `check-adr` + `pack-changed` (the last one regenerates `llms.txt` / `llms-full.txt` in affected packages — expect them to appear in `git status` after your commit lands)
 - JSX strings with `'` fail `react/no-unescaped-entities` at commit time — use `&apos;`
+- **Rialto components must NOT call `setState` inside a `useEffect` body** (pre-commit hook bans it in `packages/rialto`). Setting state re-renders → re-runs the effect → sets state again = render loop. Use render-time derivation (compute during render, the snapshot pattern) or event handlers (set state only on user actions). LLMs default to the forbidden useEffect+setState sync pattern from general React tutorials — it's a correctness bug in Rialto's rendering model
 - **lint-staged passes generated files to ESLint as explicit CLI args** — ESLint 10's `ignores` array in config only applies to glob-resolved files, not explicit paths. When lint-staged stages a Prisma generated file (`services/*/src/generated/**`), it passes the path directly to `eslint`, bypassing the ignore. `lint-staged.config.js` filters `/generated/` paths before grouping to prevent this
 
 ## Pre-push / typecheck


### PR DESCRIPTION
Closes #1886

## Monthly reflection review (2026-06)
Reviewed the accumulated memory + reflection entries per the #1886 checklist.

### Action taken
- **Promoted** the rialto `setState`-in-`useEffect` ban to `.claude/rules/gotchas.md` (Pre-commit/lint section) — it was the one recurring correction (`.claude/memory/corrections/2026-04-23-rialto-setstate-in-effect.md`) whose `feeds_back_into` target (gotchas.md) had never received it, and it wasn't in rialto's CLAUDE.md or any rule either.

### Reviewed — already captured (no action)
- `changesets-need-pushed-commits`, `worktree-missing-node-modules`, `zsh-status-reserved` → already in gotchas.md.
- `cdn-cache-html-spa` → covered in ADR-011/ADR-004 (edge routing), `docs/rollback.md`, `docs/runbooks/static-sites-unhealthy.md`.
- 3 reinforcements (`conventional-commits`, `immutable-data-patterns`, `agents-md-single-source`) → map to existing `rules/coding-style.md`/`git-workflow.md`; kept as positive-pattern records.
- 3 `docs/reflections/` (ACMM report/batching/audit-trust) → durable principles, kept.

All memory files are small (≤14 lines) — no size concerns. Correction/reinforcement records retained as the feedback-loop history (per the subsystem README).

## Test plan
- [ ] Docs-only change (`.claude/rules/gotchas.md`); no code/tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)