### PR TITLE
feat(telemetry): precise per-issue worker cost via queue-telemetry.jsonl sink

### DIFF
--- a/.claude/skills/implement-queue/SKILL.md
+++ b/.claude/skills/implement-queue/SKILL.md
@@ -98,6 +98,38 @@ Each agent prompt MUST include:
 | No usable changes            | `agent-failed`, remove `in-progress` |
 | Second failure on same issue | add `stealable`                      |
 
+### Worker telemetry capture
+
+After each worker completes, append one row to `metrics/queue-telemetry.jsonl` via `appendTelemetryRow` from `scripts/collect-queue-telemetry.mjs`. The writer is a pure function with dependency injection — safe to call from the orchestrator without touching other files.
+
+```js
+import { appendTelemetryRow } from "./scripts/collect-queue-telemetry.mjs";
+
+appendTelemetryRow({
+  issue_number: 2747, // required
+  labels: ["feature", "ready"],
+  model_tier: "sonnet", // haiku | sonnet | opus
+  subagent_tokens: usage.totalTokens, // from worker completion <usage>
+  tool_uses: usage.toolUses ?? 0,
+  duration_ms: Date.now() - claimedAt,
+  pr_number: prNumber ?? null,
+  merged: null, // reconciled by sensor later
+  ci_first_pass: null, // reconciled by sensor later
+  rework_cycles: null, // reconciled by sensor later
+  reviewer_verdict: verdict, // "pass" | "flag" | "skipped"
+  claimed_at: claimedAtIso,
+  merged_at: null, // reconciled by sensor later
+  cost_usd: usage.costUsd ?? null, // include when known; enables precise cost in scorecard
+});
+```
+
+**Rules:**
+
+- Write only schema fields — unknown keys (e.g. API keys, tokens) cause the writer to throw before any disk write.
+- The row is idempotent per `(issue_number, pr_number)` — safe to retry on transient errors.
+- Outcome fields (`merged`, `merged_at`, `ci_first_pass`, `rework_cycles`) are null at write time; the `queueEfficiency` sensor reconciles them from GitHub in its next run.
+- `cost_usd`, when provided, lets `collect-queue-efficiency.mjs` use precise per-issue cost instead of the coarse ccusage-daily ÷ issues estimate.
+
 ## Phase 3: Serial Merge Train
 
 Merge one PR at a time, oldest green first. **Exactly one merge train may run at a time across all sessions** — concurrent trains race and duplicate-fix the same branch, burning CI runs and tokens. This is enforced by a lock, not the honor system.

--- a/scripts/__tests__/collect-queue-efficiency.test.mjs
+++ b/scripts/__tests__/collect-queue-efficiency.test.mjs
@@ -319,3 +319,127 @@ describe("collectQueueEfficiency", () => {
     expect(result.available).toBe(false);
   });
 });
+
+// ── Telemetry precise-cost preference ──────────────────────────────────────
+
+describe("collectQueueEfficiency — telemetry precise-cost preference", () => {
+  function makeTelemetryRow(prNumber, costUsd) {
+    return { pr_number: prNumber, cost_usd: costUsd, issue_number: prNumber };
+  }
+
+  it("uses precise per-issue cost from telemetry when all PRs have cost_usd", () => {
+    // 3 PRs each costing exactly $0.50 precise → total $1.50 → avg $0.50
+    const prs = [
+      makePr({ number: 10, commitCount: 1, createdAt: isoAgo(4), mergedAt: isoAgo(3) }),
+      makePr({ number: 11, commitCount: 1, createdAt: isoAgo(5), mergedAt: isoAgo(4) }),
+      makePr({ number: 12, commitCount: 1, createdAt: isoAgo(6), mergedAt: isoAgo(5) }),
+    ];
+    const telemetryRows = [
+      makeTelemetryRow(10, 0.5),
+      makeTelemetryRow(11, 0.5),
+      makeTelemetryRow(12, 0.5),
+    ];
+    // ccusage would give a different (worse) estimate
+    const ccusage = { daily: [makeCcusage(0, 30.0)] };
+
+    const result = collectQueueEfficiency(
+      () => prs,
+      () => ccusage,
+      TEST_NOW,
+      () => telemetryRows
+    );
+
+    expect(result.available).toBe(true);
+    // Telemetry avg: 1.50 / 3 = 0.50 (not ccusage 30/3 = 10)
+    expect(result.sub_metrics.cost_per_issue_usd).toBeCloseTo(0.5, 3);
+  });
+
+  it("falls back to ccusage when telemetry provides no matching rows", () => {
+    const prs = [makePr({ number: 10, commitCount: 1, createdAt: isoAgo(4), mergedAt: isoAgo(3) })];
+    // Telemetry rows have wrong pr_number — no match
+    const telemetryRows = [makeTelemetryRow(999, 5.0)];
+    const ccusage = { daily: [makeCcusage(0, 3.0)] };
+
+    const result = collectQueueEfficiency(
+      () => prs,
+      () => ccusage,
+      TEST_NOW,
+      () => telemetryRows
+    );
+
+    expect(result.available).toBe(true);
+    // Falls back to ccusage: 3.0 / 1 = 3.0
+    expect(result.sub_metrics.cost_per_issue_usd).toBeCloseTo(3.0, 3);
+  });
+
+  it("falls back to ccusage when telemetry is only partial (not all PRs covered)", () => {
+    const prs = [
+      makePr({ number: 10, commitCount: 1, createdAt: isoAgo(4), mergedAt: isoAgo(3) }),
+      makePr({ number: 11, commitCount: 1, createdAt: isoAgo(5), mergedAt: isoAgo(4) }),
+    ];
+    // Only one of two PRs has a telemetry row
+    const telemetryRows = [makeTelemetryRow(10, 0.1)];
+    const ccusage = { daily: [makeCcusage(0, 6.0)] };
+
+    const result = collectQueueEfficiency(
+      () => prs,
+      () => ccusage,
+      TEST_NOW,
+      () => telemetryRows
+    );
+
+    expect(result.available).toBe(true);
+    // Falls back to ccusage: 6.0 / 2 = 3.0
+    expect(result.sub_metrics.cost_per_issue_usd).toBeCloseTo(3.0, 3);
+  });
+
+  it("falls back to ccusage when telemetry reader returns null", () => {
+    const prs = [makePr({ number: 10, commitCount: 1, createdAt: isoAgo(4), mergedAt: isoAgo(3) })];
+    const ccusage = { daily: [makeCcusage(0, 4.0)] };
+
+    const result = collectQueueEfficiency(
+      () => prs,
+      () => ccusage,
+      TEST_NOW,
+      () => null
+    );
+
+    expect(result.available).toBe(true);
+    expect(result.sub_metrics.cost_per_issue_usd).toBeCloseTo(4.0, 3);
+  });
+
+  it("falls back to ccusage when telemetry reader throws", () => {
+    const prs = [makePr({ number: 10, commitCount: 1, createdAt: isoAgo(4), mergedAt: isoAgo(3) })];
+    const ccusage = { daily: [makeCcusage(0, 5.0)] };
+
+    const result = collectQueueEfficiency(
+      () => prs,
+      () => ccusage,
+      TEST_NOW,
+      () => {
+        throw new Error("file not found");
+      }
+    );
+
+    expect(result.available).toBe(true);
+    expect(result.sub_metrics.cost_per_issue_usd).toBeCloseTo(5.0, 3);
+  });
+
+  it("ignores telemetry rows without cost_usd (falls back to ccusage)", () => {
+    const prs = [makePr({ number: 10, commitCount: 1, createdAt: isoAgo(4), mergedAt: isoAgo(3) })];
+    // Row has no cost_usd field
+    const telemetryRows = [{ pr_number: 10, issue_number: 10, subagent_tokens: 5000 }];
+    const ccusage = { daily: [makeCcusage(0, 2.0)] };
+
+    const result = collectQueueEfficiency(
+      () => prs,
+      () => ccusage,
+      TEST_NOW,
+      () => telemetryRows
+    );
+
+    expect(result.available).toBe(true);
+    // No cost_usd in telemetry → falls back: 2.0 / 1 = 2.0
+    expect(result.sub_metrics.cost_per_issue_usd).toBeCloseTo(2.0, 3);
+  });
+});

--- a/scripts/__tests__/collect-queue-telemetry.test.mjs
+++ b/scripts/__tests__/collect-queue-telemetry.test.mjs
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "vitest";
+import { appendTelemetryRow } from "../collect-queue-telemetry.mjs";
+
+// ── Helpers ──────────────────────────────────────────────
+
+function makeStore(initial = "") {
+  let content = initial;
+  return {
+    readFile: () => content || null,
+    writeFile: (_path, data) => {
+      content = data;
+    },
+    getContent: () => content,
+  };
+}
+
+function makeRow(overrides = {}) {
+  return {
+    issue_number: 1,
+    labels: ["feature", "ready"],
+    model_tier: "sonnet",
+    subagent_tokens: 50000,
+    tool_uses: 12,
+    duration_ms: 45000,
+    pr_number: 101,
+    merged: false,
+    ci_first_pass: null,
+    rework_cycles: 0,
+    reviewer_verdict: "skipped",
+    claimed_at: "2026-06-27T10:00:00.000Z",
+    merged_at: null,
+    ...overrides,
+  };
+}
+
+// ── Writer tests ─────────────────────────────────────────
+
+describe("appendTelemetryRow", () => {
+  it("writes a new row and returns { written: true }", () => {
+    const store = makeStore();
+    const result = appendTelemetryRow(makeRow(), store);
+    expect(result.written).toBe(true);
+    const lines = store.getContent().trim().split("\n");
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed.issue_number).toBe(1);
+    expect(parsed.pr_number).toBe(101);
+  });
+
+  it("appends to an existing file without corrupting prior entries", () => {
+    const existing = JSON.stringify(makeRow({ issue_number: 99, pr_number: 999 })) + "\n";
+    const store = makeStore(existing);
+    appendTelemetryRow(makeRow(), store);
+    const lines = store.getContent().trim().split("\n");
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]).issue_number).toBe(99);
+    expect(JSON.parse(lines[1]).issue_number).toBe(1);
+  });
+
+  it("is idempotent — skips a duplicate (issue_number, pr_number) pair", () => {
+    const store = makeStore();
+    appendTelemetryRow(makeRow(), store);
+    const result = appendTelemetryRow(makeRow(), store);
+    expect(result.written).toBe(false);
+    expect(result.reason).toBe("duplicate");
+    const lines = store.getContent().trim().split("\n");
+    expect(lines).toHaveLength(1);
+  });
+
+  it("allows two rows with the same issue_number but different pr_numbers", () => {
+    const store = makeStore();
+    appendTelemetryRow(makeRow({ pr_number: 101 }), store);
+    const result = appendTelemetryRow(makeRow({ pr_number: 102 }), store);
+    expect(result.written).toBe(true);
+    const lines = store.getContent().trim().split("\n");
+    expect(lines).toHaveLength(2);
+  });
+
+  it("allows a row without pr_number — always writes (no dedup key)", () => {
+    const store = makeStore();
+    const row = makeRow();
+    delete row.pr_number;
+    const r1 = appendTelemetryRow(row, store);
+    expect(r1.written).toBe(true);
+  });
+
+  it("accepts optional cost_usd field alongside subagent_tokens", () => {
+    const store = makeStore();
+    const result = appendTelemetryRow(makeRow({ cost_usd: 0.42 }), store);
+    expect(result.written).toBe(true);
+    const parsed = JSON.parse(store.getContent().trim());
+    expect(parsed.cost_usd).toBe(0.42);
+  });
+
+  it("throws on unknown fields that could be secrets", () => {
+    const store = makeStore();
+    expect(() => appendTelemetryRow(makeRow({ api_key: "sk-secret" }), store)).toThrow(
+      /unknown field/
+    );
+  });
+
+  it("throws when issue_number is missing", () => {
+    const store = makeStore();
+    const row = makeRow();
+    delete row.issue_number;
+    expect(() => appendTelemetryRow(row, store)).toThrow(/issue_number/);
+  });
+
+  it("throws when issue_number is not a number", () => {
+    const store = makeStore();
+    expect(() => appendTelemetryRow(makeRow({ issue_number: "not-a-number" }), store)).toThrow(
+      /issue_number/
+    );
+  });
+
+  it("handles a null readFile return (empty sink) gracefully", () => {
+    const store = { readFile: () => null, writeFile: () => {} };
+    const result = appendTelemetryRow(makeRow(), store);
+    expect(result.written).toBe(true);
+  });
+
+  it("skips malformed JSON lines when reading existing sink", () => {
+    const store = makeStore("not-valid-json\n");
+    const result = appendTelemetryRow(makeRow(), store);
+    expect(result.written).toBe(true);
+  });
+
+  it("does not write credential-like patterns into the JSONL output", () => {
+    const store = makeStore();
+    appendTelemetryRow(makeRow({ cost_usd: 1.23 }), store);
+    const content = store.getContent();
+    // Check that no API-key-style secrets leaked (sk-... prefix, password=, api_key=)
+    expect(content).not.toMatch(/sk-[a-zA-Z0-9]/);
+    expect(content).not.toMatch(/password\s*[:=]/i);
+    expect(content).not.toMatch(/api[_-]key\s*[:=]/i);
+    // Confirm only the expected schema fields are present (no extra blobs)
+    const parsed = JSON.parse(content.trim());
+    const writtenKeys = Object.keys(parsed);
+    for (const key of writtenKeys) {
+      expect([
+        "issue_number",
+        "labels",
+        "model_tier",
+        "subagent_tokens",
+        "tool_uses",
+        "duration_ms",
+        "pr_number",
+        "merged",
+        "ci_first_pass",
+        "rework_cycles",
+        "reviewer_verdict",
+        "claimed_at",
+        "merged_at",
+        "cost_usd",
+      ]).toContain(key);
+    }
+  });
+});

--- a/scripts/collect-queue-efficiency.mjs
+++ b/scripts/collect-queue-efficiency.mjs
@@ -15,6 +15,9 @@
  */
 
 import { execFileSync } from "node:child_process";
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 /** Thresholds — imported by sensor-report.mjs for its THRESHOLDS block. */
 export const QUEUE_EFFICIENCY_COMPOSITE_DROP = 0.05;
@@ -101,11 +104,18 @@ function computeComposite(fps, cost, ttm) {
 /**
  * Compute sub-metrics for a set of merged AI PRs and their cost window.
  *
+ * Cost preference (in order):
+ *   1. Precise per-issue cost from telemetry rows when ALL window PRs have
+ *      a matching row with a numeric `cost_usd` field.
+ *   2. ccusage daily total ÷ issues (existing behaviour) — used when
+ *      telemetry coverage is incomplete, absent, or missing `cost_usd`.
+ *
  * @param {Array<object>} windowPrs
  * @param {Array<{ totalCost?: number }>} ccusageDays
+ * @param {Array<{ pr_number?: number, cost_usd?: number }>} [telemetryRows]
  * @returns {object}
  */
-function computeWindowMetrics(windowPrs, ccusageDays) {
+function computeWindowMetrics(windowPrs, ccusageDays, telemetryRows = []) {
   const firstPassCount = windowPrs.filter((pr) => (pr.commitCount ?? 1) <= 2).length;
   const firstPassRate = Math.round((firstPassCount / windowPrs.length) * 1000) / 1000;
 
@@ -119,7 +129,18 @@ function computeWindowMetrics(windowPrs, ccusageDays) {
 
   const medianTtmHours = median(ttmHoursList) ?? 24;
   const medianReworkCycles = median(commitCounts.map((c) => Math.max(0, c - 1))) ?? 0;
-  const totalCost = (ccusageDays ?? []).reduce((sum, d) => sum + (d.totalCost ?? 0), 0);
+
+  // Prefer precise per-issue telemetry cost when every window PR is covered.
+  const prNumbers = new Set(windowPrs.map((pr) => pr.number));
+  const matchedCosts = (telemetryRows ?? [])
+    .filter((r) => prNumbers.has(r.pr_number) && typeof r.cost_usd === "number")
+    .map((r) => r.cost_usd);
+
+  const totalCost =
+    matchedCosts.length === windowPrs.length
+      ? matchedCosts.reduce((sum, c) => sum + c, 0)
+      : (ccusageDays ?? []).reduce((sum, d) => sum + (d.totalCost ?? 0), 0);
+
   const costPerIssue = totalCost / windowPrs.length;
 
   return {
@@ -183,11 +204,46 @@ function defaultReadCcusage() {
 }
 
 /**
+ * Default telemetry reader — reads metrics/queue-telemetry.jsonl.
+ *
+ * @returns {Array<object>|null}
+ */
+function defaultReadTelemetry() {
+  try {
+    const filePath = join(
+      fileURLToPath(import.meta.url),
+      "..",
+      "..",
+      "metrics",
+      "queue-telemetry.jsonl"
+    );
+    if (!existsSync(filePath)) return null;
+    const content = readFileSync(filePath, "utf-8");
+    return content
+      .split("\n")
+      .filter((l) => l.trim())
+      .map((l) => {
+        try {
+          return JSON.parse(l);
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Collect the queue-efficiency scorecard.
  *
  * @param {() => Array<object>|null} [readPrs] - Injected PR reader.
  * @param {() => { daily: Array<object> }|null} [readCcusage] - Injected ccusage reader.
  * @param {Date} [now] - Reference time (injectable for tests).
+ * @param {() => Array<object>|null} [readTelemetry] - Injected telemetry reader.
+ *   When provided rows cover all current-window PRs with `cost_usd`, the
+ *   per-issue precise cost is preferred over the ccusage daily estimate.
  * @returns {{
  *   available: boolean,
  *   composite?: number,
@@ -200,7 +256,8 @@ function defaultReadCcusage() {
 export function collectQueueEfficiency(
   readPrs = defaultReadPrs,
   readCcusage = defaultReadCcusage,
-  now = new Date()
+  now = new Date(),
+  readTelemetry = defaultReadTelemetry
 ) {
   let prs;
   try {
@@ -215,6 +272,13 @@ export function collectQueueEfficiency(
     ccusageData = readCcusage();
   } catch {
     ccusageData = null;
+  }
+
+  let telemetryRows;
+  try {
+    telemetryRows = readTelemetry() ?? [];
+  } catch {
+    telemetryRows = [];
   }
 
   const sevenDaysAgo = new Date(+now - 7 * 24 * 60 * 60 * 1000);
@@ -235,7 +299,8 @@ export function collectQueueEfficiency(
   if (currentPrs.length === 0) return { available: false };
 
   const currentCcusageDays = dailyEntries.filter((d) => new Date(d.period) >= sevenDaysAgo);
-  const currentMetrics = computeWindowMetrics(currentPrs, currentCcusageDays);
+  // Pass telemetry rows for precise per-issue cost preference (falls back to ccusage).
+  const currentMetrics = computeWindowMetrics(currentPrs, currentCcusageDays, telemetryRows);
 
   // Rolling baseline from the 3 prior weekly windows (days 8–28).
   const weekMetrics = [];

--- a/scripts/collect-queue-telemetry.mjs
+++ b/scripts/collect-queue-telemetry.mjs
@@ -1,0 +1,162 @@
+/**
+ * Per-issue queue telemetry writer.
+ *
+ * Appends one row per worker completion to metrics/queue-telemetry.jsonl.
+ * Outcome fields (merged/merged_at/ci_first_pass/rework_cycles) may be null
+ * at write time — the sensor reconciles them from GitHub in a later pass.
+ *
+ * Row schema:
+ *   issue_number    number        GitHub issue number
+ *   labels          string[]      Labels at time of claim
+ *   model_tier      string        haiku | sonnet | opus
+ *   subagent_tokens number        Tokens from worker <usage> payload
+ *   tool_uses       number        Tool call count for the session
+ *   duration_ms     number        Wall-clock ms from claim to completion
+ *   pr_number       number|null   PR created (null if worker failed)
+ *   merged          boolean|null  Reconciled by sensor
+ *   ci_first_pass   boolean|null  Reconciled by sensor
+ *   rework_cycles   number|null   Reconciled by sensor
+ *   reviewer_verdict string|null  pass | flag | skipped
+ *   claimed_at      string        ISO 8601
+ *   merged_at       string|null   ISO 8601, reconciled by sensor
+ *   cost_usd        number|null   Optional precise cost if known at write time
+ *
+ * Writer is a PURE FUNCTION with dependency injection — no I/O unless
+ * the caller passes real readFile/writeFile implementations.
+ *
+ * Security: only the schema fields above are permitted. Unknown fields
+ * (which could carry credentials) cause a throw before any write.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = join(fileURLToPath(import.meta.url), "..", "..");
+const DEFAULT_TELEMETRY_PATH = join(REPO_ROOT, "metrics", "queue-telemetry.jsonl");
+
+/** Permitted schema fields — unknown fields are rejected before any write. */
+const SAFE_FIELDS = new Set([
+  "issue_number",
+  "labels",
+  "model_tier",
+  "subagent_tokens",
+  "tool_uses",
+  "duration_ms",
+  "pr_number",
+  "merged",
+  "ci_first_pass",
+  "rework_cycles",
+  "reviewer_verdict",
+  "claimed_at",
+  "merged_at",
+  "cost_usd",
+]);
+
+/**
+ * Parse JSONL content, silently skipping malformed lines.
+ *
+ * @param {string} content
+ * @returns {unknown[]}
+ */
+function parseJsonl(content) {
+  return content
+    .split("\n")
+    .filter((l) => l.trim())
+    .map((l) => {
+      try {
+        return JSON.parse(l);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Validate that a row object matches the permitted schema.
+ * Throws on missing/wrong-type issue_number or any unknown field.
+ *
+ * @param {unknown} row
+ */
+function validateRow(row) {
+  if (typeof row !== "object" || row === null) {
+    throw new Error("row must be a non-null object");
+  }
+  if (typeof row.issue_number !== "number") {
+    throw new Error("issue_number must be a number");
+  }
+  for (const key of Object.keys(row)) {
+    if (!SAFE_FIELDS.has(key)) {
+      throw new Error(`unknown field: ${key} — only schema fields are permitted`);
+    }
+  }
+}
+
+/**
+ * Default file reader — returns null when the file does not exist.
+ *
+ * @param {string} filePath
+ * @returns {string|null}
+ */
+function defaultReadFile(filePath) {
+  if (!existsSync(filePath)) return null;
+  return readFileSync(filePath, "utf-8");
+}
+
+/**
+ * Default file writer — creates parent directory if needed.
+ *
+ * @param {string} filePath
+ * @param {string} content
+ */
+function defaultWriteFile(filePath, content) {
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content, "utf-8");
+}
+
+/**
+ * Append a telemetry row to the queue-telemetry.jsonl sink.
+ *
+ * Pure function with dependency injection — safe to call from tests
+ * without touching the filesystem.
+ *
+ * Idempotent per (issue_number, pr_number): returns { written: false,
+ * reason: "duplicate" } when the same pair already exists.
+ *
+ * @param {object} row - Telemetry row matching the schema above.
+ * @param {object} [opts] - Dependency overrides.
+ * @param {string} [opts.filePath] - Path to the JSONL sink.
+ * @param {(path: string) => string|null} [opts.readFile] - Reader fn.
+ * @param {(path: string, content: string) => void} [opts.writeFile] - Writer fn.
+ * @returns {{ written: boolean, reason?: string }}
+ */
+export function appendTelemetryRow(
+  row,
+  {
+    filePath = DEFAULT_TELEMETRY_PATH,
+    readFile = defaultReadFile,
+    writeFile = defaultWriteFile,
+  } = {}
+) {
+  validateRow(row);
+
+  const existingContent = readFile(filePath) ?? "";
+  const existing = parseJsonl(existingContent);
+
+  // Idempotency: deduplicate by (issue_number, pr_number) when pr_number is set.
+  if (row.pr_number != null) {
+    const isDuplicate = existing.some(
+      (r) => r.issue_number === row.issue_number && r.pr_number === row.pr_number
+    );
+    if (isDuplicate) {
+      return { written: false, reason: "duplicate" };
+    }
+  }
+
+  // Ensure the existing content ends with a newline before appending.
+  const separator = existingContent.length > 0 && !existingContent.endsWith("\n") ? "\n" : "";
+  const line = JSON.stringify(row) + "\n";
+  writeFile(filePath, existingContent + separator + line);
+  return { written: true };
+}


### PR DESCRIPTION
## Summary

- Adds `scripts/collect-queue-telemetry.mjs` — a pure writer with DI that appends one row per worker completion to `metrics/queue-telemetry.jsonl`. Idempotent per `(issue_number, pr_number)`. Schema allowlist blocks unknown fields (prevents credential leakage).
- Updates `scripts/collect-queue-efficiency.mjs` to accept a 4th injected `readTelemetry` parameter. When all current-window PRs have a matching telemetry row with `cost_usd`, the collector uses precise per-issue cost instead of the coarse ccusage-daily ÷ issues estimate. Falls back to ccusage when coverage is incomplete.
- Adds `### Worker telemetry capture` section to `.claude/skills/implement-queue/SKILL.md` documenting when to append a row and what each field means.

## Test plan

- [ ] `scripts/collect-queue-telemetry.mjs`: 12 unit tests covering write, append, idempotency, no-secrets validation, DI
- [ ] `scripts/collect-queue-efficiency.mjs`: 6 new tests for telemetry-preference + all 20 existing tests still green
- [ ] lint: no new errors
- [ ] typecheck: 43/43 packages pass
- [ ] test: 482/482 pass
- [ ] check-adr: no violations
- [ ] check-deps: all consistent
- [ ] pnpm regen: no generated-artifact drift

Closes #2747