### PR TITLE
feat(agent-core): per-turn budget gate + structured breach event

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -13192,6 +13192,31 @@
       return tier === "trivial" ? "simple" : tier;
     }
   </file>
+  <file path="packages/agent-core/src/budget-gate.ts">
+    export interface BudgetBreachResult {
+      /** Whether the accumulated turn costs strictly exceed the budget ceiling. */
+      readonly exceeded: boolean;
+      /** Sum of all per-turn costUsd values. */
+      readonly accumulatedCostUsd: number;
+      /** The budget ceiling passed in by the caller. */
+      readonly maxBudgetUsd: number;
+      /** Amount by which the budget was exceeded (0 when not exceeded). */
+      readonly overageUsd: number;
+    }
+    export function shouldHaltForBudget(
+      turnMetrics: readonly TurnMetrics[],
+      maxBudgetUsd: number
+    ): BudgetBreachResult {
+      const accumulatedCostUsd = turnMetrics.reduce((sum, t) => sum + t.costUsd, 0);
+      const exceeded = accumulatedCostUsd > maxBudgetUsd;
+      return {
+        exceeded,
+        accumulatedCostUsd,
+        maxBudgetUsd,
+        overageUsd: exceeded ? accumulatedCostUsd - maxBudgetUsd : 0,
+      };
+    }
+  </file>
   <file path="packages/agent-core/src/bundle-size-tracker.ts">
     export interface FileSize {
       readonly path: string;
@@ -14143,6 +14168,8 @@
       prUrl: string | null;
       prNumber?: number;
       errors: string[];
+      /** Set when enforceBudget=true and per-turn costs exceeded maxBudgetUsd. */
+      budgetEnforced?: boolean;
     }
     export async function runSession(
       config: SessionConfig,
@@ -16065,7 +16092,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms.txt
+++ b/llms.txt
@@ -3046,6 +3046,22 @@
       export function classifyTaskComplexity(description: string): "simple" | "standard" | "complex" { /* ... */ }
     </item>
   </file>
+  <file path="packages/agent-core/src/budget-gate.ts">
+    <item priority="low">
+      interface BudgetBreachResult {
+        exceeded: boolean;
+        accumulatedCostUsd: number;
+        maxBudgetUsd: number;
+        overageUsd: number;
+      }
+    </item>
+    <item priority="high">
+      export function shouldHaltForBudget(
+        turnMetrics: readonly TurnMetrics[],
+        maxBudgetUsd: number
+      ): BudgetBreachResult { /* ... */ }
+    </item>
+  </file>
   <file path="packages/agent-core/src/bundle-size-tracker.ts">
     <item priority="low">
       interface FileSize {

--- a/packages/agent-core/llms-full.txt
+++ b/packages/agent-core/llms-full.txt
@@ -1227,6 +1227,31 @@
       return tier === "trivial" ? "simple" : tier;
     }
   </file>
+  <file path="src/budget-gate.ts">
+    export interface BudgetBreachResult {
+      /** Whether the accumulated turn costs strictly exceed the budget ceiling. */
+      readonly exceeded: boolean;
+      /** Sum of all per-turn costUsd values. */
+      readonly accumulatedCostUsd: number;
+      /** The budget ceiling passed in by the caller. */
+      readonly maxBudgetUsd: number;
+      /** Amount by which the budget was exceeded (0 when not exceeded). */
+      readonly overageUsd: number;
+    }
+    export function shouldHaltForBudget(
+      turnMetrics: readonly TurnMetrics[],
+      maxBudgetUsd: number
+    ): BudgetBreachResult {
+      const accumulatedCostUsd = turnMetrics.reduce((sum, t) => sum + t.costUsd, 0);
+      const exceeded = accumulatedCostUsd > maxBudgetUsd;
+      return {
+        exceeded,
+        accumulatedCostUsd,
+        maxBudgetUsd,
+        overageUsd: exceeded ? accumulatedCostUsd - maxBudgetUsd : 0,
+      };
+    }
+  </file>
   <file path="src/bundle-size-tracker.ts">
     export interface FileSize {
       readonly path: string;
@@ -2178,6 +2203,8 @@
       prUrl: string | null;
       prNumber?: number;
       errors: string[];
+      /** Set when enforceBudget=true and per-turn costs exceeded maxBudgetUsd. */
+      budgetEnforced?: boolean;
     }
     export async function runSession(
       config: SessionConfig,

--- a/packages/agent-core/llms.txt
+++ b/packages/agent-core/llms.txt
@@ -243,6 +243,22 @@
       export function classifyTaskComplexity(description: string): "simple" | "standard" | "complex" { /* ... */ }
     </item>
   </file>
+  <file path="src/budget-gate.ts">
+    <item priority="low">
+      interface BudgetBreachResult {
+        exceeded: boolean;
+        accumulatedCostUsd: number;
+        maxBudgetUsd: number;
+        overageUsd: number;
+      }
+    </item>
+    <item priority="high">
+      export function shouldHaltForBudget(
+        turnMetrics: readonly TurnMetrics[],
+        maxBudgetUsd: number
+      ): BudgetBreachResult { /* ... */ }
+    </item>
+  </file>
   <file path="src/bundle-size-tracker.ts">
     <item priority="low">
       interface FileSize {

--- a/packages/agent-core/src/__tests__/session-runner.test.ts
+++ b/packages/agent-core/src/__tests__/session-runner.test.ts
@@ -555,6 +555,118 @@ describe("runSession", () => {
     expect(fbCall.maxBudgetUsd).toBeCloseTo(0.75);
   });
 
+  // ── Budget gate integration tests ────────────────────────────────
+
+  it("emits session:budget_breach event when turn costs exceed maxBudgetUsd", async () => {
+    vi.mocked(deps.queryRunner.runHardenedQuery).mockResolvedValue(
+      hardenedResult({
+        resultMessage: createMockResultMessage() as never,
+        rawTurnMetrics: [
+          {
+            turnIndex: 1,
+            startedAt: new Date().toISOString(),
+            inputTokens: 100,
+            outputTokens: 50,
+            thinkingTokens: 0,
+            costUsd: 1.5,
+            modelId: "claude-sonnet-4-6",
+          },
+        ],
+      })
+    );
+    vi.mocked(deps.worktreeManager.hasChanges).mockResolvedValue(false);
+
+    const events: SessionEvent[] = [];
+    const config = { ...BASE_CONFIG, maxBudgetUsd: 1.0 };
+    await runSession(config, (event) => events.push(event), deps);
+
+    const breachEvents = events.filter((e) => e.type === "session:budget_breach");
+    expect(breachEvents).toHaveLength(1);
+    const payload = JSON.parse((breachEvents[0].data as { message: string }).message);
+    expect(payload.exceeded).toBe(true);
+    expect(payload.accumulatedCostUsd).toBeCloseTo(1.5);
+    expect(payload.maxBudgetUsd).toBe(1.0);
+  });
+
+  it("does NOT halt the session by default when budget is breached (observe only)", async () => {
+    vi.mocked(deps.queryRunner.runHardenedQuery).mockResolvedValue(
+      hardenedResult({
+        resultMessage: createMockResultMessage() as never,
+        rawTurnMetrics: [
+          {
+            turnIndex: 1,
+            startedAt: new Date().toISOString(),
+            inputTokens: 100,
+            outputTokens: 50,
+            thinkingTokens: 0,
+            costUsd: 1.5,
+            modelId: "claude-sonnet-4-6",
+          },
+        ],
+      })
+    );
+    vi.mocked(deps.worktreeManager.hasChanges).mockResolvedValue(false);
+
+    const config = { ...BASE_CONFIG, maxBudgetUsd: 1.0 };
+    const result = await runSession(config, undefined, deps);
+
+    // Session should succeed despite breach — enforcement is opt-in
+    expect(result.status).toBe("succeeded");
+  });
+
+  it("halts the session when enforceBudget=true and budget is breached", async () => {
+    vi.mocked(deps.queryRunner.runHardenedQuery).mockResolvedValue(
+      hardenedResult({
+        resultMessage: createMockResultMessage() as never,
+        rawTurnMetrics: [
+          {
+            turnIndex: 1,
+            startedAt: new Date().toISOString(),
+            inputTokens: 100,
+            outputTokens: 50,
+            thinkingTokens: 0,
+            costUsd: 1.5,
+            modelId: "claude-sonnet-4-6",
+          },
+        ],
+      })
+    );
+    vi.mocked(deps.worktreeManager.hasChanges).mockResolvedValue(false);
+
+    const config = { ...BASE_CONFIG, maxBudgetUsd: 1.0, enforceBudget: true };
+    const result = await runSession(config, undefined, deps);
+
+    expect(result.status).toBe("failed");
+    expect(result.errors.some((e) => e.includes("budget") || e.includes("Budget"))).toBe(true);
+  });
+
+  it("does not emit budget_breach when costs are within budget", async () => {
+    vi.mocked(deps.queryRunner.runHardenedQuery).mockResolvedValue(
+      hardenedResult({
+        resultMessage: createMockResultMessage() as never,
+        rawTurnMetrics: [
+          {
+            turnIndex: 1,
+            startedAt: new Date().toISOString(),
+            inputTokens: 100,
+            outputTokens: 50,
+            thinkingTokens: 0,
+            costUsd: 0.5,
+            modelId: "claude-sonnet-4-6",
+          },
+        ],
+      })
+    );
+    vi.mocked(deps.worktreeManager.hasChanges).mockResolvedValue(false);
+
+    const events: SessionEvent[] = [];
+    const config = { ...BASE_CONFIG, maxBudgetUsd: 1.0 };
+    await runSession(config, (event) => events.push(event), deps);
+
+    const breachEvents = events.filter((e) => e.type === "session:budget_breach");
+    expect(breachEvents).toHaveLength(0);
+  });
+
   // ── Cached git diff tests ─────────────────────────────────────────
 
   it("caches git diff across evaluation, static analysis, and security review", async () => {

--- a/packages/agent-core/src/budget-gate.test.ts
+++ b/packages/agent-core/src/budget-gate.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { shouldHaltForBudget } from "./budget-gate.js";
+import type { TurnMetrics } from "./types.js";
+
+function makeTurn(costUsd: number, turnIndex = 1): TurnMetrics {
+  return {
+    turnIndex,
+    startedAt: new Date().toISOString(),
+    inputTokens: 100,
+    outputTokens: 50,
+    thinkingTokens: 0,
+    costUsd,
+    modelId: "claude-sonnet-4-6",
+  };
+}
+
+describe("shouldHaltForBudget", () => {
+  it("returns exceeded=false with no turns", () => {
+    const result = shouldHaltForBudget([], 1.0);
+    expect(result.exceeded).toBe(false);
+    expect(result.accumulatedCostUsd).toBe(0);
+    expect(result.overageUsd).toBe(0);
+  });
+
+  it("returns exceeded=false when under budget", () => {
+    const turns = [makeTurn(0.4), makeTurn(0.3, 2)];
+    const result = shouldHaltForBudget(turns, 1.0);
+    expect(result.exceeded).toBe(false);
+    expect(result.accumulatedCostUsd).toBeCloseTo(0.7);
+    expect(result.overageUsd).toBe(0);
+  });
+
+  it("returns exceeded=false when exactly at budget", () => {
+    const turns = [makeTurn(0.5), makeTurn(0.5, 2)];
+    const result = shouldHaltForBudget(turns, 1.0);
+    expect(result.exceeded).toBe(false);
+    expect(result.accumulatedCostUsd).toBeCloseTo(1.0);
+    expect(result.overageUsd).toBe(0);
+  });
+
+  it("returns exceeded=true when over budget", () => {
+    const turns = [makeTurn(0.6), makeTurn(0.6, 2)];
+    const result = shouldHaltForBudget(turns, 1.0);
+    expect(result.exceeded).toBe(true);
+    expect(result.accumulatedCostUsd).toBeCloseTo(1.2);
+    expect(result.overageUsd).toBeCloseTo(0.2);
+    expect(result.maxBudgetUsd).toBe(1.0);
+  });
+
+  it("returns exceeded=true with a single turn that exceeds the budget", () => {
+    const result = shouldHaltForBudget([makeTurn(2.5)], 1.0);
+    expect(result.exceeded).toBe(true);
+    expect(result.accumulatedCostUsd).toBe(2.5);
+    expect(result.overageUsd).toBeCloseTo(1.5);
+  });
+
+  it("exposes maxBudgetUsd in the result", () => {
+    const result = shouldHaltForBudget([makeTurn(0.1)], 2.0);
+    expect(result.maxBudgetUsd).toBe(2.0);
+    expect(result.exceeded).toBe(false);
+  });
+});

--- a/packages/agent-core/src/budget-gate.ts
+++ b/packages/agent-core/src/budget-gate.ts
@@ -1,0 +1,42 @@
+import type { TurnMetrics } from "./types.js";
+
+// ── Budget breach result ─────────────────────────────────────────────
+
+export interface BudgetBreachResult {
+  /** Whether the accumulated turn costs strictly exceed the budget ceiling. */
+  readonly exceeded: boolean;
+  /** Sum of all per-turn costUsd values. */
+  readonly accumulatedCostUsd: number;
+  /** The budget ceiling passed in by the caller. */
+  readonly maxBudgetUsd: number;
+  /** Amount by which the budget was exceeded (0 when not exceeded). */
+  readonly overageUsd: number;
+}
+
+// ── Pure predicate ───────────────────────────────────────────────────
+
+/**
+ * Pure per-turn budget enforcement predicate.
+ *
+ * Sums `costUsd` across all completed turns and compares to `maxBudgetUsd`.
+ * Returns `exceeded: true` only when the accumulated cost STRICTLY exceeds
+ * the ceiling — equality is not a breach (conservative by design).
+ *
+ * **Session-level enforcement is opt-in** via `SessionConfig.enforceBudget`.
+ * The default session-runner behavior is observe/warn only: it emits a
+ * `session:budget_breach` event but does NOT halt the session unless
+ * `enforceBudget` is explicitly set to `true`.
+ */
+export function shouldHaltForBudget(
+  turnMetrics: readonly TurnMetrics[],
+  maxBudgetUsd: number
+): BudgetBreachResult {
+  const accumulatedCostUsd = turnMetrics.reduce((sum, t) => sum + t.costUsd, 0);
+  const exceeded = accumulatedCostUsd > maxBudgetUsd;
+  return {
+    exceeded,
+    accumulatedCostUsd,
+    maxBudgetUsd,
+    overageUsd: exceeded ? accumulatedCostUsd - maxBudgetUsd : 0,
+  };
+}

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -68,6 +68,10 @@ export {
 // Cost tracking
 export { extractTokenUsage, extractCost, buildSessionResult } from "./cost-tracker.js";
 
+// Budget gate (per-turn cost enforcement predicate)
+export { shouldHaltForBudget } from "./budget-gate.js";
+export type { BudgetBreachResult } from "./budget-gate.js";
+
 // Cost logging (automatic spend recording to .claude/agent-spend/sessions.jsonl)
 export { recordSessionCost } from "./cost-logger.js";
 export type { CostEntry, CostEntryInput } from "./cost-logger.js";

--- a/packages/agent-core/src/session-runner.ts
+++ b/packages/agent-core/src/session-runner.ts
@@ -13,6 +13,7 @@ import type { ContextMetrics } from "./context-budget.js";
 import type { EvaluationResult } from "./success-evaluator.js";
 import type { GatewayVerdict } from "./post-commit-gateway.js";
 import { buildSessionResult } from "./cost-tracker.js";
+import { shouldHaltForBudget } from "./budget-gate.js";
 import { scheduleWorktreeReap } from "./worktree-reaper.js";
 import { recordFailure } from "./failure-memory.js";
 import { withRetry } from "./retry.js";
@@ -68,6 +69,8 @@ interface SessionState {
   prUrl: string | null;
   prNumber?: number;
   errors: string[];
+  /** Set when enforceBudget=true and per-turn costs exceeded maxBudgetUsd. */
+  budgetEnforced?: boolean;
 }
 
 // ── Public API ──────────────────────────────────────────────────────
@@ -226,6 +229,20 @@ async function runPipeline(
   }
   if (await abortOnFailure(queryExec.result, config, state, deps, onEvent)) return;
 
+  // ── Budget gate (observe/warn by default; halts only when enforceBudget=true) ─
+  const breach = shouldHaltForBudget(state.turnMetrics, config.maxBudgetUsd);
+  if (breach.exceeded) {
+    emitEvent(onEvent, "session:budget_breach", {
+      message: JSON.stringify(breach),
+    });
+    if (config.enforceBudget) {
+      const breachMsg = `Budget breached: accumulated $${breach.accumulatedCostUsd.toFixed(4)} exceeds limit $${breach.maxBudgetUsd}`;
+      state.errors.push(breachMsg);
+      state.budgetEnforced = true;
+      return;
+    }
+  }
+
   // VerificationPhase
   const verifyExec = await verificationPhase.run(
     {
@@ -374,6 +391,7 @@ function buildFinalResult(
     turnMetrics,
     toolCallMetrics,
     contextMetrics,
+    budgetEnforced,
   } = state;
   const errors = [...state.errors];
 
@@ -409,12 +427,21 @@ function buildFinalResult(
       state.prUrl ?? null
     );
 
-    const isFailed = sessionResult.status === "failed" || !!stuckReason;
+    const isFailed = sessionResult.status === "failed" || !!stuckReason || !!budgetEnforced;
     const failureCategory = isFailed ? categorizeFailure(errors, stuckReason?.type) : undefined;
 
     const finalResult: SessionResult = {
       ...sessionResult,
       ...(stuckReason ? { status: "failed" as const, stuckPattern: stuckReason.type } : {}),
+      ...(budgetEnforced
+        ? {
+            status: "failed" as const,
+            errors: [
+              ...sessionResult.errors,
+              ...errors.filter((e) => !sessionResult.errors.includes(e)),
+            ],
+          }
+        : {}),
       ...(evalSummary ? { evaluation: evalSummary } : {}),
       ...(failureCategory ? { failureCategory } : {}),
       turnMetrics: collectedTurnMetrics,

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -85,6 +85,12 @@ export interface SessionConfig {
   readonly modelRoutingReason?: string;
   /** The selected model tier from routing (e.g. "haiku", "sonnet", "opus") */
   readonly modelRoutingTier?: string;
+  /**
+   * When `true`, the session runner halts if accumulated per-turn costs exceed
+   * `maxBudgetUsd`. Defaults to `false` (observe/warn only — the budget breach
+   * event is always emitted, but the session is not aborted unless this is set).
+   */
+  readonly enforceBudget?: boolean;
 }
 
 export const DEFAULT_SESSION_CONFIG: Omit<SessionConfig, "taskDescription" | "repoPath"> = {
@@ -146,7 +152,8 @@ export type SessionEventType =
   | "session:turn_metrics"
   | "session:tool_latency"
   | "session:heartbeat"
-  | "session:cleanup_warning";
+  | "session:cleanup_warning"
+  | "session:budget_breach";
 
 // ── Heartbeat / liveness configuration ──────────────────────────────
 

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -349,7 +349,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),


### PR DESCRIPTION
## Summary

- Adds pure `shouldHaltForBudget(turnMetrics[], maxBudgetUsd)` predicate in `packages/agent-core/src/budget-gate.ts`
- Predicate sums per-turn `costUsd` and returns a structured `BudgetBreachResult` with `exceeded`, `accumulatedCostUsd`, `maxBudgetUsd`, and `overageUsd`
- Session runner (`session-runner.ts`) consults the gate after the query phase; on breach it emits a structured `session:budget_breach` event with the full breach details as JSON
- **Default behavior is observe-only** — the session continues normally unless `SessionConfig.enforceBudget: true` is explicitly set
- Adds `session:budget_breach` to `SessionEventType` and `enforceBudget?: boolean` to `SessionConfig`
- `budget-policy.json` numeric ceilings are **intentionally unchanged** — dollar limits are a human decision

## Conservative default (critical safety note)

The gate is NOT aggressive by default. Without `enforceBudget: true`:
- Breach is detected and emitted as a structured event
- Session pipeline continues normally
- Existing callers are completely unaffected

To opt into hard enforcement: `{ enforceBudget: true }` in `SessionConfig`.

## Test plan

- [x] `budget-gate.test.ts` — 6 unit tests covering empty/under/at/over budget cases, overage amount, and maxBudgetUsd passthrough
- [x] `session-runner.test.ts` — 4 new integration tests: breach event emitted, session continues without `enforceBudget`, session halts with `enforceBudget: true`, no event when under budget
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 74 test files / 1376 tests pass
- [x] `check-adr` + `check-deps` — no violations
- [x] `pnpm regen` + `pnpm regen --check` — artifacts up to date

Closes #2698