### PR TITLE
fix(hospitality): stop premature /onboarding redirect during venue load

### DIFF
--- a/apps/hospitality/llms-full.txt
+++ b/apps/hospitality/llms-full.txt
@@ -428,7 +428,7 @@
   <file path="src/hooks/useVenueReadiness.ts">
     export type SetupStep = "onboarding" | "operating-hours" | "floor-plan";
     export interface VenueReadiness {
-      status: "no-venue" | "setup" | "operational";
+      status: "loading" | "no-venue" | "setup" | "operational";
       completedSteps: readonly SetupStep[];
       nextStep: SetupStep | null;
       progress: number; // 0–100

--- a/apps/hospitality/llms.txt
+++ b/apps/hospitality/llms.txt
@@ -344,7 +344,7 @@
     </item>
     <item priority="low">
       interface VenueReadiness {
-        status: "no-venue" | "setup" | "operational";
+        status: "loading" | "no-venue" | "setup" | "operational";
         completedSteps: readonly SetupStep[];
         nextStep: SetupStep | null;
         progress: number;

--- a/apps/hospitality/src/components/DashboardLayout.test.tsx
+++ b/apps/hospitality/src/components/DashboardLayout.test.tsx
@@ -102,6 +102,18 @@ describe("DashboardLayout", () => {
     );
   };
 
+  it("does not redirect while readiness status is loading", () => {
+    vi.mocked(useVenueReadiness).mockReturnValue({
+      status: "loading",
+      completedSteps: [],
+      nextStep: null,
+      progress: 0,
+    } as any);
+    renderLayout("/timeline");
+    // Should stay on the requested route — not bounce to /onboarding
+    expect(screen.getByText("Timeline Content")).toBeDefined();
+  });
+
   it("redirects to onboarding when no venue exists", () => {
     vi.mocked(useVenueReadiness).mockReturnValue({
       status: "no-venue",

--- a/apps/hospitality/src/components/DashboardLayout.test.tsx
+++ b/apps/hospitality/src/components/DashboardLayout.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 import { useAuth } from "@mbe/auth/react";
 import { useVenueReadiness } from "../hooks/useVenueReadiness.js";
+import type { VenueReadiness } from "../hooks/useVenueReadiness.js";
 import { DashboardLayout } from "./DashboardLayout.js";
 import React from "react";
 
@@ -103,12 +104,13 @@ describe("DashboardLayout", () => {
   };
 
   it("does not redirect while readiness status is loading", () => {
-    vi.mocked(useVenueReadiness).mockReturnValue({
+    const loading: VenueReadiness = {
       status: "loading",
       completedSteps: [],
       nextStep: null,
       progress: 0,
-    } as any);
+    };
+    vi.mocked(useVenueReadiness).mockReturnValue(loading);
     renderLayout("/timeline");
     // Should stay on the requested route — not bounce to /onboarding
     expect(screen.getByText("Timeline Content")).toBeDefined();

--- a/apps/hospitality/src/components/DashboardLayout.tsx
+++ b/apps/hospitality/src/components/DashboardLayout.tsx
@@ -66,6 +66,13 @@ function DashboardLayoutInner() {
   useEffect(() => {
     const path = location.pathname.replace(/^\/hospitality/, "");
 
+    // Do not redirect while venue data is still loading — the real status
+    // is not yet known and an early redirect would be sticky (operational
+    // recovery only handles /setup and /, not /onboarding).
+    if (readiness.status === "loading") {
+      return;
+    }
+
     if (readiness.status === "no-venue") {
       if (!path.startsWith("/onboarding") && !path.startsWith("/callback")) {
         navigate("/onboarding", { replace: true });

--- a/apps/hospitality/src/hooks/useVenueReadiness.test.ts
+++ b/apps/hospitality/src/hooks/useVenueReadiness.test.ts
@@ -190,7 +190,7 @@ describe("useVenueReadiness", () => {
     } as any);
   });
 
-  it("returns no-venue state when loading", () => {
+  it("returns 'loading' status when venue context is loading", () => {
     vi.mocked(useVenue).mockReturnValue({
       selectedVenue: null,
       selectedVenueId: null,
@@ -202,9 +202,10 @@ describe("useVenueReadiness", () => {
 
     const { result } = renderHook(() => useVenueReadiness());
 
-    expect(result.current.status).toBe("no-venue");
+    expect(result.current.status).toBe("loading");
     expect(result.current.progress).toBe(0);
     expect(result.current.nextStep).toBeNull();
+    expect(result.current.completedSteps).toHaveLength(0);
   });
 
   it("fetches floor plans on mount when venue and token are available", async () => {

--- a/apps/hospitality/src/hooks/useVenueReadiness.ts
+++ b/apps/hospitality/src/hooks/useVenueReadiness.ts
@@ -8,7 +8,7 @@ import type { FloorPlan } from "@mbe/types";
 export type SetupStep = "onboarding" | "operating-hours" | "floor-plan";
 
 export interface VenueReadiness {
-  status: "no-venue" | "setup" | "operational";
+  status: "loading" | "no-venue" | "setup" | "operational";
   completedSteps: readonly SetupStep[];
   nextStep: SetupStep | null;
   progress: number; // 0–100
@@ -16,8 +16,8 @@ export interface VenueReadiness {
 
 export const STEP_ORDER: readonly SetupStep[] = ["onboarding", "operating-hours", "floor-plan"];
 
-const NO_VENUE: VenueReadiness = {
-  status: "no-venue",
+const LOADING: VenueReadiness = {
+  status: "loading",
   completedSteps: [],
   nextStep: null,
   progress: 0,
@@ -126,7 +126,7 @@ export function useVenueReadiness(): VenueReadiness {
   );
 
   if (isLoading) {
-    return NO_VENUE;
+    return LOADING;
   }
 
   return readiness;

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -16065,18 +16065,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3603,7 +3603,7 @@
   <file path="apps/hospitality/src/hooks/useVenueReadiness.ts">
     export type SetupStep = "onboarding" | "operating-hours" | "floor-plan";
     export interface VenueReadiness {
-      status: "no-venue" | "setup" | "operational";
+      status: "loading" | "no-venue" | "setup" | "operational";
       completedSteps: readonly SetupStep[];
       nextStep: SetupStep | null;
       progress: number; // 0–100
@@ -16065,7 +16065,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms.txt
+++ b/llms.txt
@@ -1385,7 +1385,7 @@
     </item>
     <item priority="low">
       interface VenueReadiness {
-        status: "no-venue" | "setup" | "operational";
+        status: "loading" | "no-venue" | "setup" | "operational";
         completedSteps: readonly SetupStep[];
         nextStep: SetupStep | null;
         progress: number;

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -349,7 +349,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -349,18 +349,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),


### PR DESCRIPTION
## Root cause

`useVenueReadiness` returned the `NO_VENUE` sentinel (`status: "no-venue"`) while `isLoading` was still `true` — conflating "venues still loading" with "user genuinely has no venue."

`DashboardLayout`'s redirect guard fires on every status change: when it saw `"no-venue"` it navigated to `/onboarding` with `replace: true`. The `operational` recovery branch only redirects away from `/setup` and `/`, not from `/onboarding`, so once Playwright (or the browser) was bounced there the redirect was sticky — venues could resolve to `operational` but the user remained on the wizard. This caused ~31 E2E tests to fail on every fresh `authPage.goto()`.

## Fix

1. **`src/hooks/useVenueReadiness.ts`** — added `"loading"` to the `VenueReadiness.status` union and returned a `LOADING` sentinel when `isLoading` is `true` (instead of `NO_VENUE`). `computeReadiness` is unchanged.
2. **`src/components/DashboardLayout.tsx`** — added an early `return` in the redirect-guard `useEffect` when `readiness.status === "loading"`, preventing any navigation while readiness is indeterminate.

## Tests added

- `src/hooks/useVenueReadiness.test.ts`: `"returns 'loading' status when venue context is loading"` — verifies the hook returns `{ status: "loading", progress: 0, nextStep: null, completedSteps: [] }` when `useVenue` reports `isLoading: true` (was RED before implementation, GREEN after).
- `src/components/DashboardLayout.test.tsx`: `"does not redirect while readiness status is loading"` — typed as a proper `VenueReadiness` (no `as any`) since `"loading"` is now in the union; verifies the user stays on `/timeline` instead of being bounced to `/onboarding`.

## Gate results

- `pnpm lint`: 0 errors (203 pre-existing warnings, unchanged)
- `pnpm typecheck`: clean
- `pnpm test`: 1130 passed (90 test files)
- `check-adr` / `check-deps`: no violations
- `pnpm regen --check`: all artifacts up to date
- `detect-instruction-rot`: no rot

Closes #1968