### PR TITLE
feat(acmm): collect threshold-change entry for L6 self-improvement

### DIFF
--- a/metrics/threshold-changes.jsonl
+++ b/metrics/threshold-changes.jsonl
@@ -1,1 +1,2 @@
 {"timestamp":"2026-05-23T00:00:00.000Z","criterion":"ci-fix","old_value":1.0,"new_value":0.95,"trigger":"seed"}
+{"date":"2026-05-10","reason":"Acceptance rate 100% is excellent (>=95%). Stuck-turns threshold relaxed from 8 to 9 — agents are producing quality work and may benefit from more turns."}


### PR DESCRIPTION
## Summary
- Runs `collect-threshold-changes.mjs` to append the pending threshold adjustment entry from `.github/auto-qa-tuning.json` history
- Satisfies the ACMM L6 threshold self-tuning detection criterion (`metrics/threshold-changes.jsonl` with a recent entry)
- Entry records the relaxation of stuck-turns threshold from 8→9 based on 100% acceptance rate

## Test plan
- [ ] `metrics/threshold-changes.jsonl` contains 2 entries (seed + new real entry)
- [ ] ACMM L6 `threshold-tuning` criterion will pass detection on next audit
- [ ] No generated artifacts drift (only JSONL data file modified)

Closes #2625