### PR TITLE
fix: manage token parsing breaks for emails containing colons

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8469,8 +8469,14 @@
         if (parts.length < 4) return { valid: false };
     
         const signature = parts.pop()!;
-        const payload = parts.join(":");
-        const [reservationId, guestEmail, expiryStr] = parts;
+        // Pop expiry from the right, shift reservationId from the left, then
+        // rejoin whatever remains as the email. This handles RFC-valid emails
+        // containing colons (e.g. "user:tag@example.com") without breaking the
+        // HMAC payload reconstruction.
+        const expiryStr = parts.pop()!;
+        const reservationId = parts.shift()!;
+        const guestEmail = parts.join(":");
+        const payload = `${reservationId}:${guestEmail}:${expiryStr}`;
     
         const expected = createHmac("sha256", TOKEN_SECRET).update(payload).digest("hex");
         if (signature !== expected) return { valid: false };

--- a/services/reservations/llms-full.txt
+++ b/services/reservations/llms-full.txt
@@ -2638,8 +2638,14 @@
         if (parts.length < 4) return { valid: false };
     
         const signature = parts.pop()!;
-        const payload = parts.join(":");
-        const [reservationId, guestEmail, expiryStr] = parts;
+        // Pop expiry from the right, shift reservationId from the left, then
+        // rejoin whatever remains as the email. This handles RFC-valid emails
+        // containing colons (e.g. "user:tag@example.com") without breaking the
+        // HMAC payload reconstruction.
+        const expiryStr = parts.pop()!;
+        const reservationId = parts.shift()!;
+        const guestEmail = parts.join(":");
+        const payload = `${reservationId}:${guestEmail}:${expiryStr}`;
     
         const expected = createHmac("sha256", TOKEN_SECRET).update(payload).digest("hex");
         if (signature !== expected) return { valid: false };

--- a/services/reservations/src/routes/public-reservations.test.ts
+++ b/services/reservations/src/routes/public-reservations.test.ts
@@ -265,4 +265,14 @@ describe("manage token", () => {
     expect(verifyManageToken("not-a-token").valid).toBe(false);
     expect(verifyManageToken("").valid).toBe(false);
   });
+
+  it("verifies a token for an email address that contains colons", () => {
+    const email = "user:admin@example.com";
+    const token = generateManageToken("res_456", email);
+    const result = verifyManageToken(token);
+
+    expect(result.valid).toBe(true);
+    expect(result.reservationId).toBe("res_456");
+    expect(result.guestEmail).toBe(email);
+  });
 });

--- a/services/reservations/src/routes/public-reservations.ts
+++ b/services/reservations/src/routes/public-reservations.ts
@@ -31,8 +31,14 @@ export function verifyManageToken(token: string): {
     if (parts.length < 4) return { valid: false };
 
     const signature = parts.pop()!;
-    const payload = parts.join(":");
-    const [reservationId, guestEmail, expiryStr] = parts;
+    // Pop expiry from the right, shift reservationId from the left, then
+    // rejoin whatever remains as the email. This handles RFC-valid emails
+    // containing colons (e.g. "user:tag@example.com") without breaking the
+    // HMAC payload reconstruction.
+    const expiryStr = parts.pop()!;
+    const reservationId = parts.shift()!;
+    const guestEmail = parts.join(":");
+    const payload = `${reservationId}:${guestEmail}:${expiryStr}`;
 
     const expected = createHmac("sha256", TOKEN_SECRET).update(payload).digest("hex");
     if (signature !== expected) return { valid: false };


### PR DESCRIPTION
## Summary

`verifyManageToken` split the decoded token on `:` and used a naive positional destructure:

```typescript
const [reservationId, guestEmail, expiryStr] = parts;
```

This breaks for RFC 5321-valid email addresses that contain colons (e.g. `user:admin@example.com`). The `guestEmail` field would be silently truncated to the prefix before the first colon, and `expiryStr` would be assigned the colon-separated fragment instead of the actual expiry timestamp — causing `parseInt` to return `NaN`, which makes the expiry check `Date.now() > NaN` evaluate to `false`. Net result: the token "validates" but returns the wrong `guestEmail`, bypassing any downstream email-ownership assertion.

The fix parses positionally from both ends: pop the signature from the right, pop the expiry from the right, shift the `reservationId` from the left, then rejoin the remaining parts as the email. This correctly reconstructs the HMAC payload regardless of how many colons the email contains.

## Changes

- `services/reservations/src/routes/public-reservations.ts` — fixed `verifyManageToken` parsing logic
- `services/reservations/src/routes/public-reservations.test.ts` — added regression test for colon-containing email
- Regenerated `llms-full.txt` artifacts

## Test plan

- [x] New test `"verifies a token for an email address that contains colons"` was RED before the fix, GREEN after
- [x] Existing manage-token tests (`"generates and verifies a valid token"`, `"rejects tampered tokens"`, `"rejects garbage input"`) all pass
- [x] Full reservations test suite: 948 tests pass
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` all green across 43 turbo tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgDJ2zSEgL2aU5ScRxzN8K

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgDJ2zSEgL2aU5ScRxzN8K)_