### PR TITLE
fix(acmm): query --status=success so skipped runs don't mask workflow liveness

### DIFF
--- a/metrics/ai-antipattern-baselines.json
+++ b/metrics/ai-antipattern-baselines.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-22T22:41:34.625Z",
+  "generatedAt": "2026-06-23T05:54:55.137Z",
   "patterns": {
     "magicTimeouts": {
       "count": 32,
@@ -10,7 +10,7 @@
       "description": "Empty catch blocks that swallow errors silently"
     },
     "noopTestAssertions": {
-      "count": 314,
+      "count": 315,
       "description": "Test functions containing no expect() calls"
     },
     "hardcodedRoutes": {

--- a/plugins/acmm/scripts/__tests__/detection.test.js
+++ b/plugins/acmm/scripts/__tests__/detection.test.js
@@ -242,6 +242,37 @@ test("isWorkflowActive: returns degraded when gh CLI is unavailable", () => {
   fx.cleanup();
 });
 
+test("isWorkflowActive: queries only successful runs so skipped/failed noise can't crowd out the success", () => {
+  // Regression: auto-rollback.yml concludes `skipped` on every passing deploy.
+  // A `--status=completed --limit=5` query gets flooded by those skipped runs,
+  // crowding the real weekly-drill success out of the window → false `inactive`
+  // → ACMM gap re-files forever. Fix: query `--status=success` directly.
+  const fx = fixture();
+  let capturedArgs;
+  const mockExecFileSync = (_cmd, args) => {
+    capturedArgs = args;
+    return JSON.stringify([
+      {
+        conclusion: "success",
+        updatedAt: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+      },
+    ]);
+  };
+  const result = isWorkflowActive(fx.root, "auto-rollback.yml", 365, {
+    execFileSyncFn: mockExecFileSync,
+  });
+  assert.equal(result.active, true);
+  assert.ok(
+    capturedArgs.includes("--status=success"),
+    `gh query must filter to successful runs; got args: ${JSON.stringify(capturedArgs)}`
+  );
+  assert.ok(
+    !capturedArgs.includes("--status=completed"),
+    "must not query --status=completed (lets skipped/failed runs flood the window)"
+  );
+  fx.cleanup();
+});
+
 test("detect: active type — file missing → false", () => {
   const fx = fixture();
   const c = {

--- a/plugins/acmm/scripts/detection.js
+++ b/plugins/acmm/scripts/detection.js
@@ -51,7 +51,11 @@ export function isWorkflowActive(cwd, workflowFile, maxAgeDays, opts = {}) {
         "run",
         "list",
         `--workflow=${workflowFile}`,
-        "--status=completed",
+        // Query successful runs directly. A high volume of `skipped`/`failure`
+        // runs — e.g. auto-rollback.yml skips on every passing deploy — must not
+        // crowd the real success out of the result window and falsely report the
+        // workflow inactive. We still filter by conclusion below as defense.
+        "--status=success",
         "--limit=5",
         "--json",
         "conclusion,updatedAt",
@@ -60,7 +64,7 @@ export function isWorkflowActive(cwd, workflowFile, maxAgeDays, opts = {}) {
     );
     const runs = JSON.parse(result);
     if (runs.length === 0) {
-      return { active: false, reason: "no completed runs" };
+      return { active: false, reason: "no successful runs in recent history" };
     }
     // Only count successful runs — failed/skipped/cancelled runs don't prove the workflow works
     const successfulRuns = runs.filter((r) => r.conclusion === "success");


### PR DESCRIPTION
## What

`isWorkflowActive` (ACMM `type:active` detection) queried `gh run list --status=completed --limit=5` then filtered for `conclusion=="success"`. Workflows that conclude `skipped` on most triggers — `auto-rollback.yml` skips on **every passing deploy** — flood the 5-run window and crowd the real success (e.g. the weekly drill) out of view. Detection then reports the workflow **inactive**, so the L6 `acmm:auto-rollback` criterion re-files as a phantom gap.

That phantom gap was filed as #2589 — even though the auto-rollback feature was already complete and hardened across #2285 / #2425 / #2470 / #2522 **before** the issue was created. Run history confirms it: the lone successful run is the weekly drill; 14 `skipped` `workflow_run` runs on the same day bury it.

## Fix

Query `--status=success` directly so `skipped`/`failure` noise can't displace the success in the result window. The in-code conclusion filter stays as defense (keeps the "skipped runs do NOT count" contract). One code path → fixes all 10 `type:active` criteria; auto-rollback is the worst case.

## Tests

- New RED→GREEN test in `detection.test.js`: asserts the gh query uses `--status=success` (not `--status=completed`).
- Full detection + auto-rollback-drill suites green (34/34).
- Note: a pre-existing, unrelated failure (`evals-score.test.js › parseTask: rejects unknown gate`) exists on `main` independent of this change — out of scope here.

Closes #2589