### PR TITLE
fix(api-client): resolve PaginatedResponse type mismatch and remove unsafe cast

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -10893,14 +10893,6 @@
       .catchall(z.unknown());
   </file>
   <file path="packages/types/src/schemas/common.ts">
-    export function paginatedResponseSchema<T>(itemSchema: z.ZodSchema<T>) {
-      return z.object({
-        data: z.array(itemSchema),
-        total: z.number(),
-        page: z.number(),
-        limit: z.number(),
-      });
-    }
     export const PaginationSchema = z.object({
       page: z.number(),
       limit: z.number(),
@@ -10909,6 +10901,12 @@
       hasNext: z.boolean(),
       hasPrev: z.boolean(),
     });
+    export function paginatedResponseSchema<T>(itemSchema: z.ZodSchema<T>) {
+      return z.object({
+        data: z.array(itemSchema),
+        pagination: PaginationSchema,
+      });
+    }
   </file>
   <file path="packages/types/src/schemas/floor-plan.ts">
     export const TableShapeMetadataSchema = z.object({
@@ -14286,10 +14284,7 @@
         return this.client.get<PaginatedResponse<Reservation>>(
           "/api/v1/reservations",
           params as QueryParams,
-          // PaginatedResponse<T> has a nested `pagination` object in the TS type but the
-          // actual API returns a flat shape (data, total, page, limit). The schema matches
-          // the real wire format; cast through unknown to satisfy the TS return type.
-          reservationListSchema as unknown as z.ZodSchema<PaginatedResponse<Reservation>>
+          reservationListSchema
         );
       }
     
@@ -14300,10 +14295,7 @@
         return this.client.get<PaginatedResponse<Reservation>>(
           `/api/v1/reservations/me?page=${page}&limit=${limit}`,
           undefined,
-          // PaginatedResponse<T> has a nested `pagination` object in the TS type but the
-          // actual API returns a flat shape (data, total, page, limit). The schema matches
-          // the real wire format; cast through unknown to satisfy the TS return type.
-          reservationListSchema as unknown as z.ZodSchema<PaginatedResponse<Reservation>>
+          reservationListSchema
         );
       }
     

--- a/llms.txt
+++ b/llms.txt
@@ -2125,10 +2125,10 @@
   </file>
   <file path="packages/types/src/schemas/common.ts">
     <item priority="high">
-      export function paginatedResponseSchema<T>(itemSchema: z.ZodSchema<T>) { /* ... */ }
+      export const PaginationSchema: unknown;
     </item>
     <item priority="high">
-      export const PaginationSchema: unknown;
+      export function paginatedResponseSchema<T>(itemSchema: z.ZodSchema<T>) { /* ... */ }
     </item>
   </file>
   <file path="packages/types/src/schemas/floor-plan.ts">

--- a/packages/api-client/llms-full.txt
+++ b/packages/api-client/llms-full.txt
@@ -233,10 +233,7 @@
         return this.client.get<PaginatedResponse<Reservation>>(
           "/api/v1/reservations",
           params as QueryParams,
-          // PaginatedResponse<T> has a nested `pagination` object in the TS type but the
-          // actual API returns a flat shape (data, total, page, limit). The schema matches
-          // the real wire format; cast through unknown to satisfy the TS return type.
-          reservationListSchema as unknown as z.ZodSchema<PaginatedResponse<Reservation>>
+          reservationListSchema
         );
       }
     
@@ -247,10 +244,7 @@
         return this.client.get<PaginatedResponse<Reservation>>(
           `/api/v1/reservations/me?page=${page}&limit=${limit}`,
           undefined,
-          // PaginatedResponse<T> has a nested `pagination` object in the TS type but the
-          // actual API returns a flat shape (data, total, page, limit). The schema matches
-          // the real wire format; cast through unknown to satisfy the TS return type.
-          reservationListSchema as unknown as z.ZodSchema<PaginatedResponse<Reservation>>
+          reservationListSchema
         );
       }
     

--- a/packages/api-client/src/reservations.test.ts
+++ b/packages/api-client/src/reservations.test.ts
@@ -18,6 +18,15 @@ function makeClient() {
   return new ReservationsClient(apiClient);
 }
 
+const fakePagination = {
+  page: 1,
+  limit: 10,
+  total: 1,
+  totalPages: 1,
+  hasNext: false,
+  hasPrev: false,
+};
+
 const fakeReservation = {
   id: "r1",
   venueId: "v1",
@@ -50,7 +59,7 @@ describe("ReservationsClient", () => {
   describe("list", () => {
     it("requests /api/v1/reservations with no params when called with defaults", async () => {
       mockFetch.mockResolvedValueOnce(
-        jsonResponse({ data: [fakeReservation], total: 1, page: 1, limit: 10 })
+        jsonResponse({ data: [fakeReservation], pagination: { ...fakePagination, total: 1 } })
       );
 
       await makeClient().list();
@@ -60,7 +69,9 @@ describe("ReservationsClient", () => {
     });
 
     it("appends filter query params", async () => {
-      mockFetch.mockResolvedValueOnce(jsonResponse({ data: [], total: 0, page: 1, limit: 10 }));
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ data: [], pagination: { ...fakePagination, total: 0 } })
+      );
 
       await makeClient().list({ venueId: "v1", date: "2026-06-01", status: "CONFIRMED" });
 
@@ -71,18 +82,36 @@ describe("ReservationsClient", () => {
       expect(parsed.searchParams.get("status")).toBe("CONFIRMED");
     });
 
-    it("returns the paginated response directly", async () => {
-      const body = { data: [fakeReservation], total: 1, page: 1, limit: 10 };
+    it("returns the nested paginated response", async () => {
+      const body = { data: [fakeReservation], pagination: { ...fakePagination, total: 1 } };
       mockFetch.mockResolvedValueOnce(jsonResponse(body));
 
       const result = await makeClient().list();
       expect(result).toEqual(body);
     });
+
+    it("throws ApiValidationError when response is missing pagination object", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ data: [fakeReservation], total: 1, page: 1, limit: 10 })
+      );
+
+      await expect(makeClient().list()).rejects.toThrow(ApiValidationError);
+    });
+
+    it("throws ApiValidationError when data is not an array", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ data: fakeReservation, pagination: fakePagination })
+      );
+
+      await expect(makeClient().list()).rejects.toThrow(ApiValidationError);
+    });
   });
 
   describe("me", () => {
     it("requests /api/v1/reservations/me with pagination", async () => {
-      mockFetch.mockResolvedValueOnce(jsonResponse({ data: [], total: 0, page: 1, limit: 10 }));
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ data: [], pagination: { ...fakePagination, total: 0 } })
+      );
 
       await makeClient().me();
 
@@ -91,12 +120,23 @@ describe("ReservationsClient", () => {
     });
 
     it("passes custom page and limit", async () => {
-      mockFetch.mockResolvedValueOnce(jsonResponse({ data: [], total: 0, page: 3, limit: 5 }));
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({
+          data: [],
+          pagination: { page: 3, limit: 5, total: 0, totalPages: 0, hasNext: false, hasPrev: true },
+        })
+      );
 
       await makeClient().me(3, 5);
 
       const [url] = mockFetch.mock.calls[0]!;
       expect(url).toBe("https://api.test.com/api/v1/reservations/me?page=3&limit=5");
+    });
+
+    it("throws ApiValidationError when pagination object is absent", async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ data: [], total: 0, page: 1, limit: 10 }));
+
+      await expect(makeClient().me()).rejects.toThrow(ApiValidationError);
     });
   });
 

--- a/packages/api-client/src/reservations.ts
+++ b/packages/api-client/src/reservations.ts
@@ -20,7 +20,8 @@ export interface ListReservationsParams {
 }
 
 const reservationEnvelope = z.object({ data: ReservationSchema });
-const reservationListSchema = paginatedResponseSchema(ReservationSchema);
+const reservationListSchema: z.ZodSchema<PaginatedResponse<Reservation>> =
+  paginatedResponseSchema(ReservationSchema);
 
 export class ReservationsClient {
   constructor(private client: ApiClient) {}
@@ -32,10 +33,7 @@ export class ReservationsClient {
     return this.client.get<PaginatedResponse<Reservation>>(
       "/api/v1/reservations",
       params as QueryParams,
-      // PaginatedResponse<T> has a nested `pagination` object in the TS type but the
-      // actual API returns a flat shape (data, total, page, limit). The schema matches
-      // the real wire format; cast through unknown to satisfy the TS return type.
-      reservationListSchema as unknown as z.ZodSchema<PaginatedResponse<Reservation>>
+      reservationListSchema
     );
   }
 
@@ -46,10 +44,7 @@ export class ReservationsClient {
     return this.client.get<PaginatedResponse<Reservation>>(
       `/api/v1/reservations/me?page=${page}&limit=${limit}`,
       undefined,
-      // PaginatedResponse<T> has a nested `pagination` object in the TS type but the
-      // actual API returns a flat shape (data, total, page, limit). The schema matches
-      // the real wire format; cast through unknown to satisfy the TS return type.
-      reservationListSchema as unknown as z.ZodSchema<PaginatedResponse<Reservation>>
+      reservationListSchema
     );
   }
 

--- a/packages/types/llms-full.txt
+++ b/packages/types/llms-full.txt
@@ -61,14 +61,6 @@
       .catchall(z.unknown());
   </file>
   <file path="src/schemas/common.ts">
-    export function paginatedResponseSchema<T>(itemSchema: z.ZodSchema<T>) {
-      return z.object({
-        data: z.array(itemSchema),
-        total: z.number(),
-        page: z.number(),
-        limit: z.number(),
-      });
-    }
     export const PaginationSchema = z.object({
       page: z.number(),
       limit: z.number(),
@@ -77,6 +69,12 @@
       hasNext: z.boolean(),
       hasPrev: z.boolean(),
     });
+    export function paginatedResponseSchema<T>(itemSchema: z.ZodSchema<T>) {
+      return z.object({
+        data: z.array(itemSchema),
+        pagination: PaginationSchema,
+      });
+    }
   </file>
   <file path="src/schemas/floor-plan.ts">
     export const TableShapeMetadataSchema = z.object({

--- a/packages/types/llms.txt
+++ b/packages/types/llms.txt
@@ -18,10 +18,10 @@
   </file>
   <file path="src/schemas/common.ts">
     <item priority="high">
-      export function paginatedResponseSchema<T>(itemSchema: z.ZodSchema<T>) { /* ... */ }
+      export const PaginationSchema: unknown;
     </item>
     <item priority="high">
-      export const PaginationSchema: unknown;
+      export function paginatedResponseSchema<T>(itemSchema: z.ZodSchema<T>) { /* ... */ }
     </item>
   </file>
   <file path="src/schemas/floor-plan.ts">

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -55,9 +55,11 @@ export function createProblemDetails(
 }
 
 /**
- * Paginated API response
+ * Paginated API response.
+ * Shape matches the wire format produced by buildPaginatedResponse in @mbe/database.
  */
-export interface PaginatedResponse<T> extends ApiResponse<T[]> {
+export interface PaginatedResponse<T> {
+  data: T[];
   pagination: Pagination;
 }
 

--- a/packages/types/src/schemas.test.ts
+++ b/packages/types/src/schemas.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { z } from "zod";
 import { UserSchema, UserPreferencesSchema, UserProfileSchema } from "./schemas/user.js";
 import { GuestSchema, GuestSegmentSchema } from "./schemas/guest.js";
 import {
@@ -6,7 +7,6 @@ import {
   ErrorResponseSchema,
   paginatedResponseSchema,
 } from "./schemas/common.js";
-import { z } from "zod";
 import { ProblemDetailsSchema } from "./schemas/api.js";
 
 // ── UserPreferencesSchema ──────────────────────────────────────────
@@ -244,6 +244,49 @@ describe("ErrorResponseSchema", () => {
   });
 });
 
+// ── paginatedResponseSchema ────────────────────────────────────────
+
+describe("paginatedResponseSchema", () => {
+  const ItemSchema = z.object({ id: z.string(), name: z.string() });
+  const schema = paginatedResponseSchema(ItemSchema);
+
+  const validBody = {
+    data: [{ id: "1", name: "Alice" }],
+    pagination: {
+      page: 1,
+      limit: 10,
+      total: 1,
+      totalPages: 1,
+      hasNext: false,
+      hasPrev: false,
+    },
+  };
+
+  it("accepts a valid nested paginated response", () => {
+    expect(schema.safeParse(validBody).success).toBe(true);
+  });
+
+  it("rejects a flat wire format without pagination object", () => {
+    const flat = { data: [{ id: "1", name: "Alice" }], total: 1, page: 1, limit: 10 };
+    expect(schema.safeParse(flat).success).toBe(false);
+  });
+
+  it("rejects when data items fail item schema", () => {
+    const bad = { ...validBody, data: [{ id: 1, name: "Alice" }] };
+    expect(schema.safeParse(bad).success).toBe(false);
+  });
+
+  it("rejects missing pagination", () => {
+    const { pagination: _, ...noPagination } = validBody;
+    expect(schema.safeParse(noPagination).success).toBe(false);
+  });
+
+  it("rejects missing required pagination fields", () => {
+    const bad = { data: [], pagination: { page: 1, limit: 10 } };
+    expect(schema.safeParse(bad).success).toBe(false);
+  });
+});
+
 // ── ProblemDetailsSchema (RFC 9457) ────────────────────────────────
 
 describe("ProblemDetailsSchema", () => {
@@ -327,32 +370,3 @@ describe("ProblemDetailsSchema", () => {
   });
 });
 
-// ── paginatedResponseSchema ────────────────────────────────────────
-
-describe("paginatedResponseSchema", () => {
-  const itemSchema = z.object({ id: z.string(), name: z.string() });
-  const schema = paginatedResponseSchema(itemSchema);
-
-  it("accepts a valid paginated response", () => {
-    const valid = {
-      data: [{ id: "1", name: "Alice" }],
-      total: 1,
-      page: 1,
-      limit: 10,
-    };
-    expect(schema.safeParse(valid).success).toBe(true);
-  });
-
-  it("accepts empty data array", () => {
-    expect(schema.safeParse({ data: [], total: 0, page: 1, limit: 10 }).success).toBe(true);
-  });
-
-  it("rejects items that fail the item schema", () => {
-    const invalid = { data: [{ id: 1, name: "Alice" }], total: 1, page: 1, limit: 10 };
-    expect(schema.safeParse(invalid).success).toBe(false);
-  });
-
-  it("rejects missing pagination fields", () => {
-    expect(schema.safeParse({ data: [] }).success).toBe(false);
-  });
-});

--- a/packages/types/src/schemas/common.ts
+++ b/packages/types/src/schemas/common.ts
@@ -1,14 +1,5 @@
 import { z } from "zod";
 
-export function paginatedResponseSchema<T>(itemSchema: z.ZodSchema<T>) {
-  return z.object({
-    data: z.array(itemSchema),
-    total: z.number(),
-    page: z.number(),
-    limit: z.number(),
-  });
-}
-
 export const PaginationSchema = z.object({
   page: z.number(),
   limit: z.number(),
@@ -17,6 +8,17 @@ export const PaginationSchema = z.object({
   hasNext: z.boolean(),
   hasPrev: z.boolean(),
 });
+
+/**
+ * Generic schema factory for paginated API responses.
+ * Matches the PaginatedResponse<T> TypeScript type: { data: T[], pagination: {...} }.
+ */
+export function paginatedResponseSchema<T>(itemSchema: z.ZodSchema<T>) {
+  return z.object({
+    data: z.array(itemSchema),
+    pagination: PaginationSchema,
+  });
+}
 
 export const ErrorResponseSchema = z.object({
   error: z.string(),


### PR DESCRIPTION
Closes #2635

## Summary

- Changed `PaginatedResponse<T>` in `@mbe/types` from extending `ApiResponse<T[]>` (which added a phantom `meta?` field) to a standalone interface matching the wire format produced by `buildPaginatedResponse` in `@mbe/database`
- Added `paginatedResponseSchema<T>()` factory to `@mbe/types/schemas/common.ts` that generates a Zod schema with nested `{ data: T[], pagination: {...} }` shape — the actual wire format
- Wired `paginatedResponseSchema(ReservationSchema)` into `ReservationsClient.list()` and `ReservationsClient.me()` — eliminates the `as unknown as z.ZodSchema<PaginatedResponse<Reservation>>` cast
- Updated test fixtures in `reservations.test.ts` from flat `{ data, total, page, limit }` to nested `{ data, pagination: {...} }` format; added 3 new schema-validation tests that confirm `ApiValidationError` is thrown on malformed responses

## Test plan

- [ ] `pnpm --dir packages/types test` — 5 new tests for `paginatedResponseSchema` all pass
- [ ] `pnpm --dir packages/api-client test` — all existing tests + 3 new validation tests pass
- [ ] `pnpm --dir packages/types typecheck` — no type errors
- [ ] `pnpm --dir packages/api-client typecheck` — no type errors (no `as unknown` cast)
- [ ] Pre-push hook: 35 turbo tasks successful, all packages in scope pass