### PR TITLE
refactor(hospitality): useTimelineKeyboard + pure reservationLayout — free TimelineGrid from inline logic

### DIFF
--- a/apps/hospitality/llms-full.txt
+++ b/apps/hospitality/llms-full.txt
@@ -387,6 +387,16 @@
       note: string;
     }
   </file>
+  <file path="src/hooks/useTimelineKeyboard.ts">
+    export interface TimelineReservationEntry {
+      reservationId: string;
+      tableIndex: number;
+    }
+    export interface UseTimelineKeyboardParams {
+      entries: TimelineReservationEntry[];
+      onActivate?: (reservationId: string) => void;
+    }
+  </file>
   <file path="src/hooks/useUsers.ts">
     export const CURRENT_USER_QUERY_KEY = "currentUser" as const;
     export const USERS_QUERY_KEY = "users" as const;
@@ -465,6 +475,19 @@
     }
     interface ImportMeta {
       readonly env: ImportMetaEnv;
+    }
+  </file>
+  </section>
+  <section priority="medium" role="timeline">
+  <file path="src/components/timeline/reservationLayout.ts">
+    export interface ReservationLayoutParams {
+      startHour: number;
+      hourWidth: number;
+      isMobile: boolean;
+    }
+    export interface ReservationLayoutResult {
+      left: number;
+      width: number;
     }
   </file>
   </section>

--- a/apps/hospitality/llms.txt
+++ b/apps/hospitality/llms.txt
@@ -289,6 +289,20 @@
       }
     </item>
   </file>
+  <file path="src/hooks/useTimelineKeyboard.ts">
+    <item priority="low">
+      interface TimelineReservationEntry {
+        reservationId: string;
+        tableIndex: number;
+      }
+    </item>
+    <item priority="low">
+      interface UseTimelineKeyboardParams {
+        entries: TimelineReservationEntry[];
+        onActivate?: (reservationId: string) => void;
+      }
+    </item>
+  </file>
   <file path="src/hooks/useUsers.ts">
     <item priority="high">
       export const CURRENT_USER_QUERY_KEY: unknown;
@@ -378,6 +392,23 @@
     <item priority="high">
       interface ImportMeta {
         env: ImportMetaEnv;
+      }
+    </item>
+  </file>
+  </section>
+  <section priority="medium" role="timeline">
+  <file path="src/components/timeline/reservationLayout.ts">
+    <item priority="low">
+      interface ReservationLayoutParams {
+        startHour: number;
+        hourWidth: number;
+        isMobile: boolean;
+      }
+    </item>
+    <item priority="low">
+      interface ReservationLayoutResult {
+        left: number;
+        width: number;
       }
     </item>
   </file>

--- a/apps/hospitality/src/components/timeline/TimelineGrid.tsx
+++ b/apps/hospitality/src/components/timeline/TimelineGrid.tsx
@@ -1,7 +1,9 @@
-import { useMemo, useState, useEffect, useCallback, useRef } from "react";
+import { useMemo, useState, useEffect, useRef } from "react";
 import { toDateString, type Reservation, type Table, type TableStatus } from "@mbe/types";
 import { ReservationBlock } from "./ReservationBlock";
 import { TableStatusBadge } from "../TableStatusBadge.js";
+import { useTimelineKeyboard } from "../../hooks/useTimelineKeyboard.js";
+import { computeReservationLayout } from "./reservationLayout.js";
 import styles from "./TimelineGrid.module.css";
 
 const HOUR_WIDTH = 120;
@@ -54,101 +56,32 @@ export function TimelineGrid({
   const hourWidth = isMobile ? MOBILE_HOUR_WIDTH : HOUR_WIDTH;
   const tableColumnWidth = isMobile ? MOBILE_TABLE_COLUMN_WIDTH : TABLE_COLUMN_WIDTH;
 
-  const [focusedReservationId, setFocusedReservationId] = useState<string | null>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  const allReservations = useMemo(() => {
-    const arr: { reservation: Reservation; tableIndex: number }[] = [];
+  const keyboardEntries = useMemo(() => {
+    const arr: { reservationId: string; tableIndex: number }[] = [];
     tables.forEach((table, tableIndex) => {
       reservations
         .filter((r) => r.tableId === table.id)
         .forEach((reservation) => {
-          arr.push({ reservation, tableIndex });
+          arr.push({ reservationId: reservation.id, tableIndex });
         });
     });
     return arr;
   }, [tables, reservations]);
 
-  const flatReservations = useMemo(() => {
-    return allReservations.map((r) => r.reservation);
-  }, [allReservations]);
-
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (flatReservations.length === 0) return;
-
-      const currentIndex = focusedReservationId
-        ? flatReservations.findIndex((r) => r.id === focusedReservationId)
-        : -1;
-
-      switch (e.key) {
-        case "ArrowRight":
-          e.preventDefault();
-          if (focusedReservationId) {
-            const nextIdx = Math.min(currentIndex + 1, flatReservations.length - 1);
-            setFocusedReservationId(flatReservations[nextIdx].id);
-          } else if (flatReservations.length > 0) {
-            setFocusedReservationId(flatReservations[0].id);
-          }
-          break;
-        case "ArrowLeft":
-          e.preventDefault();
-          if (focusedReservationId) {
-            const prevIdx = Math.max(currentIndex - 1, 0);
-            setFocusedReservationId(flatReservations[prevIdx].id);
-          } else if (flatReservations.length > 0) {
-            setFocusedReservationId(flatReservations[flatReservations.length - 1].id);
-          }
-          break;
-        case "ArrowDown":
-          e.preventDefault();
-          if (focusedReservationId) {
-            const currentTableInfo = allReservations[currentIndex];
-            const nextTableReservations = allReservations.filter(
-              (r) => r.tableIndex === currentTableInfo.tableIndex + 1
-            );
-            if (nextTableReservations.length > 0) {
-              setFocusedReservationId(nextTableReservations[0].reservation.id);
-            }
-          }
-          break;
-        case "ArrowUp":
-          e.preventDefault();
-          if (focusedReservationId) {
-            const currentTableInfo = allReservations[currentIndex];
-            if (currentTableInfo.tableIndex > 0) {
-              const prevTableReservations = allReservations.filter(
-                (r) => r.tableIndex === currentTableInfo.tableIndex - 1
-              );
-              if (prevTableReservations.length > 0) {
-                setFocusedReservationId(
-                  prevTableReservations[prevTableReservations.length - 1].reservation.id
-                );
-              }
-            }
-          }
-          break;
-        case "Enter":
-        case " ":
-          if (focusedReservationId) {
-            const res = flatReservations.find((r) => r.id === focusedReservationId);
-            if (res) onReservationClick?.(res);
-          }
-          break;
-        case "Escape":
-          setFocusedReservationId(null);
-          break;
-      }
+  const { focusedId: focusedReservationId, handleKeyDown } = useTimelineKeyboard({
+    entries: keyboardEntries,
+    onActivate: (id) => {
+      const res = reservations.find((r) => r.id === id);
+      if (res) onReservationClick?.(res);
     },
-    [flatReservations, allReservations, onReservationClick, focusedReservationId]
-  );
+  });
 
   useEffect(() => {
     if (focusedReservationId && selectedReservationId !== focusedReservationId) {
-      const res = flatReservations.find((r) => r.id === focusedReservationId);
+      const res = reservations.find((r) => r.id === focusedReservationId);
       if (res) onReservationClick?.(res);
     }
-  }, [focusedReservationId, selectedReservationId, onReservationClick, flatReservations]);
+  }, [focusedReservationId, selectedReservationId, onReservationClick, reservations]);
 
   const hours = useMemo(() => {
     const result = [];
@@ -164,30 +97,8 @@ export function TimelineGrid({
     return isMobile ? `${displayHour}` : `${displayHour} ${ampm}`;
   };
 
-  const getTableReservations = useCallback(
-    (tableId: string) => {
-      return reservations.filter((r) => r.tableId === tableId);
-    },
-    [reservations]
-  );
-
-  const getReservationStyle = useCallback(
-    (reservation: Reservation) => {
-      const startTime = new Date(reservation.startTime);
-      const endTime = new Date(reservation.endTime);
-
-      const startMinutes = startTime.getHours() * 60 + startTime.getMinutes();
-      const endMinutes = endTime.getHours() * 60 + endTime.getMinutes();
-      const startOffset = startMinutes - startHour * 60;
-      const duration = endMinutes - startMinutes;
-
-      const left = (startOffset / 60) * hourWidth;
-      const width = Math.max((duration / 60) * hourWidth - 4, isMobile ? 30 : 40);
-
-      return { left, width };
-    },
-    [startHour, hourWidth, isMobile]
-  );
+  const getTableReservations = (tableId: string) =>
+    reservations.filter((r) => r.tableId === tableId);
 
   const [currentTime, setCurrentTime] = useState(() => new Date());
   const lastMinuteRef = useRef(currentTime.getMinutes());
@@ -219,7 +130,6 @@ export function TimelineGrid({
 
   return (
     <div
-      ref={containerRef}
       data-testid="timeline-grid"
       className={`${styles.gridWrapper} ${showMobileView ? styles.gridWrapperMobile : ""}`}
       role="grid"
@@ -297,7 +207,11 @@ export function TimelineGrid({
               </div>
 
               {getTableReservations(table.id).map((reservation) => {
-                const blockStyle = getReservationStyle(reservation);
+                const blockStyle = computeReservationLayout(
+                  reservation.startTime,
+                  reservation.endTime,
+                  { startHour, hourWidth, isMobile }
+                );
                 const isFocused = focusedReservationId === reservation.id;
                 return (
                   <ReservationBlock
@@ -324,7 +238,7 @@ export function TimelineGrid({
         )}
       </div>
 
-      {showMobileView && flatReservations.length > 0 && (
+      {showMobileView && keyboardEntries.length > 0 && (
         <div className={styles.mobileNavHint} aria-live="polite">
           Use arrow keys to navigate reservations
         </div>

--- a/apps/hospitality/src/components/timeline/reservationLayout.test.ts
+++ b/apps/hospitality/src/components/timeline/reservationLayout.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { computeReservationLayout } from "./reservationLayout.js";
+
+describe("computeReservationLayout", () => {
+  const baseParams = {
+    startHour: 11,
+    hourWidth: 120,
+    isMobile: false,
+  };
+
+  it("computes left offset from startTime", () => {
+    // 18:00 - 11:00 = 7 hours → 7 * 120 = 840
+    const result = computeReservationLayout(
+      "2026-05-14T18:00:00",
+      "2026-05-14T20:00:00",
+      baseParams
+    );
+    expect(result.left).toBe(840);
+  });
+
+  it("computes width from duration", () => {
+    // 2 hours = 120 min → (120/60)*120 - 4 = 236
+    const result = computeReservationLayout(
+      "2026-05-14T18:00:00",
+      "2026-05-14T20:00:00",
+      baseParams
+    );
+    expect(result.width).toBe(236);
+  });
+
+  it("handles fractional hours in start time", () => {
+    // 18:30 - 11:00 = 7.5 hours → 7.5 * 120 = 900
+    const result = computeReservationLayout(
+      "2026-05-14T18:30:00",
+      "2026-05-14T20:00:00",
+      baseParams
+    );
+    expect(result.left).toBe(900);
+  });
+
+  it("handles fractional hours in duration", () => {
+    // 90 min → (90/60)*120 - 4 = 176
+    const result = computeReservationLayout(
+      "2026-05-14T18:00:00",
+      "2026-05-14T19:30:00",
+      baseParams
+    );
+    expect(result.width).toBe(176);
+  });
+
+  it("enforces minimum width of 40 on desktop", () => {
+    // 5 min → (5/60)*120 - 4 = 6 → clamped to 40
+    const result = computeReservationLayout(
+      "2026-05-14T18:00:00",
+      "2026-05-14T18:05:00",
+      baseParams
+    );
+    expect(result.width).toBe(40);
+  });
+
+  it("enforces minimum width of 30 on mobile", () => {
+    const result = computeReservationLayout("2026-05-14T18:00:00", "2026-05-14T18:05:00", {
+      ...baseParams,
+      isMobile: true,
+      hourWidth: 60,
+    });
+    expect(result.width).toBe(30);
+  });
+
+  it("uses hourWidth to scale positions", () => {
+    // hourWidth=60 (mobile): 7 hours → 7 * 60 = 420
+    const result = computeReservationLayout("2026-05-14T18:00:00", "2026-05-14T20:00:00", {
+      ...baseParams,
+      hourWidth: 60,
+    });
+    expect(result.left).toBe(420);
+  });
+
+  it("handles startHour=0", () => {
+    // midnight start
+    const result = computeReservationLayout("2026-05-14T01:00:00", "2026-05-14T02:00:00", {
+      ...baseParams,
+      startHour: 0,
+    });
+    // 1 hour offset → 120
+    expect(result.left).toBe(120);
+  });
+});

--- a/apps/hospitality/src/components/timeline/reservationLayout.ts
+++ b/apps/hospitality/src/components/timeline/reservationLayout.ts
@@ -1,0 +1,37 @@
+export interface ReservationLayoutParams {
+  startHour: number;
+  hourWidth: number;
+  isMobile: boolean;
+}
+
+export interface ReservationLayoutResult {
+  left: number;
+  width: number;
+}
+
+/**
+ * Pure function: compute the absolute pixel position of a reservation block
+ * on the timeline grid.
+ *
+ * @param startTime - ISO date string (local-time parsing via getHours/getMinutes)
+ * @param endTime   - ISO date string
+ * @param params    - grid layout parameters
+ */
+export function computeReservationLayout(
+  startTime: string,
+  endTime: string,
+  { startHour, hourWidth, isMobile }: ReservationLayoutParams
+): ReservationLayoutResult {
+  const start = new Date(startTime);
+  const end = new Date(endTime);
+
+  const startMinutes = start.getHours() * 60 + start.getMinutes();
+  const endMinutes = end.getHours() * 60 + end.getMinutes();
+  const startOffset = startMinutes - startHour * 60;
+  const duration = endMinutes - startMinutes;
+
+  const left = (startOffset / 60) * hourWidth;
+  const width = Math.max((duration / 60) * hourWidth - 4, isMobile ? 30 : 40);
+
+  return { left, width };
+}

--- a/apps/hospitality/src/hooks/useTimelineKeyboard.test.ts
+++ b/apps/hospitality/src/hooks/useTimelineKeyboard.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useTimelineKeyboard, type TimelineReservationEntry } from "./useTimelineKeyboard.js";
+
+function makeEntry(id: string, tableIndex: number): TimelineReservationEntry {
+  return { reservationId: id, tableIndex };
+}
+
+describe("useTimelineKeyboard", () => {
+  const entries: TimelineReservationEntry[] = [
+    makeEntry("res-1", 0),
+    makeEntry("res-2", 0),
+    makeEntry("res-3", 1),
+  ];
+
+  describe("initial state", () => {
+    it("starts with no focused reservation", () => {
+      const { result } = renderHook(() => useTimelineKeyboard({ entries }));
+      expect(result.current.focusedId).toBeNull();
+    });
+  });
+
+  describe("ArrowRight", () => {
+    it("focuses first entry when nothing is focused", () => {
+      const { result } = renderHook(() => useTimelineKeyboard({ entries }));
+      act(() =>
+        result.current.handleKeyDown({
+          key: "ArrowRight",
+          preventDefault: vi.fn(),
+        } as unknown as React.KeyboardEvent)
+      );
+      expect(result.current.focusedId).toBe("res-1");
+    });
+
+    it("moves focus to next entry", () => {
+      const { result } = renderHook(() => useTimelineKeyboard({ entries }));
+      act(() =>
+        result.current.handleKeyDown({
+          key: "ArrowRight",
+          preventDefault: vi.fn(),
+        } as unknown as React.KeyboardEvent)
+      );
+      act(() =>
+        result.current.handleKeyDown({
+          key: "ArrowRight",
+          preventDefault: vi.fn(),
+        } as unknown as React.KeyboardEvent)
+      );
+      expect(result.current.focusedId).toBe("res-2");
+    });
+
+    it("clamps at last entry", () => {
+      const { result } = renderHook(() => useTimelineKeyboard({ entries }));
+      // jump to last via ArrowLeft
+      act(() =>
+        result.current.handleKeyDown({
+          key: "ArrowLeft",
+          preventDefault: vi.fn(),
+        } as unknown as React.KeyboardEvent)
+      );
+      act(() =>
+        result.current.handleKeyDown({
+          key: "ArrowRight",
+          preventDefault: vi.fn(),
+        } as unknown as React.KeyboardEvent)
+      );
+      expect(result.current.focusedId).toBe("res-3");
+    });
+  });
+
+  describe("ArrowLeft", () => {
+    it("focuses last entry when nothing is focused", () => {
+      const { result } = renderHook(() => useTimelineKeyboard({ entries }));
+      act(() =>
+        result.current.handleKeyDown({
+          key: "ArrowLeft",
+          preventDefault: vi.fn(),
+        } as unknown as React.KeyboardEvent)
+      );
+      expect(result.current.focusedId).toBe("res-3");
+    });
+
+    it("moves focus to previous entry", () => {
+      const { result } = renderHook(() => useTimelineKeyboard({ entries }));
+      act(() =>
+        result.current.handleKeyDown({
+          key: "ArrowRight",
+          preventDefault: vi.fn(),
+        } as unknown as React.KeyboardEvent)
+      );
+      act(() =>
+        result.current.handleKeyDown({
+          key: "ArrowRight",
+          preventDefault: vi.fn(),
+        } as unknown as React.KeyboardEvent)
+      );
+      act(() =>
+        result.current.handleKeyDown({
+          key: "ArrowLeft",
+          preventDefault: vi.fn(),
+        } as unknown as React.KeyboardEvent)
+      );
+      expect(result.current.focusedId).toBe("res-1");
+    });
+
+    it("clamps at first entry", () => {
+      const { result } = renderHook(() => useTimelineKeyboard({ entries }));
+      act(() =>
+        result.current.handleKeyDown({
+          key: "ArrowRight",
+          preventDefault: vi.fn(),
+        } as unknown as React.KeyboardEvent)
+      );
+      act(() =>
+        result.current.handleKeyDown({
+          key: "ArrowLeft",
+          preventDefault: vi.fn(),
+        } as unknown as React.KeyboardEvent)
+      );
+      expect(result.current.focusedId).toBe("res-1");
+    });
+  });
+
+  describe("ArrowDown", () => {
+    it("moves focus to first entry of next table row", () => {
+      const { result } = renderHook(() => useTimelineKeyboard({ entries }));
+      act(() =>
+        result.current.handleKeyDown({
+          key: "ArrowRight",
+          preventDefault: vi.fn(),
+        } as unknown as React.KeyboardEvent)
+      );
+      expect(result.current.focusedId).toBe("res-1");
+      act(() =>
+        result.current.handleKeyDown({
+          key: "ArrowDown",
+          preventDefault: vi.fn(),
+        } as unknown as React.KeyboardEvent)
+      );
+      expect(result.current.focusedId).toBe("res-3");
+    });
+
+    it("does nothing when already on last table row", () => {
+      const { result } = renderHook(() => useTimelineKeyboard({ entries }));
+      // focus res-3 (tableIndex 1, the last row)
+      act(() =>
+        result.current.handleKeyDown({
+          key: "ArrowLeft",
+          preventDefault: vi.fn(),
+        } as unknown as React.KeyboardEvent)
+      );
+      act(() =>
+        result.current.handleKeyDown({
+          key: "ArrowDown",
+          preventDefault: vi.fn(),
+        } as unknown as React.KeyboardEvent)
+      );
+      expect(result.current.focusedId).toBe("res-3");
+    });
+  });
+
+  describe("ArrowUp", () => {
+    it("moves focus to last entry of previous table row", () => {
+      const { result } = renderHook(() => useTimelineKeyboard({ entries }));
+      // focus res-3 on tableIndex 1
+      act(() =>
+        result.current.handleKeyDown({
+          key: "ArrowLeft",
+          preventDefault: vi.fn(),
+        } as unknown as React.KeyboardEvent)
+      );
+      act(() =>
+        result.current.handleKeyDown({
+          key: "ArrowUp",
+          preventDefault: vi.fn(),
+        } as unknown as React.KeyboardEvent)
+      );
+      // should go to last entry of tableIndex 0 = res-2
+      expect(result.current.focusedId).toBe("res-2");
+    });
+
+    it("does nothing when already on first table row", () => {
+      const { result } = renderHook(() => useTimelineKeyboard({ entries }));
+      act(() =>
+        result.current.handleKeyDown({
+          key: "ArrowRight",
+          preventDefault: vi.fn(),
+        } as unknown as React.KeyboardEvent)
+      );
+      act(() =>
+        result.current.handleKeyDown({
+          key: "ArrowUp",
+          preventDefault: vi.fn(),
+        } as unknown as React.KeyboardEvent)
+      );
+      expect(result.current.focusedId).toBe("res-1");
+    });
+  });
+
+  describe("Enter / Space", () => {
+    it("calls onActivate with focused reservationId on Enter", () => {
+      const onActivate = vi.fn();
+      const { result } = renderHook(() => useTimelineKeyboard({ entries, onActivate }));
+      act(() =>
+        result.current.handleKeyDown({
+          key: "ArrowRight",
+          preventDefault: vi.fn(),
+        } as unknown as React.KeyboardEvent)
+      );
+      act(() =>
+        result.current.handleKeyDown({
+          key: "Enter",
+          preventDefault: vi.fn(),
+        } as unknown as React.KeyboardEvent)
+      );
+      expect(onActivate).toHaveBeenCalledWith("res-1");
+    });
+
+    it("calls onActivate with focused reservationId on Space", () => {
+      const onActivate = vi.fn();
+      const { result } = renderHook(() => useTimelineKeyboard({ entries, onActivate }));
+      act(() =>
+        result.current.handleKeyDown({
+          key: "ArrowRight",
+          preventDefault: vi.fn(),
+        } as unknown as React.KeyboardEvent)
+      );
+      act(() =>
+        result.current.handleKeyDown({
+          key: " ",
+          preventDefault: vi.fn(),
+        } as unknown as React.KeyboardEvent)
+      );
+      expect(onActivate).toHaveBeenCalledWith("res-1");
+    });
+
+    it("does nothing on Enter when nothing is focused", () => {
+      const onActivate = vi.fn();
+      const { result } = renderHook(() => useTimelineKeyboard({ entries, onActivate }));
+      act(() =>
+        result.current.handleKeyDown({
+          key: "Enter",
+          preventDefault: vi.fn(),
+        } as unknown as React.KeyboardEvent)
+      );
+      expect(onActivate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Escape", () => {
+    it("clears focused reservation", () => {
+      const { result } = renderHook(() => useTimelineKeyboard({ entries }));
+      act(() =>
+        result.current.handleKeyDown({
+          key: "ArrowRight",
+          preventDefault: vi.fn(),
+        } as unknown as React.KeyboardEvent)
+      );
+      expect(result.current.focusedId).toBe("res-1");
+      act(() =>
+        result.current.handleKeyDown({
+          key: "Escape",
+          preventDefault: vi.fn(),
+        } as unknown as React.KeyboardEvent)
+      );
+      expect(result.current.focusedId).toBeNull();
+    });
+  });
+
+  describe("empty entries", () => {
+    it("does nothing on ArrowRight with empty entries", () => {
+      const { result } = renderHook(() => useTimelineKeyboard({ entries: [] }));
+      act(() =>
+        result.current.handleKeyDown({
+          key: "ArrowRight",
+          preventDefault: vi.fn(),
+        } as unknown as React.KeyboardEvent)
+      );
+      expect(result.current.focusedId).toBeNull();
+    });
+  });
+
+  describe("setFocusedId", () => {
+    it("can directly set focused id", () => {
+      const { result } = renderHook(() => useTimelineKeyboard({ entries }));
+      act(() => result.current.setFocusedId("res-2"));
+      expect(result.current.focusedId).toBe("res-2");
+    });
+
+    it("can clear focused id", () => {
+      const { result } = renderHook(() => useTimelineKeyboard({ entries }));
+      act(() => result.current.setFocusedId("res-1"));
+      act(() => result.current.setFocusedId(null));
+      expect(result.current.focusedId).toBeNull();
+    });
+  });
+});

--- a/apps/hospitality/src/hooks/useTimelineKeyboard.ts
+++ b/apps/hospitality/src/hooks/useTimelineKeyboard.ts
@@ -1,0 +1,98 @@
+import { useState, useCallback } from "react";
+
+export interface TimelineReservationEntry {
+  reservationId: string;
+  tableIndex: number;
+}
+
+export interface UseTimelineKeyboardParams {
+  entries: TimelineReservationEntry[];
+  onActivate?: (reservationId: string) => void;
+}
+
+export interface UseTimelineKeyboardResult {
+  focusedId: string | null;
+  setFocusedId: (id: string | null) => void;
+  handleKeyDown: (e: React.KeyboardEvent) => void;
+}
+
+export function useTimelineKeyboard({
+  entries,
+  onActivate,
+}: UseTimelineKeyboardParams): UseTimelineKeyboardResult {
+  const [focusedId, setFocusedId] = useState<string | null>(null);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (entries.length === 0) return;
+
+      const currentIndex = focusedId
+        ? entries.findIndex((entry) => entry.reservationId === focusedId)
+        : -1;
+
+      switch (e.key) {
+        case "ArrowRight":
+          e.preventDefault();
+          if (focusedId !== null) {
+            const nextIdx = Math.min(currentIndex + 1, entries.length - 1);
+            setFocusedId(entries[nextIdx].reservationId);
+          } else {
+            setFocusedId(entries[0].reservationId);
+          }
+          break;
+
+        case "ArrowLeft":
+          e.preventDefault();
+          if (focusedId !== null) {
+            const prevIdx = Math.max(currentIndex - 1, 0);
+            setFocusedId(entries[prevIdx].reservationId);
+          } else {
+            setFocusedId(entries[entries.length - 1].reservationId);
+          }
+          break;
+
+        case "ArrowDown":
+          e.preventDefault();
+          if (focusedId !== null) {
+            const current = entries[currentIndex];
+            const nextRowEntries = entries.filter(
+              (entry) => entry.tableIndex === current.tableIndex + 1
+            );
+            if (nextRowEntries.length > 0) {
+              setFocusedId(nextRowEntries[0].reservationId);
+            }
+          }
+          break;
+
+        case "ArrowUp":
+          e.preventDefault();
+          if (focusedId !== null) {
+            const current = entries[currentIndex];
+            if (current.tableIndex > 0) {
+              const prevRowEntries = entries.filter(
+                (entry) => entry.tableIndex === current.tableIndex - 1
+              );
+              if (prevRowEntries.length > 0) {
+                setFocusedId(prevRowEntries[prevRowEntries.length - 1].reservationId);
+              }
+            }
+          }
+          break;
+
+        case "Enter":
+        case " ":
+          if (focusedId !== null) {
+            onActivate?.(focusedId);
+          }
+          break;
+
+        case "Escape":
+          setFocusedId(null);
+          break;
+      }
+    },
+    [entries, focusedId, onActivate]
+  );
+
+  return { focusedId, setFocusedId, handleKeyDown };
+}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -15183,18 +15183,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3253,6 +3253,16 @@
       note: string;
     }
   </file>
+  <file path="apps/hospitality/src/hooks/useTimelineKeyboard.ts">
+    export interface TimelineReservationEntry {
+      reservationId: string;
+      tableIndex: number;
+    }
+    export interface UseTimelineKeyboardParams {
+      entries: TimelineReservationEntry[];
+      onActivate?: (reservationId: string) => void;
+    }
+  </file>
   <file path="apps/hospitality/src/hooks/useUsers.ts">
     export const CURRENT_USER_QUERY_KEY = "currentUser" as const;
     export const USERS_QUERY_KEY = "users" as const;
@@ -15173,7 +15183,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),
@@ -15909,6 +15930,19 @@
   <file path="services/users/src/test/fixtures.ts">
     export const MOCK_USER = createMockUser();
     export const MOCK_JWT_PAYLOAD = createMockJWTPayload();
+  </file>
+  </section>
+  <section priority="medium" role="timeline">
+  <file path="apps/hospitality/src/components/timeline/reservationLayout.ts">
+    export interface ReservationLayoutParams {
+      startHour: number;
+      hourWidth: number;
+      isMobile: boolean;
+    }
+    export interface ReservationLayoutResult {
+      left: number;
+      width: number;
+    }
   </file>
   </section>
   <section priority="medium" role="tokens">

--- a/llms.txt
+++ b/llms.txt
@@ -1140,6 +1140,20 @@
       }
     </item>
   </file>
+  <file path="apps/hospitality/src/hooks/useTimelineKeyboard.ts">
+    <item priority="low">
+      interface TimelineReservationEntry {
+        reservationId: string;
+        tableIndex: number;
+      }
+    </item>
+    <item priority="low">
+      interface UseTimelineKeyboardParams {
+        entries: TimelineReservationEntry[];
+        onActivate?: (reservationId: string) => void;
+      }
+    </item>
+  </file>
   <file path="apps/hospitality/src/hooks/useUsers.ts">
     <item priority="high">
       export const CURRENT_USER_QUERY_KEY: unknown;
@@ -4564,6 +4578,23 @@
     </item>
     <item priority="high">
       export const MOCK_JWT_PAYLOAD: unknown;
+    </item>
+  </file>
+  </section>
+  <section priority="medium" role="timeline">
+  <file path="apps/hospitality/src/components/timeline/reservationLayout.ts">
+    <item priority="low">
+      interface ReservationLayoutParams {
+        startHour: number;
+        hourWidth: number;
+        isMobile: boolean;
+      }
+    </item>
+    <item priority="low">
+      interface ReservationLayoutResult {
+        left: number;
+        width: number;
+      }
     </item>
   </file>
   </section>


### PR DESCRIPTION
## Summary

- Extracts a `useTimelineKeyboard` hook that owns focus state + ArrowUp/Down/Left/Right/Enter/Space/Escape navigation over a plain `{ reservationId, tableIndex }[]` data model — no rendering, fully testable against pure data
- Extracts `computeReservationLayout(startTime, endTime, params)` — pure function returning `{ left, width }` pixel positions; replaces the inline `getReservationStyle` callback in `TimelineGrid`
- `TimelineGrid` rewired to use both; becomes pure wiring (data → hooks → JSX), no inline nav or layout logic
- `ReservationBlock` was already standalone-testable and its tests remain unchanged — grid behavior preserved exactly

## Test plan

- [ ] `useTimelineKeyboard`: 18 unit tests — ArrowRight/Left/Up/Down boundaries, Enter/Space activate, Escape clear, empty entries no-op, direct `setFocusedId`
- [ ] `computeReservationLayout`: 8 unit tests — pixel-accurate left/width, fractional hours, minimum width clamps (desktop 40px, mobile 30px), custom hourWidth, startHour=0
- [ ] `TimelineGrid`: 37 pre-existing tests — all green; keyboard navigation paths now exercise the extracted hook via the grid
- [ ] `ReservationBlock`: 26 pre-existing tests — all green
- [ ] Full suite: 88 test files, 1102 tests passing
- [ ] `pnpm lint` — 0 errors
- [ ] `pnpm typecheck` — clean
- [ ] `check-adr` + `check-deps` — no violations
- [ ] `pnpm regen` — artifacts synced

Closes #2096