### PR TITLE
test(hospitality): fix 2 more strict-mode selector dups (#1968)

### DIFF
--- a/apps/hospitality/e2e/dashboard.spec.ts
+++ b/apps/hospitality/e2e/dashboard.spec.ts
@@ -13,10 +13,10 @@ test.describe("CF-2: Dashboard morning load", () => {
     await mockedPage.goto("dashboard");
 
     // All four Stat widgets defined in HomePage
-    await expect(mockedPage.getByText("Today's Reservations")).toBeVisible();
-    await expect(mockedPage.getByText("Expected Covers")).toBeVisible();
-    await expect(mockedPage.getByText("Upcoming (2 hrs)")).toBeVisible();
-    await expect(mockedPage.getByText("Cancellation Rate")).toBeVisible();
+    await expect(mockedPage.getByRole("heading", { name: "Today's Reservations" })).toBeVisible();
+    await expect(mockedPage.getByRole("heading", { name: "Expected Covers" })).toBeVisible();
+    await expect(mockedPage.getByRole("heading", { name: "Upcoming (2 hrs)" })).toBeVisible();
+    await expect(mockedPage.getByRole("heading", { name: "Cancellation Rate" })).toBeVisible();
     await mockedPage.screenshot({ path: "e2e/screenshots/dashboard-stats.png", fullPage: true });
   });
 

--- a/apps/hospitality/e2e/reservations.spec.ts
+++ b/apps/hospitality/e2e/reservations.spec.ts
@@ -62,7 +62,7 @@ test.describe("CF-6: Reservations page with filtering", () => {
     const searchInput = mockedPage.getByPlaceholder("Search by guest name...");
     await searchInput.fill("zzzzz-no-match-9999");
 
-    await expect(mockedPage.getByText("No reservations")).toBeVisible();
+    await expect(mockedPage.getByText("No reservations", { exact: true })).toBeVisible();
     await mockedPage.screenshot({ path: "e2e/screenshots/reservations-empty.png", fullPage: true });
   });
 });


### PR DESCRIPTION
## What

Round 2 of #1968 selector-drift cleanup, diagnosed from CI `error-context.md` DOM snapshots (the UI already renders correctly — only the test locators were too loose):

| Spec | Issue | Fix |
|------|-------|-----|
| dashboard 'stats widgets render' | each stat label matches both a Stat `<span>` and a Card `<h3>` (strict-mode dup ×4) | `getByRole('heading', {name})` |
| reservations 'empty state' | `'No reservations'` matched the EmptyState heading **and** its description | `{ exact: true }` |

## Why

These two were misdiagnosed earlier as app gaps; the DOM snapshots prove the empty-state and stat widgets render fine — pure locator drift. Expected: E2E failing 9 → 7.

## Test plan
- [ ] CI: dashboard + reservations specs pass
- [ ] CI Gate green

Part of #1968.