### PR TITLE
fix(security): harden Stripe MCP — secret to env, least-privilege tools

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -48,7 +48,8 @@
     },
     "stripe": {
       "command": "npx",
-      "args": ["-y", "@stripe/mcp", "--tools=all", "--api-key=${STRIPE_SECRET_KEY}"]
+      "args": ["-y", "@stripe/mcp", "--tools=customers.read,products.read,paymentIntents.read,balance.read"],
+      "env": { "STRIPE_SECRET_KEY": "${STRIPE_SECRET_KEY}" }
     }
   }
 }


### PR DESCRIPTION
Addresses 2 HIGH findings from the automated push security review against `.mcp.json` (the Stripe MCP entry added in #2575).

## Findings fixed
1. **Secret exposure via process argv** — `--api-key=${STRIPE_SECRET_KEY}` in `args` leaks the key to `ps`, `/proc/<pid>/cmdline`, and any debug/telemetry that captures the command line. Moved into the `env` block (matches every other server entry).
2. **Over-broad capability grant** — `--tools=all` gave full write access; a successful prompt-injection could create charges or move funds. Replaced with a read-only allowlist: `customers.read,products.read,paymentIntents.read,balance.read`.

Test-mode key, but least-privilege is the right default. Add specific write scopes deliberately if a payment-dev flow needs them.