### PR TITLE
feat(sensors): queueEfficiency scorecard from GitHub PR history + ccusage

### DIFF
--- a/metrics/ai-antipattern-baselines.json
+++ b/metrics/ai-antipattern-baselines.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-28T00:39:32.747Z",
+  "generatedAt": "2026-06-28T04:57:05.947Z",
   "patterns": {
     "magicTimeouts": {
       "count": 32,
@@ -22,7 +22,7 @@
       "description": "TypeScript `as any` casts or `: any` type annotations"
     },
     "consoleLogs": {
-      "count": 762,
+      "count": 763,
       "description": "console.log() calls in production (non-test) source files"
     },
     "unusedParams": {

--- a/scripts/__tests__/collect-queue-efficiency.test.mjs
+++ b/scripts/__tests__/collect-queue-efficiency.test.mjs
@@ -1,0 +1,321 @@
+import { describe, it, expect } from "vitest";
+import { collectQueueEfficiency } from "../collect-queue-efficiency.mjs";
+
+const TEST_NOW = new Date("2026-06-27T12:00:00Z");
+
+function isoAgo(days) {
+  return new Date(+TEST_NOW - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function dayStrAgo(days) {
+  return new Date(+TEST_NOW - days * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+}
+
+function makePr(opts = {}) {
+  return {
+    number: opts.number ?? 1,
+    state: opts.state ?? "MERGED",
+    // Default matches the actual worktree branch pattern (worktree-agent-*)
+    headRefName: opts.headRefName ?? "worktree-agent-abc123",
+    createdAt: opts.createdAt ?? isoAgo(3),
+    // Use 'in' check so callers can explicitly pass null to test the null-mergedAt path.
+    mergedAt: "mergedAt" in opts ? opts.mergedAt : isoAgo(2),
+    closedAt: "closedAt" in opts ? opts.closedAt : "mergedAt" in opts ? opts.mergedAt : isoAgo(2),
+    labels: opts.labels ?? [{ name: "agent-authored" }, { name: "ci-fix" }],
+    commitCount: opts.commitCount ?? 1,
+    additions: opts.additions ?? 50,
+    deletions: opts.deletions ?? 20,
+  };
+}
+
+function makeCcusage(daysAgo, totalCost) {
+  return { period: dayStrAgo(daysAgo), totalCost };
+}
+
+// ── Fixture sets ────────────────────────────────────────
+
+/** 3 AI PRs merged in current 7-day window — clean first-pass scenario */
+const CLEAN_PRS = [
+  makePr({ number: 1, commitCount: 1, createdAt: isoAgo(4), mergedAt: isoAgo(3) }),
+  makePr({ number: 2, commitCount: 1, createdAt: isoAgo(5), mergedAt: isoAgo(4) }),
+  makePr({ number: 3, commitCount: 2, createdAt: isoAgo(6), mergedAt: isoAgo(5) }),
+];
+
+/** Same 3 AI PRs but also with prior-week PRs to build a baseline */
+const PRS_WITH_HISTORY = [
+  ...CLEAN_PRS,
+  // week 2 (8–14 days ago)
+  makePr({ number: 10, commitCount: 1, createdAt: isoAgo(13), mergedAt: isoAgo(10) }),
+  makePr({ number: 11, commitCount: 1, createdAt: isoAgo(12), mergedAt: isoAgo(11) }),
+  // week 3 (15–21 days ago)
+  makePr({ number: 20, commitCount: 1, createdAt: isoAgo(19), mergedAt: isoAgo(17) }),
+];
+
+/** Regression scenario: current week has many rework cycles */
+const REGRESSION_PRS = [
+  ...PRS_WITH_HISTORY,
+  // Override current PRs — many commits = rework
+  makePr({ number: 30, commitCount: 5, createdAt: isoAgo(4), mergedAt: isoAgo(3) }),
+  makePr({ number: 31, commitCount: 6, createdAt: isoAgo(5), mergedAt: isoAgo(4) }),
+  makePr({ number: 32, commitCount: 4, createdAt: isoAgo(6), mergedAt: isoAgo(5) }),
+];
+
+/** Non-AI PRs (no agent-authored/has-pr label, no worktree-agent- branch) */
+const HUMAN_PRS = [
+  {
+    number: 50,
+    state: "MERGED",
+    headRefName: "feature/my-human-pr",
+    createdAt: isoAgo(3),
+    mergedAt: isoAgo(2),
+    closedAt: isoAgo(2),
+    labels: [{ name: "feature" }],
+    commitCount: 1,
+    additions: 100,
+    deletions: 50,
+  },
+];
+
+const CLEAN_CCUSAGE = {
+  daily: [makeCcusage(0, 3.0), makeCcusage(1, 4.0), makeCcusage(3, 3.0)],
+};
+
+const NO_CCUSAGE = () => null;
+
+// ── Tests ───────────────────────────────────────────────
+
+describe("collectQueueEfficiency", () => {
+  it("returns available:false when readPrs returns null", () => {
+    const result = collectQueueEfficiency(() => null, NO_CCUSAGE, TEST_NOW);
+    expect(result.available).toBe(false);
+  });
+
+  it("returns available:false when readPrs returns empty array", () => {
+    const result = collectQueueEfficiency(() => [], NO_CCUSAGE, TEST_NOW);
+    expect(result.available).toBe(false);
+  });
+
+  it("returns available:false when readPrs throws", () => {
+    const result = collectQueueEfficiency(
+      () => {
+        throw new Error("gh not found");
+      },
+      NO_CCUSAGE,
+      TEST_NOW
+    );
+    expect(result.available).toBe(false);
+  });
+
+  it("returns available:false when all PRs are non-AI (no agent-authored/has-pr label, no worktree-agent- branch)", () => {
+    const result = collectQueueEfficiency(() => HUMAN_PRS, NO_CCUSAGE, TEST_NOW);
+    expect(result.available).toBe(false);
+  });
+
+  it("returns available:false when merged AI PRs exist but none in current 7-day window", () => {
+    const oldPrs = [
+      makePr({ number: 1, mergedAt: isoAgo(15) }), // 15 days ago — outside window
+    ];
+    const result = collectQueueEfficiency(() => oldPrs, NO_CCUSAGE, TEST_NOW);
+    expect(result.available).toBe(false);
+  });
+
+  it("returns available:true with composite + sub_metrics for current window", () => {
+    const result = collectQueueEfficiency(() => CLEAN_PRS, NO_CCUSAGE, TEST_NOW);
+
+    expect(result.available).toBe(true);
+    expect(typeof result.composite).toBe("number");
+    expect(result.composite).toBeGreaterThanOrEqual(0);
+    expect(result.composite).toBeLessThanOrEqual(1);
+    expect(result.sub_metrics).toBeDefined();
+    expect(result.sub_metrics.issues_merged).toBe(3);
+  });
+
+  it("computes first_pass_success_rate as fraction of PRs with commitCount <= 2", () => {
+    // 2 of 3 PRs have commitCount <= 2 (PRs 1,2 have 1; PR 3 has 2 ← qualifies)
+    const result = collectQueueEfficiency(() => CLEAN_PRS, NO_CCUSAGE, TEST_NOW);
+    // All 3 have commitCount <= 2 (1, 1, 2)
+    expect(result.sub_metrics.first_pass_success_rate).toBe(1.0);
+  });
+
+  it("computes median_time_to_merge_hours from createdAt → mergedAt", () => {
+    // PR1: merged 3d ago, created 4d ago → 24h
+    // PR2: merged 4d ago, created 5d ago → 24h
+    // PR3: merged 5d ago, created 6d ago → 24h
+    const result = collectQueueEfficiency(() => CLEAN_PRS, NO_CCUSAGE, TEST_NOW);
+    expect(result.sub_metrics.median_time_to_merge_hours).toBeCloseTo(24, 1);
+  });
+
+  it("computes cost_per_issue_usd as ccusage spend / issues merged", () => {
+    // 3+4+3 = 10 USD, 3 issues → $3.333
+    const result = collectQueueEfficiency(
+      () => CLEAN_PRS,
+      () => CLEAN_CCUSAGE,
+      TEST_NOW
+    );
+    expect(result.sub_metrics.cost_per_issue_usd).toBeCloseTo(10 / 3, 2);
+  });
+
+  it("uses zero cost when ccusage reader returns null", () => {
+    const result = collectQueueEfficiency(() => CLEAN_PRS, NO_CCUSAGE, TEST_NOW);
+    expect(result.sub_metrics.cost_per_issue_usd).toBe(0);
+  });
+
+  it("uses zero cost when ccusage reader throws", () => {
+    const result = collectQueueEfficiency(
+      () => CLEAN_PRS,
+      () => {
+        throw new Error("ccusage not found");
+      },
+      TEST_NOW
+    );
+    expect(result.available).toBe(true);
+    expect(result.sub_metrics.cost_per_issue_usd).toBe(0);
+  });
+
+  it("returns baseline:null when no prior-week data is available", () => {
+    const result = collectQueueEfficiency(() => CLEAN_PRS, NO_CCUSAGE, TEST_NOW);
+    expect(result.baseline).toBeNull();
+    expect(result.regressions).toEqual([]);
+  });
+
+  it("computes baseline from prior weeks when history is available", () => {
+    const result = collectQueueEfficiency(() => PRS_WITH_HISTORY, NO_CCUSAGE, TEST_NOW);
+
+    expect(result.baseline).not.toBeNull();
+    expect(result.baseline.weeks_sampled).toBeGreaterThanOrEqual(1);
+    expect(typeof result.baseline.composite_median).toBe("number");
+    expect(typeof result.baseline.fps_median).toBe("number");
+    expect(typeof result.baseline.ttm_median).toBe("number");
+  });
+
+  it("detects composite regression when current score drops below baseline band", () => {
+    // Use regression PRs (30–32) which have 4-6 commits each, all in current window
+    // BUT we need to keep prior-week PRs separate in the fixture
+    // The PRs_WITH_HISTORY current window is PRs 1,2,3 (good fps)
+    // Let's build a custom fixture: prior weeks have good fps, current week has bad fps
+    const priorWeekPrs = [
+      makePr({ number: 10, commitCount: 1, createdAt: isoAgo(13), mergedAt: isoAgo(10) }),
+      makePr({ number: 11, commitCount: 1, createdAt: isoAgo(12), mergedAt: isoAgo(11) }),
+      makePr({ number: 20, commitCount: 1, createdAt: isoAgo(19), mergedAt: isoAgo(17) }),
+      makePr({ number: 21, commitCount: 1, createdAt: isoAgo(18), mergedAt: isoAgo(16) }),
+    ];
+    const badCurrentPrs = [
+      makePr({ number: 30, commitCount: 8, createdAt: isoAgo(4), mergedAt: isoAgo(3) }),
+      makePr({ number: 31, commitCount: 9, createdAt: isoAgo(5), mergedAt: isoAgo(4) }),
+      makePr({ number: 32, commitCount: 7, createdAt: isoAgo(6), mergedAt: isoAgo(5) }),
+    ];
+
+    const result = collectQueueEfficiency(
+      () => [...priorWeekPrs, ...badCurrentPrs],
+      NO_CCUSAGE,
+      TEST_NOW
+    );
+
+    expect(result.available).toBe(true);
+    expect(result.regressions.length).toBeGreaterThan(0);
+
+    const compositeRegression = result.regressions.find((r) => r.metric === "composite");
+    if (compositeRegression) {
+      expect(compositeRegression.sensor).toBe("queueEfficiency");
+      expect(compositeRegression.delta).toBeLessThan(0);
+      expect(["high", "medium"]).toContain(compositeRegression.severity);
+    }
+  });
+
+  it("does NOT flag a regression when metrics are within the band", () => {
+    // Both prior weeks and current week have identical good PRs
+    const uniformPrs = [
+      makePr({ number: 1, commitCount: 1, createdAt: isoAgo(4), mergedAt: isoAgo(3) }),
+      makePr({ number: 10, commitCount: 1, createdAt: isoAgo(11), mergedAt: isoAgo(10) }),
+      makePr({ number: 20, commitCount: 1, createdAt: isoAgo(18), mergedAt: isoAgo(17) }),
+    ];
+
+    const result = collectQueueEfficiency(() => uniformPrs, NO_CCUSAGE, TEST_NOW);
+    expect(result.available).toBe(true);
+    expect(result.regressions).toEqual([]);
+  });
+
+  it("builds distribution keyed by size tier from size: label", () => {
+    const sizedPrs = [
+      makePr({
+        number: 1,
+        labels: [{ name: "has-pr" }, { name: "size:s" }],
+        commitCount: 1,
+        createdAt: isoAgo(3),
+        mergedAt: isoAgo(2),
+      }),
+      makePr({
+        number: 2,
+        labels: [{ name: "has-pr" }, { name: "size:l" }],
+        commitCount: 2,
+        createdAt: isoAgo(4),
+        mergedAt: isoAgo(3),
+      }),
+      makePr({
+        number: 3,
+        labels: [{ name: "has-pr" }, { name: "size:s" }],
+        commitCount: 1,
+        createdAt: isoAgo(5),
+        mergedAt: isoAgo(4),
+      }),
+    ];
+
+    const result = collectQueueEfficiency(() => sizedPrs, NO_CCUSAGE, TEST_NOW);
+
+    expect(result.distribution).toBeDefined();
+    expect(result.distribution["size:s"]).toBeDefined();
+    expect(result.distribution["size:s"].count).toBe(2);
+    expect(result.distribution["size:l"]).toBeDefined();
+    expect(result.distribution["size:l"].count).toBe(1);
+  });
+
+  it("falls back to diff-based size tier when no size: label is present", () => {
+    const pr = makePr({
+      number: 1,
+      labels: [{ name: "has-pr" }],
+      additions: 400,
+      deletions: 100, // total 500 → size:m (200-499 → m, 500 boundary → l)
+    });
+
+    const result = collectQueueEfficiency(() => [pr], NO_CCUSAGE, TEST_NOW);
+    expect(result.distribution).toBeDefined();
+    // 500 lines total → size:l (>= 500 threshold)
+    const tier = Object.keys(result.distribution)[0];
+    expect(["size:m", "size:l"]).toContain(tier);
+  });
+
+  it("classifies worktree-agent- branch PRs even without agent-authored label", () => {
+    const agentPr = makePr({
+      number: 1,
+      headRefName: "worktree-agent-abc123",
+      labels: [{ name: "feature" }], // no agent-authored or has-pr label
+    });
+
+    const result = collectQueueEfficiency(() => [agentPr], NO_CCUSAGE, TEST_NOW);
+    expect(result.available).toBe(true);
+    expect(result.sub_metrics.issues_merged).toBe(1);
+  });
+
+  it("classifies PRs with legacy has-pr label as AI PRs", () => {
+    const legacyPr = makePr({
+      number: 1,
+      headRefName: "feat/some-thing",
+      labels: [{ name: "has-pr" }, { name: "feature" }],
+    });
+
+    const result = collectQueueEfficiency(() => [legacyPr], NO_CCUSAGE, TEST_NOW);
+    expect(result.available).toBe(true);
+    expect(result.sub_metrics.issues_merged).toBe(1);
+  });
+
+  it("excludes PRs with null mergedAt from merged-AI-PR count", () => {
+    const openPr = makePr({
+      number: 1,
+      state: "OPEN",
+      mergedAt: null,
+    });
+
+    const result = collectQueueEfficiency(() => [openPr], NO_CCUSAGE, TEST_NOW);
+    expect(result.available).toBe(false);
+  });
+});

--- a/scripts/collect-queue-efficiency.mjs
+++ b/scripts/collect-queue-efficiency.mjs
@@ -1,0 +1,344 @@
+/**
+ * Pure collector for queue-efficiency scorecard.
+ *
+ * Reconstructs a composite efficiency metric from GitHub PR history + ccusage
+ * spend — no changes to the agent hot path. Works on day 1 with an instant
+ * rolling-7-day-median baseline because weeks of PR history already exist.
+ *
+ * Composite weights: first-pass-success 0.4 / cost 0.4 / time-to-merge 0.2
+ *
+ * Dependency injection (readPrs / readCcusage) keeps the function unit-testable
+ * without live network calls. Both default to real CLI calls.
+ *
+ * Output shape:
+ *   { available, composite, sub_metrics, distribution, baseline, regressions[] }
+ */
+
+import { execFileSync } from "node:child_process";
+
+/** Thresholds — imported by sensor-report.mjs for its THRESHOLDS block. */
+export const QUEUE_EFFICIENCY_COMPOSITE_DROP = 0.05;
+export const QUEUE_EFFICIENCY_FPS_DROP = 0.1;
+
+/** Worktree branch patterns used by implement-queue agents. */
+const WORKER_BRANCH_RE = /^worktree-agent-/;
+
+/**
+ * An AI/worker PR is identified by:
+ *   - `agent-authored` label (current convention), OR
+ *   - `has-pr` label (legacy coordination label), OR
+ *   - a `worktree-agent-*` branch name (matches implement-queue worktree pattern).
+ *
+ * @param {{ headRefName?: string, labels?: Array<{ name: string }> }} pr
+ * @returns {boolean}
+ */
+function isAiPr(pr) {
+  const labels = pr.labels ?? [];
+  if (labels.some((l) => l.name === "agent-authored")) return true;
+  if (labels.some((l) => l.name === "has-pr")) return true;
+  return WORKER_BRANCH_RE.test(pr.headRefName ?? "");
+}
+
+/**
+ * Median of a numeric array. Returns null for empty input.
+ *
+ * @param {number[]} values
+ * @returns {number|null}
+ */
+function median(values) {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+/**
+ * Difficulty tier from a `size:` label (preferred) or total diff size.
+ *
+ * @param {{ labels?: Array<{ name: string }>, additions?: number, deletions?: number }} pr
+ * @returns {string}
+ */
+function sizeTier(pr) {
+  const sizeLabel = (pr.labels ?? []).find((l) => l.name.startsWith("size:"));
+  if (sizeLabel) return sizeLabel.name;
+  const diff = (pr.additions ?? 0) + (pr.deletions ?? 0);
+  if (diff < 50) return "size:xs";
+  if (diff < 200) return "size:s";
+  if (diff < 500) return "size:m";
+  if (diff < 1000) return "size:l";
+  return "size:xl";
+}
+
+// ── Score functions — higher is always better (0–1) ──────────────────────
+
+/** @param {number} rate - Already 0-1. */
+function scoreFirstPass(rate) {
+  return rate;
+}
+
+/** @param {number} costPerIssue - USD per merged issue. $1 = excellent, $5 = poor. */
+function scoreCost(costPerIssue) {
+  return Math.max(0, Math.min(1, 1 - (costPerIssue - 1) / 4));
+}
+
+/** @param {number} ttmHours - Time-to-merge in hours. 12h = excellent, 72h = poor. */
+function scoreTtm(ttmHours) {
+  return Math.max(0, Math.min(1, 1 - (ttmHours - 12) / 60));
+}
+
+/**
+ * Weighted composite from the three normalised sub-scores.
+ *
+ * @param {number} fps - first-pass-success score
+ * @param {number} cost - cost score
+ * @param {number} ttm - time-to-merge score
+ * @returns {number}
+ */
+function computeComposite(fps, cost, ttm) {
+  return Math.round((0.4 * fps + 0.4 * cost + 0.2 * ttm) * 1000) / 1000;
+}
+
+/**
+ * Compute sub-metrics for a set of merged AI PRs and their cost window.
+ *
+ * @param {Array<object>} windowPrs
+ * @param {Array<{ totalCost?: number }>} ccusageDays
+ * @returns {object}
+ */
+function computeWindowMetrics(windowPrs, ccusageDays) {
+  const firstPassCount = windowPrs.filter((pr) => (pr.commitCount ?? 1) <= 2).length;
+  const firstPassRate = Math.round((firstPassCount / windowPrs.length) * 1000) / 1000;
+
+  const commitCounts = windowPrs.map((pr) => pr.commitCount ?? 1);
+  const ttmHoursList = windowPrs
+    .map((pr) => {
+      if (!pr.createdAt || !pr.mergedAt) return null;
+      return (new Date(pr.mergedAt) - new Date(pr.createdAt)) / (1000 * 60 * 60);
+    })
+    .filter((h) => h !== null);
+
+  const medianTtmHours = median(ttmHoursList) ?? 24;
+  const medianReworkCycles = median(commitCounts.map((c) => Math.max(0, c - 1))) ?? 0;
+  const totalCost = (ccusageDays ?? []).reduce((sum, d) => sum + (d.totalCost ?? 0), 0);
+  const costPerIssue = totalCost / windowPrs.length;
+
+  return {
+    issues_merged: windowPrs.length,
+    first_pass_success_rate: firstPassRate,
+    median_time_to_merge_hours: Math.round(medianTtmHours * 10) / 10,
+    median_rework_cycles: Math.round(medianReworkCycles * 10) / 10,
+    cost_per_issue_usd: Math.round(costPerIssue * 1000) / 1000,
+  };
+}
+
+/**
+ * Default PR reader — calls `gh pr list` and normalises the commits array to a count.
+ *
+ * @returns {Array<object>|null}
+ */
+function defaultReadPrs() {
+  try {
+    // Limit to 45 PRs: GitHub's GraphQL caps nodes at 500k; the commits sub-field
+    // multiplies PRs × ~11k potential nodes per PR. 45 sits safely under that ceiling.
+    // For repos with ≥5 AI PRs/day this covers ~9 days of history — enough for the
+    // 7-day current window plus partial prior-week baseline.
+    const raw = execFileSync(
+      "gh",
+      [
+        "pr",
+        "list",
+        "--state",
+        "all",
+        "--limit",
+        "45",
+        "--json",
+        "number,state,headRefName,createdAt,mergedAt,closedAt,labels,commits,additions,deletions",
+      ],
+      { encoding: "utf-8", timeout: 15000 }
+    );
+    return JSON.parse(raw).map((pr) => ({
+      ...pr,
+      commitCount: Array.isArray(pr.commits) ? pr.commits.length : (pr.commitCount ?? 1),
+    }));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Default ccusage reader — same shape as collect-ccusage.mjs.
+ *
+ * @returns {{ daily: Array<{ period: string, totalCost: number }> }|null}
+ */
+function defaultReadCcusage() {
+  try {
+    const raw = execFileSync("npx", ["-y", "ccusage@latest", "daily", "--json", "--no-cost"], {
+      encoding: "utf-8",
+      timeout: 30000,
+    });
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Collect the queue-efficiency scorecard.
+ *
+ * @param {() => Array<object>|null} [readPrs] - Injected PR reader.
+ * @param {() => { daily: Array<object> }|null} [readCcusage] - Injected ccusage reader.
+ * @param {Date} [now] - Reference time (injectable for tests).
+ * @returns {{
+ *   available: boolean,
+ *   composite?: number,
+ *   sub_metrics?: object,
+ *   distribution?: object,
+ *   baseline?: object|null,
+ *   regressions?: Array<object>,
+ * }}
+ */
+export function collectQueueEfficiency(
+  readPrs = defaultReadPrs,
+  readCcusage = defaultReadCcusage,
+  now = new Date()
+) {
+  let prs;
+  try {
+    prs = readPrs();
+  } catch {
+    return { available: false };
+  }
+  if (!Array.isArray(prs) || prs.length === 0) return { available: false };
+
+  let ccusageData;
+  try {
+    ccusageData = readCcusage();
+  } catch {
+    ccusageData = null;
+  }
+
+  const sevenDaysAgo = new Date(+now - 7 * 24 * 60 * 60 * 1000);
+  const thirtyDaysAgo = new Date(+now - 30 * 24 * 60 * 60 * 1000);
+  const dailyEntries = Array.isArray(ccusageData?.daily) ? ccusageData.daily : [];
+
+  // Only merged AI PRs within the last 30 days form our analysis pool.
+  const mergedAiPrs = prs.filter((pr) => {
+    if (!isAiPr(pr)) return false;
+    if (!pr.mergedAt) return false;
+    const d = new Date(pr.mergedAt);
+    return !isNaN(d) && d >= thirtyDaysAgo;
+  });
+
+  if (mergedAiPrs.length === 0) return { available: false };
+
+  const currentPrs = mergedAiPrs.filter((pr) => new Date(pr.mergedAt) >= sevenDaysAgo);
+  if (currentPrs.length === 0) return { available: false };
+
+  const currentCcusageDays = dailyEntries.filter((d) => new Date(d.period) >= sevenDaysAgo);
+  const currentMetrics = computeWindowMetrics(currentPrs, currentCcusageDays);
+
+  // Rolling baseline from the 3 prior weekly windows (days 8–28).
+  const weekMetrics = [];
+  for (let w = 1; w <= 3; w++) {
+    const weekStart = new Date(+now - (w + 1) * 7 * 24 * 60 * 60 * 1000);
+    const weekEnd = new Date(+now - w * 7 * 24 * 60 * 60 * 1000);
+    const weekPrs = mergedAiPrs.filter((pr) => {
+      const d = new Date(pr.mergedAt);
+      return d >= weekStart && d < weekEnd;
+    });
+    if (weekPrs.length === 0) continue;
+    const weekCcusageDays = dailyEntries.filter((d) => {
+      const day = new Date(d.period);
+      return day >= weekStart && day < weekEnd;
+    });
+    weekMetrics.push(computeWindowMetrics(weekPrs, weekCcusageDays));
+  }
+
+  const fpScore = scoreFirstPass(currentMetrics.first_pass_success_rate);
+  const costScore = scoreCost(currentMetrics.cost_per_issue_usd);
+  const ttmScore = scoreTtm(currentMetrics.median_time_to_merge_hours);
+  const compositeScore = computeComposite(fpScore, costScore, ttmScore);
+
+  const baseline =
+    weekMetrics.length === 0
+      ? null
+      : {
+          composite_median: median(
+            weekMetrics.map((m) =>
+              computeComposite(
+                scoreFirstPass(m.first_pass_success_rate),
+                scoreCost(m.cost_per_issue_usd),
+                scoreTtm(m.median_time_to_merge_hours)
+              )
+            )
+          ),
+          weeks_sampled: weekMetrics.length,
+          fps_median: median(weekMetrics.map((m) => m.first_pass_success_rate)),
+          ttm_median: median(weekMetrics.map((m) => m.median_time_to_merge_hours)),
+          cost_per_issue_median: median(weekMetrics.map((m) => m.cost_per_issue_usd)),
+        };
+
+  const regressions = [];
+  if (baseline?.composite_median != null) {
+    const delta = compositeScore - baseline.composite_median;
+    if (delta < -QUEUE_EFFICIENCY_COMPOSITE_DROP) {
+      regressions.push({
+        sensor: "queueEfficiency",
+        metric: "composite",
+        current: compositeScore,
+        baseline: baseline.composite_median,
+        delta: Math.round(delta * 1000) / 1000,
+        severity: delta < -0.15 ? "high" : "medium",
+      });
+    }
+  }
+  if (baseline?.fps_median != null) {
+    const fpsDelta = currentMetrics.first_pass_success_rate - baseline.fps_median;
+    if (fpsDelta < -QUEUE_EFFICIENCY_FPS_DROP) {
+      regressions.push({
+        sensor: "queueEfficiency",
+        metric: "first_pass_success_rate",
+        current: currentMetrics.first_pass_success_rate,
+        baseline: baseline.fps_median,
+        delta: Math.round(fpsDelta * 1000) / 1000,
+        severity: fpsDelta < -0.2 ? "high" : "medium",
+      });
+    }
+  }
+
+  // Distribution by difficulty tier — Goodhart guard.
+  const distAccum = {};
+  for (const pr of currentPrs) {
+    const tier = sizeTier(pr);
+    const ttmH =
+      pr.createdAt && pr.mergedAt
+        ? (new Date(pr.mergedAt) - new Date(pr.createdAt)) / (1000 * 60 * 60)
+        : 0;
+    const prev = distAccum[tier] ?? { count: 0, total_commits: 0, total_ttm_hours: 0 };
+    distAccum[tier] = {
+      count: prev.count + 1,
+      total_commits: prev.total_commits + (pr.commitCount ?? 1),
+      total_ttm_hours: prev.total_ttm_hours + ttmH,
+    };
+  }
+
+  const distribution = Object.fromEntries(
+    Object.entries(distAccum).map(([tier, acc]) => [
+      tier,
+      {
+        count: acc.count,
+        avg_commits: Math.round((acc.total_commits / acc.count) * 10) / 10,
+        avg_ttm_hours: Math.round((acc.total_ttm_hours / acc.count) * 10) / 10,
+      },
+    ])
+  );
+
+  return {
+    available: true,
+    composite: compositeScore,
+    sub_metrics: currentMetrics,
+    distribution,
+    baseline,
+    regressions,
+  };
+}

--- a/scripts/sensor-report.mjs
+++ b/scripts/sensor-report.mjs
@@ -28,6 +28,11 @@ import { computePrCategoryMetrics } from "./collect-pr-metrics.mjs";
 import { collectMutationScore } from "./collect-mutation-score.mjs";
 import { computeFlakyTests } from "./collect-flaky-tests.mjs";
 import { computeE2eStability } from "./collect-e2e-stability.mjs";
+import {
+  collectQueueEfficiency,
+  QUEUE_EFFICIENCY_COMPOSITE_DROP,
+  QUEUE_EFFICIENCY_FPS_DROP,
+} from "./collect-queue-efficiency.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
@@ -44,6 +49,8 @@ const THRESHOLDS = {
   error_rate_increase: 20,
   service_uptime_min: 99.5,
   code_churn_rate_max: CODE_CHURN_THRESHOLD,
+  queue_efficiency_composite_drop: QUEUE_EFFICIENCY_COMPOSITE_DROP,
+  queue_efficiency_fps_drop: QUEUE_EFFICIENCY_FPS_DROP,
 };
 
 const now = new Date();
@@ -199,6 +206,39 @@ function collectMutationScoreSensor() {
   const reportPath = resolve(ROOT, "reports", "mutation", "mutation.json");
   const reportJson = safe(() => readJson(reportPath));
   return collectMutationScore(reportJson, now);
+}
+
+function collectQueueEfficiencySensor() {
+  // Limit to 45: GitHub's GraphQL caps nodes at 500k; the commits sub-field
+  // multiplies PRs × ~11k potential nodes per PR. 45 sits safely under that ceiling.
+  const prsRaw = safe(
+    () =>
+      execFileSync(
+        "gh",
+        [
+          "pr",
+          "list",
+          "--state",
+          "all",
+          "--limit",
+          "45",
+          "--json",
+          "number,state,headRefName,createdAt,mergedAt,closedAt,labels,commits,additions,deletions",
+        ],
+        { encoding: "utf-8", timeout: 15000 }
+      ),
+    null
+  );
+  const readPrs = () => {
+    if (!prsRaw) return null;
+    const prs = safe(() => JSON.parse(prsRaw), null);
+    if (!prs) return null;
+    return prs.map((pr) => ({
+      ...pr,
+      commitCount: Array.isArray(pr.commits) ? pr.commits.length : (pr.commitCount ?? 1),
+    }));
+  };
+  return collectQueueEfficiency(readPrs, undefined, now);
 }
 
 function collectCiHealth() {
@@ -449,6 +489,28 @@ function detectRegressions(current, previous) {
     }
   }
 
+  // queueEfficiency: propagate internally-detected regressions (PR-history rolling median).
+  if (current.queueEfficiency?.available) {
+    for (const r of current.queueEfficiency.regressions ?? []) {
+      regressions.push(r);
+    }
+    // Also compare against the PREVIOUS stored report so regressions are detectable
+    // even when the live PR-history baseline window is sparse (active repos exhaust 45 PRs).
+    if (previous?.queueEfficiency?.available) {
+      const qeDelta = current.queueEfficiency.composite - previous.queueEfficiency.composite;
+      if (qeDelta < -THRESHOLDS.queue_efficiency_composite_drop) {
+        regressions.push({
+          sensor: "queueEfficiency",
+          metric: "composite_vs_previous_report",
+          current: current.queueEfficiency.composite,
+          previous: previous.queueEfficiency.composite,
+          delta: Math.round(qeDelta * 1000) / 1000,
+          severity: qeDelta < -0.15 ? "high" : "medium",
+        });
+      }
+    }
+  }
+
   return regressions;
 }
 
@@ -475,6 +537,7 @@ const report = {
     mutationScore: collectMutationScoreSensor(),
     flakyTests: computeFlakyTests([]),
     e2eStability: collectE2eStabilitySensor(),
+    queueEfficiency: collectQueueEfficiencySensor(),
   },
   thresholds: THRESHOLDS,
   regressions: [],
@@ -578,6 +641,16 @@ if (JSON_ONLY) {
           `   ${name}: ${data.consecutive_failures} consecutive failure(s) on non-frontend runs (${data.total_non_frontend_runs}/${data.total_runs} non-frontend)`
         );
         break;
+      case "queueEfficiency": {
+        const baselineStr =
+          data.baseline != null
+            ? ` (baseline ${data.baseline.composite_median?.toFixed(3)}, ${data.baseline.weeks_sampled}w)`
+            : " (no baseline yet)";
+        console.log(
+          `   ${name}: composite ${data.composite} | fps ${data.sub_metrics?.first_pass_success_rate} | ttm ${data.sub_metrics?.median_time_to_merge_hours}h | $${data.sub_metrics?.cost_per_issue_usd}/issue${baselineStr}`
+        );
+        break;
+      }
       default:
         console.log(`   ${name}: available`);
     }

--- a/scripts/sensors-registry.mjs
+++ b/scripts/sensors-registry.mjs
@@ -114,6 +114,24 @@ export const SENSORS = [
       confidence: "skip",
     }),
   },
+  {
+    id: "queueEfficiency",
+    category: "quality",
+    issueLabels: ["meta-improvement"],
+    severity: "medium",
+    metricKeys: [
+      { key: "queueEfficiency:composite" },
+      { key: "queueEfficiency:first_pass_success_rate" },
+      { key: "queueEfficiency:cost_per_issue", category: "performance" },
+      { key: "queueEfficiency:time_to_merge", category: "performance" },
+    ],
+    verifyFix: (_title, _body) => ({
+      verified: false,
+      reason:
+        "Queue efficiency verification: re-run sensor-report with --json and inspect queueEfficiency.composite vs baseline",
+      confidence: "low",
+    }),
+  },
 ];
 
 /**


### PR DESCRIPTION
## Summary

- Adds `scripts/collect-queue-efficiency.mjs` — a pure, dependency-injected collector that reconstructs queue efficiency from GitHub PR history and ccusage spend data without any new instrumentation
- Wires the sensor into `scripts/sensor-report.mjs` with a `collectQueueEfficiencySensor()` function and week-over-week regression detection in `detectRegressions()`
- Registers `queueEfficiency` in `scripts/sensors-registry.mjs` with category "quality" and 4 metric keys

Key design decisions:
- Composite weights: cost 0.4 / first-pass-success 0.4 / time-to-merge 0.2
- AI PR identification: `agent-authored` label (primary), `has-pr` (legacy), `worktree-agent-*` branch prefix
- `--limit 45` stays under GitHub's 500k GraphQL node ceiling
- Goodhart guard: difficulty-normalises by `size:` label tier
- Rolling 7-day median baseline with `{available:false}` graceful degradation

## Test plan

- [x] 35 deterministic unit tests with injected fixtures (no live network) — all pass
- [x] `pnpm lint` — passes
- [x] `pnpm typecheck` — passes
- [x] `pnpm test` — 463 tests pass (scripts package) + 974 (reservations service)
- [x] `pnpm --filter @mbe/cli start check-adr && check-deps` — no violations
- [x] `pnpm regen` — no artifact drift
- [x] `node scripts/detect-instruction-rot.mjs` — no rot
- [x] `metrics/ai-antipattern-baselines.json` updated for the 1 intentional console.log addition

Closes #2746