### PR TITLE
fix(ci): copy tsconfig.build.json into users/reservations Docker builds

### DIFF
--- a/services/reservations/Dockerfile
+++ b/services/reservations/Dockerfile
@@ -43,7 +43,7 @@ COPY packages/cancellation-policy/tsconfig.json ./packages/cancellation-policy/
 COPY packages/service-bootstrap/tsconfig.json ./packages/service-bootstrap/
 COPY packages/notifications/tsconfig.json ./packages/notifications/
 COPY packages/jobs/tsconfig.json ./packages/jobs/
-COPY services/reservations/tsconfig.json ./services/reservations/
+COPY services/reservations/tsconfig.json services/reservations/tsconfig.build.json ./services/reservations/
 
 # Copy Prisma schema and config (needed for db:generate)
 COPY services/reservations/prisma ./services/reservations/prisma

--- a/services/users/Dockerfile
+++ b/services/users/Dockerfile
@@ -35,7 +35,7 @@ COPY packages/observability/tsconfig.json ./packages/observability/
 COPY packages/sentry/tsconfig.json ./packages/sentry/
 COPY packages/database/tsconfig.json ./packages/database/
 COPY packages/service-bootstrap/tsconfig.json ./packages/service-bootstrap/
-COPY services/users/tsconfig.json ./services/users/
+COPY services/users/tsconfig.json services/users/tsconfig.build.json ./services/users/
 
 # Copy Prisma schema (needed for db:generate)
 COPY services/users/prisma ./services/users/prisma


### PR DESCRIPTION
## Problem
Second deploy-build failure, revealed once #2592 fixed the prisma-postinstall error that previously aborted the build earlier:

```
> tsc -p tsconfig.build.json
error TS5058: The specified path does not exist: 'tsconfig.build.json'.
ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL @mbe/users-service build
```

`services/users` and `services/reservations` build with `tsc -p tsconfig.build.json`, and that file exists in-repo — but their Dockerfiles only `COPY tsconfig.json`, so the file is absent in the DO build image.

## Fix
Add `tsconfig.build.json` to the `COPY` alongside `tsconfig.json` in both service Dockerfiles. (`services/agent` builds with plain `tsc` and has no `tsconfig.build.json`, so it's unaffected.)

## Verification
- CI (lint/typecheck/test) unaffected — Dockerfile-only.
- Real proof: the DO Deploy Services build should now pass the `tsc -p tsconfig.build.json` step for both services. Will verify the deploy goes green.

Follow-up to #2587 / #2592 (deploy outage recovery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)