### PR TITLE
refactor(rialto): adopt cn()/variantClass() across form & input components [batch 1/3]

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -15183,18 +15183,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -15173,7 +15173,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,18 +337,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -337,7 +337,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/rialto/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/packages/rialto/src/components/Autocomplete/Autocomplete.test.tsx
@@ -226,4 +226,9 @@ describe("Autocomplete", () => {
       expect(screen.getByRole("listbox")).toBeInTheDocument();
     });
   });
+
+  it("does not emit 'undefined' in wrapper className", () => {
+    const { container } = render(<Autocomplete options={options} />);
+    expect(container.firstElementChild?.className).not.toMatch(/undefined/);
+  });
 });

--- a/packages/rialto/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/rialto/src/components/Autocomplete/Autocomplete.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import { precision } from "../../tokens/motion";
+import { cn } from "../../utils/class-composer";
 import { useCombobox } from "../../hooks/useCombobox";
 import styles from "./Autocomplete.module.css";
 
@@ -147,7 +148,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, AutocompleteProps>(
     const hintId = hint ? `${inputId}-hint` : undefined;
 
     return (
-      <div ref={wrapperRef} className={[styles.wrapper, className].filter(Boolean).join(" ")}>
+      <div ref={wrapperRef} className={cn(styles.wrapper, className)}>
         {label && (
           <label htmlFor={inputId} className={styles.label}>
             {label}
@@ -224,9 +225,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, AutocompleteProps>(
                     role="option"
                     aria-selected={focusedIndex === index}
                     data-option-index={index}
-                    className={[styles.option, focusedIndex === index && styles.optionActive]
-                      .filter(Boolean)
-                      .join(" ")}
+                    className={cn(styles.option, focusedIndex === index && styles.optionActive)}
                     onMouseDown={(e) => {
                       e.preventDefault(); // keep focus on input
                       handleSelectOption(option);

--- a/packages/rialto/src/components/ImageUpload/ImageUpload.test.tsx
+++ b/packages/rialto/src/components/ImageUpload/ImageUpload.test.tsx
@@ -191,4 +191,12 @@ describe("ImageUpload", () => {
       expect(input).toHaveAttribute("accept", "image/png,image/svg+xml");
     });
   });
+
+  it("does not emit 'undefined' in tile or wrapper className", () => {
+    const { container } = render(<ImageUpload label="Logo" onChange={() => {}} />);
+    const allClasses = Array.from(container.querySelectorAll("[class]"))
+      .map((el) => el.className)
+      .join(" ");
+    expect(allClasses).not.toMatch(/undefined/);
+  });
 });

--- a/packages/rialto/src/components/ImageUpload/ImageUpload.tsx
+++ b/packages/rialto/src/components/ImageUpload/ImageUpload.tsx
@@ -2,6 +2,7 @@ import { forwardRef, useCallback, useId, useRef, useState } from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import { Check, Plus } from "lucide-react";
 import { spring } from "../../tokens/motion";
+import { cn } from "../../utils/class-composer";
 import styles from "./ImageUpload.module.css";
 
 /**
@@ -174,19 +175,17 @@ export const ImageUpload = forwardRef<HTMLDivElement, ImageUploadProps>(
       [onChange, openPicker]
     );
 
-    const tileClass = [
+    const tileClass = cn(
       styles.tile,
       styles[size],
       dragOver && styles.dragOver,
       hasPreview && styles.hasPreview,
       error && styles.error,
       done && styles.done,
-      disabled && styles.disabled,
-    ]
-      .filter(Boolean)
-      .join(" ");
+      disabled && styles.disabled
+    );
 
-    const wrapperClass = [styles.wrapper, className].filter(Boolean).join(" ");
+    const wrapperClass = cn(styles.wrapper, className);
 
     return (
       <div ref={ref} className={wrapperClass}>

--- a/packages/rialto/src/components/InputGroup/InputGroup.tsx
+++ b/packages/rialto/src/components/InputGroup/InputGroup.tsx
@@ -1,4 +1,5 @@
 import { forwardRef, type HTMLAttributes } from "react";
+import { cn } from "../../utils/class-composer";
 import styles from "./InputGroup.module.css";
 
 /**
@@ -16,12 +17,7 @@ export type InputGroupProps = HTMLAttributes<HTMLDivElement>;
 export const InputGroup = forwardRef<HTMLDivElement, InputGroupProps>(
   ({ className, children, ...props }, ref) => {
     return (
-      <div
-        ref={ref}
-        className={[styles.group, className].filter(Boolean).join(" ")}
-        role="group"
-        {...props}
-      >
+      <div ref={ref} className={cn(styles.group, className)} role="group" {...props}>
         {children}
       </div>
     );

--- a/packages/rialto/src/components/Meter/Meter.test.tsx
+++ b/packages/rialto/src/components/Meter/Meter.test.tsx
@@ -166,4 +166,12 @@ describe("Meter", () => {
       expect(screen.getByRole("meter")).toHaveAttribute("aria-valuenow", "5");
     });
   });
+
+  it("does not emit 'undefined' in wrapper or track className", () => {
+    const { container } = render(<Meter value={50} />);
+    const allClasses = Array.from(container.querySelectorAll("[class]"))
+      .map((el) => el.className)
+      .join(" ");
+    expect(allClasses).not.toMatch(/undefined/);
+  });
 });

--- a/packages/rialto/src/components/Meter/Meter.tsx
+++ b/packages/rialto/src/components/Meter/Meter.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, type HTMLAttributes } from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import { precision } from "../../tokens/motion";
+import { cn } from "../../utils/class-composer";
 import styles from "./Meter.module.css";
 
 /**
@@ -53,14 +54,12 @@ export const Meter = forwardRef<HTMLDivElement, MeterProps>(
     const fraction = range > 0 ? Math.min(1, Math.max(0, (value - min) / range)) : 0;
     const percent = Math.round(fraction * 100);
 
-    const trackClass = [styles.track, size === "sm" ? styles.trackSm : ""]
-      .filter(Boolean)
-      .join(" ");
+    const trackClass = cn(styles.track, size === "sm" && styles.trackSm);
 
-    const fillClass = [styles.fill, styles[variant]].filter(Boolean).join(" ");
+    const fillClass = cn(styles.fill, styles[variant]);
 
     return (
-      <div ref={ref} className={[styles.wrapper, className].filter(Boolean).join(" ")} {...props}>
+      <div ref={ref} className={cn(styles.wrapper, className)} {...props}>
         {(label || showValue) && (
           <div className={styles.labelRow}>
             {label && <span className={styles.label}>{label}</span>}

--- a/packages/rialto/src/components/NumberInput/NumberInput.test.tsx
+++ b/packages/rialto/src/components/NumberInput/NumberInput.test.tsx
@@ -190,4 +190,9 @@ describe("NumberInput — rendering extras", () => {
     render(<NumberInput ref={ref} label="Qty" value={5} onChange={noop} />);
     expect(ref.current).toBeInstanceOf(HTMLDivElement);
   });
+
+  it("does not emit 'undefined' in wrapper className", () => {
+    const { container } = render(<NumberInput value={5} onChange={noop} />);
+    expect(container.firstElementChild?.className).not.toMatch(/undefined/);
+  });
 });

--- a/packages/rialto/src/components/NumberInput/NumberInput.tsx
+++ b/packages/rialto/src/components/NumberInput/NumberInput.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, useRef, useCallback, useEffect, type InputHTMLAttributes } from "react";
 import { Lock } from "lucide-react";
+import { cn, variantClass } from "../../utils/class-composer";
 import { DisabledTooltip } from "../DisabledTooltip/DisabledTooltip";
 import { useField } from "../../hooks/useField";
 import styles from "./NumberInput.module.css";
@@ -130,14 +131,12 @@ export const NumberInput = forwardRef<HTMLDivElement, NumberInputProps>(
     const atMin = min != null && value <= min;
     const atMax = max != null && value >= max;
 
-    const wrapperClasses = [
+    const wrapperClasses = cn(
       styles.wrapper,
-      size !== "default" ? styles[size] : "",
-      error ? styles.error : "",
-      className,
-    ]
-      .filter(Boolean)
-      .join(" ");
+      variantClass(styles, size, "default"),
+      error && styles.error,
+      className
+    );
 
     return (
       <DisabledTooltip disabled={disabled} disabledReason={disabledReason}>
@@ -160,7 +159,7 @@ export const NumberInput = forwardRef<HTMLDivElement, NumberInputProps>(
           <div className={styles.control}>
             <button
               type="button"
-              className={`${styles.stepper} ${styles.decrement}`}
+              className={cn(styles.stepper, styles.decrement)}
               disabled={disabled || atMin}
               tabIndex={-1}
               aria-label="Decrease"
@@ -188,7 +187,7 @@ export const NumberInput = forwardRef<HTMLDivElement, NumberInputProps>(
             />
             <button
               type="button"
-              className={`${styles.stepper} ${styles.increment}`}
+              className={cn(styles.stepper, styles.increment)}
               disabled={disabled || atMax}
               tabIndex={-1}
               aria-label="Increase"

--- a/packages/rialto/src/components/PinInput/PinInput.test.tsx
+++ b/packages/rialto/src/components/PinInput/PinInput.test.tsx
@@ -169,4 +169,9 @@ describe("PinInput", () => {
       ).toHaveNoViolations();
     });
   });
+
+  it("does not emit 'undefined' in wrapper className", () => {
+    const { container } = render(<PinInput />);
+    expect(container.firstElementChild?.className).not.toMatch(/undefined/);
+  });
 });

--- a/packages/rialto/src/components/PinInput/PinInput.tsx
+++ b/packages/rialto/src/components/PinInput/PinInput.tsx
@@ -10,6 +10,7 @@ import {
 import { motion, useReducedMotion } from "framer-motion";
 import { Lock } from "lucide-react";
 import { spring } from "../../tokens/motion";
+import { cn, variantClass } from "../../utils/class-composer";
 import { DisabledTooltip } from "../DisabledTooltip/DisabledTooltip";
 import styles from "./PinInput.module.css";
 
@@ -161,14 +162,12 @@ export const PinInput = forwardRef<HTMLDivElement, PinInputProps>(function PinIn
   );
 
   /* ── Class names ─────────────────────────── */
-  const wrapperClasses = [
+  const wrapperClasses = cn(
     styles.wrapper,
-    size !== "md" ? styles[size] : "",
-    error ? styles.error : "",
-    className,
-  ]
-    .filter(Boolean)
-    .join(" ");
+    variantClass(styles, size, "md"),
+    error && styles.error,
+    className
+  );
 
   const entryAnimation = shouldReduceMotion
     ? {}

--- a/packages/rialto/src/components/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/rialto/src/components/SegmentedControl/SegmentedControl.test.tsx
@@ -144,4 +144,11 @@ describe("SegmentedControl", () => {
       ).toHaveNoViolations();
     });
   });
+
+  it("does not emit 'undefined' in container className", () => {
+    const { container } = render(
+      <SegmentedControl segments={segments} value="day" onChange={() => {}} />
+    );
+    expect(container.firstElementChild?.className).not.toMatch(/undefined/);
+  });
 });

--- a/packages/rialto/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/rialto/src/components/SegmentedControl/SegmentedControl.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, useRef, useEffect, useState, useCallback, type HTMLAttributes } from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import { spring, boop } from "../../tokens/motion";
+import { cn, variantClass } from "../../utils/class-composer";
 import { useDirection } from "../../hooks/useDirection";
 import styles from "./SegmentedControl.module.css";
 
@@ -88,9 +89,7 @@ export const SegmentedControl = forwardRef<HTMLDivElement, SegmentedControlProps
     return (
       <div
         ref={ref}
-        className={[styles.container, size === "sm" ? styles.sm : "", className]
-          .filter(Boolean)
-          .join(" ")}
+        className={cn(styles.container, variantClass(styles, size, "md"), className)}
         {...props}
       >
         <div
@@ -123,9 +122,7 @@ export const SegmentedControl = forwardRef<HTMLDivElement, SegmentedControlProps
                 ref={(el) => {
                   if (el) segmentRefs.current.set(segment.id, el);
                 }}
-                className={[styles.segment, active ? styles.segmentActive : ""]
-                  .filter(Boolean)
-                  .join(" ")}
+                className={cn(styles.segment, active && styles.segmentActive)}
                 role="radio"
                 aria-checked={active}
                 tabIndex={active ? 0 : -1}

--- a/packages/rialto/src/components/Select/Select.test.tsx
+++ b/packages/rialto/src/components/Select/Select.test.tsx
@@ -226,4 +226,9 @@ describe("Select", () => {
       expect(ref.current).toBeInstanceOf(HTMLDivElement);
     });
   });
+
+  it("does not emit 'undefined' in wrapper className", () => {
+    const { container } = render(<Select options={options} />);
+    expect(container.firstElementChild?.className).not.toMatch(/undefined/);
+  });
 });

--- a/packages/rialto/src/components/Select/Select.tsx
+++ b/packages/rialto/src/components/Select/Select.tsx
@@ -2,6 +2,7 @@ import { forwardRef, useRef, useEffect, type KeyboardEvent } from "react";
 import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import { Lock } from "lucide-react";
 import { springGentle } from "../../tokens/motion";
+import { cn } from "../../utils/class-composer";
 import { DisabledTooltip } from "../DisabledTooltip/DisabledTooltip";
 import { useCombobox } from "../../hooks/useCombobox";
 import { useField } from "../../hooks/useField";
@@ -106,7 +107,7 @@ export const Select = forwardRef<HTMLDivElement, SelectProps>(
     };
 
     return (
-      <div ref={mergeRef} className={[styles.wrapper, className].filter(Boolean).join(" ")}>
+      <div ref={mergeRef} className={cn(styles.wrapper, className)}>
         {label && (
           <label htmlFor={triggerId} className={styles.label}>
             {label}
@@ -137,7 +138,7 @@ export const Select = forwardRef<HTMLDivElement, SelectProps>(
             data-open={open}
             onClick={disabled ? (e) => e.preventDefault() : () => toggle()}
           >
-            <span className={`${styles.triggerText} ${!selectedOption ? styles.placeholder : ""}`}>
+            <span className={cn(styles.triggerText, !selectedOption && styles.placeholder)}>
               {selectedOption?.label ?? placeholder}
             </span>
             {disabled && disabledReason && (

--- a/packages/rialto/src/components/Slider/Slider.test.tsx
+++ b/packages/rialto/src/components/Slider/Slider.test.tsx
@@ -148,4 +148,9 @@ describe("Slider", () => {
       ).toHaveNoViolations();
     });
   });
+
+  it("does not emit 'undefined' in wrapper className", () => {
+    const { container } = render(<Slider label="Volume" />);
+    expect(container.firstElementChild?.className).not.toMatch(/undefined/);
+  });
 });

--- a/packages/rialto/src/components/Slider/Slider.tsx
+++ b/packages/rialto/src/components/Slider/Slider.tsx
@@ -2,6 +2,7 @@ import { forwardRef, useState, useRef, useCallback, useEffect, useId } from "rea
 import { motion, useMotionValue, useReducedMotion } from "framer-motion";
 import { Lock } from "lucide-react";
 import { spring } from "../../tokens/motion";
+import { cn } from "../../utils/class-composer";
 import { DisabledTooltip } from "../DisabledTooltip/DisabledTooltip";
 import styles from "./Slider.module.css";
 
@@ -154,7 +155,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(
 
     return (
       <DisabledTooltip disabled={disabled} disabledReason={disabledReason}>
-        <div ref={ref} className={[styles.wrapper, className].filter(Boolean).join(" ")}>
+        <div ref={ref} className={cn(styles.wrapper, className)}>
           {(label || showValue) && (
             <div className={styles.labelRow}>
               {label && <span className={styles.label}>{label}</span>}

--- a/packages/rialto/src/components/Steps/Steps.test.tsx
+++ b/packages/rialto/src/components/Steps/Steps.test.tsx
@@ -120,4 +120,12 @@ describe("Steps", () => {
     const reviewItem = screen.getByText("Review").closest("[role='listitem']");
     expect(reviewItem).toHaveAttribute("aria-current", "step");
   });
+
+  it("does not emit 'undefined' in container or step className", () => {
+    const { container } = render(<Steps steps={steps} currentStep={1} />);
+    const allClasses = Array.from(container.querySelectorAll("[class]"))
+      .map((el) => el.className)
+      .join(" ");
+    expect(allClasses).not.toMatch(/undefined/);
+  });
 });

--- a/packages/rialto/src/components/Steps/Steps.tsx
+++ b/packages/rialto/src/components/Steps/Steps.tsx
@@ -1,4 +1,5 @@
 import { forwardRef } from "react";
+import { cn } from "../../utils/class-composer";
 import styles from "./Steps.module.css";
 
 /* ── Types ───────────────────────────────────── */
@@ -57,27 +58,23 @@ export const Steps = forwardRef<HTMLDivElement, StepsProps>(
     },
     ref
   ) => {
-    const containerClass = [
+    const containerClass = cn(
       orientation === "horizontal" ? styles.horizontal : styles.vertical,
-      compact ? styles.compact : "",
-      className,
-    ]
-      .filter(Boolean)
-      .join(" ");
+      compact && styles.compact,
+      className
+    );
 
     return (
       <div ref={ref} className={containerClass} role="list" aria-label="Progress steps">
         {steps.map((step, i) => {
           const state = i < currentStep ? "completed" : i === currentStep ? "current" : "upcoming";
 
-          const stepClass = [
+          const stepClass = cn(
             styles.step,
-            state === "completed" ? styles.completed : "",
-            state === "current" ? styles.current : "",
-            onStepClick ? styles.clickable : "",
-          ]
-            .filter(Boolean)
-            .join(" ");
+            state === "completed" && styles.completed,
+            state === "current" && styles.current,
+            onStepClick && styles.clickable
+          );
 
           const inner = (
             <>

--- a/packages/rialto/src/components/Toggle/Toggle.test.tsx
+++ b/packages/rialto/src/components/Toggle/Toggle.test.tsx
@@ -116,4 +116,9 @@ describe("Toggle", () => {
       expect(screen.getByRole("switch")).toBeInTheDocument();
     });
   });
+
+  it("does not emit 'undefined' in wrapper className", () => {
+    const { container } = render(<Toggle label="Dark mode" />);
+    expect(container.firstElementChild?.className).not.toMatch(/undefined/);
+  });
 });

--- a/packages/rialto/src/components/Toggle/Toggle.tsx
+++ b/packages/rialto/src/components/Toggle/Toggle.tsx
@@ -2,6 +2,7 @@ import { forwardRef, useId, useRef, type InputHTMLAttributes } from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import { Lock } from "lucide-react";
 import { spring, boop } from "../../tokens/motion";
+import { cn } from "../../utils/class-composer";
 import { useDirection } from "../../hooks/useDirection";
 import { DisabledTooltip } from "../DisabledTooltip/DisabledTooltip";
 import styles from "./Toggle.module.css";
@@ -38,7 +39,7 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
       <DisabledTooltip disabled={disabled} disabledReason={disabledReason}>
         <div
           ref={wrapperRef}
-          className={[styles.wrapper, className].filter(Boolean).join(" ")}
+          className={cn(styles.wrapper, className)}
           aria-disabled={disabled || undefined}
         >
           <input


### PR DESCRIPTION
## Summary

- Migrates 11 form/input components off the inline `.filter(Boolean).join(" ")` class idiom to `cn()`/`variantClass()` from the class-composer seam landed in #2236
- Components migrated: Autocomplete, InputGroup, NumberInput, PinInput, Select, SegmentedControl, Slider, Toggle, Meter, ImageUpload, Steps
- Adds a no-`undefined`-in-className contract test to each migrated component (10 new tests)

## Test plan

- [ ] `pnpm lint` — green (no errors, warnings are pre-existing)
- [ ] `pnpm typecheck` — green
- [ ] `pnpm vitest run` — 1695 tests pass (1 pre-existing ChatPanel failure unrelated to this change)
- [ ] `check-adr` + `check-deps` — clean
- [ ] `pnpm regen` — no drift (llms-full.txt updated and staged)
- [ ] Pre-push hook ran 1704 tests across 9 packages — all green

Closes #2238