### PR TITLE
test(acmm): fix stale negative test that used a valid gate name

### DIFF
--- a/plugins/acmm/scripts/__tests__/evals-score.test.js
+++ b/plugins/acmm/scripts/__tests__/evals-score.test.js
@@ -127,7 +127,7 @@ test("parseTask: rejects unknown gate", () => {
         model: "m",
         maxBudgetUsd: 0.1,
         maxTurns: 1,
-        rubric: { mustPass: ["typecheck"], diffSizeMax: 1, mustTouch: ["x"] },
+        rubric: { mustPass: ["deploy"], diffSizeMax: 1, mustTouch: ["x"] },
       }),
     /unknown gate/
   );


### PR DESCRIPTION
## What

`evals-score.test.js › parseTask: rejects unknown gate` was **red on main**. It fed `mustPass: ["typecheck"]` expecting a throw — but `typecheck` is a **valid** gate (`build, tests, lint, typecheck`). It was added to the allowed list after this negative test was written, and the test wasn't updated, so the expected exception never fired (`Missing expected exception`).

## Fix

Point the test at a genuinely unknown gate (`deploy`). The `parseTask` implementation was always correct — only the test was stale.

## Verification

- `evals-score.test.js`: 10/10 green
- Full acmm plugin suite: 274/274 green (was 1 red)

Found while validating #2618; kept separate to keep both PRs focused.