### PR TITLE
fix(sensors): re-scope agent-spend.jsonl to per-issue attribution only

### DIFF
--- a/.claude/skills/progress-tracker/SKILL.md
+++ b/.claude/skills/progress-tracker/SKILL.md
@@ -24,7 +24,7 @@ gh issue list --label "meta-improvement" --state all --json number,title,state
 cat .claude/agent-spend.jsonl 2>/dev/null | tail -100
 ```
 
-Cost: `.claude/agent-spend.jsonl` = `{date,timestamp,costUsd,issueNumber,model}`
+Per-issue attribution: `.claude/agent-spend.jsonl` = `{date,timestamp,costUsd,issueNumber,model}` (mbe-agent-run sessions only; NOT total Claude spend — use ccusage for ground-truth totals)
 
 ## Metrics
 
@@ -40,9 +40,9 @@ Cost: `.claude/agent-spend.jsonl` = `{date,timestamp,costUsd,issueNumber,model}`
 | Stale         | ready>7d                 | 0      |
 | Blocked       | agent-failed             | 0      |
 | Skipped       | agent-skip               | 0      |
-| Daily Spend   | Σ costUsd                | <$10   |
-| 7d Spend      | Σ costUsd                | <$50   |
-| Cost/Issue    | 7d/closed                | <$2    |
+| Daily Spend   | Σ costUsd (attributed)   | <$10   |
+| 7d Spend      | Σ costUsd (attributed)   | <$50   |
+| Cost/Issue    | 7d/closed (attributed)   | <$2    |
 
 ## Analysis
 
@@ -172,5 +172,5 @@ git log --oneline --grep="Revert" --since="7 days ago" | wc -l
 - Max 2 meta/run
 - Max 2 retry/run
 - Append-only log
-- Cost: `.claude/agent-spend.jsonl`
+- Per-issue attribution: `.claude/agent-spend.jsonl` (partial — covers mbe-agent-run sessions only; ccusage = ground-truth totals)
 - Circuit: 50% over 3+ days

--- a/.claude/skills/progress-tracker/SKILL.original.md
+++ b/.claude/skills/progress-tracker/SKILL.original.md
@@ -37,12 +37,12 @@ gh run list --branch main --limit 20 --json conclusion,createdAt
 # Meta-improvement suggestions created
 gh issue list --label "meta-improvement" --state all --json number,title,state
 
-# Agent spend (from local cost log)
-# Read .claude/agent-spend.jsonl and aggregate by date
+# Per-issue attribution log (mbe agent run sessions only — NOT total Claude spend)
+# Read .claude/agent-spend.jsonl and aggregate by date; use ccusage for ground-truth totals
 cat .claude/agent-spend.jsonl 2>/dev/null | tail -100
 ```
 
-#### Cost Log Format
+#### Per-Issue Attribution Log Format
 
 The file `.claude/agent-spend.jsonl` contains one JSON object per line:
 
@@ -56,27 +56,31 @@ The file `.claude/agent-spend.jsonl` contains one JSON object per line:
 }
 ```
 
-Log entries are written by `pnpm log:cost -- --cost <usd> --issue <num>` after each agent session.
+Log entries are written by `mbe agent run` (claude adapter) after each attributed session.
+
+**Important:** This log captures only `mbe agent run` sessions (~0.4% of actual Claude spend).
+It is per-issue attribution data, NOT total spend. For ground-truth Claude usage totals, use
+the `ccusage` sensor (`scripts/collect-ccusage.mjs` / `npx ccusage daily`).
 
 ### Step 2: Compute Metrics
 
 Calculate these key indicators:
 
-| Metric                  | Formula                                                                    |
-| ----------------------- | -------------------------------------------------------------------------- |
-| **Issues Created (7d)** | Count of audit + ci-fix issues created in last 7 days                      |
-| **Issues Closed (7d)**  | Count of audit + ci-fix issues closed in last 7 days                       |
-| **Closure Rate**        | Closed / Created (target: > 0.8)                                           |
-| **Avg Time-to-Close**   | Mean of (closedAt - createdAt) for closed issues                           |
-| **Agent Success Rate**  | Issues with `has-pr` / (Issues with `has-pr` + Issues with `agent-failed`) |
-| **CI Pass Rate**        | Successful runs / Total runs on main (target: > 0.95)                      |
-| **Queue Depth**         | Count of issues with `ready` label (target: < 5)                           |
-| **Stale Issues**        | Issues with `ready` label open > 7 days                                    |
-| **Blocked Issues**      | Issues with `agent-failed` label not re-queued                             |
-| **Skipped Issues**      | Issues with `agent-skip` label (exceeded max retries, need manual review)  |
-| **Daily Agent Spend**   | Sum of costUsd from .claude/agent-spend.jsonl for today (target: < $10)    |
-| **7d Agent Spend**      | Sum of costUsd from last 7 days of entries                                 |
-| **Avg Cost/Issue**      | 7d spend / issues closed in 7d                                             |
+| Metric                     | Formula                                                                                        |
+| -------------------------- | ---------------------------------------------------------------------------------------------- |
+| **Issues Created (7d)**    | Count of audit + ci-fix issues created in last 7 days                                          |
+| **Issues Closed (7d)**     | Count of audit + ci-fix issues closed in last 7 days                                           |
+| **Closure Rate**           | Closed / Created (target: > 0.8)                                                               |
+| **Avg Time-to-Close**      | Mean of (closedAt - createdAt) for closed issues                                               |
+| **Agent Success Rate**     | Issues with `has-pr` / (Issues with `has-pr` + Issues with `agent-failed`)                     |
+| **CI Pass Rate**           | Successful runs / Total runs on main (target: > 0.95)                                          |
+| **Queue Depth**            | Count of issues with `ready` label (target: < 5)                                               |
+| **Stale Issues**           | Issues with `ready` label open > 7 days                                                        |
+| **Blocked Issues**         | Issues with `agent-failed` label not re-queued                                                 |
+| **Skipped Issues**         | Issues with `agent-skip` label (exceeded max retries, need manual review)                      |
+| **Daily Attributed Spend** | Sum of costUsd from .claude/agent-spend.jsonl for today (per-issue attribution; target: < $10) |
+| **7d Attributed Spend**    | Sum of costUsd from last 7 days of entries (per-issue attribution only)                        |
+| **Avg Cost/Issue**         | 7d attributed spend / issues closed in 7d                                                      |
 
 ### Step 3: Analyze Patterns
 
@@ -172,16 +176,16 @@ Only create improvement issues for patterns seen **consistently over 3+ days**. 
 
 ## Targets & Thresholds
 
-| Metric             | Green | Yellow   | Red    |
-| ------------------ | ----- | -------- | ------ |
-| Closure Rate       | > 80% | 50-80%   | < 50%  |
-| Agent Success Rate | > 70% | 40-70%   | < 40%  |
-| CI Pass Rate       | > 95% | 85-95%   | < 85%  |
-| Queue Depth        | < 5   | 5-10     | > 10   |
-| Avg Time-to-Close  | < 24h | 24-72h   | > 72h  |
-| Daily Agent Spend  | < $10 | $10-$20  | > $20  |
-| 7d Agent Spend     | < $50 | $50-$100 | > $100 |
-| Avg Cost/Issue     | < $2  | $2-$5    | > $5   |
+| Metric                 | Green | Yellow   | Red    |
+| ---------------------- | ----- | -------- | ------ |
+| Closure Rate           | > 80% | 50-80%   | < 50%  |
+| Agent Success Rate     | > 70% | 40-70%   | < 40%  |
+| CI Pass Rate           | > 95% | 85-95%   | < 85%  |
+| Queue Depth            | < 5   | 5-10     | > 10   |
+| Avg Time-to-Close      | < 24h | 24-72h   | > 72h  |
+| Daily Attributed Spend | < $10 | $10-$20  | > $20  |
+| 7d Attributed Spend    | < $50 | $50-$100 | > $100 |
+| Avg Cost/Issue         | < $2  | $2-$5    | > $5   |
 
 ## Self-Tuning Actions
 
@@ -262,5 +266,5 @@ If reverts > 3 in a week, flag it — the loop may be pushing broken code.
 - **Max 2 meta-improvement issues per run** — avoid flooding the queue
 - **Max 2 auto-retries per run** — don't flood the ready queue
 - **Append-only log** — never delete or modify previous log entries
-- **Cost data** — read from `.claude/agent-spend.jsonl` (logged by `pnpm log:cost` after each agent session)
+- **Per-issue attribution data** — read from `.claude/agent-spend.jsonl` (logged by `mbe agent run`; partial — NOT total Claude spend; use ccusage for ground-truth totals)
 - **Circuit breaker threshold** — only pause at 50% failure rate over 3+ days, not single bad days

--- a/scripts/__tests__/collect-agent-cost.test.mjs
+++ b/scripts/__tests__/collect-agent-cost.test.mjs
@@ -4,6 +4,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { collectAgentCost } from "../collect-agent-cost.mjs";
 
+// agent-spend.jsonl is per-issue attribution only (logged by `mbe agent run`).
+// It captures ~0.4% of actual Claude spend. Ground-truth totals come from the
+// ccusage sensor (`collectCcusageSensor`), not from this collector.
+
 function makeTmpDir() {
   return mkdtempSync(join(tmpdir(), "collect-agent-cost-test-"));
 }
@@ -98,6 +102,21 @@ describe("collectAgentCost", () => {
     expect(result.total_input_tokens_7d).toBe(0);
     expect(result.total_output_tokens_7d).toBe(0);
     expect(result.avg_turns_per_session).toBe(0);
+  });
+
+  it("flags the result as attribution_only to distinguish from ground-truth totals", () => {
+    const spendPath = join(dir, ".claude", "agent-spend.jsonl");
+    const today = new Date().toISOString().slice(0, 10);
+    writeFileSync(
+      spendPath,
+      JSON.stringify({ date: today, costUsd: 0.5, issueNumber: 42, model: "claude-sonnet-4-6" }) +
+        "\n"
+    );
+    const result = collectAgentCost(spendPath);
+    expect(result.available).toBe(true);
+    // attribution_only: true signals that spend values cover only mbe-agent-run
+    // sessions (per-issue), not total Claude spend. Use ccusage for ground-truth totals.
+    expect(result.attribution_only).toBe(true);
   });
 
   it("ignores entries older than 7 days for 7d aggregates", () => {

--- a/scripts/collect-agent-cost.mjs
+++ b/scripts/collect-agent-cost.mjs
@@ -1,12 +1,20 @@
 /**
- * Pure collector for agent cost telemetry from .claude/agent-spend.jsonl.
+ * Per-issue attribution collector for .claude/agent-spend.jsonl.
  *
- * Extracted from sensor-report.mjs so it can be unit-tested without the
- * @mbe/gh-client dependency and without triggering the sensor-report runner.
+ * agent-spend.jsonl captures only sessions started via `mbe agent run`
+ * (claude adapter). It covers roughly 0.4% of actual Claude spend. For
+ * ground-truth totals, use the ccusage sensor (`collectCcusageSensor`).
+ *
+ * This collector is intentionally scoped to per-issue attribution:
+ *   - Which issues consumed how much budget?
+ *   - How many attributed sessions ran this week?
+ *   - What is the average cost per attributed session?
+ *
+ * DO NOT use the returned `spend_*_usd` fields as total Claude spend.
  *
  * Record schema (appended by log-agent-cost.js and mbe agent run):
  *   { date, timestamp, costUsd, issueNumber, model }          // legacy
- *   { date, timestamp, costUsd, issueNumber, model,           // v2 (this PR)
+ *   { date, timestamp, costUsd, issueNumber, model,           // v2
  *     inputTokens, outputTokens, numTurns }
  *
  * BACKWARD-COMPAT: records without token/turn fields parse fine; those
@@ -36,11 +44,15 @@ function readJsonl(filePath) {
 }
 
 /**
- * Aggregate agent cost telemetry from agent-spend.jsonl.
+ * Aggregate per-issue attribution data from agent-spend.jsonl.
+ *
+ * The returned `spend_*_usd` fields reflect only `mbe agent run` sessions
+ * (per-issue attribution), NOT total Claude spend. Ground-truth totals
+ * come from the ccusage sensor.
  *
  * @param {string} spendPath - Absolute path to the .claude/agent-spend.jsonl file.
  * @param {Date} [now] - Reference timestamp (defaults to current time; injectable for tests).
- * @returns {object} Aggregated metrics or { available: false } when no data.
+ * @returns {object} Aggregated attribution metrics or { available: false } when no data.
  */
 export function collectAgentCost(spendPath, now = new Date()) {
   const sevenDaysAgo = new Date(now - 7 * 24 * 60 * 60 * 1000);
@@ -67,6 +79,9 @@ export function collectAgentCost(spendPath, now = new Date()) {
 
   return {
     available: true,
+    // attribution_only signals that spend values cover only mbe-agent-run sessions.
+    // For ground-truth total Claude spend, use the ccusage sensor.
+    attribution_only: true,
     spend_today_usd: Math.round(todaySpend * 100) / 100,
     spend_7d_usd: Math.round(totalSpend7d * 100) / 100,
     sessions_7d: sevenDayEntries.length,

--- a/scripts/sensor-report.mjs
+++ b/scripts/sensor-report.mjs
@@ -125,6 +125,11 @@ function collectPrCategoryMetricsSensor() {
   return computePrCategoryMetrics(prs);
 }
 
+/**
+ * Per-issue attribution sensor (NOT total spend).
+ * Reads .claude/agent-spend.jsonl which logs only `mbe agent run` sessions.
+ * Ground-truth total spend is provided by collectCcusageCostSensor.
+ */
 function collectAgentCostSensor() {
   const spendPath = resolve(ROOT, ".claude", "agent-spend.jsonl");
   return collectAgentCost(spendPath, now);
@@ -470,7 +475,7 @@ if (JSON_ONLY) {
         break;
       case "agentCost":
         console.log(
-          `   ${name}: $${data.spend_7d_usd} (7d), $${data.spend_today_usd} (today), ${data.sessions_7d} sessions`
+          `   ${name} (per-issue attribution): $${data.spend_7d_usd} (7d), $${data.spend_today_usd} (today), ${data.sessions_7d} attributed sessions`
         );
         break;
       case "ccusageCost":


### PR DESCRIPTION
## Summary

- `collect-agent-cost.mjs`: updated file-level JSDoc to say "per-issue attribution", clarify ~0.4% coverage vs total spend, and added `attribution_only: true` to the returned result shape
- `sensor-report.mjs`: updated `collectAgentCostSensor` wrapper comment and console label for `agentCost` to say "per-issue attribution" instead of implying total spend
- Progress-tracker SKILL.md / SKILL.original.md: corrected "Daily Spend" / "7d Spend" metrics to say "attributed" and explicitly note that ccusage is the ground-truth source for totals
- `collect-agent-cost.test.mjs`: added `attribution_only: true` assertion (TDD RED → GREEN) plus clarifying comment block documenting the role boundary

## Test plan

- [x] New test `flags the result as attribution_only to distinguish from ground-truth totals` fails before implementation, passes after
- [x] All 7 collect-agent-cost tests pass
- [x] `pnpm --filter @mbe/cli start check-adr` passes
- [x] `pnpm --filter @mbe/cli start check-deps` passes
- [x] `pnpm regen` ran and regenerated llms-full.txt (staged)
- [x] `node scripts/detect-instruction-rot.mjs` passes
- [x] Pre-push hook: 23/23 tasks pass

Closes #2699