### PR TITLE
feat(skills): add /token-report skill (ccusage wrapper)

### DIFF
--- a/.claude/skills/token-report/SKILL.md
+++ b/.claude/skills/token-report/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: token-report
+description: "Pull a real-time token spend summary using ccusage. Shows daily totals, session breakdown, and block usage with cost, cache-read vs output vs cache-creation tokens, and per-model breakdown. Invoke: /token-report [daily|session|blocks]."
+user-invocable: true
+---
+
+# Token Report
+
+Read-only spend summary powered by `ccusage`. No new persistence — reads the same Claude Code usage logs that ccusage already tracks.
+
+## Usage
+
+```
+/token-report           # runs all three views: daily, session, blocks
+/token-report daily     # today's totals by model
+/token-report session   # per-session breakdown
+/token-report blocks    # 5-hour billing-block view
+```
+
+## Preflight Check
+
+Before running any view, verify ccusage is available and logs exist:
+
+```bash
+npx -y ccusage@latest --version 2>/dev/null && echo "OK" || echo "MISSING"
+```
+
+If the check fails or output contains "No data", stop and report:
+
+> "ccusage is not installed or no Claude Code usage logs were found. Logs are written by the Claude Code desktop app to `~/.claude/logs/`. If you have run Claude Code sessions, ensure you are on the same machine and try again."
+
+## Views
+
+Run the requested view(s). With no argument, run all three in order.
+
+### Daily
+
+```bash
+npx -y ccusage@latest daily --json 2>/dev/null
+```
+
+Report:
+
+- Date range covered
+- Total cost (USD)
+- Token breakdown: input / output / cache-read / cache-creation
+- Per-model cost and token row (sorted by cost desc)
+
+### Session
+
+```bash
+npx -y ccusage@latest session --json 2>/dev/null
+```
+
+Report:
+
+- Session count
+- Most expensive session (cost, model, task snippet if available)
+- Cumulative cost and tokens
+- Per-model breakdown across sessions
+
+### Blocks
+
+```bash
+npx -y ccusage@latest blocks --json 2>/dev/null
+```
+
+Report:
+
+- Active billing block window (start time, end time)
+- Tokens and cost consumed in the current block
+- Projected cost for the full block at current burn rate
+- Per-model breakdown within the block
+
+## Output Format
+
+Render each view as a compact markdown table. Example:
+
+```
+### Daily — 2026-06-26
+
+| Model                  | Input    | Output  | Cache-Read | Cache-Create | Cost    |
+|------------------------|----------|---------|------------|--------------|---------|
+| claude-sonnet-4-6      | 1,234    | 5,678   | 45,000     | 890          | $0.42   |
+| claude-haiku-4-5       | 500      | 200     | 12,000     | 0            | $0.03   |
+| **Total**              | 1,734    | 5,878   | 57,000     | 890          | **$0.45** |
+```
+
+## Graceful Degradation
+
+| Condition                    | Behavior                                                     |
+| ---------------------------- | ------------------------------------------------------------ |
+| ccusage not found            | Print install hint; do not error                             |
+| No logs / empty output       | Print "No usage data found for this period"                  |
+| JSON parse error             | Print raw output, note it may be a version incompatibility   |
+| Network error (npx download) | Print "Could not fetch ccusage — check network connectivity" |
+
+## Rules
+
+- Read-only: never write files, never modify logs
+- Do not print raw API keys, session tokens, or any secret embedded in log paths
+- Max one `npx -y ccusage@latest` invocation per view — do not retry in a loop

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ Quick reference:
 - `/ci-monitor` — auto-fix simple CI failures
 - `/progress-tracker` — metrics + circuit breaker
 - `/acmm-audit` — score repo against AI Codebase Maturity Model
+- `/token-report [daily|session|blocks]` — real-time token spend summary via ccusage
 
 ### ACMM Audit (All Agents)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ Automated system that audits the live site, finds and fixes issues, builds featu
 | `/learning-loop`    | Sensor-driven improvement: collect metrics → detect regressions → create issues → verify fixes → self-tune                                                        |
 | `/sentry-triage`    | Query Sentry for production errors, filter by severity/frequency, deduplicate, create GitHub issues for implement-queue                                           |
 | `/acmm-audit`       | Score repo against canonical AI Codebase Maturity Model (6 levels, 100+ criteria from ACMM/Fullsend/AEF/Reflect), file next-level-gap issues, update README badge |
+| `/token-report`     | Pull real-time token spend summary via ccusage: daily totals, session breakdown, block usage, per-model cost and cache-read/output/cache-creation breakdown       |
 
 ## mbe CLI Commands
 


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/token-report/SKILL.md` — a read-only slash-skill wrapping `ccusage daily|session|blocks`
- Reports cost, cache-read vs output vs cache-creation tokens, and per-model breakdown in compact markdown tables
- Degrades gracefully when ccusage is unavailable or no usage logs are found
- Documents the skill in CLAUDE.md skills table and AGENTS.md quick reference

## Gate results

- `pnpm --filter @mbe/cli start check-adr` — no violations
- `pnpm --filter @mbe/cli start check-deps` — all consistent
- `pnpm regen` — run; llms-full.txt pre-existing formatting drift staged alongside skill file
- `node scripts/detect-instruction-rot.mjs` — no rot detected
- Pre-push hook ran tests + antipattern check — all within baseline

Closes #2694