### PR TITLE
ci: wire AUDIT_TOKEN into synthetic-monitoring workflow

### DIFF
--- a/.github/workflows/synthetic-monitoring.yml
+++ b/.github/workflows/synthetic-monitoring.yml
@@ -23,8 +23,16 @@ jobs:
     steps:
       - name: Query /health/system
         id: health
+        env:
+          AUDIT_TOKEN: ${{ secrets.AUDIT_TOKEN }}
         run: |
-          RESPONSE=$(curl -sf --max-time 15 "https://mattbutlerengineering.com/health/system")
+          CURL_ARGS=(-sf --max-time 15)
+          if [ -n "${AUDIT_TOKEN:-}" ]; then
+            CURL_ARGS+=(-H "X-Audit-Token: ${AUDIT_TOKEN}")
+          else
+            echo "::warning::AUDIT_TOKEN secret not configured — request may be blocked by Cloudflare Bot Fight Mode (HTTP 403)"
+          fi
+          RESPONSE=$(curl "${CURL_ARGS[@]}" "https://mattbutlerengineering.com/health/system")
           STATUS=$(echo "$RESPONSE" | jq -r '.status')
           echo "status=$STATUS" >> "$GITHUB_OUTPUT"
           echo "response<<HEALTH_EOF" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
Closes #2630

- Passes `X-Audit-Token: <token>` header in the synthetic monitoring curl call so the request bypasses Cloudflare Bot Fight Mode (Layer 1: Worker rate-limit bypass already deployed)
- Emits a `::warning::` GHA annotation when `AUDIT_TOKEN` secret is absent, making the failure mode diagnosable instead of a cryptic `curl: (22) HTTP 403`
- `AUDIT_TOKEN` GitHub Actions secret already provisioned in this session

## Remaining HITL steps (not code — can't PR)

1. **Cloudflare Worker secret**: `wrangler secret put AUDIT_TOKEN` (Layer 1 currently reads `env.AUDIT_TOKEN`; until this is set, the Worker won't recognize the token and rate-limit bypass won't activate)
2. **Cloudflare WAF bypass rule** (Layer 2): CF Dashboard → Security → WAF → Custom Rules → create rule matching `http.request.headers["x-audit-token"][0] eq "<token>"` → Action: Skip → Bot Fight Mode

Both steps are documented in `infrastructure/AUDIT_BYPASS.md`.

## Test plan
- [x] Pre-push hook passes (`pnpm regen --check` clean, antipattern baseline unchanged)
- [x] `AUDIT_TOKEN` GHA secret set via `gh secret set`
- [x] Conditional curl array pattern avoids word-splitting on header value
- [x] `::warning::` annotation fires when secret is unset (failure is visible in GHA logs)
- [x] Existing Worker tests cover `isAuditRequest()` at `infrastructure/worker/edge-router.test.js:622-710`