### PR TITLE
fix(ci): guard exit codes of pnpm build/regen in .husky/pre-push

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -41,7 +41,13 @@ fi
 # `pnpm build && pnpm regen` in the right order, finds different content → drift.
 # Turbo caches the build so this is near-instant when CLI source is unchanged.
 echo "pre-push: building CLI for regen..."
-pnpm build --filter @mbe/cli...
+if ! pnpm build --filter @mbe/cli...; then
+  echo ""
+  echo "ERROR: CLI build failed — fix the TypeScript errors above before pushing."
+  echo "Emergency bypass: git push --no-verify"
+  echo ""
+  exit 1
+fi
 
 # Run the full artifact regeneration before checking. This mirrors what CI does:
 # `pnpm regen` (regenerate) then `pnpm regen --check` (verify the regen was
@@ -49,7 +55,13 @@ pnpm build --filter @mbe/cli...
 # it compared working-tree vs index, passing even when the committed artifacts
 # were stale relative to what CI would generate from scratch.
 echo "pre-push: regenerating generated artifacts..."
-pnpm regen
+if ! pnpm regen; then
+  echo ""
+  echo "ERROR: artifact regeneration failed — fix the error above before pushing."
+  echo "Emergency bypass: git push --no-verify"
+  echo ""
+  exit 1
+fi
 
 if ! pnpm regen --check; then
   echo ""


### PR DESCRIPTION
## Summary

- Wraps the bare `pnpm build --filter @mbe/cli...` (line 44) added by #2750 with `if ! ...; then echo; exit 1; fi` — the file's existing guard idiom.
- Wraps the bare `pnpm regen` (line 52) added by #2750 with the same idiom.
- No other changes; happy-path behavior (build → regen → regen --check) is identical.

## Why this matters

`.husky/pre-push` is `#!/bin/sh` without `set -e`. Before this fix, a TypeScript error in CLI source would cause `pnpm build --filter @mbe/cli...` to exit non-zero, but the script would continue. `pnpm regen` would then no-op (missing `@mbe/agent-core/dist`), and `pnpm regen --check` would pass falsely because the working tree matches the (stale) committed artifacts. The silent-pass mode #2745 set out to kill would have been restored.

With this fix: a failing build exits the hook immediately with a clear `ERROR:` message, blocking the push at source.

## Gate results

- `sh -n .husky/pre-push` — Syntax OK
- `pnpm --filter @mbe/cli start check-adr` — no violations
- `pnpm --filter @mbe/cli start check-deps` — no mismatches
- `pnpm regen` — no artifact drift
- Pre-push hook ran end-to-end on push (all guards passed)

Closes #2751