### PR TITLE
feat(cli): token-aware context pack cap with weight reporting

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -16817,6 +16817,12 @@
       readonly source: "frontmatter" | "router" | "escalate";
     }
   </file>
+  <file path="tools/cli/src/token-counter.ts">
+    export function countTokens(text: string): number {
+      if (text.length === 0) return 0;
+      return Math.ceil(text.length / CHARS_PER_TOKEN);
+    }
+  </file>
   </section>
   <section priority="medium" role="test">
   <file path="services/users/src/test/fixtures.ts">

--- a/llms.txt
+++ b/llms.txt
@@ -4835,6 +4835,11 @@
       }
     </item>
   </file>
+  <file path="tools/cli/src/token-counter.ts">
+    <item priority="high">
+      export function countTokens(text: string): number { /* ... */ }
+    </item>
+  </file>
   </section>
   <section priority="medium" role="test">
   <file path="services/users/src/test/fixtures.ts">

--- a/tools/cli/src/__tests__/pack-token.test.ts
+++ b/tools/cli/src/__tests__/pack-token.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Token-aware context pack tests.
+ *
+ * Covers:
+ * 1. countTokens() — fast approximation (chars / 4), documented behavior
+ * 2. Under-budget — no warning emitted, token weight logged
+ * 3. Over-budget — warning with package name + overage
+ * 4. Weight reporting at generation time
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execSync } from "node:child_process";
+
+vi.mock("node:child_process", () => ({
+  execSync: vi.fn(),
+}));
+
+vi.mocked(execSync);
+
+describe("countTokens", () => {
+  it("returns 0 for empty string", async () => {
+    const { countTokens } = await import("../token-counter.js");
+    expect(countTokens("")).toBe(0);
+  });
+
+  it("approximates token count as ceil(length / 4)", async () => {
+    const { countTokens } = await import("../token-counter.js");
+    // 8 chars → 2 tokens
+    expect(countTokens("hello wo")).toBe(2);
+    // 9 chars → ceil(9/4) = 3 tokens
+    expect(countTokens("hello wor")).toBe(3);
+    // 4 chars → 1 token
+    expect(countTokens("word")).toBe(1);
+    // 1 char → 1 token
+    expect(countTokens("a")).toBe(1);
+  });
+
+  it("handles multi-line text", async () => {
+    const { countTokens } = await import("../token-counter.js");
+    const text = "line one\nline two\n";
+    expect(countTokens(text)).toBe(Math.ceil(text.length / 4));
+  });
+});
+
+describe("pack token weight reporting", () => {
+  vi.setConfig({ testTimeout: 30_000 });
+  let tmpDir: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
+
+    tmpDir = mkdtempSync(join(tmpdir(), "pack-token-"));
+    writeFileSync(join(tmpDir, "pnpm-workspace.yaml"), "packages:\n  - packages/*\n");
+    vi.spyOn(process, "cwd").mockReturnValue(tmpDir);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function runPack(targetPath: string, extraArgs: string[] = []): Promise<void> {
+    const { packCommand } = await import("../commands/pack.js");
+    await packCommand.parseAsync([targetPath, ...extraArgs], { from: "user" });
+  }
+
+  it("reports token weight at generation time (under-budget path)", async () => {
+    const pkgDir = join(tmpDir, "packages/token-pkg");
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(
+      join(pkgDir, "types.ts"),
+      `export interface Config { apiUrl: string; timeout: number; }`
+    );
+
+    await runPack("packages/token-pkg");
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    const logOutput = logSpy.mock.calls.flat().join("\n");
+    // Token weight must appear in the generation log
+    expect(logOutput).toMatch(/~\d+ tokens/);
+  });
+
+  it("does NOT warn when llms-full.txt is under the token budget", async () => {
+    const pkgDir = join(tmpDir, "packages/under-budget");
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(join(pkgDir, "types.ts"), `export interface Small { id: string; }`);
+
+    await runPack("packages/under-budget");
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    const warnOutput = warnSpy.mock.calls.flat().join("\n");
+    expect(warnOutput).not.toMatch(/token budget/i);
+  });
+
+  it("warns with package name and overage when llms-full.txt is over budget", async () => {
+    // Create a large-ish TypeScript file that will exceed a tiny test budget.
+    // We control the budget via the TOKEN_BUDGET_FULL_TXT export and override it.
+    const pkgDir = join(tmpDir, "packages/over-budget");
+    mkdirSync(pkgDir, { recursive: true });
+
+    // Generate content large enough to exceed token budget=1
+    const content = `export interface BigType { ${"a: string; ".repeat(20)} }`;
+    writeFileSync(join(pkgDir, "types.ts"), content);
+
+    // Import pack internals with a minimal budget to force the over-budget path.
+    // packDirectory is not exported, so we test via the command with mocked budget.
+    // We override TOKEN_BUDGET_FULL_TXT by setting the env variable.
+    const origEnv = process.env["MBE_TOKEN_BUDGET"];
+    process.env["MBE_TOKEN_BUDGET"] = "1";
+    try {
+      await runPack("packages/over-budget");
+    } finally {
+      if (origEnv === undefined) {
+        delete process.env["MBE_TOKEN_BUDGET"];
+      } else {
+        process.env["MBE_TOKEN_BUDGET"] = origEnv;
+      }
+    }
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    const warnOutput = warnSpy.mock.calls.flat().join("\n");
+    // Warning must mention the package path and token overage
+    expect(warnOutput).toMatch(/token budget/i);
+    expect(warnOutput).toMatch(/over-budget/);
+    expect(warnOutput).toMatch(/overage/i);
+  });
+
+  it("does not alter generated file content when over-budget (warn-only)", async () => {
+    const pkgDir = join(tmpDir, "packages/warn-only");
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(
+      join(pkgDir, "types.ts"),
+      `export interface WarnOnly { id: string; name: string; }`
+    );
+
+    // First run: normal budget (generate baseline)
+    await runPack("packages/warn-only");
+    vi.resetModules();
+    const { readFileSync } = await import("node:fs");
+    const baseline = readFileSync(join(pkgDir, "llms-full.txt"), "utf-8");
+
+    // Second run: tiny budget (should warn but NOT truncate)
+    vi.resetModules();
+    const origEnv = process.env["MBE_TOKEN_BUDGET"];
+    process.env["MBE_TOKEN_BUDGET"] = "1";
+    try {
+      logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
+      await runPack("packages/warn-only");
+    } finally {
+      if (origEnv === undefined) {
+        delete process.env["MBE_TOKEN_BUDGET"];
+      } else {
+        process.env["MBE_TOKEN_BUDGET"] = origEnv;
+      }
+    }
+
+    vi.resetModules();
+    const { readFileSync: rfs2 } = await import("node:fs");
+    const afterBudget = rfs2(join(pkgDir, "llms-full.txt"), "utf-8");
+
+    // Content must be byte-identical regardless of token budget (warn-only)
+    expect(afterBudget).toBe(baseline);
+  });
+});

--- a/tools/cli/src/commands/pack.ts
+++ b/tools/cli/src/commands/pack.ts
@@ -5,9 +5,16 @@ import { Project, Node } from "ts-morph";
 import { glob } from "glob";
 import { execSync } from "node:child_process";
 import { findMonorepoRoot } from "../monorepo-root.js";
+import { countTokens } from "../token-counter.js";
 
 const SIZE_LIMIT_KB = 15;
 const AUTO_SPLIT_THRESHOLD_KB = 25;
+/**
+ * Default token budget for llms-full.txt. Warn-only: over-budget packs are
+ * written unchanged (no truncation). Override via MBE_TOKEN_BUDGET env var.
+ * Current root llms-full.txt is ~152K tokens, so 200K gives comfortable headroom.
+ */
+const TOKEN_BUDGET_FULL_TXT = Number(process.env["MBE_TOKEN_BUDGET"] ?? 200_000);
 
 // ── Helpers ───────────────────────────────────────────────────────────────
 
@@ -254,11 +261,12 @@ async function packDirectory(
 
   const skeletonSizeKB = Buffer.byteLength(skeletonOutput, "utf8") / 1024;
   const fullSizeKB = Buffer.byteLength(fullOutput, "utf8") / 1024;
+  const fullTokens = countTokens(fullOutput);
 
   if (forceFull) {
     writeFileSync(skeletonPath, fullOutput);
     console.log(
-      `Successfully generated full context (${fullSizeKB.toFixed(1)}KB) at: ${skeletonPath}`
+      `Successfully generated full context (${fullSizeKB.toFixed(1)}KB, ~${fullTokens} tokens) at: ${skeletonPath}`
     );
   } else {
     writeFileSync(skeletonPath, skeletonOutput);
@@ -276,8 +284,15 @@ async function packDirectory(
       );
     }
 
+    if (fullTokens > TOKEN_BUDGET_FULL_TXT) {
+      const overage = fullTokens - TOKEN_BUDGET_FULL_TXT;
+      console.warn(
+        `  ⚠️  llms-full.txt for "${targetPath}" exceeds token budget: ~${fullTokens} tokens (budget: ${TOKEN_BUDGET_FULL_TXT}, overage: ~${overage} tokens)`
+      );
+    }
+
     console.log(
-      `  ✓ llms.txt (${skeletonSizeKB.toFixed(1)}KB) + llms-full.txt (${fullSizeKB.toFixed(1)}KB)`
+      `  ✓ llms.txt (${skeletonSizeKB.toFixed(1)}KB) + llms-full.txt (${fullSizeKB.toFixed(1)}KB, ~${fullTokens} tokens)`
     );
   }
 }

--- a/tools/cli/src/token-counter.ts
+++ b/tools/cli/src/token-counter.ts
@@ -1,0 +1,22 @@
+/**
+ * Token counting for context pack generation.
+ *
+ * Approximation: 1 token ≈ 4 UTF-16 code units (chars).
+ * This is the widely-cited rule of thumb for English prose in GPT-style
+ * tokenizers (cl100k_base, claude tokenizer). Actual token counts vary by
+ * content type (code tends toward 3-5 chars/token), but the approximation is
+ * fast, dependency-free, and accurate enough for budget warnings.
+ *
+ * For exact counts, swap in a real tokenizer (e.g. gpt-tokenizer) here.
+ */
+
+const CHARS_PER_TOKEN = 4;
+
+/**
+ * Estimate the number of tokens in `text` using the 4-chars-per-token heuristic.
+ * Returns 0 for empty input.
+ */
+export function countTokens(text: string): number {
+  if (text.length === 0) return 0;
+  return Math.ceil(text.length / CHARS_PER_TOKEN);
+}


### PR DESCRIPTION
## Summary

- Adds `countTokens(text)` to `tools/cli/src/token-counter.ts` — fast approximation (ceil(chars/4), documented as heuristic; swap in a real tokenizer if exact counts are needed)
- Adds `TOKEN_BUDGET_FULL_TXT` constant (default 200K tokens; overridable via `MBE_TOKEN_BUDGET` env var) to warn when `llms-full.txt` exceeds budget
- Reports token weight at generation time: `✓ llms.txt (5.2KB) + llms-full.txt (12.3KB, ~3072 tokens)`
- Emits warning with package path + overage when over budget: `⚠️  llms-full.txt for "packages/..." exceeds token budget: ~N tokens (budget: 200000, overage: ~M tokens)`
- Warn-only by default: generated file content is never altered by budget checks, so existing committed packs remain byte-identical

## Test plan

- [x] `countTokens` unit tests: empty string, exact arithmetic (chars/4), multi-line
- [x] Under-budget: no warning, token weight appears in log
- [x] Over-budget: warning matches `/token budget/i` + package name + overage
- [x] Warn-only invariant: llms-full.txt content is byte-identical before/after budget enforcement
- [x] All 407 CLI tests pass
- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `check-adr` / `check-deps` pass
- [x] `pnpm regen` run; regen artifacts (llms.txt/llms-full.txt + rialto-catalog) staged alongside

Closes #2696