### PR TITLE
feat(skills): optimize-implement-queue daily skill

### DIFF
--- a/.claude/skills/optimize-implement-queue/SKILL.md
+++ b/.claude/skills/optimize-implement-queue/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: optimize-implement-queue
+description: Daily optimization loop for the implement-queue workflow. Measures queue efficiency via the queueEfficiency sensor, appends a trend point, logs the run, and files de-duplicated ready issues on regression. Async eval is scheduled separately — never run synchronously here. Invoke with /optimize-implement-queue.
+user-invocable: true
+---
+
+# Optimize Implement Queue
+
+Daily skill that measures implement-queue efficiency, logs trends, and files `ready` issues when a real regression is detected. Phase-2 auto-tuning (model-routing tier adjustment) is documented as a future seam but NOT yet built.
+
+## Flags
+
+| Flag        | Effect                                                   |
+| ----------- | -------------------------------------------------------- |
+| `--dry-run` | Print what would happen; write nothing to disk or GitHub |
+
+## Step 1: Collect the Queue-Efficiency Sensor
+
+Run the sensor-report to collect the `queueEfficiency` sub-report:
+
+```bash
+node scripts/sensor-report.mjs --json | jq '.sensors.queueEfficiency'
+```
+
+Or capture the whole report for later regression detection:
+
+```bash
+node scripts/sensor-report.mjs --json > /tmp/sensor-report.json
+```
+
+Read `regressions[]` from the output. Any entries with `sensor: "queueEfficiency"` are internal regressions detected by the rolling-7-day-median baseline baked into the collector (`collect-queue-efficiency.mjs`).
+
+The `distribution` field provides difficulty-normalized context (size tiers): a session dominated by `size:xl` PRs will legitimately score lower — the `isRealRegression` check in `scripts/optimize-implement-queue.mjs` accounts for this.
+
+## Step 2: Append Trend Point to process-metrics.jsonl
+
+Use the helper to build and append a JSONL entry:
+
+```javascript
+import { buildQueueEfficiencyProcessEntry } from "./scripts/optimize-implement-queue.mjs";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+
+const entry = buildQueueEfficiencyProcessEntry(new Date().toISOString().slice(0, 10), sensorResult);
+// In dry-run mode, log but do not write:
+if (!DRY_RUN) {
+  mkdirSync(dirname(METRICS_PATH), { recursive: true });
+  appendFileSync(METRICS_PATH, JSON.stringify(entry) + "\n");
+}
+```
+
+`METRICS_PATH` = `metrics/process-metrics.jsonl`
+
+## Step 3: Append Dated Log Entry
+
+**Always run this step, even when there is no regression.**
+
+```javascript
+import { buildOptimizeLogEntry, appendLogEntry } from "./scripts/optimize-implement-queue.mjs";
+
+const logEntry = buildOptimizeLogEntry(today, sensorResult, issueCount);
+appendLogEntry(".claude/improvement-loop/log.md", logEntry, DRY_RUN);
+```
+
+Log format (appended to `.claude/improvement-loop/log.md`):
+
+```markdown
+## YYYY-MM-DD
+
+**queueEfficiency:** composite 0.820 (baseline 0.800) — healthy
+**Difficulty distribution:** size:s:5, size:m:7
+**Issues filed:** 0
+```
+
+## Step 4: Triage Regressions (only when flagged)
+
+### 4a: Check if regression is real
+
+```javascript
+import { isRealRegression } from "./scripts/optimize-implement-queue.mjs";
+
+if (!isRealRegression(sensorResult)) {
+  // Log "difficulty-normalized: no action" and stop here.
+}
+```
+
+`isRealRegression` applies the difficulty-normalization guard: if >80% of merged PRs are `size:xl` and the composite drop is <10%, the regression is treated as difficulty-explained, not a real process failure.
+
+### 4b: Deduplicate against open issues
+
+```bash
+gh issue list --state open --search "queueEfficiency regression" \
+  --json number,title --limit 10
+```
+
+Use `scripts/sensor-correlator.mjs` to group and deduplicate:
+
+```javascript
+import { correlate } from "./scripts/sensor-correlator.mjs";
+const groups = correlate({ regressions: sensorResult.regressions }, openIssues);
+```
+
+Skip groups that already have an open issue matching the sensor + metric combination.
+
+### 4c: File ready issues
+
+For each non-duplicate regression group:
+
+```javascript
+import { buildRegressionIssueBody } from "./scripts/optimize-implement-queue.mjs";
+
+const body = buildRegressionIssueBody(regression, sensorResult);
+```
+
+```bash
+gh issue create \
+  --title "fix(implement-queue): queueEfficiency <metric> regressed (<delta>)" \
+  --label "ready,meta-improvement" \
+  --body "<body from buildRegressionIssueBody>"
+```
+
+**Guardrails:**
+
+- Max 2 issues per run (avoid noise)
+- `ready` label only — do NOT add `in-progress` or auto-assign
+- Never auto-merge, auto-edit skill prompts, or touch queue orchestration
+
+## Step 5: Async Eval Trigger (regression path only)
+
+When a regression is filed, schedule an async eval to distinguish agent/prompt quality issues from harder-task drift:
+
+```bash
+# Fire and forget — NEVER await this in the daily slot
+nohup mbe agent run "Run eval suite to diagnose queue efficiency regression — check first-pass-success drop vs baseline" \
+  --model sonnet --max-budget 2.00 --no-pr &
+```
+
+**CRITICAL:** Do NOT run `mbe agent eval` synchronously. The daily slot must complete in under 5 minutes. Eval can take 20–60 minutes. Fire it as a background process or file a separate GitHub issue with label `ready,eval`.
+
+## Phase-2 Seam: Auto-Tuning (NOT YET BUILT)
+
+The guard-railed model-routing tier adjustment pattern lives in `scripts/threshold-tuner.mjs`. When a regression persists across 3+ consecutive daily runs, phase-2 will:
+
+1. Query `metrics/threshold-changes.jsonl` for recent guard-rail usage.
+2. Call `determineAdjustment()` from `threshold-tuner.mjs` with per-sensor metrics.
+3. Propose a model-tier bump via a `ready` issue (human approves before any config change).
+
+**This is not built yet.** Commenting in the code would be: `// TODO(phase-2): wire threshold-tuner.mjs here once eval feedback loop is established`.
+
+## Scheduling
+
+This skill is designed to run daily. Wire it via a RemoteTrigger (HITL issue #2749):
+
+| Trigger                        | Schedule    | Notes                                   |
+| ------------------------------ | ----------- | --------------------------------------- |
+| `mbe-optimize-implement-queue` | Daily (TBD) | Do NOT schedule until #2749 is approved |
+
+Or invoke manually: `/optimize-implement-queue`
+
+For `--dry-run` validation:
+
+```bash
+node scripts/sensor-report.mjs --json | jq '.sensors.queueEfficiency'
+```
+
+## Sensor Label Map
+
+| Sensor          | Issue Label        | What It Checks                   |
+| --------------- | ------------------ | -------------------------------- |
+| queueEfficiency | `meta-improvement` | Composite efficiency index (0–1) |
+
+## Rules
+
+- **Read-only orchestration:** never mutate queue state, never edit issue prompts, never auto-merge
+- **Max 2 issues per run** (consistent with learning-loop budget)
+- **Append-only log** — never overwrite `.claude/improvement-loop/log.md`
+- **No synchronous eval** — eval runs async or as a filed issue
+- **Difficulty-normalization required** — always call `isRealRegression()` before filing
+- **Phase-2 (auto-tuning) is NOT built** — document the seam, do not implement it

--- a/scripts/__tests__/optimize-implement-queue.test.mjs
+++ b/scripts/__tests__/optimize-implement-queue.test.mjs
@@ -1,0 +1,292 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, mkdirSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildQueueEfficiencyProcessEntry,
+  buildOptimizeLogEntry,
+  buildRegressionIssueBody,
+  isRealRegression,
+  appendLogEntry,
+} from "../optimize-implement-queue.mjs";
+
+function makeTmpDir() {
+  return mkdtempSync(join(tmpdir(), "optimize-implement-queue-test-"));
+}
+
+const HEALTHY_RESULT = {
+  available: true,
+  composite: 0.82,
+  sub_metrics: {
+    issues_merged: 12,
+    first_pass_success_rate: 0.75,
+    median_time_to_merge_hours: 18.5,
+    median_rework_cycles: 0.4,
+    cost_per_issue_usd: 1.2,
+  },
+  distribution: {
+    "size:s": { count: 5, avg_commits: 1.4, avg_ttm_hours: 14.2 },
+    "size:m": { count: 7, avg_commits: 2.1, avg_ttm_hours: 21.3 },
+  },
+  baseline: {
+    composite_median: 0.8,
+    weeks_sampled: 2,
+    fps_median: 0.72,
+    ttm_median: 19.0,
+    cost_per_issue_median: 1.3,
+  },
+  regressions: [],
+};
+
+const REGRESSED_RESULT = {
+  available: true,
+  composite: 0.58,
+  sub_metrics: {
+    issues_merged: 8,
+    first_pass_success_rate: 0.5,
+    median_time_to_merge_hours: 28.0,
+    median_rework_cycles: 1.5,
+    cost_per_issue_usd: 2.8,
+  },
+  distribution: {
+    "size:xl": { count: 6, avg_commits: 3.2, avg_ttm_hours: 32.0 },
+    "size:s": { count: 2, avg_commits: 1.0, avg_ttm_hours: 12.0 },
+  },
+  baseline: {
+    composite_median: 0.8,
+    weeks_sampled: 3,
+    fps_median: 0.78,
+    ttm_median: 19.0,
+    cost_per_issue_median: 1.3,
+  },
+  regressions: [
+    {
+      sensor: "queueEfficiency",
+      metric: "composite",
+      current: 0.58,
+      baseline: 0.8,
+      delta: -0.22,
+      severity: "high",
+    },
+    {
+      sensor: "queueEfficiency",
+      metric: "first_pass_success_rate",
+      current: 0.5,
+      baseline: 0.78,
+      delta: -0.28,
+      severity: "high",
+    },
+  ],
+};
+
+describe("buildQueueEfficiencyProcessEntry", () => {
+  it("returns a JSONL-compatible object with required fields", () => {
+    const entry = buildQueueEfficiencyProcessEntry("2026-06-27", HEALTHY_RESULT);
+    expect(entry).toMatchObject({
+      date: "2026-06-27",
+      sensor: "queueEfficiency",
+      composite: 0.82,
+    });
+  });
+
+  it("includes sub_metrics", () => {
+    const entry = buildQueueEfficiencyProcessEntry("2026-06-27", HEALTHY_RESULT);
+    expect(entry.sub_metrics).toBeDefined();
+    expect(entry.sub_metrics.first_pass_success_rate).toBe(0.75);
+  });
+
+  it("includes regression count", () => {
+    const entry = buildQueueEfficiencyProcessEntry("2026-06-27", REGRESSED_RESULT);
+    expect(entry.regression_count).toBe(2);
+  });
+
+  it("handles unavailable sensor gracefully", () => {
+    const entry = buildQueueEfficiencyProcessEntry("2026-06-27", { available: false });
+    expect(entry).toMatchObject({
+      date: "2026-06-27",
+      sensor: "queueEfficiency",
+      available: false,
+    });
+  });
+
+  it("regression_count is 0 for healthy result", () => {
+    const entry = buildQueueEfficiencyProcessEntry("2026-06-27", HEALTHY_RESULT);
+    expect(entry.regression_count).toBe(0);
+  });
+});
+
+describe("buildOptimizeLogEntry", () => {
+  it("starts with the date as a heading", () => {
+    const entry = buildOptimizeLogEntry("2026-06-27", HEALTHY_RESULT, 0);
+    expect(entry).toMatch(/^## 2026-06-27/);
+  });
+
+  it("includes sensor status line", () => {
+    const entry = buildOptimizeLogEntry("2026-06-27", HEALTHY_RESULT, 0);
+    expect(entry).toContain("queueEfficiency");
+    expect(entry).toContain("0.82");
+  });
+
+  it("includes issues filed count", () => {
+    const entry = buildOptimizeLogEntry("2026-06-27", REGRESSED_RESULT, 2);
+    expect(entry).toContain("Issues filed");
+  });
+
+  it("marks healthy run when no regressions", () => {
+    const entry = buildOptimizeLogEntry("2026-06-27", HEALTHY_RESULT, 0);
+    expect(entry.toLowerCase()).toContain("healthy");
+  });
+
+  it("mentions regression when regressions present", () => {
+    const entry = buildOptimizeLogEntry("2026-06-27", REGRESSED_RESULT, 1);
+    expect(entry.toLowerCase()).toContain("regression");
+  });
+
+  it("includes difficulty distribution note when available", () => {
+    const entry = buildOptimizeLogEntry("2026-06-27", HEALTHY_RESULT, 0);
+    expect(entry).toContain("size:");
+  });
+
+  it("handles unavailable sensor", () => {
+    const entry = buildOptimizeLogEntry("2026-06-27", { available: false }, 0);
+    expect(entry).toMatch(/^## 2026-06-27/);
+    expect(entry).toContain("unavailable");
+  });
+});
+
+describe("buildRegressionIssueBody", () => {
+  const regression = REGRESSED_RESULT.regressions[0];
+
+  it("includes sensor and metric in body", () => {
+    const body = buildRegressionIssueBody(regression, REGRESSED_RESULT);
+    expect(body).toContain("queueEfficiency");
+    expect(body).toContain("composite");
+  });
+
+  it("includes current and baseline values", () => {
+    const body = buildRegressionIssueBody(regression, REGRESSED_RESULT);
+    expect(body).toContain("0.58");
+    // JavaScript renders 0.80 as "0.8"; accept either form
+    expect(body).toMatch(/0\.8(?:0)?/);
+  });
+
+  it("includes severity", () => {
+    const body = buildRegressionIssueBody(regression, REGRESSED_RESULT);
+    expect(body).toContain("high");
+  });
+
+  it("includes acceptance criteria checklist", () => {
+    const body = buildRegressionIssueBody(regression, REGRESSED_RESULT);
+    expect(body).toContain("- [ ]");
+  });
+
+  it("includes difficulty distribution when available", () => {
+    const body = buildRegressionIssueBody(regression, REGRESSED_RESULT);
+    expect(body).toContain("size:");
+  });
+
+  it("references the learning loop skill", () => {
+    const body = buildRegressionIssueBody(regression, REGRESSED_RESULT);
+    expect(body).toContain("optimize-implement-queue");
+  });
+});
+
+describe("isRealRegression", () => {
+  it("returns false for unavailable sensor", () => {
+    expect(isRealRegression({ available: false })).toBe(false);
+  });
+
+  it("returns false for empty regressions array", () => {
+    expect(isRealRegression(HEALTHY_RESULT)).toBe(false);
+  });
+
+  it("returns true when regressions exist", () => {
+    expect(isRealRegression(REGRESSED_RESULT)).toBe(true);
+  });
+
+  it("normalizes for difficulty: false when xl-dominant and composite difference is small", () => {
+    // If >80% of issues are size:xl the bar is lowered — a slight composite drop
+    // might be difficulty-explained, not a real regression.
+    const dominantXl = {
+      ...REGRESSED_RESULT,
+      composite: 0.77,
+      sub_metrics: { ...REGRESSED_RESULT.sub_metrics, issues_merged: 10 },
+      distribution: {
+        "size:xl": { count: 9, avg_commits: 3.0, avg_ttm_hours: 35.0 },
+        "size:xs": { count: 1, avg_commits: 1.0, avg_ttm_hours: 5.0 },
+      },
+      baseline: { ...REGRESSED_RESULT.baseline, composite_median: 0.8 },
+      regressions: [
+        {
+          sensor: "queueEfficiency",
+          metric: "composite",
+          current: 0.77,
+          baseline: 0.8,
+          delta: -0.03,
+          severity: "medium",
+        },
+      ],
+    };
+    expect(isRealRegression(dominantXl)).toBe(false);
+  });
+
+  it("returns true when xl-dominant but composite drop is large", () => {
+    const dominantXlLarge = {
+      ...REGRESSED_RESULT,
+      distribution: {
+        "size:xl": { count: 9, avg_commits: 3.0, avg_ttm_hours: 35.0 },
+        "size:xs": { count: 1, avg_commits: 1.0, avg_ttm_hours: 5.0 },
+      },
+    };
+    expect(isRealRegression(dominantXlLarge)).toBe(true);
+  });
+});
+
+describe("appendLogEntry", () => {
+  let dir;
+
+  beforeEach(() => {
+    dir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("appends entry to existing log file", () => {
+    const logPath = join(dir, "log.md");
+    writeFileSync(logPath, "## 2026-06-20\n\nold entry\n");
+    appendLogEntry(logPath, "## 2026-06-27\n\nnew entry\n", false);
+    const content = readFileSync(logPath, "utf-8");
+    expect(content).toContain("2026-06-20");
+    expect(content).toContain("2026-06-27");
+  });
+
+  it("creates parent directories if missing", () => {
+    const logPath = join(dir, "deep", "nested", "log.md");
+    appendLogEntry(logPath, "## 2026-06-27\n\nentry\n", false);
+    expect(existsSync(logPath)).toBe(true);
+  });
+
+  it("does NOT write when dry-run is true", () => {
+    const logPath = join(dir, "log.md");
+    appendLogEntry(logPath, "## 2026-06-27\n\nentry\n", true);
+    expect(existsSync(logPath)).toBe(false);
+  });
+
+  it("appends a blank separator line between entries", () => {
+    const logPath = join(dir, "log.md");
+    writeFileSync(logPath, "## 2026-06-20\n\nold entry\n");
+    appendLogEntry(logPath, "## 2026-06-27\n\nnew entry\n", false);
+    const content = readFileSync(logPath, "utf-8");
+    // Should have two heading blocks separated by a blank line
+    expect(content).toMatch(/old entry\n\n## 2026-06-27/);
+  });
+
+  it("creates a new log file when none exists", () => {
+    const logPath = join(dir, "new-log.md");
+    appendLogEntry(logPath, "## 2026-06-27\n\nfirst entry\n", false);
+    const content = readFileSync(logPath, "utf-8");
+    expect(content).toContain("2026-06-27");
+  });
+});

--- a/scripts/optimize-implement-queue.mjs
+++ b/scripts/optimize-implement-queue.mjs
@@ -1,0 +1,218 @@
+/**
+ * Pure helper functions for the optimize-implement-queue daily skill.
+ *
+ * Responsibilities:
+ *   - Build a process-metrics JSONL entry from a queueEfficiency sensor result.
+ *   - Build a human-readable dated log entry for .claude/improvement-loop/log.md.
+ *   - Build a regression issue body for GitHub issue creation.
+ *   - Decide whether a flagged regression is real (difficulty-normalized check).
+ *   - Append a log entry to the improvement-loop log (DI: dryRun flag).
+ *
+ * All functions are pure (except appendLogEntry which is DI-gated on dryRun).
+ * No side effects — callers control all I/O.
+ */
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+// ── Pure helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Difficulty-normalization threshold.
+ * When >80% of merged PRs are size:xl the expected composite is lower — we
+ * require a larger regression delta before treating it as real.
+ */
+const XL_DOMINANT_THRESHOLD = 0.8;
+const XL_DOMINANT_MIN_COMPOSITE_DROP = 0.1;
+
+/**
+ * Compute the fraction of merged PRs that are size:xl.
+ *
+ * @param {Record<string, { count: number }>} distribution
+ * @returns {number} 0–1
+ */
+function xlFraction(distribution) {
+  if (!distribution || Object.keys(distribution).length === 0) return 0;
+  const totalCount = Object.values(distribution).reduce((s, t) => s + (t.count ?? 0), 0);
+  if (totalCount === 0) return 0;
+  const xlCount = distribution["size:xl"]?.count ?? 0;
+  return xlCount / totalCount;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Build a process-metrics JSONL entry from a queueEfficiency sensor result.
+ * This entry is appended to metrics/process-metrics.jsonl.
+ *
+ * @param {string} date - ISO date (YYYY-MM-DD)
+ * @param {{ available: boolean, composite?: number, sub_metrics?: object, regressions?: Array }} sensorResult
+ * @returns {object}
+ */
+export function buildQueueEfficiencyProcessEntry(date, sensorResult) {
+  if (!sensorResult?.available) {
+    return { date, sensor: "queueEfficiency", available: false };
+  }
+
+  return {
+    date,
+    sensor: "queueEfficiency",
+    available: true,
+    composite: sensorResult.composite ?? null,
+    sub_metrics: sensorResult.sub_metrics ?? null,
+    regression_count: (sensorResult.regressions ?? []).length,
+  };
+}
+
+/**
+ * Build a dated markdown log entry for .claude/improvement-loop/log.md.
+ *
+ * @param {string} date - ISO date (YYYY-MM-DD)
+ * @param {{ available: boolean, composite?: number, regressions?: Array, distribution?: object, baseline?: object }} sensorResult
+ * @param {number} issueCount - number of issues filed this run
+ * @returns {string}
+ */
+export function buildOptimizeLogEntry(date, sensorResult, issueCount) {
+  const lines = [`## ${date}`];
+  lines.push("");
+
+  if (!sensorResult?.available) {
+    lines.push("**queueEfficiency:** unavailable");
+    lines.push(`**Issues filed:** 0`);
+    lines.push("");
+    return lines.join("\n");
+  }
+
+  const regressions = sensorResult.regressions ?? [];
+  const status =
+    regressions.length === 0 ? "healthy" : `${regressions.length} regression(s) detected`;
+  const composite = sensorResult.composite != null ? sensorResult.composite.toFixed(3) : "n/a";
+  const baseline =
+    sensorResult.baseline?.composite_median != null
+      ? sensorResult.baseline.composite_median.toFixed(3)
+      : "n/a";
+
+  lines.push(`**queueEfficiency:** composite ${composite} (baseline ${baseline}) — ${status}`);
+
+  const dist = sensorResult.distribution ?? {};
+  const tierSummary = Object.entries(dist)
+    .map(([tier, info]) => `${tier}:${info.count}`)
+    .join(", ");
+  if (tierSummary) {
+    lines.push(`**Difficulty distribution:** ${tierSummary}`);
+  }
+
+  lines.push(`**Issues filed:** ${issueCount}`);
+
+  if (regressions.length > 0) {
+    lines.push("**Regressions:**");
+    for (const r of regressions) {
+      lines.push(
+        `  - ${r.metric}: ${r.current} (was ${r.baseline ?? "n/a"}, Δ${r.delta ?? ""}) [${r.severity}]`
+      );
+    }
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}
+
+/**
+ * Build a GitHub issue body for a queue-efficiency regression.
+ * Body follows the learning-loop issue format: self-contained acceptance criteria.
+ *
+ * @param {{ sensor: string, metric: string, current: number, baseline?: number, delta?: number, severity: string }} regression
+ * @param {{ sub_metrics?: object, distribution?: object }} sensorResult
+ * @returns {string}
+ */
+export function buildRegressionIssueBody(regression, sensorResult) {
+  const dist = sensorResult?.distribution ?? {};
+  const tierRows = Object.entries(dist)
+    .map(
+      ([tier, info]) => `| ${tier} | ${info.count} | ${info.avg_commits} | ${info.avg_ttm_hours}h |`
+    )
+    .join("\n");
+
+  const distSection = tierRows
+    ? `\n## Difficulty Distribution (Goodhart guard)\n\n| Tier | Count | Avg commits | Avg TTM |\n|------|-------|-------------|--------|\n${tierRows}\n`
+    : "";
+
+  return `## Regression Detected
+
+**Sensor:** ${regression.sensor}
+**Metric:** ${regression.metric}
+**Current:** ${regression.current}
+**Baseline:** ${regression.baseline ?? "n/a"}
+**Delta:** ${regression.delta ?? "n/a"}
+**Severity:** ${regression.severity}
+${distSection}
+## Acceptance Criteria
+
+- [ ] \`${regression.metric}\` returns to baseline level or better (≥ ${regression.baseline ?? "previous value"})
+- [ ] Verified by next optimize-implement-queue run (composite regression clears)
+- [ ] Root cause identified (agent/prompt quality vs harder issues; use async eval to distinguish)
+
+## Notes
+
+- **Do NOT** run \`mbe agent eval\` synchronously — file a separate \`eval\` task if agent/prompt quality is suspected
+- Difficulty-normalization is applied: regressions driven by size:xl-heavy weeks require a larger drop to flag
+- Phase-2 auto-tuning (guard-railed model-routing tier adjustment via \`scripts/threshold-tuner.mjs\`) is NOT yet built — manual review required for now
+
+_Detected by [optimize-implement-queue](../../.claude/skills/optimize-implement-queue/SKILL.md) daily skill_`;
+}
+
+/**
+ * Decide whether a queueEfficiency sensor result represents a real regression,
+ * accounting for difficulty normalization.
+ *
+ * Difficulty-normalization rule:
+ *   If >80% of merged PRs in the current window are size:xl, the expected
+ *   composite score is lower. We require a composite drop > 10% (not just
+ *   the default 5%) before treating it as a real regression.
+ *
+ * @param {{ available: boolean, regressions?: Array, distribution?: object, composite?: number, baseline?: object }} sensorResult
+ * @returns {boolean}
+ */
+export function isRealRegression(sensorResult) {
+  if (!sensorResult?.available) return false;
+  const regressions = sensorResult.regressions ?? [];
+  if (regressions.length === 0) return false;
+
+  // Check difficulty normalization: if xl-dominant, require larger composite drop.
+  const xl = xlFraction(sensorResult.distribution ?? {});
+  if (xl > XL_DOMINANT_THRESHOLD) {
+    const compositeRegression = regressions.find((r) => r.metric === "composite");
+    if (compositeRegression) {
+      const dropMagnitude = Math.abs(compositeRegression.delta ?? 0);
+      // Only flag if the drop exceeds the normalized threshold.
+      if (dropMagnitude < XL_DOMINANT_MIN_COMPOSITE_DROP) return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Append a log entry to the improvement-loop log file.
+ * Creates parent directories if they don't exist.
+ * In dry-run mode, does nothing.
+ *
+ * @param {string} logPath - Absolute path to the log file.
+ * @param {string} entry - Markdown text to append.
+ * @param {boolean} dryRun - If true, skip all file writes.
+ */
+export function appendLogEntry(logPath, entry, dryRun) {
+  if (dryRun) return;
+
+  mkdirSync(dirname(logPath), { recursive: true });
+
+  if (existsSync(logPath)) {
+    // Read current content to check if we need a separator.
+    const current = readFileSync(logPath, "utf-8");
+    // Ensure entries are separated by a blank line.
+    const separator = current.endsWith("\n\n") ? "" : current.endsWith("\n") ? "\n" : "\n\n";
+    appendFileSync(logPath, separator + entry);
+  } else {
+    writeFileSync(logPath, entry, "utf-8");
+  }
+}

--- a/temp-chaos-target.tsx
+++ b/temp-chaos-target.tsx
@@ -1,10 +1,7 @@
-import React from "react";
 
 export default function MyComponent() {
-  React.useEffect(() => { console.error("CHAOS-ERROR: Synthetic bug for #MyComponent"); }, []);
-
   return (
-    <div aria-label="test-label">
+    <div >
       <h1>Hello</h1>
     </div>
   );

--- a/temp-chaos-target.tsx
+++ b/temp-chaos-target.tsx
@@ -1,7 +1,10 @@
+import React from "react";
 
 export default function MyComponent() {
+  React.useEffect(() => { console.error("CHAOS-ERROR: Synthetic bug for #MyComponent"); }, []);
+
   return (
-    <div >
+    <div aria-label="test-label">
       <h1>Hello</h1>
     </div>
   );


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/optimize-implement-queue/SKILL.md` — the `/optimize-implement-queue` daily skill that orchestrates: collect queueEfficiency sensor → append JSONL trend point → log dated entry → file deduplicated `ready` issues on regression
- Adds `scripts/optimize-implement-queue.mjs` — pure helper functions (`buildQueueEfficiencyProcessEntry`, `buildOptimizeLogEntry`, `buildRegressionIssueBody`, `isRealRegression`, `appendLogEntry`) with full DI for testability
- Adds `scripts/__tests__/optimize-implement-queue.test.mjs` — 28 unit tests with injected fixtures; all pass

Key behaviors:
- `--dry-run` mode writes nothing to disk or GitHub
- Phase-1 never auto-merges, auto-edits prompts, or runs eval synchronously
- `isRealRegression()` applies difficulty normalization: >80% size:xl PRs requires a >10% composite drop (not just 5%) before treating as real
- Phase-2 auto-tuning seam is documented in the skill as NOT-yet-built (`scripts/threshold-tuner.mjs` is cited as the pattern)
- Regression issues filed via `correlate()` from `sensor-correlator.mjs` for deduplication
- Always writes a dated log entry (even when no regression)

## Gate results

- `pnpm lint` — clean (41/41 tasks, warnings only on pre-existing SetupPage)
- `pnpm typecheck` — clean (43/43 tasks, all cached)
- `pnpm test --filter @mbe/scripts` — 36/36 test files pass, 492/492 tests pass
- `check-adr` + `check-deps` — no violations
- `pnpm regen` — no drift in generated artifacts

## Test plan

- [ ] `node scripts/sensor-report.mjs --json | jq '.sensors.queueEfficiency'` returns a non-null composite
- [ ] `/optimize-implement-queue --dry-run` prints output and writes nothing
- [ ] All 28 unit tests in `scripts/__tests__/optimize-implement-queue.test.mjs` pass
- [ ] `isRealRegression` returns false when xl-dominant with small drop; true for large drops

Closes #2748