### PR TITLE
chore(mcp): add Stripe MCP server (test-mode) for payment-path development

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -45,6 +45,10 @@
     "playwright": {
       "command": "npx",
       "args": ["-y", "@playwright/mcp@latest"]
+    },
+    "stripe": {
+      "command": "npx",
+      "args": ["-y", "@stripe/mcp", "--tools=all", "--api-key=${STRIPE_SECRET_KEY}"]
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,15 @@ The Playwright MCP server (`.mcp.json`) provides shared browser tooling for the 
 - Requires no configuration beyond the entry in `.mcp.json`
 - If you also have the personal Playwright plugin installed, both coexist without conflict (Claude Code deduplicates tools by server name)
 
+## Payments (Stripe MCP — test-mode only)
+
+The Stripe MCP server (`.mcp.json`, `@stripe/mcp`) gives Claude Code live Stripe API docs and test-mode object inspection (PaymentIntents, charges, refunds, webhook events) when working on payment-path code (`stripe`, `@stripe/react-stripe-js`, the deposit calculator, webhook handlers) — so agents read real API shapes instead of guessing.
+
+- **Test-mode only.** The server reads the key from the `STRIPE_SECRET_KEY` env var (referenced as `${STRIPE_SECRET_KEY}` in `.mcp.json` — no secret is committed). Set it to a **test-mode** key (`sk_test_…`) in your local env / secret store. **Never a live key** (`sk_live_…`).
+- When `STRIPE_SECRET_KEY` is unset the server simply fails to load — zero impact on other tooling (same posture as the Langfuse entry).
+- Prefer a Stripe **Restricted API Key (RAK)** scoped to read-only test-mode objects; tool permissions follow the RAK's scope.
+- Verify after setup: a read-only test-mode call (e.g. list PaymentIntents) should succeed.
+
 ## Cross-Session Memory (claude-mem)
 
 [claude-mem](https://github.com/thedotmack/claude-mem) provides persistent cross-session memory — observations about code patterns, architecture decisions, and domain context survive between conversations.


### PR DESCRIPTION
## What

Adds the official `@stripe/mcp` server to `.mcp.json` so agents working on payment/webhook/deposit code get live Stripe API docs + test-mode object inspection (PaymentIntents, charges, refunds, webhook events) instead of guessing API shapes.

## How

- Key sourced from `${STRIPE_SECRET_KEY}` env var — **no secret committed** (same pattern as the existing `sentry`/`langfuse` entries).
- `CLAUDE.md` documents the server, the env var, and the **test-mode-only** constraint (recommends a read-only Restricted API Key).
- When the env var is unset the server just fails to load — zero impact, like Langfuse.

## HITL boundary (per #2160)

Config scaffolding is AFK-doable and done here. The remaining two steps are **human**:
- [ ] Set a **test-mode** `STRIPE_SECRET_KEY` (`sk_test_…`) in local env / secret store — never a live key
- [ ] Verify: a read-only test-mode call (list PaymentIntents) succeeds

Closes #2160