### PR TITLE
feat(sensor): add ccusage ground-truth spend sensor

### DIFF
--- a/scripts/__tests__/collect-ccusage.test.mjs
+++ b/scripts/__tests__/collect-ccusage.test.mjs
@@ -1,0 +1,169 @@
+import { describe, it, expect } from "vitest";
+import { collectCcusageSensor } from "../collect-ccusage.mjs";
+
+const TEST_NOW = new Date("2026-06-26T12:00:00Z");
+
+/**
+ * Build a ccusage daily JSON payload.
+ * `daysAgo` is relative to TEST_NOW so entries are stable regardless of wall-clock date.
+ */
+function makeEntry(daysAgo, totalCost, opts = {}) {
+  const d = new Date(TEST_NOW - daysAgo * 24 * 60 * 60 * 1000);
+  const period = d.toISOString().slice(0, 10);
+  return {
+    period,
+    agent: "all",
+    totalCost,
+    cacheReadTokens: opts.cacheReadTokens ?? 0,
+    inputTokens: opts.inputTokens ?? 0,
+    cacheCreationTokens: opts.cacheCreationTokens ?? 0,
+    outputTokens: opts.outputTokens ?? 0,
+    totalTokens: 0,
+    modelsUsed: opts.modelsUsed ?? [],
+    modelBreakdowns: opts.modelBreakdowns ?? [],
+    metadata: { agents: ["claude"] },
+  };
+}
+
+describe("collectCcusageSensor", () => {
+  it("returns available:false when readCcusage returns null", () => {
+    const result = collectCcusageSensor(() => null);
+    expect(result.available).toBe(false);
+  });
+
+  it("returns available:false when readCcusage throws", () => {
+    const result = collectCcusageSensor(() => {
+      throw new Error("ccusage not found");
+    });
+    expect(result.available).toBe(false);
+  });
+
+  it("returns available:false when daily array is empty", () => {
+    const result = collectCcusageSensor(() => ({ daily: [] }));
+    expect(result.available).toBe(false);
+  });
+
+  it("returns available:false when JSON has no daily key", () => {
+    const result = collectCcusageSensor(() => ({}));
+    expect(result.available).toBe(false);
+  });
+
+  it("aggregates spend for today, 7d, and 30d windows", () => {
+    const now = TEST_NOW;
+    const entries = [
+      makeEntry(0, 1.5), // today
+      makeEntry(3, 2.0), // 3 days ago → within 7d + 30d
+      makeEntry(8, 0.5), // 8 days ago → outside 7d, within 30d
+      makeEntry(31, 9.9), // 31 days ago → outside 30d
+    ];
+
+    const result = collectCcusageSensor(() => ({ daily: entries }), now);
+
+    expect(result.available).toBe(true);
+    expect(result.spend_today_usd).toBeCloseTo(1.5, 2);
+    expect(result.spend_7d_usd).toBeCloseTo(3.5, 2);
+    expect(result.spend_30d_usd).toBeCloseTo(4.0, 2);
+  });
+
+  it("computes cache_hit_rate as cache_read / (cache_read + input + cache_creation)", () => {
+    const now = TEST_NOW;
+    const entries = [
+      makeEntry(0, 1.0, {
+        cacheReadTokens: 100,
+        inputTokens: 50,
+        cacheCreationTokens: 50,
+      }),
+    ];
+
+    const result = collectCcusageSensor(() => ({ daily: entries }), now);
+
+    expect(result.available).toBe(true);
+    // 100 / (100 + 50 + 50) = 0.5
+    expect(result.cache_hit_rate).toBeCloseTo(0.5, 4);
+  });
+
+  it("returns cache_hit_rate of 0 when all token counts are zero (divide-by-zero guard)", () => {
+    const now = TEST_NOW;
+    const result = collectCcusageSensor(() => ({ daily: [makeEntry(0, 0.1)] }), now);
+    expect(result.available).toBe(true);
+    expect(result.cache_hit_rate).toBe(0);
+  });
+
+  it("emits correct token totals from 30d entries", () => {
+    const now = TEST_NOW;
+    const entries = [
+      makeEntry(0, 1.0, {
+        cacheReadTokens: 1000,
+        inputTokens: 200,
+        cacheCreationTokens: 100,
+        outputTokens: 300,
+      }),
+      makeEntry(20, 0.5, {
+        cacheReadTokens: 500,
+        inputTokens: 100,
+        cacheCreationTokens: 50,
+        outputTokens: 150,
+      }),
+      // outside 30d — should not be included
+      makeEntry(35, 999, {
+        cacheReadTokens: 99999,
+        inputTokens: 99999,
+        cacheCreationTokens: 99999,
+        outputTokens: 99999,
+      }),
+    ];
+
+    const result = collectCcusageSensor(() => ({ daily: entries }), now);
+
+    expect(result.cache_read_tokens).toBe(1500);
+    expect(result.output_tokens).toBe(450);
+    expect(result.cache_creation_tokens).toBe(150);
+  });
+
+  it("builds by_model from modelBreakdowns within 30d window", () => {
+    const now = TEST_NOW;
+    const entries = [
+      makeEntry(0, 1.0, {
+        modelBreakdowns: [
+          {
+            modelName: "claude-sonnet-4-6",
+            cost: 0.8,
+            inputTokens: 100,
+            outputTokens: 200,
+            cacheReadTokens: 500,
+            cacheCreationTokens: 50,
+          },
+          {
+            modelName: "claude-haiku-4",
+            cost: 0.2,
+            inputTokens: 50,
+            outputTokens: 100,
+            cacheReadTokens: 200,
+            cacheCreationTokens: 20,
+          },
+        ],
+      }),
+      makeEntry(5, 0.5, {
+        modelBreakdowns: [
+          {
+            modelName: "claude-sonnet-4-6",
+            cost: 0.5,
+            inputTokens: 50,
+            outputTokens: 100,
+            cacheReadTokens: 250,
+            cacheCreationTokens: 25,
+          },
+        ],
+      }),
+    ];
+
+    const result = collectCcusageSensor(() => ({ daily: entries }), now);
+
+    expect(result.available).toBe(true);
+    expect(result.by_model["claude-sonnet-4-6"]).toBeDefined();
+    expect(result.by_model["claude-sonnet-4-6"].cost).toBeCloseTo(1.3, 4);
+    expect(result.by_model["claude-sonnet-4-6"].output_tokens).toBe(300);
+    expect(result.by_model["claude-haiku-4"]).toBeDefined();
+    expect(result.by_model["claude-haiku-4"].cost).toBeCloseTo(0.2, 4);
+  });
+});

--- a/scripts/collect-ccusage.mjs
+++ b/scripts/collect-ccusage.mjs
@@ -1,0 +1,133 @@
+/**
+ * Pure collector for ccusage ground-truth token spend.
+ *
+ * Reads real Claude session spend via ccusage CLI (`npx -y ccusage@latest daily --json`)
+ * and emits a structured spend shape into the sensor-report pipeline.
+ *
+ * ccusage JSON shape (daily command):
+ *   {
+ *     daily: [{
+ *       period: "YYYY-MM-DD",
+ *       totalCost: number,
+ *       cacheReadTokens: number,
+ *       inputTokens: number,
+ *       cacheCreationTokens: number,
+ *       outputTokens: number,
+ *       modelBreakdowns: [{
+ *         modelName: string,
+ *         cost: number,
+ *         inputTokens: number,
+ *         outputTokens: number,
+ *         cacheReadTokens: number,
+ *         cacheCreationTokens: number,
+ *       }]
+ *     }]
+ *   }
+ *
+ * The `readCcusage` reader is injected so the collector is unit-testable
+ * without spawning ccusage. Degrades gracefully (available:false) when
+ * ccusage or logs are absent — never throws.
+ */
+
+import { execFileSync } from "node:child_process";
+
+/**
+ * Default reader: spawns ccusage and returns parsed JSON or null on failure.
+ * @returns {object|null}
+ */
+function defaultReadCcusage() {
+  try {
+    const raw = execFileSync("npx", ["-y", "ccusage@latest", "daily", "--json", "--no-cost"], {
+      encoding: "utf-8",
+      timeout: 30000,
+    });
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Collect ground-truth token spend from ccusage.
+ *
+ * @param {() => object|null} readCcusage - Injected reader (defaults to spawning ccusage).
+ * @param {Date} [now] - Reference timestamp (defaults to current time; injectable for tests).
+ * @returns {object} Aggregated spend metrics or { available: false } when ccusage is unavailable.
+ */
+export function collectCcusageSensor(readCcusage = defaultReadCcusage, now = new Date()) {
+  let data;
+  try {
+    data = readCcusage();
+  } catch {
+    return { available: false };
+  }
+
+  if (!data || !Array.isArray(data.daily) || data.daily.length === 0) {
+    return { available: false };
+  }
+
+  const todayStr = now.toISOString().slice(0, 10);
+  const sevenDaysAgo = new Date(now - 7 * 24 * 60 * 60 * 1000);
+  const thirtyDaysAgo = new Date(now - 30 * 24 * 60 * 60 * 1000);
+
+  const within30d = data.daily.filter((e) => {
+    const d = new Date(e.period);
+    return d >= thirtyDaysAgo;
+  });
+
+  const within7d = within30d.filter((e) => new Date(e.period) >= sevenDaysAgo);
+  const today = within30d.filter((e) => e.period === todayStr);
+
+  const sum = (entries, field) => entries.reduce((acc, e) => acc + (e[field] ?? 0), 0);
+
+  const spend_today_usd = Math.round(sum(today, "totalCost") * 10000) / 10000;
+  const spend_7d_usd = Math.round(sum(within7d, "totalCost") * 10000) / 10000;
+  const spend_30d_usd = Math.round(sum(within30d, "totalCost") * 10000) / 10000;
+
+  const cache_read_tokens = sum(within30d, "cacheReadTokens");
+  const output_tokens = sum(within30d, "outputTokens");
+  const cache_creation_tokens = sum(within30d, "cacheCreationTokens");
+  const input_tokens = sum(within30d, "inputTokens");
+
+  const tokenDenominator = cache_read_tokens + input_tokens + cache_creation_tokens;
+  const cache_hit_rate =
+    tokenDenominator > 0 ? Math.round((cache_read_tokens / tokenDenominator) * 10000) / 10000 : 0;
+
+  // Aggregate per-model stats from modelBreakdowns within 30d window.
+  const by_model = {};
+  for (const entry of within30d) {
+    for (const mb of entry.modelBreakdowns ?? []) {
+      const name = mb.modelName;
+      if (!name) continue;
+      if (!by_model[name]) {
+        by_model[name] = {
+          cost: 0,
+          input_tokens: 0,
+          output_tokens: 0,
+          cache_read_tokens: 0,
+          cache_creation_tokens: 0,
+        };
+      }
+      const m = by_model[name];
+      by_model[name] = {
+        cost: m.cost + (mb.cost ?? 0),
+        input_tokens: m.input_tokens + (mb.inputTokens ?? 0),
+        output_tokens: m.output_tokens + (mb.outputTokens ?? 0),
+        cache_read_tokens: m.cache_read_tokens + (mb.cacheReadTokens ?? 0),
+        cache_creation_tokens: m.cache_creation_tokens + (mb.cacheCreationTokens ?? 0),
+      };
+    }
+  }
+
+  return {
+    available: true,
+    spend_today_usd,
+    spend_7d_usd,
+    spend_30d_usd,
+    cache_read_tokens,
+    output_tokens,
+    cache_creation_tokens,
+    cache_hit_rate,
+    by_model,
+  };
+}

--- a/scripts/sensor-report.mjs
+++ b/scripts/sensor-report.mjs
@@ -18,6 +18,7 @@ import { fileURLToPath } from "node:url";
 import { execFileSync } from "node:child_process";
 import { createGhClient } from "@mbe/gh-client";
 import { collectAgentCost } from "./collect-agent-cost.mjs";
+import { collectCcusageSensor } from "./collect-ccusage.mjs";
 import {
   computeCodeChurn,
   isGeneratedArtifact,
@@ -127,6 +128,10 @@ function collectPrCategoryMetricsSensor() {
 function collectAgentCostSensor() {
   const spendPath = resolve(ROOT, ".claude", "agent-spend.jsonl");
   return collectAgentCost(spendPath, now);
+}
+
+function collectCcusageCostSensor() {
+  return collectCcusageSensor(undefined, now);
 }
 
 /**
@@ -408,6 +413,7 @@ const report = {
     prMetrics: collectPrMetrics(),
     prCategoryMetrics: collectPrCategoryMetricsSensor(),
     agentCost: collectAgentCostSensor(),
+    ccusageCost: collectCcusageCostSensor(),
     ciHealth: collectCiHealth(),
     lighthouse: collectLighthouse(),
     issues: collectGitHubIssues(),
@@ -465,6 +471,11 @@ if (JSON_ONLY) {
       case "agentCost":
         console.log(
           `   ${name}: $${data.spend_7d_usd} (7d), $${data.spend_today_usd} (today), ${data.sessions_7d} sessions`
+        );
+        break;
+      case "ccusageCost":
+        console.log(
+          `   ${name}: $${data.spend_30d_usd} (30d), $${data.spend_7d_usd} (7d), $${data.spend_today_usd} (today), cache_hit ${Math.round(data.cache_hit_rate * 100)}%`
         );
         break;
       case "issues":


### PR DESCRIPTION
## Summary

- Adds `scripts/collect-ccusage.mjs` — a pure collector that reads real token spend from ccusage CLI (`npx -y ccusage@latest daily --json`) using dependency injection for the reader, making it fully unit-testable without spawning ccusage
- Wires `collectCcusageSensor()` into `scripts/sensor-report.mjs` alongside the existing `agentCost` sensor as `ccusageCost`
- Emits `{ available, spend_today_usd, spend_7d_usd, spend_30d_usd, cache_read_tokens, output_tokens, cache_creation_tokens, cache_hit_rate, by_model }` into `metrics/sensor-report.json`
- Degrades gracefully (`available: false`) when ccusage is absent or logs are empty — never throws

## Test plan

- [x] 9 unit tests in `scripts/__tests__/collect-ccusage.test.mjs` covering: null reader, throwing reader, empty array, missing daily key, spend windowing (today/7d/30d), cache_hit_rate calculation, divide-by-zero guard, token totals (30d filter), and by_model aggregation
- [x] All 6 existing agent-cost tests still pass
- [x] Full test suite: 30 test files, 395 tests passed (via pre-push hook)
- [x] `pnpm --filter @mbe/cli start check-adr` — no violations
- [x] `pnpm --filter @mbe/cli start check-deps` — all consistent
- [x] `pnpm regen` — no artifact drift
- [x] `node scripts/detect-instruction-rot.mjs` — no rot detected

Closes #2693