### PR TITLE
test(hospitality): fix strict-mode selector drift in 7 E2E specs (#1968)

### DIFF
--- a/apps/hospitality/e2e/booking-widget.spec.ts
+++ b/apps/hospitality/e2e/booking-widget.spec.ts
@@ -29,7 +29,7 @@ test.describe("Booking Widget demo page", () => {
   test("shows venue selector or widget preview area", async ({ mockedPage }) => {
     await mockedPage.goto("booking-widget");
 
-    const previewArea = mockedPage.getByText(/preview|select a venue/i);
+    const previewArea = mockedPage.getByText("Widget Preview");
     await expect(previewArea).toBeVisible();
   });
 });

--- a/apps/hospitality/e2e/create-reservation.spec.ts
+++ b/apps/hospitality/e2e/create-reservation.spec.ts
@@ -15,7 +15,7 @@ test.describe("CF-4: Reservation edit flow", () => {
     await expect(sidebar).toBeVisible();
 
     // Shows reservation info
-    await expect(sidebar.getByText(/guest|party/i)).toBeVisible();
+    await expect(sidebar.getByText("Party Size")).toBeVisible();
     await mockedPage.screenshot({
       path: "e2e/screenshots/create-reservation-sidebar.png",
       fullPage: true,

--- a/apps/hospitality/e2e/guests.spec.ts
+++ b/apps/hospitality/e2e/guests.spec.ts
@@ -64,7 +64,7 @@ test.describe("CF-7: Guest directory and search", () => {
     const dialog = mockedPage.getByRole("dialog", { name: /add guest/i });
     await expect(dialog).toBeVisible();
 
-    await dialog.getByRole("button", { name: /cancel|close/i }).click();
+    await dialog.getByRole("button", { name: "Cancel" }).click();
 
     await expect(dialog).not.toBeVisible();
   });

--- a/apps/hospitality/e2e/reservations.spec.ts
+++ b/apps/hospitality/e2e/reservations.spec.ts
@@ -20,7 +20,7 @@ test.describe("CF-6: Reservations page with filtering", () => {
     await expect(mockedPage.getByRole("radio", { name: "Pending" })).toBeVisible();
     await expect(mockedPage.getByRole("radio", { name: "Cancelled" })).toBeVisible();
 
-    const searchInput = mockedPage.getByRole("textbox");
+    const searchInput = mockedPage.getByPlaceholder("Search by guest name...");
     await expect(searchInput).toBeVisible();
     await mockedPage.screenshot({
       path: "e2e/screenshots/reservations-filters.png",
@@ -39,7 +39,7 @@ test.describe("CF-6: Reservations page with filtering", () => {
   test("search input filters the reservation list", async ({ mockedPage }) => {
     await mockedPage.goto("reservations");
 
-    const searchInput = mockedPage.getByRole("textbox");
+    const searchInput = mockedPage.getByPlaceholder("Search by guest name...");
     await searchInput.fill("Test");
 
     const resultCount = mockedPage
@@ -59,7 +59,7 @@ test.describe("CF-6: Reservations page with filtering", () => {
   test("shows empty state when no results match search", async ({ mockedPage }) => {
     await mockedPage.goto("reservations");
 
-    const searchInput = mockedPage.getByRole("textbox");
+    const searchInput = mockedPage.getByPlaceholder("Search by guest name...");
     await searchInput.fill("zzzzz-no-match-9999");
 
     await expect(mockedPage.getByText("No reservations")).toBeVisible();

--- a/apps/hospitality/e2e/settings.spec.ts
+++ b/apps/hospitality/e2e/settings.spec.ts
@@ -31,7 +31,7 @@ test.describe("CF-10: Settings page and preferences persistence", () => {
   test("notifications card is visible", async ({ mockedPage }) => {
     await mockedPage.goto("settings");
 
-    await expect(mockedPage.getByText("Notifications")).toBeVisible();
+    await expect(mockedPage.getByRole("heading", { name: "Notifications" })).toBeVisible();
     await mockedPage.screenshot({
       path: "e2e/screenshots/settings-notifications.png",
       fullPage: true,


### PR DESCRIPTION
## What

Narrows 7 Playwright locators that matched multiple elements (strict-mode violations) after rialto/page markup evolved. Pure test-side fixes — no app code changed.

| Spec | Was | Now |
|------|-----|-----|
| booking-widget | `/preview\|select a venue/i` (3 matches) | `Widget Preview` |
| create-reservation | sidebar `/guest\|party/i` (3 matches) | `Party Size` |
| guests | dialog `/cancel\|close/i` (2 matches) | `Cancel` |
| reservations ×3 | `getByRole('textbox')` (search + date input) | `getByPlaceholder('Search by guest name...')` |
| settings | `getByText('Notifications')` (heading + label) | `getByRole('heading', {name})` |

## Why

Cluster A of the #1968 E2E-stability triage. These 7 were the largest root-cause group in the remaining failures: selectors too loose to survive markup growth. Expected: E2E failing count 14 → ~7.

## Test plan

- [ ] CI Hospitality E2E: these 7 specs pass
- [ ] CI Gate green

Part of #1968.