### PR TITLE
perf(reservations): eliminate double venue fetch in public-venues handler

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8613,37 +8613,36 @@
         },
         async (request, reply) => {
           const { slug } = request.params;
-          const venue = await venueService.getBySlug(slug);
+          const rawVenue = await venueService.getRawBySlug(slug);
     
-          if (!venue) {
+          if (!rawVenue) {
             return reply.status(404).send({
               success: false,
               error: "Venue not found",
             } as never);
           }
     
-          // Fetch deposit-specific fields (not on the mapped Venue type) via service
-          const rawVenue = await venueService.getRawBySlug(slug);
+          const settings = rawVenue.settings as Record<string, unknown> | null;
     
           const publicVenue: PublicVenueResponse = {
-            name: venue.name,
-            slug: venue.slug,
-            ianaTimezone: venue.ianaTimezone,
-            currencyCode: venue.currencyCode,
-            operatingHours: venue.operatingHours,
+            name: rawVenue.name,
+            slug: rawVenue.slug,
+            ianaTimezone: rawVenue.ianaTimezone,
+            currencyCode: rawVenue.currencyCode,
+            operatingHours: rawVenue.operatingHours,
             settings: {
-              defaultReservationDuration: venue.settings?.defaultReservationDuration,
-              maxPartySize: venue.settings?.maxPartySize,
-              maxAdvanceBooking: venue.settings?.maxAdvanceBooking,
-              slotIntervalMinutes: venue.settings?.slotIntervalMinutes,
+              defaultReservationDuration: settings?.defaultReservationDuration as number | undefined,
+              maxPartySize: settings?.maxPartySize as number | undefined,
+              maxAdvanceBooking: settings?.maxAdvanceBooking as number | undefined,
+              slotIntervalMinutes: settings?.slotIntervalMinutes as number | undefined,
             },
             deposit: {
-              enabled: rawVenue?.depositEnabled ?? false,
-              depositType: rawVenue?.depositType ?? null,
-              amountCents: rawVenue?.depositAmountCents ?? null,
-              freeCancellationHours: rawVenue?.freeCancellationHours ?? null,
-              lateCancellationFeePercent: rawVenue?.lateCancellationFeePercent ?? null,
-              noShowFeePercent: rawVenue?.noShowFeePercent ?? null,
+              enabled: rawVenue.depositEnabled,
+              depositType: rawVenue.depositType,
+              amountCents: rawVenue.depositAmountCents,
+              freeCancellationHours: rawVenue.freeCancellationHours,
+              lateCancellationFeePercent: rawVenue.lateCancellationFeePercent,
+              noShowFeePercent: rawVenue.noShowFeePercent,
             },
           };
     
@@ -16055,7 +16054,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -16054,18 +16054,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -349,7 +349,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -349,18 +349,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/services/reservations/llms-full.txt
+++ b/services/reservations/llms-full.txt
@@ -2782,37 +2782,36 @@
         },
         async (request, reply) => {
           const { slug } = request.params;
-          const venue = await venueService.getBySlug(slug);
+          const rawVenue = await venueService.getRawBySlug(slug);
     
-          if (!venue) {
+          if (!rawVenue) {
             return reply.status(404).send({
               success: false,
               error: "Venue not found",
             } as never);
           }
     
-          // Fetch deposit-specific fields (not on the mapped Venue type) via service
-          const rawVenue = await venueService.getRawBySlug(slug);
+          const settings = rawVenue.settings as Record<string, unknown> | null;
     
           const publicVenue: PublicVenueResponse = {
-            name: venue.name,
-            slug: venue.slug,
-            ianaTimezone: venue.ianaTimezone,
-            currencyCode: venue.currencyCode,
-            operatingHours: venue.operatingHours,
+            name: rawVenue.name,
+            slug: rawVenue.slug,
+            ianaTimezone: rawVenue.ianaTimezone,
+            currencyCode: rawVenue.currencyCode,
+            operatingHours: rawVenue.operatingHours,
             settings: {
-              defaultReservationDuration: venue.settings?.defaultReservationDuration,
-              maxPartySize: venue.settings?.maxPartySize,
-              maxAdvanceBooking: venue.settings?.maxAdvanceBooking,
-              slotIntervalMinutes: venue.settings?.slotIntervalMinutes,
+              defaultReservationDuration: settings?.defaultReservationDuration as number | undefined,
+              maxPartySize: settings?.maxPartySize as number | undefined,
+              maxAdvanceBooking: settings?.maxAdvanceBooking as number | undefined,
+              slotIntervalMinutes: settings?.slotIntervalMinutes as number | undefined,
             },
             deposit: {
-              enabled: rawVenue?.depositEnabled ?? false,
-              depositType: rawVenue?.depositType ?? null,
-              amountCents: rawVenue?.depositAmountCents ?? null,
-              freeCancellationHours: rawVenue?.freeCancellationHours ?? null,
-              lateCancellationFeePercent: rawVenue?.lateCancellationFeePercent ?? null,
-              noShowFeePercent: rawVenue?.noShowFeePercent ?? null,
+              enabled: rawVenue.depositEnabled,
+              depositType: rawVenue.depositType,
+              amountCents: rawVenue.depositAmountCents,
+              freeCancellationHours: rawVenue.freeCancellationHours,
+              lateCancellationFeePercent: rawVenue.lateCancellationFeePercent,
+              noShowFeePercent: rawVenue.noShowFeePercent,
             },
           };
     

--- a/services/reservations/src/routes/public-venues.test.ts
+++ b/services/reservations/src/routes/public-venues.test.ts
@@ -99,7 +99,7 @@ vi.mock("jose", () => ({
 
 import { venueService } from "../services/venue.js";
 
-const mockVenue = {
+const rawMockVenue = {
   id: "venue_1",
   venueGroupId: "group_1",
   name: "The Oak Table",
@@ -120,8 +120,14 @@ const mockVenue = {
     maxPartySize: 12,
     maxAdvanceBooking: 30,
   },
-  createdAt: "2026-01-01T00:00:00.000Z",
-  updatedAt: "2026-01-01T00:00:00.000Z",
+  depositEnabled: false,
+  depositType: null,
+  depositAmountCents: null,
+  freeCancellationHours: null,
+  lateCancellationFeePercent: null,
+  noShowFeePercent: null,
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
 };
 
 describe("GET /public/v1/venues/:slug", () => {
@@ -139,7 +145,7 @@ describe("GET /public/v1/venues/:slug", () => {
   });
 
   it("returns venue info by slug without authentication", async () => {
-    vi.mocked(venueService.getBySlug).mockResolvedValueOnce(mockVenue);
+    vi.mocked(venueService.getRawBySlug).mockResolvedValueOnce(rawMockVenue);
 
     const response = await app.inject({
       method: "GET",
@@ -156,7 +162,7 @@ describe("GET /public/v1/venues/:slug", () => {
   });
 
   it("returns 404 for non-existent slug", async () => {
-    vi.mocked(venueService.getBySlug).mockResolvedValueOnce(null);
+    vi.mocked(venueService.getRawBySlug).mockResolvedValueOnce(null);
 
     const response = await app.inject({
       method: "GET",
@@ -167,7 +173,7 @@ describe("GET /public/v1/venues/:slug", () => {
   });
 
   it("does not expose venueGroupId or internal fields", async () => {
-    vi.mocked(venueService.getBySlug).mockResolvedValueOnce(mockVenue);
+    vi.mocked(venueService.getRawBySlug).mockResolvedValueOnce(rawMockVenue);
 
     const response = await app.inject({
       method: "GET",
@@ -177,5 +183,19 @@ describe("GET /public/v1/venues/:slug", () => {
     const body = response.json();
     expect(body.data.venueGroupId).toBeUndefined();
     expect(body.data.id).toBeUndefined();
+  });
+
+  it("fetches venue only via getRawBySlug — never calls getBySlug", async () => {
+    vi.mocked(venueService.getBySlug).mockClear();
+    vi.mocked(venueService.getRawBySlug).mockClear();
+
+    await app.inject({
+      method: "GET",
+      url: "/public/v1/venues/the-oak-table",
+    });
+
+    expect(venueService.getBySlug).not.toHaveBeenCalled();
+    expect(venueService.getRawBySlug).toHaveBeenCalledOnce();
+    expect(venueService.getRawBySlug).toHaveBeenCalledWith("the-oak-table");
   });
 });

--- a/services/reservations/src/routes/public-venues.ts
+++ b/services/reservations/src/routes/public-venues.ts
@@ -45,37 +45,36 @@ export const publicVenueRoutes: FastifyPluginAsync = async (fastify) => {
     },
     async (request, reply) => {
       const { slug } = request.params;
-      const venue = await venueService.getBySlug(slug);
+      const rawVenue = await venueService.getRawBySlug(slug);
 
-      if (!venue) {
+      if (!rawVenue) {
         return reply.status(404).send({
           success: false,
           error: "Venue not found",
         } as never);
       }
 
-      // Fetch deposit-specific fields (not on the mapped Venue type) via service
-      const rawVenue = await venueService.getRawBySlug(slug);
+      const settings = rawVenue.settings as Record<string, unknown> | null;
 
       const publicVenue: PublicVenueResponse = {
-        name: venue.name,
-        slug: venue.slug,
-        ianaTimezone: venue.ianaTimezone,
-        currencyCode: venue.currencyCode,
-        operatingHours: venue.operatingHours,
+        name: rawVenue.name,
+        slug: rawVenue.slug,
+        ianaTimezone: rawVenue.ianaTimezone,
+        currencyCode: rawVenue.currencyCode,
+        operatingHours: rawVenue.operatingHours,
         settings: {
-          defaultReservationDuration: venue.settings?.defaultReservationDuration,
-          maxPartySize: venue.settings?.maxPartySize,
-          maxAdvanceBooking: venue.settings?.maxAdvanceBooking,
-          slotIntervalMinutes: venue.settings?.slotIntervalMinutes,
+          defaultReservationDuration: settings?.defaultReservationDuration as number | undefined,
+          maxPartySize: settings?.maxPartySize as number | undefined,
+          maxAdvanceBooking: settings?.maxAdvanceBooking as number | undefined,
+          slotIntervalMinutes: settings?.slotIntervalMinutes as number | undefined,
         },
         deposit: {
-          enabled: rawVenue?.depositEnabled ?? false,
-          depositType: rawVenue?.depositType ?? null,
-          amountCents: rawVenue?.depositAmountCents ?? null,
-          freeCancellationHours: rawVenue?.freeCancellationHours ?? null,
-          lateCancellationFeePercent: rawVenue?.lateCancellationFeePercent ?? null,
-          noShowFeePercent: rawVenue?.noShowFeePercent ?? null,
+          enabled: rawVenue.depositEnabled,
+          depositType: rawVenue.depositType,
+          amountCents: rawVenue.depositAmountCents,
+          freeCancellationHours: rawVenue.freeCancellationHours,
+          lateCancellationFeePercent: rawVenue.lateCancellationFeePercent,
+          noShowFeePercent: rawVenue.noShowFeePercent,
         },
       };
 


### PR DESCRIPTION
## Summary

- Replaced two sequential DB calls (`getBySlug` + `getRawBySlug`) with a single `getRawBySlug` call in the public-venues GET handler
- `getRawBySlug` returns a superset of all fields needed (base venue fields + deposit policy fields), making the first fetch redundant
- Added a test asserting `getBySlug` is never called and `getRawBySlug` is called exactly once per request

## Test plan

- [x] TDD: wrote failing test first (RED: `getBySlug` called unexpectedly), then implemented fix (GREEN)
- [x] Existing tests updated to mock `getRawBySlug` with full raw venue data
- [x] `pnpm --dir services/reservations lint` — pass
- [x] `pnpm --dir services/reservations typecheck` — pass
- [x] `pnpm --dir services/reservations test` — 71 files, 965 tests pass
- [x] `pnpm --filter @mbe/cli start check-adr` — no violations
- [x] `pnpm --filter @mbe/cli start check-deps` — all consistent
- [x] `pnpm regen` — ran clean, staged llms-full.txt artifacts
- [x] `node scripts/detect-instruction-rot.mjs` — no rot detected

Closes #2665