### PR TITLE
fix(rialto-catalog): drop 3 stale charLimits + guard charLimit keys in drift-check

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -63,9 +63,6 @@
       description:
         "Small status indicator label. Use variant=success for active/complete states, variant=warning for pending/attention states, variant=error for failed/blocked states, variant=neutral (default) for informational tags. Use dot=true to add a status circle.",
       slots: ["default"],
-      charLimits: {
-        children: 20,
-      },
     } satisfies CatalogMeta;
   </file>
   </section>
@@ -76,9 +73,6 @@
       description:
         "Full-width page-level message displayed at the top of a view. Use for one-per-page system announcements. Unlike Alert (inline), Banner spans the full width. Use variant=info (default) for announcements, variant=warning for important notices, variant=error for critical failures.",
       slots: ["default"],
-      charLimits: {
-        title: 60,
-      },
     } satisfies CatalogMeta;
   </file>
   </section>
@@ -98,9 +92,6 @@
       description:
         "Clickable action trigger. Use variant=primary for the main CTA; variant=secondary for supporting actions; variant=ghost for tertiary or inline actions. Use size=sm for compact UIs, size=md (default) for most contexts, size=lg for prominent calls-to-action.",
       slots: ["default"],
-      charLimits: {
-        children: 30,
-      },
       aliases: {
         label: "children",
       },
@@ -312,7 +303,6 @@
       charLimits: {
         label: 40,
         hint: 80,
-        error: 80,
       },
     } satisfies CatalogMeta;
   </file>
@@ -15263,14 +15253,12 @@
         description:
           "Small status indicator label. Use variant=success for active/complete states, variant=warning for pending/attention states, variant=error for failed/blocked states, variant=neutral (default) for informational tags. Use dot=true to add a status circle.",
         slots: ["default"],
-        charLimits: { children: 20 },
       },
       Banner: {
         name: "Banner",
         description:
           "Full-width page-level message displayed at the top of a view. Use for one-per-page system announcements. Unlike Alert (inline), Banner spans the full width. Use variant=info (default) for announcements, variant=warning for important notices, variant=error for critical failures.",
         slots: ["default"],
-        charLimits: { title: 60 },
       },
       Breadcrumb: {
         name: "Breadcrumb",
@@ -15282,7 +15270,6 @@
         description:
           "Clickable action trigger. Use variant=primary for the main CTA; variant=secondary for supporting actions; variant=ghost for tertiary or inline actions. Use size=sm for compact UIs, size=md (default) for most contexts, size=lg for prominent calls-to-action.",
         slots: ["default"],
-        charLimits: { children: 30 },
         aliases: { label: "children" },
       },
       Card: {
@@ -15335,7 +15322,7 @@
         name: "Input",
         description:
           "Single-line text field. Always provide a label. Use hint for helper text below the field. Set error=true to show error styling. Use type attribute for email, password, number, etc.",
-        charLimits: { label: 40, hint: 80, error: 80 },
+        charLimits: { label: 40, hint: 80 },
       },
       NavigationMenu: {
         name: "NavigationMenu",

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -89,14 +89,12 @@
         description:
           "Small status indicator label. Use variant=success for active/complete states, variant=warning for pending/attention states, variant=error for failed/blocked states, variant=neutral (default) for informational tags. Use dot=true to add a status circle.",
         slots: ["default"],
-        charLimits: { children: 20 },
       },
       Banner: {
         name: "Banner",
         description:
           "Full-width page-level message displayed at the top of a view. Use for one-per-page system announcements. Unlike Alert (inline), Banner spans the full width. Use variant=info (default) for announcements, variant=warning for important notices, variant=error for critical failures.",
         slots: ["default"],
-        charLimits: { title: 60 },
       },
       Breadcrumb: {
         name: "Breadcrumb",
@@ -108,7 +106,6 @@
         description:
           "Clickable action trigger. Use variant=primary for the main CTA; variant=secondary for supporting actions; variant=ghost for tertiary or inline actions. Use size=sm for compact UIs, size=md (default) for most contexts, size=lg for prominent calls-to-action.",
         slots: ["default"],
-        charLimits: { children: 30 },
         aliases: { label: "children" },
       },
       Card: {
@@ -161,7 +158,7 @@
         name: "Input",
         description:
           "Single-line text field. Always provide a label. Use hint for helper text below the field. Set error=true to show error styling. Use type attribute for email, password, number, etc.",
-        charLimits: { label: 40, hint: 80, error: 80 },
+        charLimits: { label: 40, hint: 80 },
       },
       NavigationMenu: {
         name: "NavigationMenu",

--- a/packages/rialto-catalog/src/__tests__/drift-check.test.ts
+++ b/packages/rialto-catalog/src/__tests__/drift-check.test.ts
@@ -74,4 +74,25 @@ describe("drift-check: single CatalogSource is the only source of truth", () => 
       expect(generatedSchemas[name as keyof typeof generatedSchemas]).toBeDefined();
     }
   });
+
+  it("every charLimits key resolves to a field in the generated schema (stale charLimits must fail)", () => {
+    const stale: string[] = [];
+
+    for (const [componentName, meta] of Object.entries(catalogMeta)) {
+      if (!meta.charLimits) continue;
+
+      const schema = generatedSchemas[componentName as keyof typeof generatedSchemas];
+      if (!schema) continue;
+
+      const schemaShape = (schema as { shape?: Record<string, unknown> }).shape ?? {};
+
+      for (const key of Object.keys(meta.charLimits)) {
+        if (!(key in schemaShape)) {
+          stale.push(`${componentName}.charLimits.${key}`);
+        }
+      }
+    }
+
+    expect(stale).toEqual([]);
+  });
 });

--- a/packages/rialto-catalog/src/generated-catalog.ts
+++ b/packages/rialto-catalog/src/generated-catalog.ts
@@ -39,14 +39,12 @@ export const catalogMeta: Record<string, CatalogMeta> = {
     description:
       "Small status indicator label. Use variant=success for active/complete states, variant=warning for pending/attention states, variant=error for failed/blocked states, variant=neutral (default) for informational tags. Use dot=true to add a status circle.",
     slots: ["default"],
-    charLimits: { children: 20 },
   },
   Banner: {
     name: "Banner",
     description:
       "Full-width page-level message displayed at the top of a view. Use for one-per-page system announcements. Unlike Alert (inline), Banner spans the full width. Use variant=info (default) for announcements, variant=warning for important notices, variant=error for critical failures.",
     slots: ["default"],
-    charLimits: { title: 60 },
   },
   Breadcrumb: {
     name: "Breadcrumb",
@@ -58,7 +56,6 @@ export const catalogMeta: Record<string, CatalogMeta> = {
     description:
       "Clickable action trigger. Use variant=primary for the main CTA; variant=secondary for supporting actions; variant=ghost for tertiary or inline actions. Use size=sm for compact UIs, size=md (default) for most contexts, size=lg for prominent calls-to-action.",
     slots: ["default"],
-    charLimits: { children: 30 },
     aliases: { label: "children" },
   },
   Card: {
@@ -111,7 +108,7 @@ export const catalogMeta: Record<string, CatalogMeta> = {
     name: "Input",
     description:
       "Single-line text field. Always provide a label. Use hint for helper text below the field. Set error=true to show error styling. Use type attribute for email, password, number, etc.",
-    charLimits: { label: 40, hint: 80, error: 80 },
+    charLimits: { label: 40, hint: 80 },
   },
   NavigationMenu: {
     name: "NavigationMenu",

--- a/packages/rialto/llms-full.txt
+++ b/packages/rialto/llms-full.txt
@@ -63,9 +63,6 @@
       description:
         "Small status indicator label. Use variant=success for active/complete states, variant=warning for pending/attention states, variant=error for failed/blocked states, variant=neutral (default) for informational tags. Use dot=true to add a status circle.",
       slots: ["default"],
-      charLimits: {
-        children: 20,
-      },
     } satisfies CatalogMeta;
   </file>
   </section>
@@ -76,9 +73,6 @@
       description:
         "Full-width page-level message displayed at the top of a view. Use for one-per-page system announcements. Unlike Alert (inline), Banner spans the full width. Use variant=info (default) for announcements, variant=warning for important notices, variant=error for critical failures.",
       slots: ["default"],
-      charLimits: {
-        title: 60,
-      },
     } satisfies CatalogMeta;
   </file>
   </section>
@@ -98,9 +92,6 @@
       description:
         "Clickable action trigger. Use variant=primary for the main CTA; variant=secondary for supporting actions; variant=ghost for tertiary or inline actions. Use size=sm for compact UIs, size=md (default) for most contexts, size=lg for prominent calls-to-action.",
       slots: ["default"],
-      charLimits: {
-        children: 30,
-      },
       aliases: {
         label: "children",
       },
@@ -298,7 +289,6 @@
       charLimits: {
         label: 40,
         hint: 80,
-        error: 80,
       },
     } satisfies CatalogMeta;
   </file>

--- a/packages/rialto/src/components/Badge/Badge.catalog.ts
+++ b/packages/rialto/src/components/Badge/Badge.catalog.ts
@@ -9,7 +9,4 @@ export const badgeCatalogMeta = {
   description:
     "Small status indicator label. Use variant=success for active/complete states, variant=warning for pending/attention states, variant=error for failed/blocked states, variant=neutral (default) for informational tags. Use dot=true to add a status circle.",
   slots: ["default"],
-  charLimits: {
-    children: 20,
-  },
 } satisfies CatalogMeta;

--- a/packages/rialto/src/components/Banner/Banner.catalog.ts
+++ b/packages/rialto/src/components/Banner/Banner.catalog.ts
@@ -9,7 +9,4 @@ export const bannerCatalogMeta = {
   description:
     "Full-width page-level message displayed at the top of a view. Use for one-per-page system announcements. Unlike Alert (inline), Banner spans the full width. Use variant=info (default) for announcements, variant=warning for important notices, variant=error for critical failures.",
   slots: ["default"],
-  charLimits: {
-    title: 60,
-  },
 } satisfies CatalogMeta;

--- a/packages/rialto/src/components/Button/Button.catalog.ts
+++ b/packages/rialto/src/components/Button/Button.catalog.ts
@@ -9,9 +9,6 @@ export const buttonCatalogMeta = {
   description:
     "Clickable action trigger. Use variant=primary for the main CTA; variant=secondary for supporting actions; variant=ghost for tertiary or inline actions. Use size=sm for compact UIs, size=md (default) for most contexts, size=lg for prominent calls-to-action.",
   slots: ["default"],
-  charLimits: {
-    children: 30,
-  },
   aliases: {
     label: "children",
   },

--- a/packages/rialto/src/components/Input/Input.catalog.ts
+++ b/packages/rialto/src/components/Input/Input.catalog.ts
@@ -11,6 +11,5 @@ export const inputCatalogMeta = {
   charLimits: {
     label: 40,
     hint: 80,
-    error: 80,
   },
 } satisfies CatalogMeta;


### PR DESCRIPTION
## Summary

- Removes 4 stale `charLimits` entries that the generator silently discards because they point at non-string props or skipped fields:
  - `Badge.charLimits.children` — `children: ReactNode` is skipped by the generator
  - `Banner.charLimits.title` — `BannerProps` has no `title` prop (content via `children`)
  - `Button.charLimits.children` — `children: ReactNode` is skipped by the generator
  - `Input.charLimits.error` — `InputProps.error` is `boolean`, not a string; the `80` was discarded
- Adds a new assertion in `drift-check.test.ts`: every `charLimits` key must appear as a field in the generated Zod schema for its component. This guard catches dead charLimit entries before they reach CI.

## TDD Evidence (RED → GREEN)

**RED** — new assertion before removing entries:
```
AssertionError: expected [ 'Badge.charLimits.children', 'Banner.charLimits.title', 'Button.charLimits.children' ] to deeply equal []
```

**GREEN** — after removing stale entries + regenerating:
```
Test Files  5 passed (5)
     Tests  102 passed (102)
```

## generated-schemas.ts is byte-identical

The generator already discarded these no-op entries — `generated-schemas.ts` is unchanged (no diff vs main). Only `generated-catalog.ts` and `llms-full.txt` files changed (charLimits entries removed from the catalog artifact).

## Gate results

- `pnpm --dir packages/rialto-catalog lint` — pass
- `pnpm --dir packages/rialto-catalog typecheck` — pass
- `pnpm --dir packages/rialto-catalog test` — 102/102 pass
- `pnpm --dir packages/rialto typecheck` — pass
- `pnpm --dir packages/rialto test` — 1704/1704 pass
- `check-adr` / `check-deps` — no violations
- `pnpm regen --check` — all artifacts up to date
- Pre-push turbo test (19 tasks) — all pass

Closes #2607