### PR TITLE
fix(ci): ignore-scripts on service builder installs — unblock deploys (#2587)

### DIFF
--- a/services/agent/Dockerfile
+++ b/services/agent/Dockerfile
@@ -22,8 +22,12 @@ COPY packages/database/package.json ./packages/database/
 COPY packages/service-bootstrap/package.json ./packages/service-bootstrap/
 COPY services/agent/package.json ./services/agent/
 
-# Install all dependencies
-RUN pnpm install --frozen-lockfile
+# Install all dependencies.
+# --ignore-scripts: the `postinstall: prisma generate` script would run here,
+# before the Prisma schema is copied (below), and fail with "Could not find
+# Prisma Schema". The client is generated explicitly via `db:generate` in the
+# build step after the schema is copied. (postinstall still runs for local/CI.)
+RUN pnpm install --frozen-lockfile --ignore-scripts
 
 # Copy tsconfig files (needed for build, changes rarely)
 COPY packages/types/tsconfig.json ./packages/types/

--- a/services/reservations/Dockerfile
+++ b/services/reservations/Dockerfile
@@ -23,8 +23,12 @@ COPY packages/notifications/package.json ./packages/notifications/
 COPY packages/jobs/package.json ./packages/jobs/
 COPY services/reservations/package.json ./services/reservations/
 
-# Install all dependencies
-RUN pnpm install --frozen-lockfile
+# Install all dependencies.
+# --ignore-scripts: the `postinstall: prisma generate` script would run here,
+# before the Prisma schema is copied (below), and fail with "Could not find
+# Prisma Schema". The client is generated explicitly via `db:generate` in the
+# build step after the schema is copied. (postinstall still runs for local/CI.)
+RUN pnpm install --frozen-lockfile --ignore-scripts
 
 # Copy tsconfig files (needed for build, changes rarely)
 COPY packages/types/tsconfig.json ./packages/types/

--- a/services/users/Dockerfile
+++ b/services/users/Dockerfile
@@ -19,8 +19,12 @@ COPY packages/database/package.json ./packages/database/
 COPY packages/service-bootstrap/package.json ./packages/service-bootstrap/
 COPY services/users/package.json ./services/users/
 
-# Install all dependencies
-RUN pnpm install --frozen-lockfile
+# Install all dependencies.
+# --ignore-scripts: the `postinstall: prisma generate` script would run here,
+# before the Prisma schema is copied (below), and fail with "Could not find
+# Prisma Schema". The client is generated explicitly via `db:generate` in the
+# build step after the schema is copied. (postinstall still runs for local/CI.)
+RUN pnpm install --frozen-lockfile --ignore-scripts
 
 # Copy tsconfig files (needed for build, changes rarely)
 COPY packages/types/tsconfig.json ./packages/types/


### PR DESCRIPTION
## Problem
All API service Docker builds (users-api, reservations-api, agent-api) fail on DO with `BuildJobExitNonZero`, failing **Deploy Services** and tripping the deploy **circuit breaker** (#2587, deploys blocked).

Root cause (from the DO build log):
```
services/users postinstall$ prisma generate
services/users postinstall: Error: Could not find Prisma Schema that is required for this command.
```
The Prisma-ungit work (#2015/#2582) added `postinstall: prisma generate` to the services. In each service Dockerfile the **builder** stage runs `pnpm install --frozen-lockfile` *before* the Prisma schema is copied, so the postinstall can't find the schema and the build exits non-zero.

## Fix
Add `--ignore-scripts` to the **builder** install in all 3 service Dockerfiles, matching the **runner** stage (which already uses it). The Prisma client is still generated — explicitly via the existing `db:generate` step that runs *after* the schema is copied. `postinstall: prisma generate` is left intact for local/CI installs (where the full tree, incl. schema, is present).

- `services/users/Dockerfile`
- `services/reservations/Dockerfile`
- `services/agent/Dockerfile`

## Verification
- CI (lint/typecheck/test) unaffected — Dockerfile-only change.
- Real proof is the DO deploy: after merge, Deploy Services should build all 3 services and the circuit breaker can be reset. Will verify the deploy goes green post-merge.

Closes #2587

🤖 Generated with [Claude Code](https://claude.com/claude-code)