### PR TITLE
fix(health): treat cancelled deploys as degraded, not unhealthy

### DIFF
--- a/infrastructure/worker/deploy-health.js
+++ b/infrastructure/worker/deploy-health.js
@@ -42,6 +42,16 @@ export function interpretDeployHealth(kvData, now) {
     return { status: "stale", last_run: kvData };
   }
 
-  const status = kvData.conclusion === DEPLOY_HEALTH_CONCLUSIONS.SUCCESS ? "healthy" : "unhealthy";
-  return { status, last_run: kvData };
+  if (kvData.conclusion === DEPLOY_HEALTH_CONCLUSIONS.SUCCESS) {
+    return { status: "healthy", last_run: kvData };
+  }
+  // A cancelled deploy is the DO+Pulumi dual-deploy race artifact (every
+  // `doctl apps create-deployment` triggers a paired "app spec updated"
+  // deployment that gets superseded/cancelled). Treat it as stale so it
+  // surfaces as `degraded`, not a false `unhealthy` alarm. Real failures
+  // and rollbacks still map to unhealthy.
+  if (kvData.conclusion === DEPLOY_HEALTH_CONCLUSIONS.CANCELLED) {
+    return { status: "stale", last_run: kvData };
+  }
+  return { status: "unhealthy", last_run: kvData };
 }

--- a/infrastructure/worker/deploy-health.test.js
+++ b/infrastructure/worker/deploy-health.test.js
@@ -102,11 +102,23 @@ describe("interpretDeployHealth — rolled_back round-trip", () => {
 });
 
 describe("interpretDeployHealth — cancelled round-trip", () => {
-  it("classifies cancelled conclusion as unhealthy", () => {
+  it("classifies cancelled conclusion as stale (DO+Pulumi race artifact, not a real failure)", () => {
     const record = makeRecord(DEPLOY_HEALTH_CONCLUSIONS.CANCELLED);
     const result = interpretDeployHealth(record, NOW);
-    expect(result.status).toBe("unhealthy");
+    expect(result.status).toBe("stale");
     expect(result.last_run).toEqual(record);
+  });
+
+  it("still classifies failure as unhealthy (regression guard)", () => {
+    const record = makeRecord(DEPLOY_HEALTH_CONCLUSIONS.FAILURE);
+    const result = interpretDeployHealth(record, NOW);
+    expect(result.status).toBe("unhealthy");
+  });
+
+  it("still classifies rolled_back as unhealthy (regression guard)", () => {
+    const record = makeRecord(DEPLOY_HEALTH_CONCLUSIONS.ROLLED_BACK);
+    const result = interpretDeployHealth(record, NOW);
+    expect(result.status).toBe("unhealthy");
   });
 });
 

--- a/infrastructure/worker/health/system.test.js
+++ b/infrastructure/worker/health/system.test.js
@@ -23,7 +23,10 @@ vi.mock("../deploy-health.js", () => ({
     if (!data) return { status: "stale" };
     const age = now - new Date(data.updated_at).getTime();
     if (age > 60 * 60 * 1000) return { status: "stale" };
-    return { status: data.conclusion === "success" ? "healthy" : "unhealthy" };
+    if (data.conclusion === "success") return { status: "healthy" };
+    // cancelled is the DO+Pulumi race artifact — treat as stale, not unhealthy
+    if (data.conclusion === "cancelled") return { status: "stale" };
+    return { status: "unhealthy" };
   },
 }));
 
@@ -163,6 +166,18 @@ describe("deployStatus", () => {
   it("returns degraded when pipelines are stale but not failed", () => {
     const result = deployStatus(
       { static: null, services: recentSuccess, infrastructure: recentSuccess },
+      now
+    );
+    expect(result.status).toBe("degraded");
+  });
+
+  it("returns degraded (not unhealthy) when a pipeline is cancelled (DO+Pulumi race)", () => {
+    const recentCancelled = {
+      conclusion: "cancelled",
+      updated_at: new Date(now - 1000).toISOString(),
+    };
+    const result = deployStatus(
+      { static: recentSuccess, services: recentCancelled, infrastructure: recentSuccess },
       now
     );
     expect(result.status).toBe("degraded");


### PR DESCRIPTION
## Summary

- `interpretDeployHealth` in `infrastructure/worker/deploy-health.js` previously mapped `cancelled` conclusions to `unhealthy`, identical to real failures
- Every `doctl apps create-deployment` triggers a paired "app spec updated" deployment that gets cancelled (the documented DO+Pulumi dual-deploy race) — this produced false `unhealthy` alerts twice daily, which auto-filed ci-fix issues like #2663
- Fix: map `cancelled` → `stale`, so it flows through `deployStatus` as a `staleCount` and surfaces the deploys subsystem as `degraded` (visible/honest) rather than triggering a false-alarm `unhealthy`
- `failure` and `rolled_back` remain `unhealthy` (real problems, unchanged)

## Files changed

- `infrastructure/worker/deploy-health.js` — implementation fix
- `infrastructure/worker/deploy-health.test.js` — updated "cancelled round-trip" assertion + regression guards for failure/rolled_back
- `infrastructure/worker/health/system.test.js` — updated mock to match new `cancelled` → `stale` semantics + new `deployStatus` test locking in that a cancelled pipeline surfaces as `degraded`

## Test plan

- [x] `pnpm exec vitest run infrastructure/worker/deploy-health.test.js` — 15 tests pass (was 1 failing RED before implementation)
- [x] `pnpm exec vitest run infrastructure/worker/` — all 232 worker tests pass
- [x] `pnpm --filter @mbe/cli start check-adr` — no violations
- [x] `pnpm --filter @mbe/cli start check-deps` — no mismatches
- [x] `pnpm regen` — no artifact drift
- [x] Pre-push hook — all patterns within baseline, all tests pass

Closes #2663