### PR TITLE
test(hospitality): de-flake BookingWidget slot-click race with findByText

### DIFF
--- a/apps/hospitality/src/components/booking-widget/BookingWidget.test.tsx
+++ b/apps/hospitality/src/components/booking-widget/BookingWidget.test.tsx
@@ -93,7 +93,9 @@ describe("BookingWidget", () => {
 
     // Step 2: Time
     await waitFor(() => expect(screen.getByText("Time")).toBeDefined());
-    expect(screen.getByText(/6:00 PM/i)).toBeDefined();
+    // Slots render asynchronously after the "Time" heading; await the first slot
+    // so the click below doesn't race the slot list render (flaky on slow CI).
+    expect(await screen.findByText(/6:00 PM/i)).toBeDefined();
     expect(screen.getByText(/7:00 PM/i)).toBeDefined();
 
     mockApi.holds.create.mockResolvedValue({
@@ -189,7 +191,9 @@ describe("BookingWidget", () => {
     mockApi.holds.create.mockResolvedValue({
       hold: { id: "hold-1", expiresAt: new Date(Date.now() + 600000).toISOString() },
     });
-    fireEvent.click(screen.getByText(/6:00 PM/i));
+    // Slots render asynchronously after the "Time" heading; await the slot so the
+    // click doesn't race the slot list render (flaky on slow CI — Node 20 leg).
+    fireEvent.click(await screen.findByText(/6:00 PM/i));
 
     // Step 3: Details
     await waitFor(() => expect(screen.getByText("Details")).toBeDefined());


### PR DESCRIPTION
## Problem
`BookingWidget.test.tsx` intermittently fails on the **Node 20** CI leg with `Unable to find element /6:00 PM/i`. Both booking tests `await waitFor(() => getByText("Time"))` (the step heading) then **synchronously** `getByText(/6:00 PM/i)` the slot button. Time slots render asynchronously *after* the heading, so under load the click races the slot-list render.

This flake turned **main red** on bccfb1a6 (#2713 merge) and ea30b366 (#2712 merge), and fails per-PR Node-20 gates — destabilizing the merge queue.

## Fix
Switch the first slot access in each test to `await screen.findByText(/6:00 PM/i)` (polls until present). Test-only; 6 insertions / 2 deletions. Verified 3× locally.

Refs #1968