### PR TITLE
feat(rialto): WatchLoader — automatic-watch-back loader component

### DIFF
--- a/packages/rialto/package.json
+++ b/packages/rialto/package.json
@@ -310,6 +310,10 @@
       "types": "./dist/lib/components/Tree/index.d.ts",
       "import": "./dist/lib/components/Tree/index.js"
     },
+    "./WatchLoader": {
+      "types": "./dist/lib/components/WatchLoader/index.d.ts",
+      "import": "./dist/lib/components/WatchLoader/index.js"
+    },
     "./styles": {
       "types": "./dist/lib/styles.d.ts",
       "default": "./dist/lib/styles.css"

--- a/packages/rialto/registry.json
+++ b/packages/rialto/registry.json
@@ -53361,6 +53361,1473 @@
       "importPath": "@mattbutlerengineering/rialto",
       "props": [],
       "slots": []
+    },
+    {
+      "name": "WatchLoader",
+      "description": "Loader styled after the exhibition caseback of a mechanical automatic watch:\na sweeping rotor, a meshing gear train, an oscillating balance wheel, a ticking\nescape wheel, and ruby jewels at the pivots. The metaphor is *precision in\nmotion* — an indeterminate \"working\" indicator with no progress semantics.",
+      "importPath": "@mattbutlerengineering/rialto",
+      "props": [
+        {
+          "name": "aria-label",
+          "type": "string",
+          "required": true,
+          "description": "Accessible name — required because the component renders as role=\"img\"."
+        },
+        {
+          "name": "size",
+          "type": "number | \"sm\" | \"md\" | \"lg\" | undefined",
+          "required": false,
+          "description": "Preset (48 / 80 / 120px) or a raw pixel number."
+        },
+        {
+          "name": "speed",
+          "type": "\"slow\" | \"fast\" | \"normal\" | undefined",
+          "required": false,
+          "description": "Scales every animation duration proportionally."
+        },
+        {
+          "name": "variant",
+          "type": "\"default\" | \"gold\" | \"steel\" | \"rose\" | undefined",
+          "required": false,
+          "description": "Metallic finish — flips CSS custom properties only."
+        },
+        {
+          "name": "id",
+          "type": "string | undefined",
+          "required": false
+        },
+        {
+          "name": "className",
+          "type": "string | undefined",
+          "required": false
+        },
+        {
+          "name": "style",
+          "type": "CSSProperties | undefined",
+          "required": false
+        },
+        {
+          "name": "defaultChecked",
+          "type": "boolean | undefined",
+          "required": false
+        },
+        {
+          "name": "defaultValue",
+          "type": "string | number | readonly string[] | undefined",
+          "required": false
+        },
+        {
+          "name": "suppressContentEditableWarning",
+          "type": "boolean | undefined",
+          "required": false
+        },
+        {
+          "name": "suppressHydrationWarning",
+          "type": "boolean | undefined",
+          "required": false
+        },
+        {
+          "name": "accessKey",
+          "type": "string | undefined",
+          "required": false
+        },
+        {
+          "name": "autoCapitalize",
+          "type": "\"off\" | \"none\" | \"on\" | \"sentences\" | \"words\" | \"characters\" | (string & {}) | undefined",
+          "required": false
+        },
+        {
+          "name": "autoFocus",
+          "type": "boolean | undefined",
+          "required": false
+        },
+        {
+          "name": "contentEditable",
+          "type": "Booleanish | \"inherit\" | \"plaintext-only\" | undefined",
+          "required": false
+        },
+        {
+          "name": "contextMenu",
+          "type": "string | undefined",
+          "required": false
+        },
+        {
+          "name": "dir",
+          "type": "string | undefined",
+          "required": false
+        },
+        {
+          "name": "draggable",
+          "type": "Booleanish | undefined",
+          "required": false
+        },
+        {
+          "name": "enterKeyHint",
+          "type": "\"enter\" | \"done\" | \"go\" | \"next\" | \"previous\" | \"search\" | \"send\" | undefined",
+          "required": false
+        },
+        {
+          "name": "hidden",
+          "type": "boolean | undefined",
+          "required": false
+        },
+        {
+          "name": "lang",
+          "type": "string | undefined",
+          "required": false
+        },
+        {
+          "name": "nonce",
+          "type": "string | undefined",
+          "required": false
+        },
+        {
+          "name": "slot",
+          "type": "string | undefined",
+          "required": false
+        },
+        {
+          "name": "spellCheck",
+          "type": "Booleanish | undefined",
+          "required": false
+        },
+        {
+          "name": "tabIndex",
+          "type": "number | undefined",
+          "required": false
+        },
+        {
+          "name": "title",
+          "type": "string | undefined",
+          "required": false
+        },
+        {
+          "name": "translate",
+          "type": "\"yes\" | \"no\" | undefined",
+          "required": false
+        },
+        {
+          "name": "radioGroup",
+          "type": "string | undefined",
+          "required": false
+        },
+        {
+          "name": "role",
+          "type": "AriaRole | undefined",
+          "required": false
+        },
+        {
+          "name": "about",
+          "type": "string | undefined",
+          "required": false
+        },
+        {
+          "name": "content",
+          "type": "string | undefined",
+          "required": false
+        },
+        {
+          "name": "datatype",
+          "type": "string | undefined",
+          "required": false
+        },
+        {
+          "name": "inlist",
+          "type": "any",
+          "required": false
+        },
+        {
+          "name": "prefix",
+          "type": "string | undefined",
+          "required": false
+        },
+        {
+          "name": "property",
+          "type": "string | undefined",
+          "required": false
+        },
+        {
+          "name": "rel",
+          "type": "string | undefined",
+          "required": false
+        },
+        {
+          "name": "resource",
+          "type": "string | undefined",
+          "required": false
+        },
+        {
+          "name": "rev",
+          "type": "string | undefined",
+          "required": false
+        },
+        {
+          "name": "typeof",
+          "type": "string | undefined",
+          "required": false
+        },
+        {
+          "name": "vocab",
+          "type": "string | undefined",
+          "required": false
+        },
+        {
+          "name": "autoCorrect",
+          "type": "string | undefined",
+          "required": false
+        },
+        {
+          "name": "autoSave",
+          "type": "string | undefined",
+          "required": false
+        },
+        {
+          "name": "color",
+          "type": "string | undefined",
+          "required": false
+        },
+        {
+          "name": "itemProp",
+          "type": "string | undefined",
+          "required": false
+        },
+        {
+          "name": "itemScope",
+          "type": "boolean | undefined",
+          "required": false
+        },
+        {
+          "name": "itemType",
+          "type": "string | undefined",
+          "required": false
+        },
+        {
+          "name": "itemID",
+          "type": "string | undefined",
+          "required": false
+        },
+        {
+          "name": "itemRef",
+          "type": "string | undefined",
+          "required": false
+        },
+        {
+          "name": "results",
+          "type": "number | undefined",
+          "required": false
+        },
+        {
+          "name": "security",
+          "type": "string | undefined",
+          "required": false
+        },
+        {
+          "name": "unselectable",
+          "type": "\"off\" | \"on\" | undefined",
+          "required": false
+        },
+        {
+          "name": "popover",
+          "type": "\"\" | \"auto\" | \"manual\" | \"hint\" | undefined",
+          "required": false
+        },
+        {
+          "name": "popoverTargetAction",
+          "type": "\"toggle\" | \"show\" | \"hide\" | undefined",
+          "required": false
+        },
+        {
+          "name": "popoverTarget",
+          "type": "string | undefined",
+          "required": false
+        },
+        {
+          "name": "inert",
+          "type": "boolean | undefined",
+          "required": false
+        },
+        {
+          "name": "inputMode",
+          "type": "\"none\" | \"search\" | \"text\" | \"tel\" | \"url\" | \"email\" | \"numeric\" | \"decimal\" | undefined",
+          "required": false,
+          "description": "Hints at the type of data that might be entered by the user while editing the element or its contents"
+        },
+        {
+          "name": "is",
+          "type": "string | undefined",
+          "required": false,
+          "description": "Specify that a standard HTML element should behave like a defined custom built-in element"
+        },
+        {
+          "name": "exportparts",
+          "type": "string | undefined",
+          "required": false
+        },
+        {
+          "name": "part",
+          "type": "string | undefined",
+          "required": false
+        },
+        {
+          "name": "aria-activedescendant",
+          "type": "string | undefined",
+          "required": false,
+          "description": "Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application."
+        },
+        {
+          "name": "aria-atomic",
+          "type": "Booleanish | undefined",
+          "required": false,
+          "description": "Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute."
+        },
+        {
+          "name": "aria-autocomplete",
+          "type": "\"none\" | \"list\" | \"inline\" | \"both\" | undefined",
+          "required": false,
+          "description": "Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be\npresented if they are made."
+        },
+        {
+          "name": "aria-braillelabel",
+          "type": "string | undefined",
+          "required": false,
+          "description": "Defines a string value that labels the current element, which is intended to be converted into Braille."
+        },
+        {
+          "name": "aria-brailleroledescription",
+          "type": "string | undefined",
+          "required": false,
+          "description": "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille."
+        },
+        {
+          "name": "aria-busy",
+          "type": "Booleanish | undefined",
+          "required": false
+        },
+        {
+          "name": "aria-checked",
+          "type": "boolean | \"true\" | \"false\" | \"mixed\" | undefined",
+          "required": false,
+          "description": "Indicates the current \"checked\" state of checkboxes, radio buttons, and other widgets."
+        },
+        {
+          "name": "aria-colcount",
+          "type": "number | undefined",
+          "required": false,
+          "description": "Defines the total number of columns in a table, grid, or treegrid."
+        },
+        {
+          "name": "aria-colindex",
+          "type": "number | undefined",
+          "required": false,
+          "description": "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid."
+        },
+        {
+          "name": "aria-colindextext",
+          "type": "string | undefined",
+          "required": false,
+          "description": "Defines a human readable text alternative of aria-colindex."
+        },
+        {
+          "name": "aria-colspan",
+          "type": "number | undefined",
+          "required": false,
+          "description": "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid."
+        },
+        {
+          "name": "aria-controls",
+          "type": "string | undefined",
+          "required": false,
+          "description": "Identifies the element (or elements) whose contents or presence are controlled by the current element."
+        },
+        {
+          "name": "aria-current",
+          "type": "boolean | \"true\" | \"false\" | \"page\" | \"step\" | \"location\" | \"date\" | \"time\" | undefined",
+          "required": false,
+          "description": "Indicates the element that represents the current item within a container or set of related elements."
+        },
+        {
+          "name": "aria-describedby",
+          "type": "string | undefined",
+          "required": false,
+          "description": "Identifies the element (or elements) that describes the object."
+        },
+        {
+          "name": "aria-description",
+          "type": "string | undefined",
+          "required": false,
+          "description": "Defines a string value that describes or annotates the current element."
+        },
+        {
+          "name": "aria-details",
+          "type": "string | undefined",
+          "required": false,
+          "description": "Identifies the element that provides a detailed, extended description for the object."
+        },
+        {
+          "name": "aria-disabled",
+          "type": "Booleanish | undefined",
+          "required": false,
+          "description": "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable."
+        },
+        {
+          "name": "aria-dropeffect",
+          "type": "\"none\" | \"link\" | \"copy\" | \"execute\" | \"move\" | \"popup\" | undefined",
+          "required": false,
+          "description": "Indicates what functions can be performed when a dragged object is released on the drop target."
+        },
+        {
+          "name": "aria-errormessage",
+          "type": "string | undefined",
+          "required": false,
+          "description": "Identifies the element that provides an error message for the object."
+        },
+        {
+          "name": "aria-expanded",
+          "type": "Booleanish | undefined",
+          "required": false,
+          "description": "Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed."
+        },
+        {
+          "name": "aria-flowto",
+          "type": "string | undefined",
+          "required": false,
+          "description": "Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,\nallows assistive technology to override the general default of reading in document source order."
+        },
+        {
+          "name": "aria-grabbed",
+          "type": "Booleanish | undefined",
+          "required": false,
+          "description": "Indicates an element's \"grabbed\" state in a drag-and-drop operation."
+        },
+        {
+          "name": "aria-haspopup",
+          "type": "boolean | \"true\" | \"false\" | \"dialog\" | \"grid\" | \"listbox\" | \"menu\" | \"tree\" | undefined",
+          "required": false,
+          "description": "Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element."
+        },
+        {
+          "name": "aria-hidden",
+          "type": "Booleanish | undefined",
+          "required": false,
+          "description": "Indicates whether the element is exposed to an accessibility API."
+        },
+        {
+          "name": "aria-invalid",
+          "type": "boolean | \"true\" | \"false\" | \"grammar\" | \"spelling\" | undefined",
+          "required": false,
+          "description": "Indicates the entered value does not conform to the format expected by the application."
+        },
+        {
+          "name": "aria-keyshortcuts",
+          "type": "string | undefined",
+          "required": false,
+          "description": "Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element."
+        },
+        {
+          "name": "aria-labelledby",
+          "type": "string | undefined",
+          "required": false,
+          "description": "Identifies the element (or elements) that labels the current element."
+        },
+        {
+          "name": "aria-level",
+          "type": "number | undefined",
+          "required": false,
+          "description": "Defines the hierarchical level of an element within a structure."
+        },
+        {
+          "name": "aria-live",
+          "type": "\"off\" | \"assertive\" | \"polite\" | undefined",
+          "required": false,
+          "description": "Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region."
+        },
+        {
+          "name": "aria-modal",
+          "type": "Booleanish | undefined",
+          "required": false,
+          "description": "Indicates whether an element is modal when displayed."
+        },
+        {
+          "name": "aria-multiline",
+          "type": "Booleanish | undefined",
+          "required": false,
+          "description": "Indicates whether a text box accepts multiple lines of input or only a single line."
+        },
+        {
+          "name": "aria-multiselectable",
+          "type": "Booleanish | undefined",
+          "required": false,
+          "description": "Indicates that the user may select more than one item from the current selectable descendants."
+        },
+        {
+          "name": "aria-orientation",
+          "type": "\"horizontal\" | \"vertical\" | undefined",
+          "required": false,
+          "description": "Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous."
+        },
+        {
+          "name": "aria-owns",
+          "type": "string | undefined",
+          "required": false,
+          "description": "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship."
+        },
+        {
+          "name": "aria-placeholder",
+          "type": "string | undefined",
+          "required": false,
+          "description": "Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.\nA hint could be a sample value or a brief description of the expected format."
+        },
+        {
+          "name": "aria-posinset",
+          "type": "number | undefined",
+          "required": false,
+          "description": "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM."
+        },
+        {
+          "name": "aria-pressed",
+          "type": "boolean | \"true\" | \"false\" | \"mixed\" | undefined",
+          "required": false,
+          "description": "Indicates the current \"pressed\" state of toggle buttons."
+        },
+        {
+          "name": "aria-readonly",
+          "type": "Booleanish | undefined",
+          "required": false,
+          "description": "Indicates that the element is not editable, but is otherwise operable."
+        },
+        {
+          "name": "aria-relevant",
+          "type": "\"text\" | \"additions\" | \"additions removals\" | \"additions text\" | \"all\" | \"removals\" | \"removals additions\" | \"removals text\" | \"text additions\" | \"text removals\" | undefined",
+          "required": false,
+          "description": "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified."
+        },
+        {
+          "name": "aria-required",
+          "type": "Booleanish | undefined",
+          "required": false,
+          "description": "Indicates that user input is required on the element before a form may be submitted."
+        },
+        {
+          "name": "aria-roledescription",
+          "type": "string | undefined",
+          "required": false,
+          "description": "Defines a human-readable, author-localized description for the role of an element."
+        },
+        {
+          "name": "aria-rowcount",
+          "type": "number | undefined",
+          "required": false,
+          "description": "Defines the total number of rows in a table, grid, or treegrid."
+        },
+        {
+          "name": "aria-rowindex",
+          "type": "number | undefined",
+          "required": false,
+          "description": "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid."
+        },
+        {
+          "name": "aria-rowindextext",
+          "type": "string | undefined",
+          "required": false,
+          "description": "Defines a human readable text alternative of aria-rowindex."
+        },
+        {
+          "name": "aria-rowspan",
+          "type": "number | undefined",
+          "required": false,
+          "description": "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid."
+        },
+        {
+          "name": "aria-selected",
+          "type": "Booleanish | undefined",
+          "required": false,
+          "description": "Indicates the current \"selected\" state of various widgets."
+        },
+        {
+          "name": "aria-setsize",
+          "type": "number | undefined",
+          "required": false,
+          "description": "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM."
+        },
+        {
+          "name": "aria-sort",
+          "type": "\"none\" | \"ascending\" | \"descending\" | \"other\" | undefined",
+          "required": false,
+          "description": "Indicates if items in a table or grid are sorted in ascending or descending order."
+        },
+        {
+          "name": "aria-valuemax",
+          "type": "number | undefined",
+          "required": false,
+          "description": "Defines the maximum allowed value for a range widget."
+        },
+        {
+          "name": "aria-valuemin",
+          "type": "number | undefined",
+          "required": false,
+          "description": "Defines the minimum allowed value for a range widget."
+        },
+        {
+          "name": "aria-valuenow",
+          "type": "number | undefined",
+          "required": false,
+          "description": "Defines the current value for a range widget."
+        },
+        {
+          "name": "aria-valuetext",
+          "type": "string | undefined",
+          "required": false,
+          "description": "Defines the human readable text alternative of aria-valuenow for a range widget."
+        },
+        {
+          "name": "dangerouslySetInnerHTML",
+          "type": "{ __html: string | TrustedHTML; } | undefined",
+          "required": false
+        },
+        {
+          "name": "onCopy",
+          "type": "ClipboardEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onCopyCapture",
+          "type": "ClipboardEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onCut",
+          "type": "ClipboardEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onCutCapture",
+          "type": "ClipboardEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onPaste",
+          "type": "ClipboardEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onPasteCapture",
+          "type": "ClipboardEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onCompositionEnd",
+          "type": "CompositionEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onCompositionEndCapture",
+          "type": "CompositionEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onCompositionStart",
+          "type": "CompositionEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onCompositionStartCapture",
+          "type": "CompositionEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onCompositionUpdate",
+          "type": "CompositionEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onCompositionUpdateCapture",
+          "type": "CompositionEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onFocus",
+          "type": "FocusEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onFocusCapture",
+          "type": "FocusEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onBlur",
+          "type": "FocusEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onBlurCapture",
+          "type": "FocusEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onChange",
+          "type": "ChangeEventHandler<HTMLDivElement, Element> | undefined",
+          "required": false
+        },
+        {
+          "name": "onChangeCapture",
+          "type": "ChangeEventHandler<HTMLDivElement, Element> | undefined",
+          "required": false
+        },
+        {
+          "name": "onBeforeInput",
+          "type": "InputEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onBeforeInputCapture",
+          "type": "InputEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onInput",
+          "type": "InputEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onInputCapture",
+          "type": "InputEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onReset",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onResetCapture",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onSubmit",
+          "type": "SubmitEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onSubmitCapture",
+          "type": "SubmitEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onInvalid",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onInvalidCapture",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onLoad",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onLoadCapture",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onError",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onErrorCapture",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onKeyDown",
+          "type": "KeyboardEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onKeyDownCapture",
+          "type": "KeyboardEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onKeyPress",
+          "type": "KeyboardEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onKeyPressCapture",
+          "type": "KeyboardEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onKeyUp",
+          "type": "KeyboardEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onKeyUpCapture",
+          "type": "KeyboardEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onAbort",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onAbortCapture",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onCanPlay",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onCanPlayCapture",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onCanPlayThrough",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onCanPlayThroughCapture",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onDurationChange",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onDurationChangeCapture",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onEmptied",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onEmptiedCapture",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onEncrypted",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onEncryptedCapture",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onEnded",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onEndedCapture",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onLoadedData",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onLoadedDataCapture",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onLoadedMetadata",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onLoadedMetadataCapture",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onLoadStart",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onLoadStartCapture",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onPause",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onPauseCapture",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onPlay",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onPlayCapture",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onPlaying",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onPlayingCapture",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onProgress",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onProgressCapture",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onRateChange",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onRateChangeCapture",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onSeeked",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onSeekedCapture",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onSeeking",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onSeekingCapture",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onStalled",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onStalledCapture",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onSuspend",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onSuspendCapture",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onTimeUpdate",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onTimeUpdateCapture",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onVolumeChange",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onVolumeChangeCapture",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onWaiting",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onWaitingCapture",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onAuxClick",
+          "type": "MouseEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onAuxClickCapture",
+          "type": "MouseEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onClick",
+          "type": "MouseEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onClickCapture",
+          "type": "MouseEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onContextMenu",
+          "type": "MouseEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onContextMenuCapture",
+          "type": "MouseEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onDoubleClick",
+          "type": "MouseEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onDoubleClickCapture",
+          "type": "MouseEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onDrag",
+          "type": "DragEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onDragCapture",
+          "type": "DragEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onDragEnd",
+          "type": "DragEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onDragEndCapture",
+          "type": "DragEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onDragEnter",
+          "type": "DragEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onDragEnterCapture",
+          "type": "DragEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onDragExit",
+          "type": "DragEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onDragExitCapture",
+          "type": "DragEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onDragLeave",
+          "type": "DragEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onDragLeaveCapture",
+          "type": "DragEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onDragOver",
+          "type": "DragEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onDragOverCapture",
+          "type": "DragEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onDragStart",
+          "type": "DragEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onDragStartCapture",
+          "type": "DragEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onDrop",
+          "type": "DragEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onDropCapture",
+          "type": "DragEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onMouseDown",
+          "type": "MouseEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onMouseDownCapture",
+          "type": "MouseEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onMouseEnter",
+          "type": "MouseEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onMouseLeave",
+          "type": "MouseEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onMouseMove",
+          "type": "MouseEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onMouseMoveCapture",
+          "type": "MouseEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onMouseOut",
+          "type": "MouseEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onMouseOutCapture",
+          "type": "MouseEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onMouseOver",
+          "type": "MouseEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onMouseOverCapture",
+          "type": "MouseEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onMouseUp",
+          "type": "MouseEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onMouseUpCapture",
+          "type": "MouseEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onSelect",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onSelectCapture",
+          "type": "ReactEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onTouchCancel",
+          "type": "TouchEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onTouchCancelCapture",
+          "type": "TouchEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onTouchEnd",
+          "type": "TouchEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onTouchEndCapture",
+          "type": "TouchEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onTouchMove",
+          "type": "TouchEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onTouchMoveCapture",
+          "type": "TouchEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onTouchStart",
+          "type": "TouchEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onTouchStartCapture",
+          "type": "TouchEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onPointerDown",
+          "type": "PointerEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onPointerDownCapture",
+          "type": "PointerEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onPointerMove",
+          "type": "PointerEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onPointerMoveCapture",
+          "type": "PointerEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onPointerUp",
+          "type": "PointerEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onPointerUpCapture",
+          "type": "PointerEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onPointerCancel",
+          "type": "PointerEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onPointerCancelCapture",
+          "type": "PointerEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onPointerEnter",
+          "type": "PointerEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onPointerLeave",
+          "type": "PointerEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onPointerOver",
+          "type": "PointerEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onPointerOverCapture",
+          "type": "PointerEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onPointerOut",
+          "type": "PointerEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onPointerOutCapture",
+          "type": "PointerEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onGotPointerCapture",
+          "type": "PointerEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onGotPointerCaptureCapture",
+          "type": "PointerEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onLostPointerCapture",
+          "type": "PointerEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onLostPointerCaptureCapture",
+          "type": "PointerEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onScroll",
+          "type": "UIEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onScrollCapture",
+          "type": "UIEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onScrollEnd",
+          "type": "UIEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onScrollEndCapture",
+          "type": "UIEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onWheel",
+          "type": "WheelEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onWheelCapture",
+          "type": "WheelEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onAnimationStart",
+          "type": "AnimationEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onAnimationStartCapture",
+          "type": "AnimationEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onAnimationEnd",
+          "type": "AnimationEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onAnimationEndCapture",
+          "type": "AnimationEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onAnimationIteration",
+          "type": "AnimationEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onAnimationIterationCapture",
+          "type": "AnimationEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onToggle",
+          "type": "ToggleEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onBeforeToggle",
+          "type": "ToggleEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onTransitionCancel",
+          "type": "TransitionEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onTransitionCancelCapture",
+          "type": "TransitionEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onTransitionEnd",
+          "type": "TransitionEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onTransitionEndCapture",
+          "type": "TransitionEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onTransitionRun",
+          "type": "TransitionEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onTransitionRunCapture",
+          "type": "TransitionEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onTransitionStart",
+          "type": "TransitionEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        },
+        {
+          "name": "onTransitionStartCapture",
+          "type": "TransitionEventHandler<HTMLDivElement> | undefined",
+          "required": false
+        }
+      ],
+      "slots": [
+        "children"
+      ]
     }
   ]
 }

--- a/packages/rialto/src/components/WatchLoader/WatchLoader.module.css
+++ b/packages/rialto/src/components/WatchLoader/WatchLoader.module.css
@@ -1,0 +1,201 @@
+/* ── WatchLoader ──────────────────────────────────
+   An animated automatic-watch caseback. All motion is
+   transform-only (compositor thread) — no layout props.
+
+   Colours are driven by component-local `--watch-*` custom
+   properties. The metallic finishes (gold/steel/rose) are
+   decorative material treatments outside the standard rialto
+   token palette, so the variant classes set hex values here
+   (the same skeuomorphic pattern used by SplitFlap/Progress).
+   The component (.tsx) never hardcodes a colour — it only
+   references `var(--watch-*)`.
+   ─────────────────────────────────────────────── */
+
+.watchLoader {
+  display: inline-block;
+  vertical-align: middle;
+  line-height: 0;
+
+  /* Default finish — warm aluminium, ruby jewels */
+  --watch-cycle: 2s;
+  --watch-rotor: #b8b0a4;
+  --watch-rotor-edge: #8c857a;
+  --watch-gear: #a89e8c;
+  --watch-gear-hub: #6f6757;
+  --watch-bridge: #5a5347;
+  --watch-plate-hi: #2b2823;
+  --watch-plate-lo: #16140f;
+  --watch-balance: #cdbf9c;
+  --watch-jewel: #d23b54;
+}
+
+/* ── Size presets ─────────────────────────────── */
+.sizeSm {
+  width: 48px;
+  height: 48px;
+}
+.sizeMd {
+  width: 80px;
+  height: 80px;
+}
+.sizeLg {
+  width: 120px;
+  height: 120px;
+}
+
+/* ── Variants — flip custom properties only ───── */
+.variantDefault {
+  /* uses the base palette declared on .watchLoader */
+}
+
+.variantGold {
+  --watch-rotor: #d9bd6b;
+  --watch-rotor-edge: #9c7c2a;
+  --watch-gear: #c9a84c;
+  --watch-gear-hub: #8b6914;
+  --watch-bridge: #6e5722;
+  --watch-plate-hi: #2c2410;
+  --watch-plate-lo: #161005;
+  --watch-balance: #e6cd7e;
+  --watch-jewel: #dc143c;
+}
+
+.variantSteel {
+  --watch-rotor: #cdd4dc;
+  --watch-rotor-edge: #8a939d;
+  --watch-gear: #c0c8d0;
+  --watch-gear-hub: #6b7681;
+  --watch-bridge: #4d5560;
+  --watch-plate-hi: #23272d;
+  --watch-plate-lo: #121519;
+  --watch-balance: #d8dee5;
+  --watch-jewel: #dc143c;
+}
+
+.variantRose {
+  --watch-rotor: #e3b6a0;
+  --watch-rotor-edge: #b07a5e;
+  --watch-gear: #d99f86;
+  --watch-gear-hub: #9c5f47;
+  --watch-bridge: #6f463a;
+  --watch-plate-hi: #2c211d;
+  --watch-plate-lo: #171010;
+  --watch-balance: #ecc4b1;
+  --watch-jewel: #e0405c;
+}
+
+/* ── SVG canvas ───────────────────────────────── */
+.svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+}
+
+/* ── Bridges ──────────────────────────────────── */
+.bridge {
+  fill: var(--watch-bridge);
+  opacity: 0.55;
+}
+
+/* ── Gears ────────────────────────────────────── */
+.gearBody {
+  fill: var(--watch-gear);
+  stroke: var(--watch-gear-hub);
+  stroke-width: 0.6;
+}
+.gearTooth {
+  fill: var(--watch-gear);
+}
+.gearHub {
+  fill: var(--watch-gear-hub);
+}
+
+/* Rotate around the element's own centre regardless of the
+   positioning translate on the parent group. */
+.gearLarge,
+.gearMedium,
+.gearSmall,
+.rotor,
+.balance,
+.escape {
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+/* Tooth-count ratios (12 : 8 : 6) → angular-velocity ratios.
+   Fewer teeth → shorter duration → faster spin. Meshing gears
+   counter-rotate, so neighbours alternate `reverse`. */
+.gearLarge {
+  animation: watch-spin var(--watch-cycle) linear infinite;
+}
+.gearMedium {
+  animation: watch-spin calc(var(--watch-cycle) * 0.667) linear infinite reverse;
+}
+.gearSmall {
+  animation: watch-spin calc(var(--watch-cycle) * 0.5) linear infinite;
+}
+
+/* ── Escape wheel ─────────────────────────────── */
+.escapeBody {
+  fill: var(--watch-gear);
+  stroke: var(--watch-gear-hub);
+  stroke-width: 0.5;
+}
+
+/* ── Balance wheel ────────────────────────────── */
+.balanceRim {
+  fill: none;
+  stroke: var(--watch-balance);
+  stroke-width: 1.6;
+}
+.spoke {
+  stroke: var(--watch-balance);
+  stroke-width: 1.2;
+}
+
+/* ── Jewels ───────────────────────────────────── */
+.jewel {
+  fill: var(--watch-jewel);
+}
+
+/* ── Rotor ────────────────────────────────────── */
+.rotor {
+  animation: watch-spin calc(var(--watch-cycle) * 1.4) linear infinite;
+}
+.rotorBody {
+  fill: var(--watch-rotor);
+  stroke: var(--watch-rotor-edge);
+  stroke-width: 1;
+  opacity: 0.92;
+}
+.rotorWeight {
+  fill: var(--watch-rotor-edge);
+}
+
+/* ── Keyframes — transform only ───────────────── */
+@keyframes watch-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* ── Reduced motion — pause everything, static snapshot ── */
+.reduced .rotor,
+.reduced .gearLarge,
+.reduced .gearMedium,
+.reduced .gearSmall {
+  animation: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rotor,
+  .gearLarge,
+  .gearMedium,
+  .gearSmall {
+    animation: none;
+  }
+}

--- a/packages/rialto/src/components/WatchLoader/WatchLoader.test.tsx
+++ b/packages/rialto/src/components/WatchLoader/WatchLoader.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from "@testing-library/react";
+import { useReducedMotion } from "framer-motion";
+import { WatchLoader } from "./WatchLoader";
+
+// Control reduced-motion per test. The global setup mock forces it to `true`;
+// here we make it a spy so we can exercise both the animated and static paths.
+vi.mock("framer-motion", async () => {
+  const actual =
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports -- typeof import() required for vi.importActual generic
+    await vi.importActual<typeof import("framer-motion")>("framer-motion");
+  return { ...actual, useReducedMotion: vi.fn(() => false) };
+});
+
+const mockReducedMotion = vi.mocked(useReducedMotion);
+
+describe("WatchLoader", () => {
+  beforeEach(() => {
+    mockReducedMotion.mockReturnValue(false);
+  });
+
+  describe("rendering", () => {
+    it("renders without error as role=img", () => {
+      render(<WatchLoader aria-label="Loading" />);
+      expect(screen.getByRole("img")).toBeInTheDocument();
+    });
+
+    it("exposes the required aria-label as the accessible name", () => {
+      render(<WatchLoader aria-label="Processing your request" />);
+      expect(screen.getByRole("img")).toHaveAccessibleName("Processing your request");
+    });
+
+    it("does not leak motion semantics into the accessible name", () => {
+      render(<WatchLoader aria-label="Saving" />);
+      expect(screen.getByRole("img")).toHaveAccessibleName("Saving");
+    });
+
+    it("renders crisp vector output as an SVG", () => {
+      const { container } = render(<WatchLoader aria-label="Loading" />);
+      expect(container.querySelector("svg")).toBeInTheDocument();
+    });
+  });
+
+  describe("reduced motion", () => {
+    it("pauses all animation and renders a static snapshot when preferred", () => {
+      mockReducedMotion.mockReturnValue(true);
+      render(<WatchLoader aria-label="Loading" />);
+      expect(screen.getByRole("img")).toHaveAttribute("data-reduced-motion", "true");
+    });
+
+    it("animates when reduced motion is not preferred", () => {
+      mockReducedMotion.mockReturnValue(false);
+      render(<WatchLoader aria-label="Loading" />);
+      expect(screen.getByRole("img")).toHaveAttribute("data-reduced-motion", "false");
+    });
+  });
+
+  describe("size prop", () => {
+    it("applies the preset size class", () => {
+      render(<WatchLoader aria-label="Loading" size="lg" />);
+      expect(screen.getByRole("img").className).toContain("sizeLg");
+    });
+
+    it("defaults to the medium size class", () => {
+      render(<WatchLoader aria-label="Loading" />);
+      expect(screen.getByRole("img").className).toContain("sizeMd");
+    });
+
+    it("applies a raw pixel size inline without a preset size class", () => {
+      render(<WatchLoader aria-label="Loading" size={64} />);
+      const el = screen.getByRole("img");
+      expect(el).toHaveStyle({ width: "64px", height: "64px" });
+      expect(el.className).not.toContain("sizeMd");
+    });
+  });
+
+  describe("variant prop", () => {
+    it.each([
+      ["default", "variantDefault"],
+      ["gold", "variantGold"],
+      ["steel", "variantSteel"],
+      ["rose", "variantRose"],
+    ] as const)("applies the %s variant class", (variant, cls) => {
+      render(<WatchLoader aria-label="Loading" variant={variant} />);
+      expect(screen.getByRole("img").className).toContain(cls);
+    });
+  });
+
+  describe("speed prop", () => {
+    it("scales the animation cycle via a CSS custom property", () => {
+      render(<WatchLoader aria-label="Loading" speed="fast" />);
+      expect(screen.getByRole("img").getAttribute("style")).toContain("--watch-cycle");
+    });
+  });
+});

--- a/packages/rialto/src/components/WatchLoader/WatchLoader.tsx
+++ b/packages/rialto/src/components/WatchLoader/WatchLoader.tsx
@@ -1,0 +1,264 @@
+import {
+  forwardRef,
+  useEffect,
+  useMemo,
+  useRef,
+  type CSSProperties,
+  type HTMLAttributes,
+} from "react";
+import { motion, useMotionValue, useReducedMotion, useSpring } from "framer-motion";
+import styles from "./WatchLoader.module.css";
+
+/**
+ * Loader styled after the exhibition caseback of a mechanical automatic watch:
+ * a sweeping rotor, a meshing gear train, an oscillating balance wheel, a ticking
+ * escape wheel, and ruby jewels at the pivots. The metaphor is *precision in
+ * motion* — an indeterminate "working" indicator with no progress semantics.
+ *
+ * @example
+ * <WatchLoader aria-label="Loading results" />
+ * <WatchLoader aria-label="Saving" size="lg" variant="gold" speed="fast" />
+ */
+export interface WatchLoaderProps extends Omit<HTMLAttributes<HTMLDivElement>, "aria-label"> {
+  /** Accessible name — required because the component renders as role="img". */
+  "aria-label": string;
+  /** Preset (48 / 80 / 120px) or a raw pixel number. @default "md" */
+  size?: "sm" | "md" | "lg" | number;
+  /** Scales every animation duration proportionally. @default "normal" */
+  speed?: "slow" | "normal" | "fast";
+  /** Metallic finish — flips CSS custom properties only. @default "default" */
+  variant?: "default" | "gold" | "steel" | "rose";
+}
+
+/* ── Movement geometry (viewBox is 100×100, center at 50,50) ── */
+const BALANCE_AMPLITUDE = 26; // degrees the balance wheel swings each way
+const ESCAPE_TEETH = 15;
+const ESCAPE_TOOTH_ANGLE = 360 / ESCAPE_TEETH; // one tick per balance beat
+
+const CYCLE_BY_SPEED = { slow: "4s", normal: "2s", fast: "1s" } as const;
+const BEAT_MS_BY_SPEED = { slow: 700, normal: 420, fast: 240 } as const;
+
+const SIZE_CLASS = { sm: styles.sizeSm, md: styles.sizeMd, lg: styles.sizeLg } as const;
+const VARIANT_CLASS = {
+  default: styles.variantDefault,
+  gold: styles.variantGold,
+  steel: styles.variantSteel,
+  rose: styles.variantRose,
+} as const;
+
+export const WatchLoader = forwardRef<HTMLDivElement, WatchLoaderProps>(
+  (
+    {
+      "aria-label": ariaLabel,
+      size = "md",
+      speed = "normal",
+      variant = "default",
+      className,
+      style,
+      ...rest
+    },
+    ref
+  ) => {
+    const shouldReduceMotion = useReducedMotion() ?? false;
+
+    // Balance wheel: spring-physics oscillation. Escape wheel: discrete ticks.
+    // Both are framer-motion MotionValues, so the driving interval mutates them
+    // via `.set()` — never React state — keeping us clear of the rialto
+    // setState-in-effect ban and avoiding re-render churn.
+    const balanceRotation = useSpring(0, { stiffness: 80, damping: 8 });
+    const escapeRotation = useMotionValue(0);
+    const escapeAccumRef = useRef(0);
+
+    const beatMs = BEAT_MS_BY_SPEED[speed];
+
+    useEffect(() => {
+      if (shouldReduceMotion) return;
+      let direction = 1;
+      const id = setInterval(() => {
+        direction = -direction;
+        balanceRotation.set(direction * BALANCE_AMPLITUDE);
+        escapeAccumRef.current += ESCAPE_TOOTH_ANGLE;
+        escapeRotation.set(escapeAccumRef.current);
+      }, beatMs);
+      return () => clearInterval(id);
+    }, [shouldReduceMotion, beatMs, balanceRotation, escapeRotation]);
+
+    const isPreset = typeof size === "string";
+    const sizeClass = isPreset ? SIZE_CLASS[size] : "";
+
+    const rootClass = [
+      styles.watchLoader,
+      sizeClass,
+      VARIANT_CLASS[variant],
+      shouldReduceMotion ? styles.reduced : "",
+      className,
+    ]
+      .filter(Boolean)
+      .join(" ");
+
+    const rootStyle = {
+      "--watch-cycle": CYCLE_BY_SPEED[speed],
+      ...(isPreset ? {} : { width: `${size}px`, height: `${size}px` }),
+      ...style,
+    } as CSSProperties;
+
+    return (
+      <div
+        ref={ref}
+        role="img"
+        aria-label={ariaLabel}
+        data-reduced-motion={shouldReduceMotion}
+        className={rootClass}
+        style={rootStyle}
+        {...rest}
+      >
+        <svg
+          className={styles.svg}
+          viewBox="0 0 100 100"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+        >
+          <defs>
+            <radialGradient id="watch-plate" cx="38%" cy="32%" r="80%">
+              <stop offset="0%" stopColor="var(--watch-plate-hi)" />
+              <stop offset="100%" stopColor="var(--watch-plate-lo)" />
+            </radialGradient>
+          </defs>
+
+          {/* 1 · Background plate */}
+          <circle
+            cx="50"
+            cy="50"
+            r="48"
+            fill="url(#watch-plate)"
+            stroke="var(--watch-bridge)"
+            strokeWidth="1"
+          />
+
+          {/* 2 · Bridges (structural plates) */}
+          <path className={styles.bridge} d="M 18 30 Q 50 14 82 34 L 78 44 Q 50 26 24 40 Z" />
+          <path className={styles.bridge} d="M 60 58 Q 80 60 84 80 L 74 82 Q 70 66 56 66 Z" />
+
+          {/* 3 · Gear train — tooth counts set the angular-velocity ratios */}
+          <Gear cx={32} cy={56} teeth={12} radius={15} className={styles.gearLarge} />
+          <Gear cx={56} cy={62} teeth={8} radius={10} className={styles.gearMedium} />
+          <Gear cx={72} cy={50} teeth={6} radius={7.5} className={styles.gearSmall} />
+
+          {/* 4 · Escape wheel — advances one tooth per balance beat */}
+          <g transform="translate(70,72)">
+            <motion.g className={styles.escape} style={{ rotate: escapeRotation }}>
+              <EscapeWheel teeth={ESCAPE_TEETH} radius={9} />
+            </motion.g>
+          </g>
+
+          {/* 5 · Balance wheel — spring-driven oscillation */}
+          <g transform="translate(50,50)">
+            <motion.g className={styles.balance} style={{ rotate: balanceRotation }}>
+              <circle r="16" className={styles.balanceRim} />
+              <circle r="11" className={styles.balanceRim} />
+              <line x1="-16" y1="0" x2="16" y2="0" className={styles.spoke} />
+              <line x1="0" y1="-16" x2="0" y2="16" className={styles.spoke} />
+            </motion.g>
+          </g>
+
+          {/* 6 · Jewels — ruby pivots */}
+          <Jewel cx={32} cy={56} />
+          <Jewel cx={56} cy={62} />
+          <Jewel cx={72} cy={50} />
+          <Jewel cx={70} cy={72} />
+          <Jewel cx={50} cy={50} />
+
+          {/* 7 · Rotor — sweeps over everything */}
+          <g transform="translate(50,50)">
+            <g className={styles.rotor}>
+              <path
+                className={styles.rotorBody}
+                d="M -44 0 A 44 44 0 0 1 44 0 L 30 0 A 30 30 0 0 0 -30 0 Z"
+              />
+              <rect className={styles.rotorWeight} x="-44" y="-6" width="14" height="12" rx="3" />
+            </g>
+          </g>
+
+          {/* 8 · Rotor pivot jewel */}
+          <Jewel cx={50} cy={50} r={2.4} />
+        </svg>
+      </div>
+    );
+  }
+);
+
+WatchLoader.displayName = "WatchLoader";
+
+/* ── Gear ──────────────────────────────────────── */
+
+interface GearProps {
+  cx: number;
+  cy: number;
+  teeth: number;
+  radius: number;
+  className: string | undefined;
+}
+
+/**
+ * A gear positioned at (cx, cy). The outer group sets the position via the SVG
+ * transform attribute; the inner, animated group spins around its own centre
+ * (`transform-box: fill-box`) so the CSS rotate animation never clobbers the
+ * positioning translate.
+ */
+function Gear({ cx, cy, teeth, radius, className }: GearProps) {
+  const toothPositions = useMemo(
+    () => Array.from({ length: teeth }, (_, i) => (i * 360) / teeth),
+    [teeth]
+  );
+  const toothLength = radius * 0.28;
+  const toothWidth = radius * 0.22;
+
+  return (
+    <g transform={`translate(${cx},${cy})`}>
+      <g className={className}>
+        {toothPositions.map((angle) => (
+          <rect
+            key={angle}
+            className={styles.gearTooth}
+            x={-toothWidth / 2}
+            y={-radius - toothLength}
+            width={toothWidth}
+            height={toothLength + 2}
+            rx={toothWidth * 0.3}
+            transform={`rotate(${angle})`}
+          />
+        ))}
+        <circle r={radius} className={styles.gearBody} />
+        <circle r={radius * 0.32} className={styles.gearHub} />
+      </g>
+    </g>
+  );
+}
+
+/* ── Escape wheel ──────────────────────────────── */
+
+function EscapeWheel({ teeth, radius }: { teeth: number; radius: number }) {
+  const points = useMemo(() => {
+    const verts: string[] = [];
+    for (let i = 0; i < teeth; i += 1) {
+      const a0 = (i * 2 * Math.PI) / teeth;
+      const a1 = ((i + 0.5) * 2 * Math.PI) / teeth;
+      verts.push(`${Math.cos(a0) * radius},${Math.sin(a0) * radius}`);
+      verts.push(`${Math.cos(a1) * radius * 0.62},${Math.sin(a1) * radius * 0.62}`);
+    }
+    return verts.join(" ");
+  }, [teeth, radius]);
+
+  return (
+    <>
+      <polygon points={points} className={styles.escapeBody} />
+      <circle r={radius * 0.3} className={styles.gearHub} />
+    </>
+  );
+}
+
+/* ── Jewel ─────────────────────────────────────── */
+
+function Jewel({ cx, cy, r = 1.8 }: { cx: number; cy: number; r?: number }) {
+  return <circle cx={cx} cy={cy} r={r} className={styles.jewel} />;
+}

--- a/packages/rialto/src/components/WatchLoader/index.ts
+++ b/packages/rialto/src/components/WatchLoader/index.ts
@@ -1,0 +1,2 @@
+export { WatchLoader } from "./WatchLoader";
+export type { WatchLoaderProps } from "./WatchLoader";

--- a/packages/rialto/src/components/index.ts
+++ b/packages/rialto/src/components/index.ts
@@ -80,6 +80,7 @@ export * from "./SplitFlap";
 export * from "./Chalkboard";
 export * from "./SplitScreenExit";
 export * from "./Ferrofluid";
+export * from "./WatchLoader";
 
 // ── Hospitality specialty ──────────────────────
 export * from "./TapeChart";

--- a/packages/rialto/src/test/accessibility/a11y-matrix.test.tsx
+++ b/packages/rialto/src/test/accessibility/a11y-matrix.test.tsx
@@ -99,6 +99,7 @@ const BARREL_COMPONENT_NAMES: readonly BarrelExportName[] = [
   "Toggle",
   "Tooltip",
   "Tree",
+  "WatchLoader",
 ] as const;
 
 describe("A11y matrix — fixture coverage guard", () => {

--- a/packages/rialto/src/test/accessibility/component-fixtures.tsx
+++ b/packages/rialto/src/test/accessibility/component-fixtures.tsx
@@ -92,6 +92,7 @@ import { ToastProvider } from "../../components/Toast/Toast";
 import { Toggle } from "../../components/Toggle/Toggle";
 import { Tooltip } from "../../components/Tooltip/Tooltip";
 import { Tree } from "../../components/Tree/Tree";
+import { WatchLoader } from "../../components/WatchLoader/WatchLoader";
 
 // ── Types ────────────────────────────────────────────────────────────────
 
@@ -177,7 +178,8 @@ export type BarrelExportName =
   | "Toast"
   | "Toggle"
   | "Tooltip"
-  | "Tree";
+  | "Tree"
+  | "WatchLoader";
 
 // ── Helpers ──────────────────────────────────────────────────────────────
 
@@ -667,6 +669,10 @@ export const COMPONENT_FIXTURES: Record<string, ComponentFixture> = {
 
   Tree: {
     element: <Tree data={[{ id: "1", label: "Root", children: [{ id: "2", label: "Child" }] }]} />,
+  },
+
+  WatchLoader: {
+    element: <WatchLoader aria-label="Loading" />,
   },
 } as const;
 


### PR DESCRIPTION
Closes #2659

## Summary
Adds `WatchLoader` to `packages/rialto`: an animated SVG loader styled after the exhibition caseback of a mechanical automatic watch. The metaphor is *precision in motion* — an indeterminate "working" indicator with no progress semantics.

## Acceptance criteria — all met
- **SVG** output (crisp at any size).
- **Rotor** sweeps continuously; rotation via `transform: rotate()` only (compositor-thread, zero layout cost).
- **3 gears** (12:8:6 teeth) mesh with proportional angular velocities (gear2 1.5×, gear3 2×), neighbours counter-rotate.
- **Balance wheel** oscillates with framer-motion `useSpring` spring physics.
- **Escape wheel** ticks one tooth per balance beat (driven by a MotionValue, not React state).
- **Jewels** as small filled circles at every pivot.
- `size`: `sm | md | lg` (48/80/120px) or a raw pixel number.
- `speed`: `slow | normal | fast` scales all durations via a `--watch-cycle` CSS var.
- `variant`: `default | gold | steel | rose` — themed through `--watch-*` custom properties (no hardcoded hex in the component).
- `role="img"` with a required `aria-label`; no motion semantics in the accessible name.
- `useReducedMotion()` pauses all animation and renders a static snapshot, **derived at render time** — no `setState` in `useEffect` (rialto ban respected; balance/escape are driven via `motionValue.set()`, never React state).

## Wiring
- Barrel export in `src/components/index.ts`.
- a11y axe matrix: added to the barrel-name guard list, the `BarrelExportName` union, and a fixture (otherwise the matrix guard test fails).
- Regenerated `registry.json` and the `package.json` exports map (`./WatchLoader` subpath).

## Tests (TDD, written first)
`WatchLoader.test.tsx` — 14 tests: renders/role=img, required aria-label, SVG present, reduced-motion pause vs animate, size preset + raw-pixel classes, all four variant classes, speed CSS var.

## Gates (Node 22)
- `pnpm test` (rialto): all pass incl. WatchLoader + axe matrix.
- `pnpm typecheck`: clean.
- `pnpm lint`: 0 errors (only the repo-wide `forwardRef` baseline warning).
- `pnpm build`: succeeds; exports map regenerated.
- `check-adr`, `check-deps`, `detect-instruction-rot`, `pnpm regen --check`: all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)