### PR TITLE
refactor(reservations): fix resolveChannel() vocabulary drift from CommunicationPreference

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -11756,7 +11756,7 @@
     export interface ResolveChannelInput {
       email: string | null;
       phone: string | null;
-      communicationPreference: string | null;
+      communicationPreference: CommunicationPreference | null;
     }
   </file>
   <file path="services/reservations/src/services/briefing.ts">
@@ -16112,7 +16112,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -16112,18 +16112,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/llms.txt
+++ b/llms.txt
@@ -2477,7 +2477,7 @@
       interface ResolveChannelInput {
         email: string | null;
         phone: string | null;
-        communicationPreference: string | null;
+        communicationPreference: CommunicationPreference | null;
       }
     </item>
   </file>

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -349,7 +349,18 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
+        color: z
+          .enum([
+            "success",
+            "warning",
+            "error",
+            "accent",
+            "primary",
+            "secondary",
+            "tertiary",
+            "on-accent",
+          ])
+          .optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/packages/rialto-catalog/llms-full.txt
+++ b/packages/rialto-catalog/llms-full.txt
@@ -349,18 +349,7 @@
       }),
       Text: z.object({
         variant: z.enum(["body", "caption", "label", "detail", "display"]).optional(),
-        color: z
-          .enum([
-            "success",
-            "warning",
-            "error",
-            "accent",
-            "primary",
-            "secondary",
-            "tertiary",
-            "on-accent",
-          ])
-          .optional(),
+        color: z.enum(["success", "warning", "error", "accent", "primary", "secondary", "tertiary", "on-accent"]).optional(),
         align: z.enum(["center", "left", "right"]).optional(),
         mono: z.boolean().optional(),
         truncate: z.boolean().optional(),

--- a/services/reservations/llms-full.txt
+++ b/services/reservations/llms-full.txt
@@ -5046,7 +5046,7 @@
     export interface ResolveChannelInput {
       email: string | null;
       phone: string | null;
-      communicationPreference: string | null;
+      communicationPreference: CommunicationPreference | null;
     }
   </file>
   <file path="src/services/briefing.ts">

--- a/services/reservations/llms.txt
+++ b/services/reservations/llms.txt
@@ -332,7 +332,7 @@
       interface ResolveChannelInput {
         email: string | null;
         phone: string | null;
-        communicationPreference: string | null;
+        communicationPreference: CommunicationPreference | null;
       }
     </item>
   </file>

--- a/services/reservations/src/services/booking-notifications.test.ts
+++ b/services/reservations/src/services/booking-notifications.test.ts
@@ -42,20 +42,20 @@ function makeReservation(overrides: Record<string, unknown> = {}) {
 }
 
 describe("resolveChannel", () => {
-  it("returns 'email' when preference is 'email' regardless of phone availability", () => {
+  it("returns 'email' when preference is 'email_only' regardless of phone availability", () => {
     const input: ResolveChannelInput = {
       email: "a@example.com",
       phone: "+15551234567",
-      communicationPreference: "email",
+      communicationPreference: "email_only",
     };
     expect(resolveChannel(input)).toBe("email");
   });
 
-  it("returns 'sms' when preference is 'sms'", () => {
+  it("returns 'sms' when preference is 'sms_only'", () => {
     const input: ResolveChannelInput = {
       email: "a@example.com",
       phone: "+15551234567",
-      communicationPreference: "sms",
+      communicationPreference: "sms_only",
     };
     expect(resolveChannel(input)).toBe("sms");
   });
@@ -67,6 +67,15 @@ describe("resolveChannel", () => {
       communicationPreference: "both",
     };
     expect(resolveChannel(input)).toBe("both");
+  });
+
+  it("returns 'email' when preference is 'transactional_only'", () => {
+    const input: ResolveChannelInput = {
+      email: "a@example.com",
+      phone: "+15551234567",
+      communicationPreference: "transactional_only",
+    };
+    expect(resolveChannel(input)).toBe("email");
   });
 
   it("falls back to 'both' when no preference and both email and phone are present", () => {
@@ -308,14 +317,14 @@ describe("createBookingNotifier", () => {
     expect(deps.scheduler.schedule).toHaveBeenCalled();
   });
 
-  it("resolveChannel prefers communicationPreference=email over data availability", async () => {
+  it("resolveChannel prefers communicationPreference=email_only over data availability", async () => {
     const deps = makeDeps();
     const notifier = createBookingNotifier(deps);
-    // Reservation has both email and phone but pref = email (via guest field)
+    // Reservation has both email and phone but pref = email_only (via guest field)
     const startMs = Date.now() + 30 * 60 * 60 * 1000;
     const reservation = makeReservation({
       startTime: new Date(startMs).toISOString(),
-      guest: { visitCount: 1, communicationPreference: "email" },
+      guest: { visitCount: 1, communicationPreference: "email_only" },
     });
 
     await notifier.scheduleBookingNotifications(reservation as never, "token");

--- a/services/reservations/src/services/booking-notifications.ts
+++ b/services/reservations/src/services/booking-notifications.ts
@@ -16,14 +16,15 @@ function reminderJobId(jobType: string, reservationId: string): string {
 export interface ResolveChannelInput {
   email: string | null;
   phone: string | null;
-  communicationPreference: string | null;
+  communicationPreference: CommunicationPreference | null;
 }
 
 export function resolveChannel(input: ResolveChannelInput): "email" | "sms" | "both" {
   const { email, phone, communicationPreference } = input;
-  if (communicationPreference === "email") return "email";
-  if (communicationPreference === "sms") return "sms";
+  if (communicationPreference === "email_only") return "email";
+  if (communicationPreference === "sms_only") return "sms";
   if (communicationPreference === "both") return "both";
+  if (communicationPreference === "transactional_only") return "email";
   // Fall back to data availability
   if (email && phone) return "both";
   if (phone) return "sms";
@@ -93,7 +94,8 @@ export function createBookingNotifier(deps: BookingNotifierDeps): BookingNotifie
     const channel = resolveChannel({
       email: guestEmail,
       phone: guestPhone,
-      communicationPreference: reservation.guest?.communicationPreference ?? null,
+      communicationPreference:
+        (reservation.guest?.communicationPreference as CommunicationPreference | null) ?? null,
     });
 
     const dayBeforeDelay = startMs - now - DAY_MS;

--- a/services/reservations/src/services/win-back.test.ts
+++ b/services/reservations/src/services/win-back.test.ts
@@ -87,4 +87,18 @@ describe("sendWinBack", () => {
 
     expect(result).toBe(true);
   });
+
+  it("returns false for sms_only guest even when email is present", async () => {
+    const guest = makeGuest({
+      communicationPreference: "sms_only",
+      email: "alice@example.com",
+      phone: "+15551234567",
+    });
+    const port = makeNotificationPort();
+
+    const result = await sendWinBack(guest, port, "Any Venue");
+
+    expect(result).toBe(false);
+    expect(port.sendWinBack).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

- `resolveChannel()` was checking shortform strings (`"email"`, `"sms"`) but callers always pass canonical `CommunicationPreference` values (`"email_only"`, `"sms_only"`, `"both"`, `"transactional_only"`). Only `"both"` ever matched; all other preferences fell through to data-availability, causing `email_only` guests with a phone number to receive SMS reminders they had opted out of.
- Updated `ResolveChannelInput.communicationPreference` type from `string | null` to `CommunicationPreference | null`.
- Corrected mappings: `"email_only"` → `"email"`, `"sms_only"` → `"sms"`, `"transactional_only"` → `"email"`, `"both"` → `"both"`, `null` → data-availability fallback (unchanged).
- Updated tests to use canonical vocabulary; added `"transactional_only"` and `sms_only` win-back coverage.

## Test plan

- [x] TDD: wrote failing tests with canonical inputs first (5 RED), then implemented (GREEN)
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test src/services/booking-notifications.test.ts src/services/win-back.test.ts` — 29/29 pass
- [x] `check-adr` + `check-deps` — no violations
- [x] `pnpm regen` — artifacts regenerated and staged

Closes #2716