### PR TITLE
feat(eval): cost-regression gate for mbe agent eval

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1431,6 +1431,10 @@
       .option("-m, --model <model>", "Model to run the agent with", DEFAULT_SESSION_CONFIG.model)
       .option("--json", "Emit the EvalReport as JSON", false)
       .option("--threshold <pct>", "Exit non-zero if suite pass rate is below this percent")
+      .option(
+        "--max-cost-regression <pct>",
+        "Exit non-zero if mean cost-per-task exceeds the latest baseline by more than this percent"
+      )
       .option("--calibrate", "Print self-grade vs ground-truth calibration summary", false)
       .action(
         async (options: {
@@ -1439,6 +1443,7 @@
           model: string;
           json: boolean;
           threshold?: string;
+          maxCostRegression?: string;
           calibrate: boolean;
         }) => {
           const repoPath = resolve(process.cwd());
@@ -1452,6 +1457,11 @@
             process.exitCode = 1;
             return;
           }
+    
+          // Read baseline before appending the current run so the most recent prior
+          // entry is used, not the one we're about to write.
+          const costBaseline =
+            options.maxCostRegression !== undefined ? loadCostBaseline(findLogFile()) : null;
     
           const runTask = makeAgentTaskRunner(repoPath, options.model);
           const report = await runEvalSuite(tasks, {
@@ -1481,17 +1491,23 @@
               process.exitCode = 1;
             }
           }
+    
+          if (options.maxCostRegression !== undefined) {
+            const thresholdPct = Number(options.maxCostRegression);
+            const current = report.aggregate.meanCostUsd;
+            if (!checkCostRegression(current, costBaseline, thresholdPct)) {
+              const pctIncrease = (((current - costBaseline!) / costBaseline!) * 100).toFixed(1);
+              console.error(
+                `\nCost regression detected: mean cost $${current.toFixed(4)} is ${pctIncrease}% above baseline $${costBaseline!.toFixed(4)} (threshold ${options.maxCostRegression}%)`
+              );
+              process.exitCode = 1;
+            }
+          }
         }
       );
-    function persistReport(report: EvalReport): void {
+    function findLogFile(): string {
       const root = findMonorepoRoot(process.cwd());
-      const logDir = join(root, "docs/logs");
-      const logFile = join(logDir, "eval-reports.jsonl");
-      if (!existsSync(logDir)) {
-        mkdirSync(logDir, { recursive: true });
-      }
-      const record = { ...report, timestamp: new Date().toISOString() };
-      appendFileSync(logFile, JSON.stringify(record) + "\n");
+      return join(root, "docs/logs", "eval-reports.jsonl");
     }
   </file>
   <file path="tools/cli/src/commands/agent-frontmatter.ts">
@@ -2847,6 +2863,19 @@
       readonly totalWithSelfEval: number;
       /** Tasks that had no selfEvaluation field (not counted in any bucket). */
       readonly totalWithoutSelfEval: number;
+    }
+  </file>
+  <file path="packages/agent-core/src/eval/cost-regression.ts">
+    export function checkCostRegression(
+      current: number,
+      baseline: number | null,
+      thresholdPct: number
+    ): boolean {
+      if (baseline === null || baseline === 0) {
+        return true;
+      }
+      const pctIncrease = ((current - baseline) / baseline) * 100;
+      return pctIncrease <= thresholdPct;
     }
   </file>
   <file path="packages/agent-core/src/eval/eval-harness.ts">

--- a/llms.txt
+++ b/llms.txt
@@ -555,7 +555,7 @@
       export const agentEvalCommand: unknown;
     </item>
     <item priority="medium">
-      function persistReport(report: EvalReport): void { /* ... */ }
+      function findLogFile(): string { /* ... */ }
     </item>
   </file>
   <file path="tools/cli/src/commands/agent-frontmatter.ts">
@@ -972,6 +972,15 @@
         totalWithSelfEval: number;
         totalWithoutSelfEval: number;
       }
+    </item>
+  </file>
+  <file path="packages/agent-core/src/eval/cost-regression.ts">
+    <item priority="high">
+      export function checkCostRegression(
+        current: number,
+        baseline: number | null,
+        thresholdPct: number
+      ): boolean { /* ... */ }
     </item>
   </file>
   <file path="packages/agent-core/src/eval/eval-harness.ts">

--- a/packages/agent-core/llms-full.txt
+++ b/packages/agent-core/llms-full.txt
@@ -374,6 +374,19 @@
       readonly totalWithoutSelfEval: number;
     }
   </file>
+  <file path="src/eval/cost-regression.ts">
+    export function checkCostRegression(
+      current: number,
+      baseline: number | null,
+      thresholdPct: number
+    ): boolean {
+      if (baseline === null || baseline === 0) {
+        return true;
+      }
+      const pctIncrease = ((current - baseline) / baseline) * 100;
+      return pctIncrease <= thresholdPct;
+    }
+  </file>
   <file path="src/eval/eval-harness.ts">
     export interface RunEvalSuiteOptions {
       /** Agent-invocation seam. Real impl runs `runSession`; tests stub it. */

--- a/packages/agent-core/llms.txt
+++ b/packages/agent-core/llms.txt
@@ -68,6 +68,15 @@
       }
     </item>
   </file>
+  <file path="src/eval/cost-regression.ts">
+    <item priority="high">
+      export function checkCostRegression(
+        current: number,
+        baseline: number | null,
+        thresholdPct: number
+      ): boolean { /* ... */ }
+    </item>
+  </file>
   <file path="src/eval/eval-harness.ts">
     <item priority="low">
       interface RunEvalSuiteOptions {

--- a/packages/agent-core/src/eval/cost-regression.test.ts
+++ b/packages/agent-core/src/eval/cost-regression.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { checkCostRegression } from "./cost-regression.js";
+
+describe("checkCostRegression", () => {
+  it("returns true (no regression) when baseline is null", () => {
+    expect(checkCostRegression(0.5, null, 10)).toBe(true);
+  });
+
+  it("returns true when cost increase is within the threshold", () => {
+    // baseline 0.10, current 0.10 = 0% increase, threshold 10% → pass
+    expect(checkCostRegression(0.1, 0.1, 10)).toBe(true);
+    // baseline 0.10, current 0.11 = 10% increase, threshold 10% → pass (at boundary)
+    expect(checkCostRegression(0.11, 0.1, 10)).toBe(true);
+  });
+
+  it("returns false when cost increase exceeds the threshold", () => {
+    // baseline 0.10, current 0.12 = 20% increase, threshold 10% → fail
+    expect(checkCostRegression(0.12, 0.1, 10)).toBe(false);
+  });
+
+  it("returns true when cost decreases (cost regression is only upward)", () => {
+    expect(checkCostRegression(0.05, 0.1, 10)).toBe(true);
+  });
+
+  it("handles zero baseline gracefully (returns true — no sensible comparison)", () => {
+    expect(checkCostRegression(0, 0, 10)).toBe(true);
+  });
+});

--- a/packages/agent-core/src/eval/cost-regression.ts
+++ b/packages/agent-core/src/eval/cost-regression.ts
@@ -1,0 +1,22 @@
+/**
+ * Pure cost-regression predicate.
+ *
+ * Returns `true` when no regression is detected (safe to proceed),
+ * `false` when the cost increase exceeds the threshold.
+ *
+ * @param current     Mean cost-per-task for the current run.
+ * @param baseline    Mean cost-per-task from the most recent prior run,
+ *                    or `null` when no prior run exists.
+ * @param thresholdPct Maximum allowed % increase over baseline (e.g. 20 = 20%).
+ */
+export function checkCostRegression(
+  current: number,
+  baseline: number | null,
+  thresholdPct: number
+): boolean {
+  if (baseline === null || baseline === 0) {
+    return true;
+  }
+  const pctIncrease = ((current - baseline) / baseline) * 100;
+  return pctIncrease <= thresholdPct;
+}

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -344,6 +344,7 @@ export type {
 } from "./eval/types.js";
 export { calibrate } from "./eval/calibrate.js";
 export type { CalibrationBucket, CalibrationSummary } from "./eval/calibrate.js";
+export { checkCostRegression } from "./eval/cost-regression.js";
 
 // Reviewer contract (multi-agent quality gates)
 export type {

--- a/tools/cli/src/commands/agent-eval.test.ts
+++ b/tools/cli/src/commands/agent-eval.test.ts
@@ -6,6 +6,7 @@ const mockRunSession = vi.fn();
 const mockAppendFileSync = vi.fn();
 const mockMkdirSync = vi.fn();
 const mockExistsSync = vi.fn();
+const mockReadFileSync = vi.fn();
 
 // Static import keeps the heavy module load (real @mbe/agent-core via
 // importOriginal) in file setup, outside the per-test timeout window.
@@ -42,6 +43,7 @@ vi.mock("node:fs", () => ({
   existsSync: (...a: unknown[]) => mockExistsSync(...a),
   mkdirSync: (...a: unknown[]) => mockMkdirSync(...a),
   appendFileSync: (...a: unknown[]) => mockAppendFileSync(...a),
+  readFileSync: (...a: unknown[]) => mockReadFileSync(...a),
 }));
 
 function fakeSession(overrides: Record<string, unknown> = {}) {
@@ -181,5 +183,80 @@ describe("agent eval command", () => {
 
     const out = logSpy.mock.calls.flat().join("\n");
     expect(out).not.toContain("without self-eval");
+  });
+
+  describe("--max-cost-regression", () => {
+    it("exits 0 when cost is within threshold versus baseline", async () => {
+      // baseline meanCostUsd = 0.10; current session costUsd = 0.11 (10% up, threshold 20%)
+      const baseline = {
+        runId: "prev",
+        tasks: [],
+        aggregate: {
+          total: 1,
+          passRate: 1,
+          meanScore: 1,
+          meanCostUsd: 0.1,
+          meanTurns: 5,
+          stuckCount: 0,
+        },
+        timestamp: "2026-01-01T00:00:00.000Z",
+      };
+      mockReadFileSync.mockReturnValue(JSON.stringify(baseline) + "\n");
+      mockLoadSuite.mockResolvedValue([task]);
+      mockRunSession.mockResolvedValue(fakeSession({ costUsd: 0.11 }));
+
+      await agentEvalCommand.parseAsync(["--max-cost-regression", "20"], { from: "user" });
+
+      expect(process.exitCode).toBe(0);
+    });
+
+    it("exits 1 when cost exceeds the regression threshold", async () => {
+      // baseline meanCostUsd = 0.10; current session costUsd = 0.25 (150% up, threshold 20%)
+      const baseline = {
+        runId: "prev",
+        tasks: [],
+        aggregate: {
+          total: 1,
+          passRate: 1,
+          meanScore: 1,
+          meanCostUsd: 0.1,
+          meanTurns: 5,
+          stuckCount: 0,
+        },
+        timestamp: "2026-01-01T00:00:00.000Z",
+      };
+      mockReadFileSync.mockReturnValue(JSON.stringify(baseline) + "\n");
+      mockLoadSuite.mockResolvedValue([task]);
+      mockRunSession.mockResolvedValue(fakeSession({ costUsd: 0.25 }));
+
+      await agentEvalCommand.parseAsync(["--max-cost-regression", "20"], { from: "user" });
+
+      expect(process.exitCode).toBe(1);
+      const errOut = errSpy.mock.calls.flat().join("\n");
+      expect(errOut).toMatch(/cost regression/i);
+    });
+
+    it("exits 0 when no baseline exists (first run)", async () => {
+      // No prior eval-reports.jsonl
+      mockReadFileSync.mockImplementation(() => {
+        throw Object.assign(new Error("no such file"), { code: "ENOENT" });
+      });
+      mockLoadSuite.mockResolvedValue([task]);
+      mockRunSession.mockResolvedValue(fakeSession());
+
+      await agentEvalCommand.parseAsync(["--max-cost-regression", "20"], { from: "user" });
+
+      expect(process.exitCode).toBe(0);
+    });
+
+    it("exits 0 when eval-reports.jsonl is empty (no valid baseline)", async () => {
+      mockReadFileSync.mockReturnValue("");
+      mockLoadSuite.mockResolvedValue([task]);
+      mockRunSession.mockResolvedValue(fakeSession());
+
+      await agentEvalCommand.parseAsync(["--max-cost-regression", "20"], { from: "user" });
+
+      expect(process.exitCode).toBe(0);
+    });
   });
 });

--- a/tools/cli/src/commands/agent-eval.ts
+++ b/tools/cli/src/commands/agent-eval.ts
@@ -2,12 +2,13 @@ import { Command } from "commander";
 import { resolve, join } from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { existsSync, mkdirSync, appendFileSync } from "node:fs";
+import { existsSync, mkdirSync, appendFileSync, readFileSync } from "node:fs";
 import {
   runSession,
   runEvalSuite,
   loadSuite,
   calibrate,
+  checkCostRegression,
   DEFAULT_SESSION_CONFIG,
   DEFAULT_FEEDBACK_LOOP_CONFIG,
   type SessionConfig,
@@ -37,6 +38,10 @@ export const agentEvalCommand = new Command("eval")
   .option("-m, --model <model>", "Model to run the agent with", DEFAULT_SESSION_CONFIG.model)
   .option("--json", "Emit the EvalReport as JSON", false)
   .option("--threshold <pct>", "Exit non-zero if suite pass rate is below this percent")
+  .option(
+    "--max-cost-regression <pct>",
+    "Exit non-zero if mean cost-per-task exceeds the latest baseline by more than this percent"
+  )
   .option("--calibrate", "Print self-grade vs ground-truth calibration summary", false)
   .action(
     async (options: {
@@ -45,6 +50,7 @@ export const agentEvalCommand = new Command("eval")
       model: string;
       json: boolean;
       threshold?: string;
+      maxCostRegression?: string;
       calibrate: boolean;
     }) => {
       const repoPath = resolve(process.cwd());
@@ -58,6 +64,11 @@ export const agentEvalCommand = new Command("eval")
         process.exitCode = 1;
         return;
       }
+
+      // Read baseline before appending the current run so the most recent prior
+      // entry is used, not the one we're about to write.
+      const costBaseline =
+        options.maxCostRegression !== undefined ? loadCostBaseline(findLogFile()) : null;
 
       const runTask = makeAgentTaskRunner(repoPath, options.model);
       const report = await runEvalSuite(tasks, {
@@ -87,8 +98,46 @@ export const agentEvalCommand = new Command("eval")
           process.exitCode = 1;
         }
       }
+
+      if (options.maxCostRegression !== undefined) {
+        const thresholdPct = Number(options.maxCostRegression);
+        const current = report.aggregate.meanCostUsd;
+        if (!checkCostRegression(current, costBaseline, thresholdPct)) {
+          const pctIncrease = (((current - costBaseline!) / costBaseline!) * 100).toFixed(1);
+          console.error(
+            `\nCost regression detected: mean cost $${current.toFixed(4)} is ${pctIncrease}% above baseline $${costBaseline!.toFixed(4)} (threshold ${options.maxCostRegression}%)`
+          );
+          process.exitCode = 1;
+        }
+      }
     }
   );
+
+function findLogFile(): string {
+  const root = findMonorepoRoot(process.cwd());
+  return join(root, "docs/logs", "eval-reports.jsonl");
+}
+
+/**
+ * Reads the most recent entry from eval-reports.jsonl and returns its
+ * meanCostUsd, or null when the file is absent, empty, or unparseable.
+ */
+function loadCostBaseline(logFile: string): number | null {
+  try {
+    const content = readFileSync(logFile, "utf8");
+    const lines = content
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean);
+    if (lines.length === 0) return null;
+    const last = lines[lines.length - 1];
+    const parsed = JSON.parse(last) as { aggregate?: { meanCostUsd?: unknown } };
+    const cost = parsed?.aggregate?.meanCostUsd;
+    return typeof cost === "number" ? cost : null;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Appends the report to a JSONL file in docs/logs — mirrors the `mbe stats` record pattern.


### PR DESCRIPTION
## Summary

- Adds pure `checkCostRegression(current, baseline, thresholdPct)` predicate in `packages/agent-core/src/eval/cost-regression.ts` — returns `true` (no regression) when baseline is null or cost increase is within the allowed percent, `false` when it exceeds the threshold.
- Exports `checkCostRegression` from `@mbe/agent-core`.
- Adds `--max-cost-regression <pct>` option to `mbe agent eval`; reads the most recent `eval-reports.jsonl` entry as the baseline **before** appending the current run, compares `meanCostUsd`, and exits non-zero with a descriptive message when the threshold is exceeded.
- Unit tests cover: within-threshold, over-threshold, missing baseline (pass), empty file (pass), and first-run (ENOENT → pass).

## Test plan

- [x] `checkCostRegression` unit tests: within / over / null-baseline / cost-decrease / zero-baseline (5 cases, all green)
- [x] CLI integration tests: exits-0 within threshold, exits-1 over threshold, exits-0 no baseline, exits-0 empty file (4 new cases, all green)
- [x] Full agent-core test suite: 1371 tests passed
- [x] Full CLI test suite: 411 tests passed
- [x] `pnpm lint` — clean on both packages
- [x] `pnpm typecheck` — clean on both packages
- [x] `check-adr` + `check-deps` — no violations
- [x] `pnpm regen` — artifacts up to date (llms.txt updated for new file, staged)
- [x] `detect-instruction-rot` — no rot detected

Closes #2697