### PR TITLE
feat(agent): enforce owner-or-admin authz on session routes

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5363,6 +5363,11 @@
     };
   </file>
   <file path="services/agent/src/routes/sessions.ts">
+    function isOwnerOrAdmin(caller: AuthUser | undefined, sessionUserId: string | null): boolean {
+      if (hasPermission(caller, "admin")) return true;
+      if (sessionUserId === null) return false;
+      return caller?.id === sessionUserId;
+    }
     export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
       // POST /v1/sessions — Create + start a new session
       fastify.post<{
@@ -5462,7 +5467,10 @@
             | "CANCELLED"
             | undefined;
     
-          return sessionService.list({ page, limit, status: prismaStatus });
+          // Admins see all sessions; non-admins see only their own
+          const userId = hasPermission(request.user, "admin") ? undefined : request.user?.id;
+    
+          return sessionService.list({ page, limit, status: prismaStatus, userId });
         }
       );
     
@@ -5494,7 +5502,7 @@
         },
         async (request, reply) => {
           const session = await sessionService.getById(request.params.id);
-          if (!session) {
+          if (!session || !isOwnerOrAdmin(request.user, session.userId)) {
             return reply.code(404).send(createProblemDetails(404, "Not Found", "Session not found"));
           }
           return { data: session };
@@ -5530,7 +5538,7 @@
         },
         async (request, reply) => {
           const session = await sessionService.getById(request.params.id);
-          if (!session) {
+          if (!session || !isOwnerOrAdmin(request.user, session.userId)) {
             return reply.code(404).send(createProblemDetails(404, "Not Found", "Session not found"));
           }
     
@@ -5576,10 +5584,11 @@
           },
         },
         async (request, reply) => {
-          const deleted = await sessionService.delete(request.params.id);
-          if (!deleted) {
+          const session = await sessionService.getById(request.params.id);
+          if (!session || !isOwnerOrAdmin(request.user, session.userId)) {
             return reply.code(404).send(createProblemDetails(404, "Not Found", "Session not found"));
           }
+          await sessionService.delete(request.params.id);
           return reply.code(204).send();
         }
       );

--- a/llms.txt
+++ b/llms.txt
@@ -1621,6 +1621,9 @@
     </item>
   </file>
   <file path="services/agent/src/routes/sessions.ts">
+    <item priority="medium">
+      function isOwnerOrAdmin(caller: AuthUser | undefined, sessionUserId: string | null): boolean { /* ... */ }
+    </item>
     <item priority="high">
       export const sessionRoutes: FastifyPluginAsync;
     </item>

--- a/services/agent/llms-full.txt
+++ b/services/agent/llms-full.txt
@@ -1035,6 +1035,11 @@
     };
   </file>
   <file path="src/routes/sessions.ts">
+    function isOwnerOrAdmin(caller: AuthUser | undefined, sessionUserId: string | null): boolean {
+      if (hasPermission(caller, "admin")) return true;
+      if (sessionUserId === null) return false;
+      return caller?.id === sessionUserId;
+    }
     export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
       // POST /v1/sessions — Create + start a new session
       fastify.post<{
@@ -1134,7 +1139,10 @@
             | "CANCELLED"
             | undefined;
     
-          return sessionService.list({ page, limit, status: prismaStatus });
+          // Admins see all sessions; non-admins see only their own
+          const userId = hasPermission(request.user, "admin") ? undefined : request.user?.id;
+    
+          return sessionService.list({ page, limit, status: prismaStatus, userId });
         }
       );
     
@@ -1166,7 +1174,7 @@
         },
         async (request, reply) => {
           const session = await sessionService.getById(request.params.id);
-          if (!session) {
+          if (!session || !isOwnerOrAdmin(request.user, session.userId)) {
             return reply.code(404).send(createProblemDetails(404, "Not Found", "Session not found"));
           }
           return { data: session };
@@ -1202,7 +1210,7 @@
         },
         async (request, reply) => {
           const session = await sessionService.getById(request.params.id);
-          if (!session) {
+          if (!session || !isOwnerOrAdmin(request.user, session.userId)) {
             return reply.code(404).send(createProblemDetails(404, "Not Found", "Session not found"));
           }
     
@@ -1248,10 +1256,11 @@
           },
         },
         async (request, reply) => {
-          const deleted = await sessionService.delete(request.params.id);
-          if (!deleted) {
+          const session = await sessionService.getById(request.params.id);
+          if (!session || !isOwnerOrAdmin(request.user, session.userId)) {
             return reply.code(404).send(createProblemDetails(404, "Not Found", "Session not found"));
           }
+          await sessionService.delete(request.params.id);
           return reply.code(204).send();
         }
       );

--- a/services/agent/llms.txt
+++ b/services/agent/llms.txt
@@ -117,6 +117,9 @@
     </item>
   </file>
   <file path="src/routes/sessions.ts">
+    <item priority="medium">
+      function isOwnerOrAdmin(caller: AuthUser | undefined, sessionUserId: string | null): boolean { /* ... */ }
+    </item>
     <item priority="high">
       export const sessionRoutes: FastifyPluginAsync;
     </item>

--- a/services/agent/src/routes/sessions-authz.test.ts
+++ b/services/agent/src/routes/sessions-authz.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Authorization tests for session routes.
+ *
+ * Verifies owner-or-admin access control:
+ * - GET /:id, POST /:id/cancel, DELETE /:id → 404 for non-owner non-admin
+ * - GET / → filters to caller's sessions for non-admins; admins see all
+ * - Null-owner sessions → admin-only
+ *
+ * Uses @mbe/auth/fastify mock to control request.user directly per test,
+ * bypassing JWT verification — the same pattern used in gen-specs.test.ts.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { FastifyInstance } from "fastify";
+import type { AuthUser } from "@mbe/auth/fastify";
+
+// Control which user is active in each test
+let currentUser: AuthUser | undefined;
+
+vi.mock("@mbe/auth/fastify", () => ({
+  authPlugin: vi.fn(async () => {}),
+  getAuthPluginOptionsFromEnv: vi.fn(() => ({})),
+  requireAuth: vi.fn(async (req: { user?: AuthUser }) => {
+    req.user = currentUser;
+  }),
+  hasPermission: vi.fn((user: AuthUser | undefined, permission: string) => {
+    if (!user) return false;
+    const permissions = user.raw?.permissions;
+    return Array.isArray(permissions) && (permissions as string[]).includes(permission);
+  }),
+}));
+
+vi.mock("../services/session.js", () => ({
+  sessionService: {
+    list: vi.fn(),
+    getById: vi.fn(),
+    create: vi.fn(),
+    triggerSession: vi.fn(),
+    updateStatus: vi.fn(),
+    delete: vi.fn(),
+    addEvent: vi.fn(),
+    listEvents: vi.fn(),
+  },
+}));
+
+vi.mock("../services/session-executor.js", () => ({
+  executeSession: vi.fn().mockResolvedValue(undefined),
+  cancelSession: vi.fn(),
+  getActiveSessionCount: vi.fn().mockReturnValue(0),
+}));
+
+vi.mock("../services/database.js", async () => {
+  const { createMockDatabaseService } = await import("@mbe/database/testing");
+  return createMockDatabaseService();
+});
+
+import { sessionService } from "../services/session.js";
+import { cancelSession } from "../services/session-executor.js";
+import { buildApp } from "../app.js";
+
+// Helpers to create user fixtures
+function makeUser(id: string, permissions: string[] = []): AuthUser {
+  return {
+    id,
+    email: `${id}@example.com`,
+    raw: {
+      sub: id,
+      iss: "https://test.auth0.com/",
+      aud: ["https://api.example.com"],
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      iat: Math.floor(Date.now() / 1000),
+      permissions,
+    },
+  };
+}
+
+const OWNER_USER = makeUser("auth0|owner-456", []);
+const NON_OWNER_USER = makeUser("auth0|stranger-999", []);
+const ADMIN_USER = makeUser("auth0|admin-789", ["admin"]);
+
+// Session owned by "auth0|owner-456"
+const ownerSession = {
+  id: "session-123",
+  status: "pending" as const,
+  taskDescription: "Fix the login bug",
+  userId: "auth0|owner-456",
+  branchName: null,
+  baseBranch: "main",
+  model: "claude-sonnet-4-6",
+  maxTurns: 50,
+  maxBudgetUsd: 1.0,
+  prUrl: null,
+  prNumber: null,
+  resultText: null,
+  costUsd: null,
+  inputTokens: null,
+  outputTokens: null,
+  numTurns: null,
+  durationMs: null,
+  parentId: null,
+  errors: [],
+  startedAt: null,
+  completedAt: null,
+  createdAt: "2026-02-27T00:00:00.000Z",
+  updatedAt: "2026-02-27T00:00:00.000Z",
+};
+
+// Session with no owner (pre-migration/system session)
+const nullOwnerSession = { ...ownerSession, userId: null };
+
+describe("Session Routes — Authorization", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    currentUser = OWNER_USER;
+    app = await buildApp({ logger: false });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    vi.clearAllMocks();
+  });
+
+  describe("GET /v1/sessions/:id — owner-or-admin", () => {
+    it("allows the session owner to fetch their session", async () => {
+      currentUser = OWNER_USER;
+      vi.mocked(sessionService.getById).mockResolvedValueOnce(ownerSession);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/v1/sessions/session-123",
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    it("allows an admin to fetch any session", async () => {
+      currentUser = ADMIN_USER;
+      vi.mocked(sessionService.getById).mockResolvedValueOnce(ownerSession);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/v1/sessions/session-123",
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    it("returns 404 for a non-owner non-admin caller", async () => {
+      currentUser = NON_OWNER_USER;
+      vi.mocked(sessionService.getById).mockResolvedValueOnce(ownerSession);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/v1/sessions/session-123",
+      });
+
+      // 404 (not 403) to avoid revealing session existence
+      expect(response.statusCode).toBe(404);
+    });
+
+    it("returns 404 for a null-owner session when caller is not admin", async () => {
+      currentUser = OWNER_USER;
+      vi.mocked(sessionService.getById).mockResolvedValueOnce(nullOwnerSession);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/v1/sessions/session-123",
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it("allows an admin to fetch a null-owner session", async () => {
+      currentUser = ADMIN_USER;
+      vi.mocked(sessionService.getById).mockResolvedValueOnce(nullOwnerSession);
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/v1/sessions/session-123",
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+  });
+
+  describe("POST /v1/sessions/:id/cancel — owner-or-admin", () => {
+    it("allows the session owner to cancel their session", async () => {
+      currentUser = OWNER_USER;
+      const runningSession = { ...ownerSession, status: "running" as const };
+      vi.mocked(sessionService.getById)
+        .mockResolvedValueOnce(runningSession)
+        .mockResolvedValueOnce({ ...runningSession, status: "cancelled" as const });
+      vi.mocked(cancelSession).mockResolvedValueOnce(true);
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/v1/sessions/session-123/cancel",
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    it("allows an admin to cancel any session", async () => {
+      currentUser = ADMIN_USER;
+      const runningSession = { ...ownerSession, status: "running" as const };
+      vi.mocked(sessionService.getById)
+        .mockResolvedValueOnce(runningSession)
+        .mockResolvedValueOnce({ ...runningSession, status: "cancelled" as const });
+      vi.mocked(cancelSession).mockResolvedValueOnce(true);
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/v1/sessions/session-123/cancel",
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    it("returns 404 for a non-owner non-admin caller", async () => {
+      currentUser = NON_OWNER_USER;
+      const runningSession = { ...ownerSession, status: "running" as const };
+      vi.mocked(sessionService.getById).mockResolvedValueOnce(runningSession);
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/v1/sessions/session-123/cancel",
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it("returns 404 for null-owner session when caller is not admin", async () => {
+      currentUser = OWNER_USER;
+      const runningSession = { ...nullOwnerSession, status: "running" as const };
+      vi.mocked(sessionService.getById).mockResolvedValueOnce(runningSession);
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/v1/sessions/session-123/cancel",
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+  });
+
+  describe("DELETE /v1/sessions/:id — owner-or-admin", () => {
+    it("allows the session owner to delete their session", async () => {
+      currentUser = OWNER_USER;
+      vi.mocked(sessionService.getById).mockResolvedValueOnce(ownerSession);
+      vi.mocked(sessionService.delete).mockResolvedValueOnce(true);
+
+      const response = await app.inject({
+        method: "DELETE",
+        url: "/v1/sessions/session-123",
+      });
+
+      expect(response.statusCode).toBe(204);
+    });
+
+    it("allows an admin to delete any session", async () => {
+      currentUser = ADMIN_USER;
+      vi.mocked(sessionService.getById).mockResolvedValueOnce(ownerSession);
+      vi.mocked(sessionService.delete).mockResolvedValueOnce(true);
+
+      const response = await app.inject({
+        method: "DELETE",
+        url: "/v1/sessions/session-123",
+      });
+
+      expect(response.statusCode).toBe(204);
+    });
+
+    it("returns 404 for a non-owner non-admin caller", async () => {
+      currentUser = NON_OWNER_USER;
+      vi.mocked(sessionService.getById).mockResolvedValueOnce(ownerSession);
+
+      const response = await app.inject({
+        method: "DELETE",
+        url: "/v1/sessions/session-123",
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it("returns 404 for null-owner session when caller is not admin", async () => {
+      currentUser = OWNER_USER;
+      vi.mocked(sessionService.getById).mockResolvedValueOnce(nullOwnerSession);
+
+      const response = await app.inject({
+        method: "DELETE",
+        url: "/v1/sessions/session-123",
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+  });
+
+  describe("GET /v1/sessions — list filtering", () => {
+    const pagination = {
+      page: 1,
+      limit: 10,
+      total: 1,
+      totalPages: 1,
+      hasNext: false,
+      hasPrev: false,
+    };
+
+    it("passes userId filter for non-admin callers", async () => {
+      currentUser = OWNER_USER;
+      vi.mocked(sessionService.list).mockResolvedValueOnce({
+        data: [ownerSession],
+        pagination,
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/v1/sessions",
+      });
+
+      expect(response.statusCode).toBe(200);
+      // The service must be called with the caller's userId to filter results
+      expect(sessionService.list).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: "auth0|owner-456" })
+      );
+    });
+
+    it("passes no userId filter for admin callers (admins see all)", async () => {
+      currentUser = ADMIN_USER;
+      vi.mocked(sessionService.list).mockResolvedValueOnce({
+        data: [ownerSession],
+        pagination,
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/v1/sessions",
+      });
+
+      expect(response.statusCode).toBe(200);
+      // Admin: no userId restriction
+      expect(sessionService.list).toHaveBeenCalledWith(
+        expect.not.objectContaining({ userId: expect.anything() })
+      );
+    });
+  });
+});

--- a/services/agent/src/routes/sessions.test.ts
+++ b/services/agent/src/routes/sessions.test.ts
@@ -230,6 +230,8 @@ describe("Session Routes", () => {
 
   describe("DELETE /v1/sessions/:id", () => {
     it("deletes a session and returns 204", async () => {
+      // DELETE now fetches session first (for ownership check), then deletes
+      vi.mocked(sessionService.getById).mockResolvedValueOnce(mockSession);
       vi.mocked(sessionService.delete).mockResolvedValueOnce(true);
 
       const response = await app.inject({
@@ -242,7 +244,8 @@ describe("Session Routes", () => {
     });
 
     it("returns 404 for unknown session", async () => {
-      vi.mocked(sessionService.delete).mockResolvedValueOnce(false);
+      // DELETE fetches session first; null → 404 (no delete call needed)
+      vi.mocked(sessionService.getById).mockResolvedValueOnce(null);
 
       const response = await app.inject({
         method: "DELETE",

--- a/services/agent/src/routes/sessions.ts
+++ b/services/agent/src/routes/sessions.ts
@@ -8,11 +8,23 @@ import {
   type CreateAgentSessionRequest,
   createProblemDetails,
 } from "@mbe/types";
-import { requireAuth } from "@mbe/auth/fastify";
+import { requireAuth, hasPermission } from "@mbe/auth/fastify";
+import type { AuthUser } from "@mbe/auth/fastify";
 import { parseListQuery } from "@mbe/database";
 import { sessionService } from "../services/session.js";
 import { cancelSession } from "../services/session-executor.js";
 import { defaultConcurrency } from "../services/session-concurrency.js";
+
+/**
+ * Returns true if the caller is the session owner or an admin.
+ * Sessions with null userId are admin-only (no owner to match).
+ * Uses 404 (not 403) to avoid revealing session existence to unauthorized callers.
+ */
+function isOwnerOrAdmin(caller: AuthUser | undefined, sessionUserId: string | null): boolean {
+  if (hasPermission(caller, "admin")) return true;
+  if (sessionUserId === null) return false;
+  return caller?.id === sessionUserId;
+}
 
 export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
   // POST /v1/sessions — Create + start a new session
@@ -113,7 +125,10 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
         | "CANCELLED"
         | undefined;
 
-      return sessionService.list({ page, limit, status: prismaStatus });
+      // Admins see all sessions; non-admins see only their own
+      const userId = hasPermission(request.user, "admin") ? undefined : request.user?.id;
+
+      return sessionService.list({ page, limit, status: prismaStatus, userId });
     }
   );
 
@@ -145,7 +160,7 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (request, reply) => {
       const session = await sessionService.getById(request.params.id);
-      if (!session) {
+      if (!session || !isOwnerOrAdmin(request.user, session.userId)) {
         return reply.code(404).send(createProblemDetails(404, "Not Found", "Session not found"));
       }
       return { data: session };
@@ -181,7 +196,7 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (request, reply) => {
       const session = await sessionService.getById(request.params.id);
-      if (!session) {
+      if (!session || !isOwnerOrAdmin(request.user, session.userId)) {
         return reply.code(404).send(createProblemDetails(404, "Not Found", "Session not found"));
       }
 
@@ -227,10 +242,11 @@ export const sessionRoutes: FastifyPluginAsync = async (fastify) => {
       },
     },
     async (request, reply) => {
-      const deleted = await sessionService.delete(request.params.id);
-      if (!deleted) {
+      const session = await sessionService.getById(request.params.id);
+      if (!session || !isOwnerOrAdmin(request.user, session.userId)) {
         return reply.code(404).send(createProblemDetails(404, "Not Found", "Session not found"));
       }
+      await sessionService.delete(request.params.id);
       return reply.code(204).send();
     }
   );

--- a/services/agent/src/services/session.ts
+++ b/services/agent/src/services/session.ts
@@ -47,6 +47,7 @@ interface ListOptions {
   readonly page: number;
   readonly limit: number;
   readonly status?: SessionStatus;
+  readonly userId?: string;
 }
 
 export interface TriggerSessionOptions {
@@ -68,8 +69,11 @@ export interface TriggerSessionResult {
 
 export const sessionService = {
   async list(options: ListOptions): Promise<{ data: AgentSession[]; pagination: Pagination }> {
-    const { page, limit, status } = options;
-    const where: Prisma.SessionWhereInput = status ? { status } : {};
+    const { page, limit, status, userId } = options;
+    const where: Prisma.SessionWhereInput = {
+      ...(status && { status }),
+      ...(userId !== undefined && { userId }),
+    };
 
     const [sessions, total] = await Promise.all([
       prisma.session.findMany({


### PR DESCRIPTION
## Summary

- GET `/:id`, POST `/:id/cancel`, DELETE `/:id` now return **404** (not 403) when the session's `userId` doesn't match `request.user.id` AND the caller lacks the `admin` permission — avoids exposing session existence as an oracle
- GET `/` (list) is filtered to the caller's own sessions for non-admins; admins receive all sessions unfiltered
- Sessions with `null` `userId` (pre-migration / system) are admin-only
- Added `userId` optional field to `sessionService.list()` `ListOptions` for the list filter
- Added `isOwnerOrAdmin()` helper in `sessions.ts` following the `hasPermission` pattern from `services/reservations`
- Updated existing DELETE test to mock `getById` (required since DELETE now fetches the session for the ownership check before deleting)
- New `sessions-authz.test.ts` covers owner / non-owner / admin × each of the 4 routes + null-owner admin-only + list filtering (15 tests)

## Test plan

- [x] `pnpm --dir services/agent lint` passes
- [x] `pnpm --dir services/agent typecheck` passes
- [x] `pnpm --dir services/agent test` passes (307 tests, 28 test files)
- [x] `pnpm --filter @mbe/cli start check-adr` passes
- [x] `pnpm --filter @mbe/cli start check-deps` passes
- [x] `pnpm regen` ran clean, artifact drift staged
- [x] `node scripts/detect-instruction-rot.mjs` passes
- [x] PR base ref verified as `main`

Closes #2108