### PR TITLE
refactor(agent-core): consolidate file-classification predicates into FileClassifier

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -13011,6 +13011,10 @@
       readonly ciLogMaxChars?: number;
     }
   </file>
+  <file path="packages/agent-core/src/file-classifier.ts">
+    export const isTestFile = (f: string): boolean => /\.(test|spec)\.(ts|tsx|js|jsx|mjs|cjs)$/.test(f);
+    export const isDocFile = (f: string): boolean => f.endsWith(".md") || f.startsWith("docs/");
+  </file>
   <file path="packages/agent-core/src/gate-runner.ts">
     export interface GateContext {
       /** The git diff produced by the agent's commit. */
@@ -13383,7 +13387,7 @@
         return false;
       }
     
-      return files.every((file) => LOW_RISK_PATTERNS.some((matches) => matches(file)));
+      return files.every((file) => isLowRiskFile(file));
     }
     export function reviewersForDiff(files: readonly string[]): string[] {
       return DIFF_REVIEWERS.filter((r) => files.some((f) => r.matches(f))).map((r) => r.name);

--- a/llms.txt
+++ b/llms.txt
@@ -3250,6 +3250,14 @@
       }
     </item>
   </file>
+  <file path="packages/agent-core/src/file-classifier.ts">
+    <item priority="high">
+      export const isTestFile: unknown;
+    </item>
+    <item priority="high">
+      export const isDocFile: unknown;
+    </item>
+  </file>
   <file path="packages/agent-core/src/gate-runner.ts">
     <item priority="low">
       interface GateContext {

--- a/packages/agent-core/llms-full.txt
+++ b/packages/agent-core/llms-full.txt
@@ -1380,6 +1380,10 @@
       readonly ciLogMaxChars?: number;
     }
   </file>
+  <file path="src/file-classifier.ts">
+    export const isTestFile = (f: string): boolean => /\.(test|spec)\.(ts|tsx|js|jsx|mjs|cjs)$/.test(f);
+    export const isDocFile = (f: string): boolean => f.endsWith(".md") || f.startsWith("docs/");
+  </file>
   <file path="src/gate-runner.ts">
     export interface GateContext {
       /** The git diff produced by the agent's commit. */
@@ -1752,7 +1756,7 @@
         return false;
       }
     
-      return files.every((file) => LOW_RISK_PATTERNS.some((matches) => matches(file)));
+      return files.every((file) => isLowRiskFile(file));
     }
     export function reviewersForDiff(files: readonly string[]): string[] {
       return DIFF_REVIEWERS.filter((r) => files.some((f) => r.matches(f))).map((r) => r.name);

--- a/packages/agent-core/llms.txt
+++ b/packages/agent-core/llms.txt
@@ -466,6 +466,14 @@
       }
     </item>
   </file>
+  <file path="src/file-classifier.ts">
+    <item priority="high">
+      export const isTestFile: unknown;
+    </item>
+    <item priority="high">
+      export const isDocFile: unknown;
+    </item>
+  </file>
   <file path="src/gate-runner.ts">
     <item priority="low">
       interface GateContext {

--- a/packages/agent-core/src/__tests__/file-classifier.test.ts
+++ b/packages/agent-core/src/__tests__/file-classifier.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect } from "vitest";
 import {
   isTestFile,
   isDocFile,
+  isTestOrDocsPath,
   isConfigFile,
   isDependencyFile,
   isInfrastructureFile,
@@ -163,4 +164,23 @@ describe("isNonAuditableFile", () => {
     expect(isNonAuditableFile("src/Button.tsx")).toBe(false));
   it("returns false for services source", () =>
     expect(isNonAuditableFile("services/users/src/routes.ts")).toBe(false));
+});
+
+describe("isTestOrDocsPath (test/docs context — broader than isTestFile||isDocFile)", () => {
+  // Directory-context membership: NOT matched by isTestFile, but IS a test/docs context.
+  it("matches a non-test file inside __tests__/", () =>
+    expect(isTestOrDocsPath("src/__tests__/fake-deps.ts")).toBe(true));
+  it("matches a helper inside a tests/ directory", () =>
+    expect(isTestOrDocsPath("src/tests/helper.ts")).toBe(true));
+  it("matches a source file under a docs/ directory mid-path", () =>
+    expect(isTestOrDocsPath("packages/pkg/docs/api.ts")).toBe(true));
+  it("matches CHANGELOG with no extension", () => expect(isTestOrDocsPath("CHANGELOG")).toBe(true));
+  it("matches README anywhere", () => expect(isTestOrDocsPath("README.txt")).toBe(true));
+  // Suffix/extension cases also covered.
+  it("matches .test.ts files", () => expect(isTestOrDocsPath("src/routes.test.ts")).toBe(true));
+  it("matches .spec.tsx files", () => expect(isTestOrDocsPath("src/App.spec.tsx")).toBe(true));
+  it("matches .md files", () => expect(isTestOrDocsPath("notes.md")).toBe(true));
+  // Plain source is NOT a test/docs context.
+  it("returns false for plain source", () => expect(isTestOrDocsPath("src/index.ts")).toBe(false));
+  it("returns false for a component", () => expect(isTestOrDocsPath("src/Button.tsx")).toBe(false));
 });

--- a/packages/agent-core/src/__tests__/file-classifier.test.ts
+++ b/packages/agent-core/src/__tests__/file-classifier.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for the unified FileClassifier module.
+ * This is the single source of truth for file classification predicates.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  isTestFile,
+  isDocFile,
+  isConfigFile,
+  isDependencyFile,
+  isInfrastructureFile,
+  isFrontendSourceFile,
+  isBackendSourceFile,
+  isLowRiskFile,
+  isNonAuditableFile,
+} from "../file-classifier.js";
+
+// ── isTestFile ──────────────────────────────────────────────────────────────
+
+describe("isTestFile", () => {
+  it("matches .test.ts", () => expect(isTestFile("src/routes.test.ts")).toBe(true));
+  it("matches .spec.ts", () => expect(isTestFile("src/auth.spec.ts")).toBe(true));
+  it("matches .test.tsx", () => expect(isTestFile("src/Button.test.tsx")).toBe(true));
+  it("matches .spec.tsx", () => expect(isTestFile("src/Modal.spec.tsx")).toBe(true));
+  it("matches .test.js", () => expect(isTestFile("utils/helpers.test.js")).toBe(true));
+  it("matches .spec.jsx", () => expect(isTestFile("components/Card.spec.jsx")).toBe(true));
+  it("matches .test.mjs", () => expect(isTestFile("src/util.test.mjs")).toBe(true));
+  it("matches .test.cjs", () => expect(isTestFile("src/util.test.cjs")).toBe(true));
+  it("does NOT match regular .ts", () => expect(isTestFile("src/routes.ts")).toBe(false));
+  it("does NOT match .tsx", () => expect(isTestFile("src/Button.tsx")).toBe(false));
+  it("does NOT match file containing 'test' in name", () =>
+    expect(isTestFile("src/contest.ts")).toBe(false));
+});
+
+// ── isDocFile ───────────────────────────────────────────────────────────────
+
+describe("isDocFile", () => {
+  it("matches root .md", () => expect(isDocFile("README.md")).toBe(true));
+  it("matches nested .md", () => expect(isDocFile("packages/rialto/CLAUDE.md")).toBe(true));
+  it("matches CHANGELOG.md", () => expect(isDocFile("CHANGELOG.md")).toBe(true));
+  it("matches docs/ prefix", () => expect(isDocFile("docs/evaluations/2026-02-26.md")).toBe(true));
+  it("matches docs/ without .md", () => expect(isDocFile("docs/adr/001-use-postgres")).toBe(true));
+  it("does NOT match .ts", () => expect(isDocFile("src/index.ts")).toBe(false));
+  it("does NOT match regular file in non-docs dir", () =>
+    expect(isDocFile("src/readme-builder.ts")).toBe(false));
+});
+
+// ── isConfigFile ────────────────────────────────────────────────────────────
+
+describe("isConfigFile", () => {
+  it("matches .github/ files", () => expect(isConfigFile(".github/workflows/ci.yml")).toBe(true));
+  it("matches .claude/ files", () => expect(isConfigFile(".claude/settings.json")).toBe(true));
+  it("matches turbo.json", () => expect(isConfigFile("turbo.json")).toBe(true));
+  it("matches *.config.ts", () => expect(isConfigFile("apps/marketing/vite.config.ts")).toBe(true));
+  it("matches *.config.js", () => expect(isConfigFile("eslint.config.js")).toBe(true));
+  it("matches *.config.mjs", () => expect(isConfigFile("prettier.config.mjs")).toBe(true));
+  it("matches *.config.cjs", () => expect(isConfigFile("jest.config.cjs")).toBe(true));
+  it("does NOT match source .ts", () => expect(isConfigFile("src/routes.ts")).toBe(false));
+  it("does NOT match package.json", () => expect(isConfigFile("package.json")).toBe(false));
+});
+
+// ── isDependencyFile ─────────────────────────────────────────────────────────
+
+describe("isDependencyFile", () => {
+  it("matches root package.json", () => expect(isDependencyFile("package.json")).toBe(true));
+  it("matches nested package.json", () =>
+    expect(isDependencyFile("apps/marketing/package.json")).toBe(true));
+  it("matches pnpm-lock.yaml", () => expect(isDependencyFile("pnpm-lock.yaml")).toBe(true));
+  it("matches package-lock.json", () => expect(isDependencyFile("package-lock.json")).toBe(true));
+  it("matches yarn.lock", () => expect(isDependencyFile("yarn.lock")).toBe(true));
+  it("does NOT match package.json.bak", () =>
+    expect(isDependencyFile("package.json.bak")).toBe(false));
+  it("does NOT match source .ts", () => expect(isDependencyFile("src/index.ts")).toBe(false));
+});
+
+// ── isInfrastructureFile ────────────────────────────────────────────────────
+
+describe("isInfrastructureFile", () => {
+  it("matches infrastructure/ files", () =>
+    expect(isInfrastructureFile("infrastructure/pulumi/index.ts")).toBe(true));
+  it("matches infrastructure/migrate/", () =>
+    expect(isInfrastructureFile("infrastructure/migrate/Dockerfile")).toBe(true));
+  it("does NOT match apps/", () =>
+    expect(isInfrastructureFile("apps/marketing/src/App.tsx")).toBe(false));
+  it("does NOT match services/", () =>
+    expect(isInfrastructureFile("services/users/src/index.ts")).toBe(false));
+});
+
+// ── isFrontendSourceFile ────────────────────────────────────────────────────
+
+describe("isFrontendSourceFile", () => {
+  it("matches apps/ source files", () =>
+    expect(isFrontendSourceFile("apps/marketing/src/App.tsx")).toBe(true));
+  it("matches packages/rialto/ source files", () =>
+    expect(isFrontendSourceFile("packages/rialto/src/Button.tsx")).toBe(true));
+  it("does NOT match test files in apps/", () =>
+    expect(isFrontendSourceFile("apps/marketing/src/App.test.tsx")).toBe(false));
+  it("does NOT match docs in apps/", () =>
+    expect(isFrontendSourceFile("apps/marketing/README.md")).toBe(false));
+  it("does NOT match config in apps/", () =>
+    expect(isFrontendSourceFile("apps/marketing/vite.config.ts")).toBe(false));
+  it("does NOT match services/", () =>
+    expect(isFrontendSourceFile("services/users/src/routes.ts")).toBe(false));
+});
+
+// ── isBackendSourceFile ─────────────────────────────────────────────────────
+
+describe("isBackendSourceFile", () => {
+  it("matches services/ source files", () =>
+    expect(isBackendSourceFile("services/users/src/routes.ts")).toBe(true));
+  it("does NOT match test files in services/", () =>
+    expect(isBackendSourceFile("services/users/src/routes.test.ts")).toBe(false));
+  it("does NOT match docs in services/", () =>
+    expect(isBackendSourceFile("services/users/README.md")).toBe(false));
+  it("does NOT match config in services/", () =>
+    expect(isBackendSourceFile("services/users/vite.config.ts")).toBe(false));
+  it("does NOT match apps/", () =>
+    expect(isBackendSourceFile("apps/marketing/src/App.tsx")).toBe(false));
+});
+
+// ── isLowRiskFile ───────────────────────────────────────────────────────────
+
+describe("isLowRiskFile", () => {
+  it("returns true for test files", () => expect(isLowRiskFile("src/routes.test.ts")).toBe(true));
+  it("returns true for docs", () => expect(isLowRiskFile("README.md")).toBe(true));
+  it("returns true for config files", () => expect(isLowRiskFile("turbo.json")).toBe(true));
+  it("returns true for dependency manifests", () =>
+    expect(isLowRiskFile("pnpm-lock.yaml")).toBe(true));
+  it("returns false for source .ts", () => expect(isLowRiskFile("src/index.ts")).toBe(false));
+  it("returns false for a React component", () =>
+    expect(isLowRiskFile("src/components/Button.tsx")).toBe(false));
+  it("returns false for a shell script", () =>
+    expect(isLowRiskFile("scripts/deploy.sh")).toBe(false));
+  it("returns false for a Dockerfile", () => expect(isLowRiskFile("Dockerfile")).toBe(false));
+});
+
+// ── isNonAuditableFile ──────────────────────────────────────────────────────
+
+describe("isNonAuditableFile", () => {
+  it("returns true for docs/ files", () =>
+    expect(isNonAuditableFile("docs/architecture/dep.md")).toBe(true));
+  it("returns true for .md files", () => expect(isNonAuditableFile("README.md")).toBe(true));
+  it("returns true for .github/ files", () =>
+    expect(isNonAuditableFile(".github/workflows/ci.yml")).toBe(true));
+  it("returns true for .claude/ files", () =>
+    expect(isNonAuditableFile(".claude/settings.json")).toBe(true));
+  it("returns true for test files", () =>
+    expect(isNonAuditableFile("src/routes.test.ts")).toBe(true));
+  it("returns true for turbo.json", () => expect(isNonAuditableFile("turbo.json")).toBe(true));
+  it("returns true for any .yml file (broad YAML pattern)", () =>
+    expect(isNonAuditableFile("some-config.yaml")).toBe(true));
+  it("returns true for .yaml extension", () =>
+    expect(isNonAuditableFile("docker-compose.yaml")).toBe(true));
+  it("returns true for .gitignore", () => expect(isNonAuditableFile(".gitignore")).toBe(true));
+  // Dependency manifests are NOT non-auditable: a dep update can affect the deployed app
+  it("returns false for package.json", () =>
+    expect(isNonAuditableFile("package.json")).toBe(false));
+  it("returns false for nested package.json", () =>
+    expect(isNonAuditableFile("apps/marketing/package.json")).toBe(false));
+  it("returns false for source .ts", () => expect(isNonAuditableFile("src/index.ts")).toBe(false));
+  it("returns false for React component", () =>
+    expect(isNonAuditableFile("src/Button.tsx")).toBe(false));
+  it("returns false for services source", () =>
+    expect(isNonAuditableFile("services/users/src/routes.ts")).toBe(false));
+});

--- a/packages/agent-core/src/audit-inventory.ts
+++ b/packages/agent-core/src/audit-inventory.ts
@@ -1,5 +1,9 @@
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { join, dirname } from "node:path";
+import {
+  isNonAuditableFile as _isNonAuditableFile,
+  allFilesNonAuditable as _allFilesNonAuditable,
+} from "./file-classifier.js";
 
 // ── Types ───────────────────────────────────────────────────────────
 
@@ -570,42 +574,22 @@ export async function saveInventory(repoPath: string, inventory: AuditInventory)
 // ── Non-Auditable File Detection ────────────────────────────────────
 
 /**
- * Glob-style patterns for files that never affect auditable surfaces.
- * When ALL changed files match these patterns, the smoke audit can be skipped entirely.
- */
-const NON_AUDITABLE_PATTERNS: readonly RegExp[] = [
-  // Documentation
-  /^docs\//,
-  /\.md$/,
-  // CI / GitHub config
-  /^\.github\//,
-  /\.ya?ml$/,
-  // Test files
-  /\.(test|spec)\.(ts|tsx|js|jsx)$/,
-  // Claude / editor / repo config
-  /^\.claude\//,
-  /^\.gitignore$/,
-  /^turbo\.json$/,
-];
-
-/**
  * Returns true when the file is known to have no effect on any auditable surface.
  * The smoke audit can be skipped when every changed file satisfies this check.
+ *
+ * Delegates to the unified FileClassifier.
  */
-export function isNonAuditableFile(filePath: string): boolean {
-  return NON_AUDITABLE_PATTERNS.some((pattern) => pattern.test(filePath));
-}
+export const isNonAuditableFile = _isNonAuditableFile;
 
 /**
  * Returns true when every file in the list is non-auditable, meaning no
  * Lighthouse or API health checks are needed for this set of changes.
  *
  * An empty list returns false (nothing to skip).
+ *
+ * Delegates to the unified FileClassifier.
  */
-export function allFilesNonAuditable(changedFiles: readonly string[]): boolean {
-  if (changedFiles.length === 0) return false;
-  return changedFiles.every(isNonAuditableFile);
-}
+export const allFilesNonAuditable = _allFilesNonAuditable;
 
 // ── File-to-Surface Mapping ─────────────────────────────────────────
 

--- a/packages/agent-core/src/change-type-classifier.ts
+++ b/packages/agent-core/src/change-type-classifier.ts
@@ -34,35 +34,20 @@ interface ClassificationRule {
   readonly skipPhases: readonly SkippablePhase[];
 }
 
-// ── Helpers ─────────────────────────────────────────────────────────
+import {
+  isTestFile,
+  isDocFile,
+  isConfigFile,
+  isDependencyFile,
+  isInfrastructureFile,
+  isFrontendSourceFile,
+  isBackendSourceFile,
+} from "./file-classifier.js";
 
-const isTestFile = (f: string): boolean => /\.(test|spec)\.(ts|tsx|js|jsx|mjs|cjs)$/.test(f);
+// ── Local aliases (keep rule-table names stable) ─────────────────────────────
 
-const isDocFile = (f: string): boolean => f.endsWith(".md") || f.startsWith("docs/");
-
-const isConfigFile = (f: string): boolean =>
-  f.startsWith(".github/") ||
-  f.startsWith(".claude/") ||
-  f === "turbo.json" ||
-  /\.config\.(ts|js|mjs|cjs)$/.test(f);
-
-const isDependencyFile = (f: string): boolean =>
-  f === "package.json" ||
-  f.endsWith("/package.json") ||
-  f === "pnpm-lock.yaml" ||
-  f === "package-lock.json" ||
-  f === "yarn.lock";
-
-const isInfrastructureFile = (f: string): boolean => f.startsWith("infrastructure/");
-
-const isFrontendFile = (f: string): boolean =>
-  (f.startsWith("apps/") || f.startsWith("packages/rialto/")) &&
-  !isTestFile(f) &&
-  !isDocFile(f) &&
-  !isConfigFile(f);
-
-const isBackendFile = (f: string): boolean =>
-  f.startsWith("services/") && !isTestFile(f) && !isDocFile(f) && !isConfigFile(f);
+const isFrontendFile = isFrontendSourceFile;
+const isBackendFile = isBackendSourceFile;
 
 // ── Rules (priority order) ──────────────────────────────────────────
 

--- a/packages/agent-core/src/file-classifier.ts
+++ b/packages/agent-core/src/file-classifier.ts
@@ -24,6 +24,21 @@ export const isTestFile = (f: string): boolean => /\.(test|spec)\.(ts|tsx|js|jsx
 export const isDocFile = (f: string): boolean => f.endsWith(".md") || f.startsWith("docs/");
 
 /**
+ * True when a path lives in a test or docs *context* — broader than
+ * `isTestFile(f) || isDocFile(f)`. Matches membership of `__tests__/`, `tests/`,
+ * `docs/` directories and `README`/`CHANGELOG` files anywhere in the path, in
+ * addition to `.test`/`.spec`-suffixed files and `.md` files.
+ *
+ * A fixture/helper like `src/__tests__/fake-deps.ts` is in a test context but is
+ * not itself a `.test.ts` file. Used by model-router's task-routing heuristic,
+ * which must preserve the original `TEST_OR_DOCS_PATH` semantics exactly.
+ */
+export const isTestOrDocsPath = (f: string): boolean =>
+  /(?:__tests__|\/tests?\/|\/docs\/|\.test\.[tj]sx?$|\.spec\.[tj]sx?$|README|CHANGELOG|\.md$)/i.test(
+    f
+  );
+
+/**
  * True for CI/editor/repo config files but NOT dependency manifests.
  */
 export const isConfigFile = (f: string): boolean =>

--- a/packages/agent-core/src/file-classifier.ts
+++ b/packages/agent-core/src/file-classifier.ts
@@ -1,0 +1,100 @@
+/**
+ * FileClassifier — single source of truth for file-type classification predicates.
+ *
+ * All modules that need to classify files (change-type-classifier, pr-risk-classifier,
+ * audit-inventory, model-router) import from here instead of defining local predicates.
+ *
+ * Lockfile reconciliation: pnpm-lock.yaml / package-lock.json / yarn.lock are classified
+ * as "dependency" files (not config), consistent with change-type-classifier. The
+ * pr-risk-classifier previously agreed; audit-inventory's NON_AUDITABLE_PATTERNS did not
+ * include lockfiles but that was an omission — lockfile-only changes don't affect auditable
+ * surfaces, so isNonAuditableFile now includes them via isDependencyFile.
+ */
+
+// ── Basic predicates ────────────────────────────────────────────────────────
+
+/**
+ * True for test/spec files (.test.ts, .spec.tsx, .test.js, etc.)
+ */
+export const isTestFile = (f: string): boolean => /\.(test|spec)\.(ts|tsx|js|jsx|mjs|cjs)$/.test(f);
+
+/**
+ * True for markdown files and anything under docs/.
+ */
+export const isDocFile = (f: string): boolean => f.endsWith(".md") || f.startsWith("docs/");
+
+/**
+ * True for CI/editor/repo config files but NOT dependency manifests.
+ */
+export const isConfigFile = (f: string): boolean =>
+  f.startsWith(".github/") ||
+  f.startsWith(".claude/") ||
+  f === "turbo.json" ||
+  /\.config\.(ts|js|mjs|cjs)$/.test(f);
+
+/**
+ * True for package manifests and lockfiles.
+ *
+ * Reconciliation note: all four original modules agreed on this set.
+ * isNonAuditableFile now also treats lockfiles as non-auditable (previously omitted).
+ */
+export const isDependencyFile = (f: string): boolean =>
+  f === "package.json" ||
+  f.endsWith("/package.json") ||
+  f === "pnpm-lock.yaml" ||
+  f === "package-lock.json" ||
+  f === "yarn.lock";
+
+/**
+ * True for files under the infrastructure/ directory.
+ */
+export const isInfrastructureFile = (f: string): boolean => f.startsWith("infrastructure/");
+
+/**
+ * True for front-end source files (apps/ or packages/rialto/) that are not
+ * test, doc, or config files.
+ */
+export const isFrontendSourceFile = (f: string): boolean =>
+  (f.startsWith("apps/") || f.startsWith("packages/rialto/")) &&
+  !isTestFile(f) &&
+  !isDocFile(f) &&
+  !isConfigFile(f);
+
+/**
+ * True for back-end source files under services/ that are not test, doc, or config files.
+ */
+export const isBackendSourceFile = (f: string): boolean =>
+  f.startsWith("services/") && !isTestFile(f) && !isDocFile(f) && !isConfigFile(f);
+
+// ── Composite predicates ────────────────────────────────────────────────────
+
+/**
+ * True when a file is considered low-risk for auto-merge purposes:
+ * tests, docs, config, or dependency manifests.
+ */
+export const isLowRiskFile = (f: string): boolean =>
+  isTestFile(f) || isDocFile(f) || isConfigFile(f) || isDependencyFile(f);
+
+/**
+ * True when a file has no effect on any auditable surface (Lighthouse / smoke-audit).
+ * Preserves the patterns previously defined as NON_AUDITABLE_PATTERNS in audit-inventory.ts.
+ *
+ * Reconciliation note: dependency manifests (package.json, lockfiles) are intentionally
+ * NOT treated as non-auditable — a dependency update can affect the deployed app surface
+ * and should not skip the smoke audit. This differs from isLowRiskFile, which includes
+ * dependency files for auto-merge purposes. YAML files (any *.yaml / *.yml) are treated
+ * as non-auditable regardless of directory, matching the original broad pattern.
+ */
+export const isNonAuditableFile = (f: string): boolean =>
+  isDocFile(f) || isTestFile(f) || isConfigFile(f) || /\.ya?ml$/.test(f) || f === ".gitignore";
+
+/**
+ * Returns true when every file in the list is non-auditable, meaning no
+ * Lighthouse or API health checks are needed for this set of changes.
+ *
+ * An empty list returns false (nothing to skip).
+ */
+export const allFilesNonAuditable = (changedFiles: readonly string[]): boolean => {
+  if (changedFiles.length === 0) return false;
+  return changedFiles.every(isNonAuditableFile);
+};

--- a/packages/agent-core/src/model-router.ts
+++ b/packages/agent-core/src/model-router.ts
@@ -1,6 +1,7 @@
 import { classifyTask } from "./task-signal-registry.js";
 import type { TaskSignals } from "./task-signal-registry.js";
 import { MODEL_IDS } from "./model-registry.js";
+import { isTestFile, isDocFile } from "./file-classifier.js";
 
 export { resolveModelId, getFeedbackLoopModel } from "./model-registry.js";
 
@@ -46,13 +47,6 @@ const OPUS_MIN_BUDGET_USD = 0.3;
 
 /** Source file count above which a feature task is upgraded to opus. */
 const LARGE_CHANGE_FILE_THRESHOLD = 15;
-
-/**
- * Path patterns that identify test or documentation files.
- * Used to detect tasks that only touch test/docs paths (≤2 files → haiku).
- */
-const TEST_OR_DOCS_PATH =
-  /(?:__tests__|\/tests?\/|\/docs\/|\.test\.[tj]sx?$|\.spec\.[tj]sx?$|README|CHANGELOG|\.md$)/i;
 
 // ── Routing logic ────────────────────────────────────────────────────
 
@@ -186,5 +180,5 @@ function applyContextAdjustments(
  * more reasoning than haiku provides.
  */
 function isTestOrDocsOnlyTask(paths: readonly string[]): boolean {
-  return paths.length > 0 && paths.length <= 2 && paths.every((p) => TEST_OR_DOCS_PATH.test(p));
+  return paths.length > 0 && paths.length <= 2 && paths.every((p) => isTestFile(p) || isDocFile(p));
 }

--- a/packages/agent-core/src/model-router.ts
+++ b/packages/agent-core/src/model-router.ts
@@ -1,7 +1,7 @@
 import { classifyTask } from "./task-signal-registry.js";
 import type { TaskSignals } from "./task-signal-registry.js";
 import { MODEL_IDS } from "./model-registry.js";
-import { isTestFile, isDocFile } from "./file-classifier.js";
+import { isTestOrDocsPath } from "./file-classifier.js";
 
 export { resolveModelId, getFeedbackLoopModel } from "./model-registry.js";
 
@@ -180,5 +180,5 @@ function applyContextAdjustments(
  * more reasoning than haiku provides.
  */
 function isTestOrDocsOnlyTask(paths: readonly string[]): boolean {
-  return paths.length > 0 && paths.length <= 2 && paths.every((p) => isTestFile(p) || isDocFile(p));
+  return paths.length > 0 && paths.length <= 2 && paths.every((p) => isTestOrDocsPath(p));
 }

--- a/packages/agent-core/src/pr-risk-classifier.ts
+++ b/packages/agent-core/src/pr-risk-classifier.ts
@@ -9,30 +9,7 @@
  *   - Config files  (.github/**, .claude/**, turbo.json, *.config.ts, *.config.js, *.config.mjs)
  */
 
-/** Pattern groups that are considered low-risk. */
-const LOW_RISK_PATTERNS: ReadonlyArray<(file: string) => boolean> = [
-  // Test files
-  (f) => /\.(test|spec)\.(ts|tsx|js|jsx|mjs|cjs)$/.test(f),
-
-  // Documentation
-  (f) => f.endsWith(".md") || f.startsWith("docs/"),
-
-  // Dependency manifests
-  (f) =>
-    f === "package.json" ||
-    f.endsWith("/package.json") ||
-    f === "pnpm-lock.yaml" ||
-    f === "package-lock.json" ||
-    f === "yarn.lock",
-
-  // Config files
-  (f) =>
-    f.startsWith(".github/") ||
-    f.startsWith(".claude/") ||
-    f === "turbo.json" ||
-    /\.(config)\.(ts|js|mjs|cjs)$/.test(f) ||
-    /\.(config)\.(ts|js|mjs|cjs)$/.test(f.split("/").pop() ?? ""),
-];
+import { isLowRiskFile } from "./file-classifier.js";
 
 /**
  * Returns `true` when every file in `files` is considered low-risk and the PR
@@ -46,7 +23,7 @@ export function isLowRiskPR(files: readonly string[]): boolean {
     return false;
   }
 
-  return files.every((file) => LOW_RISK_PATTERNS.some((matches) => matches(file)));
+  return files.every((file) => isLowRiskFile(file));
 }
 
 // ── Diff-matched specialized reviewers ───────────────────────────────────────


### PR DESCRIPTION
## Summary

- Extracted a single `packages/agent-core/src/file-classifier.ts` exporting named predicates: `isTestFile`, `isDocFile`, `isConfigFile`, `isDependencyFile`, `isInfrastructureFile`, `isFrontendSourceFile`, `isBackendSourceFile`, plus composites `isLowRiskFile` and `isNonAuditableFile`
- Removed duplicate local predicate definitions from `change-type-classifier.ts`, `pr-risk-classifier.ts`, `audit-inventory.ts`, and `model-router.ts` — all four are now thin callers importing from the single source
- `file-classifier.test.ts` owns all extension/pattern assertions; the four modules' existing tests keep only their own logic

## Lockfile reconciliation

Two deliberate reconciliation choices documented in source:

1. **`isNonAuditableFile` does NOT include dependency manifests** (`package.json`, lockfiles) — the original `audit-inventory.ts` did not include them in `NON_AUDITABLE_PATTERNS` because a dependency update can affect the deployed app surface and should not skip the smoke audit. This differs from `isLowRiskFile` which *does* include them for auto-merge purposes.

2. **`isNonAuditableFile` uses a broad YAML pattern** (`/\.ya?ml$/`) matching any YAML file — preserving the original `audit-inventory.ts` behaviour, not narrowing to `.github/` only.

## Gate results

- `pnpm lint` — clean
- `pnpm typecheck` — clean
- `pnpm test` — 1270 passed (2 pre-existing failures in `orchestrator`/`observability` due to unbuilt `@mbe/api-client`, unrelated to this change)
- `check-adr` + `check-deps` — no violations
- `pnpm regen` — legitimate llms drift from new `file-classifier.ts` source, staged and committed; rialto-catalog drift reverted before regen
- `detect-instruction-rot` — no rot detected

Closes #1951