### PR TITLE
feat(eval): add cost eval suite with --suite cost support

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1442,7 +1442,7 @@
           calibrate: boolean;
         }) => {
           const repoPath = resolve(process.cwd());
-          const suiteDir = resolve(repoPath, options.suite);
+          const suiteDir = resolve(repoPath, resolveSuitePath(options.suite));
     
           let tasks: Task[];
           try {
@@ -2847,6 +2847,12 @@
       readonly totalWithSelfEval: number;
       /** Tasks that had no selfEvaluation field (not counted in any bucket). */
       readonly totalWithoutSelfEval: number;
+    }
+  </file>
+  <file path="packages/agent-core/src/eval/cost-suite.ts">
+    export const COST_SUITE_DIR = "packages/agent-core/eval-suite/cost";
+    export function resolveSuitePath(suite: string): string {
+      return NAMED_SUITES[suite] ?? suite;
     }
   </file>
   <file path="packages/agent-core/src/eval/eval-harness.ts">
@@ -16065,7 +16071,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms.txt
+++ b/llms.txt
@@ -974,6 +974,14 @@
       }
     </item>
   </file>
+  <file path="packages/agent-core/src/eval/cost-suite.ts">
+    <item priority="high">
+      export const COST_SUITE_DIR: unknown;
+    </item>
+    <item priority="high">
+      export function resolveSuitePath(suite: string): string { /* ... */ }
+    </item>
+  </file>
   <file path="packages/agent-core/src/eval/eval-harness.ts">
     <item priority="low">
       interface RunEvalSuiteOptions {

--- a/packages/agent-core/eval-suite/cost/cost-001-bugfix.json
+++ b/packages/agent-core/eval-suite/cost/cost-001-bugfix.json
@@ -1,0 +1,19 @@
+{
+  "id": "cost-001-bugfix",
+  "category": "bugfix",
+  "prompt": "In packages/agent-core/src/eval/eval-harness.ts the stuckCount in the aggregate result counts any task whose 'error' field is not undefined. A task whose error field is set to an empty string should NOT count as stuck — only non-empty error strings indicate a mid-run crash. Fix the stuckCount predicate to filter on non-empty strings and add a unit test in eval-harness.test.ts that verifies an empty-string error does not increment stuckCount.",
+  "fixtureRef": "packages/agent-core",
+  "rubric": {
+    "testsMustPass": true,
+    "typecheckMustPass": true,
+    "lintMustPass": false,
+    "judgeCriteria": [
+      "stuckCount only increments for tasks whose error field is a non-empty string",
+      "A test covers the empty-string edge case"
+    ]
+  },
+  "budget": {
+    "maxTurns": 20,
+    "maxCostUsd": 0.5
+  }
+}

--- a/packages/agent-core/eval-suite/cost/cost-002-refactor.json
+++ b/packages/agent-core/eval-suite/cost/cost-002-refactor.json
@@ -1,0 +1,20 @@
+{
+  "id": "cost-002-refactor",
+  "category": "refactor",
+  "prompt": "In packages/agent-core/src/eval/eval-harness.ts the aggregate() function contains an inline arrow function called 'sum' that is only used within that function body. Extract it to a module-level helper named sumScores(scores, pick) so it can be tested independently. All existing tests in eval-harness.test.ts must continue to pass.",
+  "fixtureRef": "packages/agent-core",
+  "rubric": {
+    "testsMustPass": true,
+    "typecheckMustPass": true,
+    "lintMustPass": false,
+    "judgeCriteria": [
+      "The sum helper is lifted to module scope as sumScores",
+      "aggregate() delegates to sumScores",
+      "No external API changes — EvalReport shape is unchanged"
+    ]
+  },
+  "budget": {
+    "maxTurns": 15,
+    "maxCostUsd": 0.4
+  }
+}

--- a/packages/agent-core/eval-suite/cost/cost-003-test-writing.json
+++ b/packages/agent-core/eval-suite/cost/cost-003-test-writing.json
@@ -1,0 +1,19 @@
+{
+  "id": "cost-003-test-writing",
+  "category": "test-writing",
+  "prompt": "Add a vitest unit test to packages/agent-core/src/eval/golden-task-set.test.ts that verifies loadSuite() throws an error containing the directory path when the suite directory does not exist. The test should use a non-existent path such as '/tmp/no-such-eval-suite' and assert that the thrown error message includes that path.",
+  "fixtureRef": "packages/agent-core",
+  "rubric": {
+    "testsMustPass": true,
+    "typecheckMustPass": true,
+    "lintMustPass": false,
+    "judgeCriteria": [
+      "A test calls loadSuite with a non-existent directory and expects it to throw",
+      "The error message check includes the directory path"
+    ]
+  },
+  "budget": {
+    "maxTurns": 15,
+    "maxCostUsd": 0.4
+  }
+}

--- a/packages/agent-core/llms-full.txt
+++ b/packages/agent-core/llms-full.txt
@@ -374,6 +374,12 @@
       readonly totalWithoutSelfEval: number;
     }
   </file>
+  <file path="src/eval/cost-suite.ts">
+    export const COST_SUITE_DIR = "packages/agent-core/eval-suite/cost";
+    export function resolveSuitePath(suite: string): string {
+      return NAMED_SUITES[suite] ?? suite;
+    }
+  </file>
   <file path="src/eval/eval-harness.ts">
     export interface RunEvalSuiteOptions {
       /** Agent-invocation seam. Real impl runs `runSession`; tests stub it. */

--- a/packages/agent-core/llms.txt
+++ b/packages/agent-core/llms.txt
@@ -68,6 +68,14 @@
       }
     </item>
   </file>
+  <file path="src/eval/cost-suite.ts">
+    <item priority="high">
+      export const COST_SUITE_DIR: unknown;
+    </item>
+    <item priority="high">
+      export function resolveSuitePath(suite: string): string { /* ... */ }
+    </item>
+  </file>
   <file path="src/eval/eval-harness.ts">
     <item priority="low">
       interface RunEvalSuiteOptions {

--- a/packages/agent-core/src/eval/cost-suite.test.ts
+++ b/packages/agent-core/src/eval/cost-suite.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { COST_SUITE_DIR, resolveSuitePath } from "./cost-suite.js";
+
+describe("cost suite resolver", () => {
+  it("exports COST_SUITE_DIR pointing to the cost subdirectory", () => {
+    expect(COST_SUITE_DIR).toBe("packages/agent-core/eval-suite/cost");
+  });
+
+  it("resolveSuitePath maps 'cost' to COST_SUITE_DIR", () => {
+    expect(resolveSuitePath("cost")).toBe(COST_SUITE_DIR);
+  });
+
+  it("resolveSuitePath passes unknown names through unchanged", () => {
+    expect(resolveSuitePath("packages/agent-core/eval-suite")).toBe(
+      "packages/agent-core/eval-suite"
+    );
+  });
+});

--- a/packages/agent-core/src/eval/cost-suite.ts
+++ b/packages/agent-core/src/eval/cost-suite.ts
@@ -1,0 +1,32 @@
+/**
+ * Cost eval suite — a fixed, representative task set for tracking cost-per-task
+ * trends over time, independent of the pass-rate threshold.
+ *
+ * Tasks live as JSON in {@link COST_SUITE_DIR}. Use {@link resolveSuitePath} to
+ * translate the short name `"cost"` to the directory path before calling `loadSuite`.
+ *
+ * Suite design:
+ *   - Fixed tasks (deterministic selection) — same set every run
+ *   - Tight budgets (maxTurns ≤ 20, maxCostUsd ≤ 0.5) — keep per-run cost low
+ *   - One task per common category (bugfix, refactor, test-writing)
+ *   - All tasks target `packages/agent-core` to minimise fixture setup
+ */
+
+/** Relative path (from repo root) to the cost eval suite task directory. */
+export const COST_SUITE_DIR = "packages/agent-core/eval-suite/cost";
+
+/** Short-name → relative-path map for built-in named suites. */
+const NAMED_SUITES: Readonly<Record<string, string>> = {
+  cost: COST_SUITE_DIR,
+};
+
+/**
+ * Resolves a suite identifier to a relative directory path.
+ *
+ * Named suites (e.g. `"cost"`) are mapped to their canonical directory.
+ * Any other value is returned unchanged so callers can still pass an
+ * explicit relative or absolute path.
+ */
+export function resolveSuitePath(suite: string): string {
+  return NAMED_SUITES[suite] ?? suite;
+}

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -325,6 +325,7 @@ export { SecurityReviewGate } from "./gates/security-review-gate.js";
 
 // Golden-task eval harness — run fixed benchmark tasks through the agent and score them
 export { loadSuite } from "./eval/golden-task-set.js";
+export { resolveSuitePath, COST_SUITE_DIR } from "./eval/cost-suite.js";
 export { scoreTask } from "./eval/task-scorer.js";
 export { runEvalSuite } from "./eval/eval-harness.js";
 export type { RunEvalSuiteOptions } from "./eval/eval-harness.js";

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -349,7 +349,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/tools/cli/src/commands/agent-eval.test.ts
+++ b/tools/cli/src/commands/agent-eval.test.ts
@@ -182,4 +182,13 @@ describe("agent eval command", () => {
     const out = logSpy.mock.calls.flat().join("\n");
     expect(out).not.toContain("without self-eval");
   });
+
+  it("resolves --suite cost to the cost eval suite directory", async () => {
+    mockLoadSuite.mockResolvedValue([task]);
+    mockRunSession.mockResolvedValue(fakeSession());
+
+    await agentEvalCommand.parseAsync(["--suite", "cost", "--task", "t1"], { from: "user" });
+
+    expect(mockLoadSuite).toHaveBeenCalledWith(expect.stringContaining("eval-suite/cost"));
+  });
 });

--- a/tools/cli/src/commands/agent-eval.ts
+++ b/tools/cli/src/commands/agent-eval.ts
@@ -8,6 +8,7 @@ import {
   runEvalSuite,
   loadSuite,
   calibrate,
+  resolveSuitePath,
   DEFAULT_SESSION_CONFIG,
   DEFAULT_FEEDBACK_LOOP_CONFIG,
   type SessionConfig,
@@ -48,7 +49,7 @@ export const agentEvalCommand = new Command("eval")
       calibrate: boolean;
     }) => {
       const repoPath = resolve(process.cwd());
-      const suiteDir = resolve(repoPath, options.suite);
+      const suiteDir = resolve(repoPath, resolveSuitePath(options.suite));
 
       let tasks: Task[];
       try {


### PR DESCRIPTION
## Summary

- Adds `packages/agent-core/src/eval/cost-suite.ts` with `COST_SUITE_DIR` constant and `resolveSuitePath()` — maps named suites (e.g. `"cost"`) to their directory, passing unknown values through unchanged
- Adds three fixed cost-suite tasks in `packages/agent-core/eval-suite/cost/` (bugfix, refactor, test-writing) with tight budgets (≤ 20 turns, ≤ \$0.50) to keep per-run cost low and measurable
- Exports `resolveSuitePath` / `COST_SUITE_DIR` from `@mbe/agent-core`
- Updates `agent-eval.ts` to call `resolveSuitePath` before directory resolution so `mbe agent eval --suite cost` selects the cost suite
- Per-task cost flows into `docs/logs/eval-reports.jsonl` via the existing `persistReport` pipeline — trend tracking works immediately

The cost-regression gate (`checkCostRegression`) from #2707 is intentionally absent — this PR delivers the suite the gate will consume.

## Test plan

- [x] `cost-suite.test.ts` — 3 tests cover `COST_SUITE_DIR`, `resolveSuitePath("cost")`, and passthrough for unknown names
- [x] New CLI test: `--suite cost` resolves to a path containing `eval-suite/cost`
- [x] `pnpm lint` — clean (agent-core + cli)
- [x] `pnpm typecheck` — clean (agent-core + cli)
- [x] `pnpm test` — 74 files / 1369 tests (agent-core), 43 files / 408 tests (cli)
- [x] `check-adr` + `check-deps` — no violations
- [x] `pnpm regen` — artifacts regenerated and staged; `regen --check` clean

Closes #2700