### PR TITLE
chore: stop .gitignore from ignoring tracked ACMM files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,7 +70,14 @@ services/*/src/generated/
 .claude/agent-spend.jsonl
 .claude/governor-state.json
 .claude/session-logs/*.json
-.claude/acmm/
+# Ignore acmm dir *contents* (not the dir itself) so the negations below can
+# re-include the tracked files — git won't descend into a dir ignored as a whole.
+.claude/acmm/*
+# These ACMM files are intentionally tracked and required in a fresh checkout
+# (regression baseline + scanner inputs).
+!.claude/acmm/state.json
+!.claude/acmm/repo-bench-results.json
+!.claude/acmm/onboarding-benchmark.json
 .claude/*.lock
 .superpowers/
 


### PR DESCRIPTION
## Summary
Fixes the `.gitignore` config smell in #2710: the broad `.claude/acmm/` rule ignored the whole directory, flagging three intentionally-tracked, fresh-checkout-required files as tracked-but-ignored (`git ls-files -ci --exclude-standard` listed all three).

These files are required by the ACMM scan + regression workflows:
- `.claude/acmm/state.json` — regression baseline / trend history
- `.claude/acmm/repo-bench-results.json` — scanner asserts existence + `results`
- `.claude/acmm/onboarding-benchmark.json` — onboarding benchmark input

## Fix
Switch `.claude/acmm/` → `.claude/acmm/*` (ignore *contents*, not the directory) so the negation patterns can re-include the three tracked files. Git won't descend into a directory ignored as a whole, so negations only work against a contents glob.

## Verification
- `git ls-files -ci --exclude-standard` → **empty** (acceptance criterion met)
- `git check-ignore` on all 3 files → not ignored
- A transient `.claude/acmm/some-transient.json` → still correctly ignored

Closes #2710