### PR TITLE
refactor(agent-core): add outputFormat to HardenedQueryConfig; reviewer uses runHardenedQuery

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -13595,6 +13595,14 @@
       readonly stuckDetectorConfig?: Partial<StuckDetectorConfig>;
       /** Heartbeat configuration overrides. */
       readonly heartbeatConfig?: Partial<HeartbeatConfig>;
+      /**
+       * Structured output format. When provided, forwarded to query() options.
+       * Use for single-turn structured-output calls (e.g. reviewer).
+       */
+      readonly outputFormat?: {
+        readonly type: "json_schema";
+        readonly schema: Record<string, unknown>;
+      };
     }
   </file>
   <file path="packages/agent-core/src/sanitize-output.ts">

--- a/packages/agent-core/llms-full.txt
+++ b/packages/agent-core/llms-full.txt
@@ -1972,6 +1972,14 @@
       readonly stuckDetectorConfig?: Partial<StuckDetectorConfig>;
       /** Heartbeat configuration overrides. */
       readonly heartbeatConfig?: Partial<HeartbeatConfig>;
+      /**
+       * Structured output format. When provided, forwarded to query() options.
+       * Use for single-turn structured-output calls (e.g. reviewer).
+       */
+      readonly outputFormat?: {
+        readonly type: "json_schema";
+        readonly schema: Record<string, unknown>;
+      };
     }
   </file>
   <file path="src/sanitize-output.ts">

--- a/packages/agent-core/src/__tests__/reviewer-runner.test.ts
+++ b/packages/agent-core/src/__tests__/reviewer-runner.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
-  query: vi.fn(),
+vi.mock("../run-hardened-query.js", () => ({
+  runHardenedQuery: vi.fn(),
 }));
 
-import { query } from "@anthropic-ai/claude-agent-sdk";
-import { createMockQueryStream } from "@mbe/agent-test-utils";
+import { runHardenedQuery } from "../run-hardened-query.js";
+import type { HardenedQueryResult } from "../run-hardened-query.js";
 import {
   runReviewer,
   parseReviewerVerdict,
@@ -42,6 +42,31 @@ function makeSdkResult(
     },
     modelUsage: {},
     permission_denials: [],
+  };
+}
+
+function makeHardenedResult(
+  structured_output: unknown,
+  subtype: "success" | "error_max_turns" = "success"
+): HardenedQueryResult {
+  return {
+    resultMessage: makeSdkResult(structured_output, subtype),
+    stuckReason: null,
+    rawTurnMetrics: [],
+    rawToolCallMetrics: [],
+    errorMessage: null,
+    contextMetrics: null,
+  };
+}
+
+function makeFailedHardenedResult(errorMessage: string): HardenedQueryResult {
+  return {
+    resultMessage: null,
+    stuckReason: null,
+    rawTurnMetrics: [],
+    rawToolCallMetrics: [],
+    errorMessage,
+    contextMetrics: null,
   };
 }
 
@@ -157,9 +182,7 @@ describe("runReviewer", () => {
 
   it("returns pass outcome when LLM returns a passing verdict", async () => {
     const raw = makeVerdict({ verdict: "pass", score: 9 });
-    vi.mocked(query).mockReturnValue(
-      createMockQueryStream([makeSdkResult(raw)]) as ReturnType<typeof query>
-    );
+    vi.mocked(runHardenedQuery).mockResolvedValue(makeHardenedResult(raw));
 
     const outcome = await runReviewer(makeReviewInput());
     expect(outcome.verdict.verdict).toBe("pass");
@@ -174,9 +197,7 @@ describe("runReviewer", () => {
       issues: [{ category: "regression", description: "broke existing test" }],
       assessment: "Regression found",
     });
-    vi.mocked(query).mockReturnValue(
-      createMockQueryStream([makeSdkResult(raw)]) as ReturnType<typeof query>
-    );
+    vi.mocked(runHardenedQuery).mockResolvedValue(makeHardenedResult(raw));
 
     const outcome = await runReviewer(makeReviewInput());
     expect(outcome.verdict.verdict).toBe("flag");
@@ -185,9 +206,7 @@ describe("runReviewer", () => {
 
   it("records cost from the SDK result", async () => {
     const raw = makeVerdict();
-    vi.mocked(query).mockReturnValue(
-      createMockQueryStream([makeSdkResult(raw)]) as ReturnType<typeof query>
-    );
+    vi.mocked(runHardenedQuery).mockResolvedValue(makeHardenedResult(raw));
 
     const outcome = await runReviewer(makeReviewInput());
     expect(outcome.costUsd).toBe(0.02);
@@ -195,9 +214,7 @@ describe("runReviewer", () => {
 
   it("records positive durationMs", async () => {
     const raw = makeVerdict();
-    vi.mocked(query).mockReturnValue(
-      createMockQueryStream([makeSdkResult(raw)]) as ReturnType<typeof query>
-    );
+    vi.mocked(runHardenedQuery).mockResolvedValue(makeHardenedResult(raw));
 
     const outcome = await runReviewer(makeReviewInput());
     expect(outcome.durationMs).toBeGreaterThanOrEqual(0);
@@ -205,70 +222,50 @@ describe("runReviewer", () => {
 
   it("passes retryCount into the outcome", async () => {
     const raw = makeVerdict();
-    vi.mocked(query).mockReturnValue(
-      createMockQueryStream([makeSdkResult(raw)]) as ReturnType<typeof query>
-    );
+    vi.mocked(runHardenedQuery).mockResolvedValue(makeHardenedResult(raw));
 
     const outcome = await runReviewer(makeReviewInput(), { retryCount: 2 });
     expect(outcome.retryCount).toBe(2);
   });
 
   it("fails-open (pass) when the LLM returns a non-success subtype", async () => {
-    vi.mocked(query).mockReturnValue(
-      createMockQueryStream([makeSdkResult(null, "error_max_turns")]) as ReturnType<typeof query>
-    );
+    vi.mocked(runHardenedQuery).mockResolvedValue(makeHardenedResult(null, "error_max_turns"));
 
     const outcome = await runReviewer(makeReviewInput());
     expect(outcome.verdict.verdict).toBe("pass");
   });
 
-  it("fails-open (pass) on LLM call error", async () => {
-    vi.mocked(query).mockImplementation(() => {
-      throw new Error("Network error");
-    });
+  it("fails-open (pass) when runHardenedQuery throws an error", async () => {
+    vi.mocked(runHardenedQuery).mockRejectedValue(new Error("Network error"));
 
     const outcome = await runReviewer(makeReviewInput());
     expect(outcome.verdict.verdict).toBe("pass");
     expect(outcome.costUsd).toBe(0);
   });
 
-  it("fails-open (pass) on timeout", async () => {
-    vi.useFakeTimers();
-
-    // Simulate a hanging query by returning a promise that never resolves.
-    // Cast through unknown to satisfy the async-iterable return type.
-    vi.mocked(query).mockReturnValue(
-      new Promise<never>(() => {}) as unknown as ReturnType<typeof query>
+  it("fails-open (pass) when runHardenedQuery returns errorMessage (circuit breaker / timeout)", async () => {
+    vi.mocked(runHardenedQuery).mockResolvedValue(
+      makeFailedHardenedResult("Circuit breaker is OPEN")
     );
 
-    const outcomePromise = runReviewer(makeReviewInput(), {
-      config: { ...DEFAULT_REVIEWER_CONFIG, timeoutMs: 100 },
-    });
-
-    vi.advanceTimersByTime(200);
-    const outcome = await outcomePromise;
+    const outcome = await runReviewer(makeReviewInput());
     expect(outcome.verdict.verdict).toBe("pass");
-
-    vi.useRealTimers();
+    expect(outcome.costUsd).toBe(0);
   });
 
   it("uses the haiku model by default", async () => {
     const raw = makeVerdict();
-    vi.mocked(query).mockReturnValue(
-      createMockQueryStream([makeSdkResult(raw)]) as ReturnType<typeof query>
-    );
+    vi.mocked(runHardenedQuery).mockResolvedValue(makeHardenedResult(raw));
 
     await runReviewer(makeReviewInput());
 
-    const callArgs = vi.mocked(query).mock.calls[0];
-    expect(callArgs[0].options?.model).toMatch(/haiku/i);
+    const callArgs = vi.mocked(runHardenedQuery).mock.calls[0];
+    expect(callArgs[0].model).toMatch(/haiku/i);
   });
 
   it("honours model override in config", async () => {
     const raw = makeVerdict();
-    vi.mocked(query).mockReturnValue(
-      createMockQueryStream([makeSdkResult(raw)]) as ReturnType<typeof query>
-    );
+    vi.mocked(runHardenedQuery).mockResolvedValue(makeHardenedResult(raw));
 
     const config: Partial<ReviewerConfig> = {
       ...DEFAULT_REVIEWER_CONFIG,
@@ -277,7 +274,43 @@ describe("runReviewer", () => {
 
     await runReviewer(makeReviewInput(), { config });
 
-    const callArgs = vi.mocked(query).mock.calls[0];
-    expect(callArgs[0].options?.model).toBe("claude-sonnet-4-6");
+    const callArgs = vi.mocked(runHardenedQuery).mock.calls[0];
+    expect(callArgs[0].model).toBe("claude-sonnet-4-6");
+  });
+
+  it("calls runHardenedQuery with outputFormat json_schema", async () => {
+    const raw = makeVerdict();
+    vi.mocked(runHardenedQuery).mockResolvedValue(makeHardenedResult(raw));
+
+    await runReviewer(makeReviewInput());
+
+    const callArgs = vi.mocked(runHardenedQuery).mock.calls[0];
+    expect(callArgs[0].outputFormat?.type).toBe("json_schema");
+    expect(callArgs[0].outputFormat?.schema).toBeDefined();
+  });
+
+  it("calls runHardenedQuery with maxTurns: 1", async () => {
+    const raw = makeVerdict();
+    vi.mocked(runHardenedQuery).mockResolvedValue(makeHardenedResult(raw));
+
+    await runReviewer(makeReviewInput());
+
+    const callArgs = vi.mocked(runHardenedQuery).mock.calls[0];
+    expect(callArgs[0].maxTurns).toBe(1);
+  });
+
+  it("uses heartbeatConfig inactivity timeout instead of manual Promise.race", async () => {
+    const raw = makeVerdict();
+    vi.mocked(runHardenedQuery).mockResolvedValue(makeHardenedResult(raw));
+
+    const config: Partial<ReviewerConfig> = {
+      ...DEFAULT_REVIEWER_CONFIG,
+      timeoutMs: 15_000,
+    };
+
+    await runReviewer(makeReviewInput(), { config });
+
+    const callArgs = vi.mocked(runHardenedQuery).mock.calls[0];
+    expect(callArgs[0].heartbeatConfig?.inactivityTimeoutMs).toBe(15_000);
   });
 });

--- a/packages/agent-core/src/__tests__/run-hardened-query.test.ts
+++ b/packages/agent-core/src/__tests__/run-hardened-query.test.ts
@@ -242,6 +242,39 @@ describe("runHardenedQuery", () => {
     expect(stuckReason).toBeNull();
   });
 
+  it("forwards outputFormat to query() options when provided", async () => {
+    const mockResult = createMockResultMessage();
+    vi.mocked(query).mockReturnValue(
+      createMockQueryStream([mockResult]) as ReturnType<typeof query>
+    );
+
+    const outputFormat = {
+      type: "json_schema" as const,
+      schema: { type: "object" as const, properties: { verdict: { type: "string" as const } } },
+    };
+
+    const resultPromise = runHardenedQuery({ ...BASE_CONFIG, outputFormat });
+    await vi.runAllTimersAsync();
+    await resultPromise;
+
+    const callArgs = vi.mocked(query).mock.calls[0];
+    expect(callArgs[0].options?.outputFormat).toEqual(outputFormat);
+  });
+
+  it("does not set outputFormat in query() options when omitted", async () => {
+    const mockResult = createMockResultMessage();
+    vi.mocked(query).mockReturnValue(
+      createMockQueryStream([mockResult]) as ReturnType<typeof query>
+    );
+
+    const resultPromise = runHardenedQuery(BASE_CONFIG);
+    await vi.runAllTimersAsync();
+    await resultPromise;
+
+    const callArgs = vi.mocked(query).mock.calls[0];
+    expect(callArgs[0].options?.outputFormat).toBeUndefined();
+  });
+
   it("records turn and tool-call metrics", async () => {
     const { mapSdkMessage } = await import("../event-mapper.js");
     vi.mocked(mapSdkMessage).mockReturnValue([

--- a/packages/agent-core/src/reviewer-runner.ts
+++ b/packages/agent-core/src/reviewer-runner.ts
@@ -1,5 +1,4 @@
-import { query } from "@anthropic-ai/claude-agent-sdk";
-import type { SDKResultMessage } from "@anthropic-ai/claude-agent-sdk";
+import { runHardenedQuery } from "./run-hardened-query.js";
 import { resolveModelId } from "./model-registry.js";
 import type {
   ReviewInput,
@@ -232,66 +231,48 @@ export async function runReviewer(
   try {
     const prompt = buildReviewerPrompt(input);
 
-    let result: SDKResultMessage | null = null;
-
-    const queryIterable = query({
+    const { resultMessage, errorMessage } = await runHardenedQuery({
       prompt,
-      options: {
-        model: config.model,
-        maxTurns: 1,
-        maxBudgetUsd: config.maxBudgetUsd,
-        permissionMode: "plan",
-        systemPrompt: "You are a code reviewer. Respond only with the requested JSON verdict.",
-        outputFormat: {
-          type: "json_schema",
-          schema: VERDICT_SCHEMA,
-        },
+      cwd: process.cwd(),
+      model: config.model,
+      maxTurns: 1,
+      maxBudgetUsd: config.maxBudgetUsd,
+      allowedTools: [],
+      systemPromptAppend: "You are a code reviewer. Respond only with the requested JSON verdict.",
+      outputFormat: {
+        type: "json_schema",
+        schema: VERDICT_SCHEMA,
+      },
+      heartbeatConfig: {
+        inactivityTimeoutMs: config.timeoutMs,
       },
     });
 
-    const timeoutPromise = new Promise<null>((resolve) =>
-      setTimeout(() => resolve(null), config.timeoutMs)
-    );
-
-    // Race the iterable against the timeout.
-    const collected = await Promise.race([
-      (async () => {
-        for await (const message of queryIterable) {
-          if (message.type === "result") {
-            result = message as SDKResultMessage;
-          }
-        }
-        return result;
-      })(),
-      timeoutPromise,
-    ]);
-
-    if (collected === null) {
-      // Timeout — fail-open
+    if (errorMessage !== null) {
       return {
-        verdict: makePassVerdict("Reviewer timed out — proceeding fail-open"),
+        verdict: makePassVerdict(`Reviewer failed: ${errorMessage} — proceeding fail-open`),
         costUsd: 0,
         durationMs: Date.now() - startMs,
         retryCount,
       };
     }
 
-    if (!collected || collected.subtype !== "success") {
+    if (!resultMessage || resultMessage.subtype !== "success") {
       return {
         verdict: makePassVerdict(
-          `Reviewer returned non-success subtype (${collected?.subtype ?? "no result"}) — proceeding fail-open`
+          `Reviewer returned non-success subtype (${resultMessage?.subtype ?? "no result"}) — proceeding fail-open`
         ),
-        costUsd: (collected as SDKResultMessage | null)?.total_cost_usd ?? 0,
+        costUsd: resultMessage?.total_cost_usd ?? 0,
         durationMs: Date.now() - startMs,
         retryCount,
       };
     }
 
-    const raw = collected.structured_output as ReviewVerdict | undefined;
+    const raw = resultMessage.structured_output as ReviewVerdict | undefined;
     if (!raw || typeof raw.score !== "number") {
       return {
         verdict: makePassVerdict("Reviewer returned unreadable output — proceeding fail-open"),
-        costUsd: collected.total_cost_usd ?? 0,
+        costUsd: resultMessage.total_cost_usd ?? 0,
         durationMs: Date.now() - startMs,
         retryCount,
       };
@@ -299,7 +280,7 @@ export async function runReviewer(
 
     return {
       verdict: parseReviewerVerdict(raw),
-      costUsd: collected.total_cost_usd ?? 0,
+      costUsd: resultMessage.total_cost_usd ?? 0,
       durationMs: Date.now() - startMs,
       retryCount,
     };

--- a/packages/agent-core/src/run-hardened-query.ts
+++ b/packages/agent-core/src/run-hardened-query.ts
@@ -67,6 +67,14 @@ export interface HardenedQueryConfig {
   readonly stuckDetectorConfig?: Partial<StuckDetectorConfig>;
   /** Heartbeat configuration overrides. */
   readonly heartbeatConfig?: Partial<HeartbeatConfig>;
+  /**
+   * Structured output format. When provided, forwarded to query() options.
+   * Use for single-turn structured-output calls (e.g. reviewer).
+   */
+  readonly outputFormat?: {
+    readonly type: "json_schema";
+    readonly schema: Record<string, unknown>;
+  };
 }
 
 export interface RawTurnMetric {
@@ -169,6 +177,7 @@ export async function runHardenedQuery(
                 preset: "claude_code" as const,
               },
             }),
+        ...(config.outputFormat !== undefined ? { outputFormat: config.outputFormat } : {}),
         canUseTool: async (toolName, input) => canUseTool(toolName, input),
       },
     });


### PR DESCRIPTION
## Summary

- Adds `outputFormat?: { type: "json_schema"; schema: Record<string, unknown> }` to `HardenedQueryConfig` and threads it through to the `query()` options in `runHardenedQuery`
- `reviewer-runner.ts` now calls `runHardenedQuery` with `maxTurns: 1`, `outputFormat: { type: "json_schema", schema: VERDICT_SCHEMA }`, and `heartbeatConfig.inactivityTimeoutMs` instead of a hand-rolled `Promise.race` timeout
- The reviewer gains the shared circuit breaker, OTel spans, Langfuse traces, and heartbeat monitoring for free
- The raw `query()` import and manual `Promise.race` + `setTimeout` deleted from `reviewer-runner.ts`
- `reviewer-runner.test.ts` now mocks `runHardenedQuery` instead of `query()` — narrower, behaviour-focused seam

## Test plan

- [x] TDD: failing tests written first for `outputFormat` forwarding in `runHardenedQuery` (RED)
- [x] Implementation added to pass tests (GREEN)
- [x] New `reviewer-runner.test.ts` tests mocking `runHardenedQuery` written (RED), then implementation updated (GREEN)
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (1285 tests, 2 pre-existing failures unrelated to this change: `@mbe/api-client` resolution in orchestrator/observability tests)
- [x] `check-adr` passes
- [x] `check-deps` passes
- [x] `pnpm regen` run and stale artifacts committed

Closes #2647